### PR TITLE
fix(4642): clear dispatched-origin ghost turns

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -933,6 +933,7 @@ src/
 │   │   │   ├── lifecycle/
 │   │   │   │   └── activity.rs
 │   │   │   ├── codex_tui_restore.rs
+│   │   │   ├── dispatched_origin_ghost.rs
 │   │   │   ├── lifecycle.rs
 │   │   │   └── lifecycle_decision.rs
 │   │   ├── abandon_request_store.rs

--- a/migrations/postgres/0099_dispatched_origin_turn_marker.sql
+++ b/migrations/postgres/0099_dispatched_origin_turn_marker.sql
@@ -1,0 +1,4 @@
+-- #4642: distinguish dispatched-origin turns from ordinary interactive turns during restore.
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS active_turn_nonce TEXT,
+    ADD COLUMN IF NOT EXISTS dispatched_origin_turn_nonce TEXT;

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -505,6 +505,11 @@
       "path": "migrations/postgres/0098_scheduled_message_snapshot_reclaim.sql",
       "sha256": "655db436b1545c761338a20460b81cee80269040fe1958bd8f52e7f24743ebb6",
       "version": 98
+    },
+    {
+      "path": "migrations/postgres/0099_dispatched_origin_turn_marker.sql",
+      "sha256": "737bf8d3fa5a05cdd51b041bed6e94825bd7829f79c3b4366c823097cf4f9c14",
+      "version": 99
     }
   ],
   "version": 1

--- a/src/db/dispatched_sessions.rs
+++ b/src/db/dispatched_sessions.rs
@@ -1211,6 +1211,8 @@ mod selector_cleanup_tests {
                 channel_id: None,
                 claude_session_id,
                 raw_provider_session_id,
+                turn_start_nonce: None,
+                dispatched_origin: false,
             },
         )
         .await
@@ -2353,6 +2355,8 @@ pub(crate) struct HookSessionUpsert<'a> {
     pub(crate) channel_id: Option<&'a str>,
     pub(crate) claude_session_id: Option<&'a str>,
     pub(crate) raw_provider_session_id: Option<&'a str>,
+    pub(crate) turn_start_nonce: Option<&'a str>,
+    pub(crate) dispatched_origin: bool,
 }
 
 pub(crate) struct DeleteSessionResult {
@@ -2446,6 +2450,12 @@ pub(crate) async fn upsert_hook_session_pg(
               ELSE COALESCE(sessions.claude_session_id_recorded_at, NOW())
             END,
             raw_provider_session_id = COALESCE(EXCLUDED.raw_provider_session_id, sessions.raw_provider_session_id),
+            active_turn_nonce = COALESCE(EXCLUDED.active_turn_nonce, sessions.active_turn_nonce),
+            dispatched_origin_turn_nonce = CASE
+              WHEN EXCLUDED.active_turn_nonce IS NULL THEN sessions.dispatched_origin_turn_nonce
+              WHEN EXCLUDED.dispatched_origin_turn_nonce IS NULL THEN NULL
+              ELSE EXCLUDED.dispatched_origin_turn_nonce
+            END,
             last_heartbeat = NOW()
          RETURNING (xmax = 0) AS inserted",
     )
@@ -2463,6 +2473,8 @@ pub(crate) async fn upsert_hook_session_pg(
     .bind(params.channel_id)
     .bind(params.claude_session_id)
     .bind(params.raw_provider_session_id)
+    .bind(params.turn_start_nonce)
+    .bind(params.dispatched_origin)
     .fetch_one(pool)
     .await
     .map_err(|error| format!("upsert postgres session {}: {error}", params.session_key))?;

--- a/src/db/dispatched_sessions.rs
+++ b/src/db/dispatched_sessions.rs
@@ -2416,13 +2416,16 @@ pub(crate) async fn upsert_hook_session_pg(
             channel_id,
             claude_session_id,
             raw_provider_session_id,
+            active_turn_nonce,
+            dispatched_origin_turn_nonce,
             claude_session_id_recorded_at,
             last_heartbeat
          ) VALUES (
             $1, $2, $3, $4, $5, $6, $7,
             COALESCE($8, 0),
             CASE WHEN $8 IS NOT NULL THEN NOW() ELSE NULL END,
-            $9, $10, $11, $12, $13, $14,
+            $9, $10, $11, $12, $13, $14, $15,
+            CASE WHEN $16 THEN $15 ELSE NULL END,
             CASE WHEN NULLIF(BTRIM($13), '') IS NOT NULL THEN NOW() ELSE NULL END,
             NOW()
          )

--- a/src/services/discord/adk_session.rs
+++ b/src/services/discord/adk_session.rs
@@ -193,6 +193,45 @@ pub(super) fn derive_adk_session_info(
     "AgentDesk 작업 진행 중".to_string()
 }
 
+/// Persist the origin classification at turn start. Every started turn overwrites
+/// the previous marker, so an ordinary interactive turn can never inherit a
+/// dispatched-origin marker from an older turn.
+pub(super) async fn record_turn_start_origin(
+    session_key: Option<&str>,
+    provider: &ProviderKind,
+    channel_id: serenity::ChannelId,
+    turn_nonce: Option<&str>,
+    dispatched_origin: bool,
+) {
+    let (Some(session_key), Some(turn_nonce)) =
+        (session_key, turn_nonce.filter(|value| !value.is_empty()))
+    else {
+        return;
+    };
+    let body = crate::services::dispatched_sessions::HookSessionBody {
+        session_key: session_key.to_string(),
+        instance_id: None,
+        agent_id: None,
+        status: Some(crate::db::session_status::TURN_ACTIVE.to_string()),
+        provider: Some(provider.as_str().to_string()),
+        session_info: None,
+        name: None,
+        model: None,
+        tokens: None,
+        cwd: None,
+        dispatch_id: None,
+        thread_channel_id: None,
+        claude_session_id: None,
+        session_id: None,
+        channel_id: Some(channel_id.get().to_string()),
+        turn_start_nonce: Some(turn_nonce.to_string()),
+        dispatched_origin: Some(dispatched_origin),
+    };
+    if let Err(err) = super::internal_api::hook_session(body).await {
+        tracing::warn!(channel_id = channel_id.get(), error = %err, "failed to persist turn-start origin marker");
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn post_adk_session_status(
     session_key: Option<&str>,
@@ -233,6 +272,8 @@ pub(super) async fn post_adk_session_status(
         claude_session_id: None,
         session_id: None,
         channel_id: channel_id.map(|id| id.get().to_string()),
+        turn_start_nonce: None,
+        dispatched_origin: None,
     };
 
     if let Err(err) = super::internal_api::hook_session(body).await {
@@ -295,6 +336,8 @@ pub(super) async fn save_provider_session_id(
         claude_session_id: Some(session_id.to_string()),
         session_id: raw_provider_session_id.map(str::to_string),
         channel_id: Some(channel_id.get().to_string()),
+        turn_start_nonce: None,
+        dispatched_origin: None,
     };
     if let Err(err) = super::internal_api::hook_session(body).await {
         let ts = chrono::Local::now().format("%H:%M:%S");

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2390,6 +2390,14 @@ pub(super) async fn handle_text_message(
     }
     inflight_state.session_key = adk_session_key.clone();
     inflight_state.dispatch_id = dispatch_id.clone();
+    super::super::super::adk_session::record_turn_start_origin(
+        adk_session_key.as_deref(),
+        &provider,
+        channel_id,
+        inflight_state.turn_nonce.as_deref(),
+        dispatch_id.is_some(),
+    )
+    .await;
     inflight_create_log::log_create_new_inflight_outcome(
         super::super::super::inflight::save_inflight_state_create_new(&inflight_state),
         &provider,

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2390,14 +2390,7 @@ pub(super) async fn handle_text_message(
     }
     inflight_state.session_key = adk_session_key.clone();
     inflight_state.dispatch_id = dispatch_id.clone();
-    super::super::super::adk_session::record_turn_start_origin(
-        adk_session_key.as_deref(),
-        &provider,
-        channel_id,
-        inflight_state.turn_nonce.as_deref(),
-        dispatch_id.is_some(),
-    )
-    .await;
+    inflight_create_log::record_turn_start_origin(&provider, channel_id, &inflight_state).await;
     inflight_create_log::log_create_new_inflight_outcome(
         super::super::super::inflight::save_inflight_state_create_new(&inflight_state),
         &provider,

--- a/src/services/discord/router/message_handler/intake_turn/inflight_create_log.rs
+++ b/src/services/discord/router/message_handler/intake_turn/inflight_create_log.rs
@@ -1,5 +1,22 @@
+use poise::serenity_prelude as serenity;
+
 use crate::services::discord::inflight::{CreateNewInflightError, InflightTurnState};
 use crate::services::provider::ProviderKind;
+
+pub(crate) async fn record_turn_start_origin(
+    provider: &ProviderKind,
+    channel_id: serenity::ChannelId,
+    state: &InflightTurnState,
+) {
+    crate::services::discord::adk_session::record_turn_start_origin(
+        state.session_key.as_deref(),
+        provider,
+        channel_id,
+        state.turn_nonce.as_deref(),
+        state.dispatch_id.is_some(),
+    )
+    .await;
+}
 
 pub(crate) fn log_create_new_inflight_outcome(
     result: Result<(), CreateNewInflightError>,

--- a/src/services/discord/watchers/dispatched_origin_ghost.rs
+++ b/src/services/discord/watchers/dispatched_origin_ghost.rs
@@ -1,0 +1,70 @@
+//! Restore-time cleanup of dispatched-origin turns whose dispatch link vanished.
+
+/// Consume only a dispatched-origin marker for this exact turn after its
+/// identity-guarded inflight clear succeeded. Dispatch-less interactive turns
+/// never have `dispatched_origin_turn_nonce`, so this fails closed for them.
+pub(super) async fn consume_dispatched_origin_ghost_if_current(
+    pg_pool: Option<&sqlx::PgPool>,
+    state: &crate::services::discord::inflight::InflightTurnState,
+) -> bool {
+    let (Some(pool), Some(session_key), Some(turn_nonce)) = (
+        pg_pool,
+        state.session_key.as_deref(),
+        state
+            .turn_nonce
+            .as_deref()
+            .filter(|value| !value.is_empty()),
+    ) else {
+        return false;
+    };
+
+    let Some(provider) = state.provider_kind() else {
+        return false;
+    };
+    let identity = crate::services::discord::inflight::InflightTurnIdentity::from_state(state);
+    match crate::services::discord::inflight::clear_inflight_state_if_matches_identity_turn_nonce(
+        &provider,
+        state.channel_id,
+        &identity,
+        Some(turn_nonce),
+    ) {
+        crate::services::discord::inflight::GuardedClearOutcome::Cleared
+        | crate::services::discord::inflight::GuardedClearOutcome::Missing => {}
+        _ => return false,
+    }
+
+    // The inflight clear is pinned to the same identity and nonce. This CAS
+    // independently requires the durable origin marker, so a concurrent newer
+    // interactive turn can neither lose its inflight nor be marked idle.
+    let channel_id = state.channel_id.to_string();
+    match sqlx::query(
+        "UPDATE sessions
+            SET status = 'idle',
+                active_dispatch_id = NULL,
+                dispatched_origin_turn_nonce = NULL,
+                session_info = 'Cleared orphaned dispatched-origin turn',
+                last_heartbeat = NOW()
+          WHERE session_key = $1
+            AND channel_id = $2
+            AND status IN ('turn_active', 'working')
+            AND active_turn_nonce = $3
+            AND dispatched_origin_turn_nonce = $3
+            AND COALESCE(BTRIM(active_dispatch_id), '') = ''",
+    )
+    .bind(session_key)
+    .bind(channel_id)
+    .bind(turn_nonce)
+    .execute(pool)
+    .await
+    {
+        Ok(result) => result.rows_affected() == 1,
+        Err(error) => {
+            tracing::warn!(
+                channel_id = state.channel_id,
+                error = %error,
+                "failed to consume dispatched-origin ghost marker"
+            );
+            false
+        }
+    }
+}

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -11,6 +11,9 @@ pub(in crate::services::discord) use self::activity::{
 
 #[path = "codex_tui_restore.rs"]
 mod codex_restore;
+#[path = "dispatched_origin_ghost.rs"]
+mod dispatched_origin_ghost;
+use dispatched_origin_ghost::consume_dispatched_origin_ghost_if_current;
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum LivenessProbeOutcome {
@@ -2518,7 +2521,18 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
             if let Some(restored_tmux) =
                 restored_watcher_turn_from_inflight(&state, session_name, false)
             {
-                let _ = rebind_restored_dispatch_if_missing(shared.pg_pool.as_ref(), &state).await;
+                let rebound =
+                    rebind_restored_dispatch_if_missing(shared.pg_pool.as_ref(), &state).await;
+                if rebound == RestoreDispatchRebindOutcome::NotRebound
+                    && consume_dispatched_origin_ghost_if_current(shared.pg_pool.as_ref(), &state)
+                        .await
+                {
+                    tracing::info!(
+                        channel_id = state.channel_id,
+                        "cleared orphaned dispatched-origin turn during watcher restore"
+                    );
+                    continue;
+                }
                 let finish_mailbox_on_completion =
                     super::super::recovery::reregister_active_turn_from_inflight(&shared, &state)
                         .await;
@@ -2878,8 +2892,8 @@ mod restored_session_cwd_channel_isolation_tests {
     //! recovering channel would recover into the OTHER channel's working tree.
     //! RED before the predicate was added, GREEN after.
     use super::{
-        RestoreDispatchRebindOutcome, load_restored_session_cwd,
-        rebind_restored_dispatch_if_missing,
+        RestoreDispatchRebindOutcome, consume_dispatched_origin_ghost_if_current,
+        load_restored_session_cwd, rebind_restored_dispatch_if_missing,
     };
     use crate::db::auto_queue::test_support::TestPostgresDb;
     use crate::services::discord::adk_session::build_namespaced_session_key;
@@ -3016,6 +3030,58 @@ mod restored_session_cwd_channel_isolation_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dispatched_origin_ghost_marker_is_consumed_only_for_matching_turn() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        let session_key = "claude/test/dispatched-origin-ghost-4642";
+        let channel_id = 464_200_004_u64;
+        let turn_nonce = "turn-nonce-4642";
+        sqlx::query(
+            "INSERT INTO sessions (session_key, provider, status, channel_id, active_turn_nonce, dispatched_origin_turn_nonce, last_heartbeat)
+             VALUES ($1, 'claude', 'turn_active', $2, $3, $3, NOW())",
+        )
+        .bind(session_key)
+        .bind(channel_id.to_string())
+        .bind(turn_nonce)
+        .execute(&pool)
+        .await
+        .expect("seed dispatched-origin ghost");
+
+        let mut state = crate::services::discord::inflight::InflightTurnState::new(
+            crate::services::provider::ProviderKind::Claude,
+            channel_id,
+            Some("dispatched-origin-ghost-4642".to_string()),
+            7,
+            464_200_401,
+            464_200_402,
+            "orphaned dispatch".to_string(),
+            Some(session_key.to_string()),
+            Some("AgentDesk-claude-dispatched-origin-ghost-4642".to_string()),
+            None,
+            None,
+            0,
+        );
+        state.session_key = Some(session_key.to_string());
+        state.turn_nonce = Some(turn_nonce.to_string());
+        // No runtime root is configured in this database mutation proof, so the
+        // identity-guarded clear reports Missing and is safe to consume.
+        assert!(consume_dispatched_origin_ghost_if_current(Some(&pool), &state).await);
+        let row: (String, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT status, active_dispatch_id, dispatched_origin_turn_nonce FROM sessions WHERE session_key = $1",
+        )
+        .bind(session_key)
+        .fetch_one(&pool)
+        .await
+        .expect("load consumed ghost");
+        assert_eq!(row.0, "idle");
+        assert!(row.1.is_none());
+        assert!(row.2.is_none());
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn interactive_restore_without_dispatch_is_untouched() {
         let pg_db = TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
@@ -3050,6 +3116,10 @@ mod restored_session_cwd_channel_isolation_tests {
             rebind_restored_dispatch_if_missing(Some(&pool), &state).await,
             RestoreDispatchRebindOutcome::NotRebound,
             "dispatch-less interactive inflight must retain ordinary restore behavior"
+        );
+        assert!(
+            !consume_dispatched_origin_ghost_if_current(Some(&pool), &state).await,
+            "dispatch-less interactive turn must fail closed without a dispatched-origin marker"
         );
         let row: (String, Option<String>) = sqlx::query_as(
             "SELECT status, active_dispatch_id FROM sessions WHERE session_key = $1",

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -640,7 +640,7 @@ async fn rebind_restored_dispatch_if_missing(
     pg_pool: Option<&sqlx::PgPool>,
     state: &super::super::inflight::InflightTurnState,
 ) -> RestoreDispatchRebindOutcome {
-    let (Some(pool), Some(session_key), Some(dispatch_id)) = (
+    let (Some(pool), Some(session_key), Some(dispatch_id), Some(turn_nonce)) = (
         pg_pool,
         state.session_key.as_deref(),
         state
@@ -648,6 +648,10 @@ async fn rebind_restored_dispatch_if_missing(
             .as_deref()
             .map(str::trim)
             .filter(|dispatch_id| !dispatch_id.is_empty()),
+        state
+            .turn_nonce
+            .as_deref()
+            .filter(|nonce| !nonce.is_empty()),
     ) else {
         return RestoreDispatchRebindOutcome::NotRebound;
     };
@@ -661,6 +665,7 @@ async fn rebind_restored_dispatch_if_missing(
           WHERE s.session_key = $1
             AND s.channel_id = $2
             AND s.status = 'turn_active'
+            AND s.active_turn_nonce = $4
             AND COALESCE(BTRIM(s.active_dispatch_id), '') = ''
             AND EXISTS (
                 SELECT 1 FROM task_dispatches d
@@ -670,6 +675,7 @@ async fn rebind_restored_dispatch_if_missing(
     .bind(session_key)
     .bind(&channel_id)
     .bind(dispatch_id)
+    .bind(turn_nonce)
     .execute(pool)
     .await
     {
@@ -2896,8 +2902,41 @@ mod restored_session_cwd_channel_isolation_tests {
         load_restored_session_cwd, rebind_restored_dispatch_if_missing,
     };
     use crate::db::auto_queue::test_support::TestPostgresDb;
+    use crate::db::dispatched_sessions::{HookSessionUpsert, upsert_hook_session_pg};
     use crate::services::discord::adk_session::build_namespaced_session_key;
     use crate::services::provider::ProviderKind;
+
+    async fn write_turn_start_marker(
+        pool: &sqlx::PgPool,
+        session_key: &str,
+        channel_id: u64,
+        turn_nonce: &str,
+        dispatched_origin: bool,
+    ) {
+        upsert_hook_session_pg(
+            pool,
+            HookSessionUpsert {
+                session_key,
+                instance_id: None,
+                agent_id: None,
+                provider: "claude",
+                status: "turn_active",
+                session_info: None,
+                model: None,
+                tokens: None,
+                cwd: None,
+                active_dispatch_id: None,
+                thread_channel_id: None,
+                channel_id: Some(&channel_id.to_string()),
+                claude_session_id: None,
+                raw_provider_session_id: None,
+                turn_start_nonce: Some(turn_nonce),
+                dispatched_origin,
+            },
+        )
+        .await
+        .expect("write turn-start marker");
+    }
 
     async fn seed_session(
         pool: &sqlx::PgPool,
@@ -2955,6 +2994,13 @@ mod restored_session_cwd_channel_isolation_tests {
         );
         state.session_key = Some(session_key.to_string());
         state.dispatch_id = Some(dispatch_id.to_string());
+        state.turn_nonce = Some("rebind-valid-4642".to_string());
+        sqlx::query("UPDATE sessions SET active_turn_nonce = $2 WHERE session_key = $1")
+            .bind(session_key)
+            .bind("rebind-valid-4642")
+            .execute(&pool)
+            .await
+            .expect("seed matching rebind nonce");
         assert_eq!(
             rebind_restored_dispatch_if_missing(Some(&pool), &state).await,
             RestoreDispatchRebindOutcome::Rebound,
@@ -3036,16 +3082,16 @@ mod restored_session_cwd_channel_isolation_tests {
         let session_key = "claude/test/dispatched-origin-ghost-4642";
         let channel_id = 464_200_004_u64;
         let turn_nonce = "turn-nonce-4642";
-        sqlx::query(
-            "INSERT INTO sessions (session_key, provider, status, channel_id, active_turn_nonce, dispatched_origin_turn_nonce, last_heartbeat)
-             VALUES ($1, 'claude', 'turn_active', $2, $3, $3, NOW())",
+        write_turn_start_marker(&pool, session_key, channel_id, turn_nonce, true).await;
+        let marker: (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT active_turn_nonce, dispatched_origin_turn_nonce FROM sessions WHERE session_key = $1",
         )
         .bind(session_key)
-        .bind(channel_id.to_string())
-        .bind(turn_nonce)
-        .execute(&pool)
+        .fetch_one(&pool)
         .await
-        .expect("seed dispatched-origin ghost");
+        .expect("load persisted dispatched-origin marker");
+        assert_eq!(marker.0.as_deref(), Some(turn_nonce));
+        assert_eq!(marker.1.as_deref(), Some(turn_nonce));
 
         let mut state = crate::services::discord::inflight::InflightTurnState::new(
             crate::services::provider::ProviderKind::Claude,
@@ -3087,15 +3133,17 @@ mod restored_session_cwd_channel_isolation_tests {
         let pool = pg_db.connect_and_migrate().await;
         let session_key = "claude/test/interactive-restore-4642";
         let channel_id = 464_200_003_u64;
-        sqlx::query(
-            "INSERT INTO sessions (session_key, provider, status, channel_id, last_heartbeat)
-             VALUES ($1, 'claude', 'turn_active', $2, NOW())",
+        let turn_nonce = "interactive-turn-4642";
+        write_turn_start_marker(&pool, session_key, channel_id, turn_nonce, false).await;
+        let marker: (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT active_turn_nonce, dispatched_origin_turn_nonce FROM sessions WHERE session_key = $1",
         )
         .bind(session_key)
-        .bind(channel_id.to_string())
-        .execute(&pool)
+        .fetch_one(&pool)
         .await
-        .expect("seed dispatch-less interactive turn");
+        .expect("load persisted interactive marker");
+        assert_eq!(marker.0.as_deref(), Some(turn_nonce));
+        assert!(marker.1.is_none());
 
         let mut state = crate::services::discord::inflight::InflightTurnState::new(
             crate::services::provider::ProviderKind::Claude,
@@ -3112,6 +3160,7 @@ mod restored_session_cwd_channel_isolation_tests {
             0,
         );
         state.session_key = Some(session_key.to_string());
+        state.turn_nonce = Some(turn_nonce.to_string());
         assert_eq!(
             rebind_restored_dispatch_if_missing(Some(&pool), &state).await,
             RestoreDispatchRebindOutcome::NotRebound,

--- a/src/services/dispatched_sessions.rs
+++ b/src/services/dispatched_sessions.rs
@@ -57,6 +57,11 @@ async fn hook_session_pg(
     // and similar callers used to zero this column on every metadata update).
     let tokens = body.tokens.map(|t| t as i64);
     let active_dispatch_id = normalize_hook_active_dispatch_id(status, body.dispatch_id.as_deref());
+    let turn_start_nonce = body
+        .turn_start_nonce
+        .as_deref()
+        .filter(|value| !value.is_empty());
+    let dispatched_origin = body.dispatched_origin.unwrap_or(false);
     let instance_id = body
         .instance_id
         .as_deref()
@@ -98,6 +103,8 @@ async fn hook_session_pg(
                 .or(thread_channel_id.as_deref()),
             claude_session_id,
             raw_provider_session_id,
+            turn_start_nonce,
+            dispatched_origin,
         },
     )
     .await;
@@ -256,6 +263,12 @@ pub struct HookSessionBody {
     /// satisfy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub channel_id: Option<String>,
+    /// Durable turn-start identity. Present only for an authoritative new turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_start_nonce: Option<String>,
+    /// Whether the turn start was initiated by a dispatch. Paired with nonce.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dispatched_origin: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
## 요약
dispatched-origin ghost turn(원격 dispatch로 시작됐다가 owner가 사라진 turn)을 durable DB marker 기반으로 안전하게 정리한다.

## 근본원인
`turn_active + active_dispatch_id=NULL`은 정상 interactive turn에도 존재해 기존 형태만으로 ghost 구분 불가.

## 결정
turn-start에 UUID nonce + dispatched_origin을 durable DB marker로 기록(`sessions.active_turn_nonce`, `sessions.dispatched_origin_turn_nonce`). restore 시 slice1 rebind 실패하면 inflight identity+nonce 원자적 clear 시도 → 같은 nonce의 dispatched-origin marker+blank dispatch link를 SQL CAS 검증 → 일치할 때만 idle 전환. interactive turn은 marker 없어 fail-closed(무정리).

## 변경
migration 0099 + 신규 `dispatched_origin_ghost.rs` helper + session webhook/upsert/intake turn-start/lifecycle restore 등 9파일.

## 검증
- cargo fmt/check 통과
- `restored_session_cwd_channel_isolation_tests` 6/6 (interactive 무정리 + ghost marker 소비 mutation proof + slice1 CAS 회귀)
- migration checksum + docs 게이트 통과

Closes #4642

🤖 Generated with [Claude Code](https://claude.com/claude-code)