### PR TITLE
ux(tui): machine auto-turn busy 상태를 Discord idle/status UI에 노출

### DIFF
--- a/src/services/agent_protocol.rs
+++ b/src/services/agent_protocol.rs
@@ -412,6 +412,10 @@ pub enum StatusEvent {
     MachineTurnBusy {
         reason: String,
     },
+    /// A terminal background notification lacked the tool-use id required to
+    /// update a footer task slot. It still closes its own machine-only display
+    /// turn without changing ownership or injection state.
+    BackgroundMachineTurnCompleted,
     Heartbeat,
 }
 

--- a/src/services/agent_protocol.rs
+++ b/src/services/agent_protocol.rs
@@ -407,6 +407,11 @@ pub enum StatusEvent {
         background: bool,
         background_agent_pending: bool,
     },
+    /// A provider-injected completion notification started a machine-only turn.
+    /// This is display-only: it never creates user-turn ownership or queue state.
+    MachineTurnBusy {
+        reason: String,
+    },
     Heartbeat,
 }
 

--- a/src/services/discord/placeholder_live_events/background_task_events.rs
+++ b/src/services/discord/placeholder_live_events/background_task_events.rs
@@ -62,7 +62,7 @@ pub(super) fn tool_use_id_from_notification(value: &Value) -> Option<String> {
         .map(str::to_string)
 }
 
-pub(super) fn notification_is_terminal(status: &str) -> bool {
+pub(in crate::services::discord) fn notification_is_terminal(status: &str) -> bool {
     matches!(
         status.trim().to_ascii_lowercase().as_str(),
         "completed"

--- a/src/services/discord/placeholder_live_events/background_task_events.rs
+++ b/src/services/discord/placeholder_live_events/background_task_events.rs
@@ -42,6 +42,10 @@ pub(super) fn events_from_background_notification(
                 success: !notification_is_error(status),
             }];
         }
+        // Older/background notification shapes can omit the slot identity. The
+        // terminal envelope still ends the machine-only turn even though no
+        // footer slot can be updated.
+        return vec![StatusEvent::BackgroundMachineTurnCompleted];
     }
     (!summary.is_empty())
         .then_some(StatusEvent::Heartbeat)

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -95,6 +95,13 @@ pub(super) fn render_activity_line(status: &DerivedStatus) -> String {
             let label = escape_status_panel_markdown(label);
             format!("🧬 workflow 실행 중 ({})", truncate_chars(&label, 120))
         }
+        DerivedStatus::MachineTurnBusy { reason } => {
+            let reason = escape_status_panel_markdown(reason);
+            format!(
+                "🤖 백그라운드 완료 알림 처리 중 ({})",
+                truncate_chars(&reason, 120)
+            )
+        }
     }
 }
 
@@ -141,6 +148,16 @@ mod tests {
     }
 
     #[test]
+    fn machine_turn_busy_renders_distinct_background_notification_label() {
+        assert_eq!(
+            render_activity_line(&DerivedStatus::MachineTurnBusy {
+                reason: "subagent 완료 알림".to_string(),
+            }),
+            "🤖 백그라운드 완료 알림 처리 중 (subagent 완료 알림)"
+        );
+    }
+
+    #[test]
     fn activity_labels_lead_with_a_spinner_swap_marker() {
         // Every actively-rendered label must lead with a status emoji so the
         // spinner-merge swaps it for the animation cleanly (spinner-prefix parity).
@@ -158,6 +175,9 @@ mod tests {
             DerivedStatus::WorkflowRunning {
                 label: "review".to_string(),
             },
+            DerivedStatus::MachineTurnBusy {
+                reason: "subagent 완료 알림".to_string(),
+            },
             DerivedStatus::Completed {
                 kind: CompletedKind::Foreground,
             },
@@ -165,7 +185,7 @@ mod tests {
             let line = render_activity_line(&status);
             let first = line.chars().next().expect("non-empty label");
             assert!(
-                ['🟢', '💤', '⏰', '🔧', '🧵', '🧬', '✅'].contains(&first),
+                ['🟢', '💤', '⏰', '🔧', '🧵', '🧬', '🤖', '✅'].contains(&first),
                 "label {line:?} must lead with a spinner-swap marker"
             );
         }

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -51,6 +51,7 @@ use common::{
 #[cfg(test)]
 use status_panel::truncate_status_panel_sections;
 
+pub(in crate::services::discord) use background_task_events::notification_is_terminal;
 pub(in crate::services::discord) use recent_events::RecentPlaceholderEvent;
 pub(in crate::services::discord) use status_events::{
     status_events_from_task_notification_with_tool_use_id, status_events_from_tool_result_with_id,

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -459,18 +459,22 @@ impl StatusPanelState {
                 tool_use_id,
                 success,
             } => {
-                finish_background_task_tool_slot(&mut self.tasks, &tool_use_id, success);
+                let slot_matched =
+                    finish_background_task_tool_slot(&mut self.tasks, &tool_use_id, success);
                 // A footer-only background completion has no assistant body and
-                // therefore no ordinary TurnCompleted producer. Its terminal
-                // event is the machine turn's final observable lifecycle edge.
-                // Clear only the derived display status; task slots and all
-                // ownership/injection state remain untouched.
-                if matches!(self.status, DerivedStatus::MachineTurnBusy { .. }) {
-                    self.status = DerivedStatus::Completed {
-                        kind: CompletedKind::Background,
-                    };
-                    self.background_agent_pending = false;
-                    self.completed_at = Some(std::time::Instant::now());
+                // therefore no ordinary TurnCompleted producer. Only a matching
+                // background slot can close its own busy display state; stale or
+                // cross-kind terminal events leave an active machine turn alone.
+                if slot_matched && self.machine_turn_busy_is_background() {
+                    self.complete_background_machine_turn();
+                }
+            }
+            StatusEvent::BackgroundMachineTurnCompleted => {
+                // Terminal background envelopes without a tool-use id cannot
+                // update a slot, but still provide a complete display-only
+                // lifecycle. They cannot clear a subagent-origin busy turn.
+                if self.machine_turn_busy_is_background() {
+                    self.complete_background_machine_turn();
                 }
             }
             StatusEvent::TodoUpdate { items } => {
@@ -583,6 +587,22 @@ impl StatusPanelState {
                 }
             }
         }
+    }
+
+    fn machine_turn_busy_is_background(&self) -> bool {
+        matches!(
+            &self.status,
+            DerivedStatus::MachineTurnBusy { reason }
+                if reason == "background task 완료 알림"
+        )
+    }
+
+    fn complete_background_machine_turn(&mut self) {
+        self.status = DerivedStatus::Completed {
+            kind: CompletedKind::Background,
+        };
+        self.background_agent_pending = false;
+        self.completed_at = Some(std::time::Instant::now());
     }
 
     /// #3204/#3198: routes a running subagent's live step onto its slot's recent

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -73,6 +73,9 @@ pub(super) enum DerivedStatus {
     WorkflowRunning {
         label: String,
     },
+    MachineTurnBusy {
+        reason: String,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -548,6 +551,12 @@ impl StatusPanelState {
                 };
                 self.background_agent_pending = background_agent_pending;
                 self.completed_at = Some(std::time::Instant::now()); // #3477 item 3
+            }
+            StatusEvent::MachineTurnBusy { reason } => {
+                self.status = DerivedStatus::MachineTurnBusy {
+                    reason: normalize_summary(&reason),
+                };
+                self.completed_at = None;
             }
             StatusEvent::Heartbeat => {
                 if matches!(self.status, DerivedStatus::Running) {

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -459,13 +459,13 @@ impl StatusPanelState {
                 tool_use_id,
                 success,
             } => {
-                let slot_matched =
-                    finish_background_task_tool_slot(&mut self.tasks, &tool_use_id, success);
+                finish_background_task_tool_slot(&mut self.tasks, &tool_use_id, success);
                 // A footer-only background completion has no assistant body and
-                // therefore no ordinary TurnCompleted producer. Only a matching
-                // background slot can close its own busy display state; stale or
-                // cross-kind terminal events leave an active machine turn alone.
-                if slot_matched && self.machine_turn_busy_is_background() {
+                // therefore no ordinary TurnCompleted producer. A terminal
+                // background envelope closes its own busy display state even
+                // when no footer slot exists; the origin gate prevents it from
+                // affecting a subagent machine turn.
+                if self.machine_turn_busy_is_background() {
                     self.complete_background_machine_turn();
                 }
             }

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -418,7 +418,14 @@ impl StatusPanelState {
                         slot.summary = Some(summary);
                     }
                 }
-                self.status = DerivedStatus::Running;
+                // A terminal subagent notification can arrive while its
+                // machine-only parent turn is still running. Preserve the
+                // read-only busy label until the parent emits TurnCompleted;
+                // otherwise this terminal slot update is the normal return to
+                // the live running state.
+                if !matches!(self.status, DerivedStatus::MachineTurnBusy { .. }) {
+                    self.status = DerivedStatus::Running;
+                }
             }
             StatusEvent::TaskToolUpdate {
                 name,
@@ -453,6 +460,18 @@ impl StatusPanelState {
                 success,
             } => {
                 finish_background_task_tool_slot(&mut self.tasks, &tool_use_id, success);
+                // A footer-only background completion has no assistant body and
+                // therefore no ordinary TurnCompleted producer. Its terminal
+                // event is the machine turn's final observable lifecycle edge.
+                // Clear only the derived display status; task slots and all
+                // ownership/injection state remain untouched.
+                if matches!(self.status, DerivedStatus::MachineTurnBusy { .. }) {
+                    self.status = DerivedStatus::Completed {
+                        kind: CompletedKind::Background,
+                    };
+                    self.background_agent_pending = false;
+                    self.completed_at = Some(std::time::Instant::now());
+                }
             }
             StatusEvent::TodoUpdate { items } => {
                 self.todos = items

--- a/src/services/discord/placeholder_live_events/task_panel.rs
+++ b/src/services/discord/placeholder_live_events/task_panel.rs
@@ -203,17 +203,19 @@ pub(super) fn finish_background_task_tool_slot(
     slots: &mut [TaskToolSlot],
     tool_use_id: &str,
     success: bool,
-) {
+) -> bool {
     let Some(tool_use_id) = clean_task_tool_value(tool_use_id) else {
-        return;
+        return false;
     };
-    if let Some(slot) = slots
+    let Some(slot) = slots
         .iter_mut()
         .rev()
         .find(|slot| slot.background && slot.tool_use_id.as_deref() == Some(&tool_use_id))
-    {
-        slot.status = Some(if success { "completed" } else { "failed" }.to_string());
-    }
+    else {
+        return false;
+    };
+    slot.status = Some(if success { "completed" } else { "failed" }.to_string());
+    true
 }
 
 pub(super) fn render_task_tool_slot(slot: &TaskToolSlot) -> String {

--- a/src/services/discord/placeholder_live_events/task_panel.rs
+++ b/src/services/discord/placeholder_live_events/task_panel.rs
@@ -203,19 +203,17 @@ pub(super) fn finish_background_task_tool_slot(
     slots: &mut [TaskToolSlot],
     tool_use_id: &str,
     success: bool,
-) -> bool {
+) {
     let Some(tool_use_id) = clean_task_tool_value(tool_use_id) else {
-        return false;
+        return;
     };
-    let Some(slot) = slots
+    if let Some(slot) = slots
         .iter_mut()
         .rev()
         .find(|slot| slot.background && slot.tool_use_id.as_deref() == Some(&tool_use_id))
-    else {
-        return false;
-    };
-    slot.status = Some(if success { "completed" } else { "failed" }.to_string());
-    true
+    {
+        slot.status = Some(if success { "completed" } else { "failed" }.to_string());
+    }
 }
 
 pub(super) fn render_task_tool_slot(slot: &TaskToolSlot) -> String {

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -399,6 +399,95 @@ fn status_panel_machine_turn_busy_replaces_idle_activity_label() {
 }
 
 #[test]
+fn background_task_terminal_event_clears_machine_turn_busy_footer_only() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_783_001);
+    let tool_use_id = "background-bash-1";
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Bash",
+            &json!({"command": "sleep 1", "run_in_background": true}).to_string(),
+            Some(tool_use_id),
+        ),
+    );
+    events.push_status_event(
+        channel_id,
+        StatusEvent::MachineTurnBusy {
+            reason: "background task 완료 알림".to_string(),
+        },
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_task_notification_with_tool_use_id(
+            "background",
+            "completed",
+            "Background command finished",
+            Some(tool_use_id),
+        ),
+    );
+
+    assert_eq!(
+        status_for(&events, channel_id),
+        DerivedStatus::Completed {
+            kind: CompletedKind::Background
+        },
+        "footer-only background completion must clear the machine busy label"
+    );
+}
+
+#[test]
+fn subagent_terminal_event_keeps_machine_turn_busy_until_turn_completed() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_783_002);
+    let tool_use_id = "subagent-1";
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({"description": "Review changes"}).to_string(),
+            Some(tool_use_id),
+        ),
+    );
+    events.push_status_event(
+        channel_id,
+        StatusEvent::MachineTurnBusy {
+            reason: "subagent 완료 알림".to_string(),
+        },
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_task_notification_with_tool_use_id(
+            "subagent",
+            "completed",
+            "Agent \"Review changes\" completed",
+            Some(tool_use_id),
+        ),
+    );
+
+    assert!(matches!(
+        status_for(&events, channel_id),
+        DerivedStatus::MachineTurnBusy { .. }
+    ));
+
+    events.push_status_event(
+        channel_id,
+        StatusEvent::TurnCompleted {
+            background: false,
+            background_agent_pending: false,
+        },
+    );
+    assert_eq!(
+        status_for(&events, channel_id),
+        DerivedStatus::Completed {
+            kind: CompletedKind::Foreground
+        }
+    );
+}
+
+#[test]
 fn status_panel_absorbs_stale_and_final_into_the_activity_emoji() {
     // #3983 items 2 + B: the separate 신뢰도 line is retired; the freshness class is
     // absorbed into the activity emoji, and the following fields carry stable times.

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -437,23 +437,49 @@ fn background_task_terminal_event_clears_machine_turn_busy_footer_only() {
 }
 
 #[test]
-fn unmatched_background_task_end_cannot_clear_subagent_machine_turn_busy() {
+fn terminal_background_xml_closes_background_busy_without_matching_slot() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(4_783_003);
+    events.push_status_event(
+        channel_id,
+        StatusEvent::MachineTurnBusy {
+            reason: "background task 완료 알림".to_string(),
+        },
+    );
 
+    let raw_background = "<task-notification>\n\
+        <tool-use-id>unknown-background-id</tool-use-id>\n\
+        <status>completed</status>\n\
+        <summary>Background command \"unknown wait\" completed</summary>\n\
+        </task-notification>";
+    events.bridge_task_notification_xml(channel_id, raw_background);
+
+    assert_eq!(
+        status_for(&events, channel_id),
+        DerivedStatus::Completed {
+            kind: CompletedKind::Background
+        },
+        "id-bearing terminal background XML must not leave busy stuck without a footer slot"
+    );
+}
+
+#[test]
+fn terminal_background_xml_cannot_clear_subagent_machine_turn_busy() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_783_005);
     events.push_status_event(
         channel_id,
         StatusEvent::MachineTurnBusy {
             reason: "subagent 완료 알림".to_string(),
         },
     );
-    events.push_status_event(
-        channel_id,
-        StatusEvent::BackgroundTaskEnd {
-            tool_use_id: "stale-background-id".to_string(),
-            success: true,
-        },
-    );
+
+    let raw_background = "<task-notification>\n\
+        <tool-use-id>unknown-background-id</tool-use-id>\n\
+        <status>completed</status>\n\
+        <summary>Background command \"unknown wait\" completed</summary>\n\
+        </task-notification>";
+    events.bridge_task_notification_xml(channel_id, raw_background);
 
     assert!(matches!(
         status_for(&events, channel_id),

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -418,15 +418,14 @@ fn background_task_terminal_event_clears_machine_turn_busy_footer_only() {
             reason: "background task 완료 알림".to_string(),
         },
     );
-    events.push_status_events(
-        channel_id,
-        status_events_from_task_notification_with_tool_use_id(
-            "background",
-            "completed",
-            "Background command finished",
-            Some(tool_use_id),
-        ),
+    let raw_background = format!(
+        "<task-notification>\n\
+         <tool-use-id>{tool_use_id}</tool-use-id>\n\
+         <status>completed</status>\n\
+         <summary>Background command \"sleep 1\" completed</summary>\n\
+         </task-notification>"
     );
+    events.bridge_task_notification_xml(channel_id, &raw_background);
 
     assert_eq!(
         status_for(&events, channel_id),
@@ -434,6 +433,60 @@ fn background_task_terminal_event_clears_machine_turn_busy_footer_only() {
             kind: CompletedKind::Background
         },
         "footer-only background completion must clear the machine busy label"
+    );
+}
+
+#[test]
+fn unmatched_background_task_end_cannot_clear_subagent_machine_turn_busy() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_783_003);
+
+    events.push_status_event(
+        channel_id,
+        StatusEvent::MachineTurnBusy {
+            reason: "subagent 완료 알림".to_string(),
+        },
+    );
+    events.push_status_event(
+        channel_id,
+        StatusEvent::BackgroundTaskEnd {
+            tool_use_id: "stale-background-id".to_string(),
+            success: true,
+        },
+    );
+
+    assert!(matches!(
+        status_for(&events, channel_id),
+        DerivedStatus::MachineTurnBusy { ref reason } if reason == "subagent 완료 알림"
+    ));
+}
+
+#[test]
+fn idless_terminal_background_xml_clears_background_machine_turn_busy() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_783_004);
+    events.push_status_event(
+        channel_id,
+        StatusEvent::MachineTurnBusy {
+            reason: "background task 완료 알림".to_string(),
+        },
+    );
+
+    let raw_background = "<task-notification>\n\
+        <task-id>legacy-background</task-id>\n\
+        <status>completed</status>\n\
+        <summary>Background command \"legacy wait\" completed</summary>\n\
+        </task-notification>";
+    let bridged = status_events_from_task_notification_xml_for_footer_mode(raw_background, true);
+    assert_eq!(bridged, vec![StatusEvent::BackgroundMachineTurnCompleted]);
+    events.bridge_task_notification_xml(channel_id, raw_background);
+
+    assert_eq!(
+        status_for(&events, channel_id),
+        DerivedStatus::Completed {
+            kind: CompletedKind::Background
+        },
+        "idless terminal background XML must end its machine-only display turn"
     );
 }
 

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -374,6 +374,31 @@ fn status_panel_turn_completed_renders_foreground_completion() {
 }
 
 #[test]
+fn status_panel_machine_turn_busy_replaces_idle_activity_label() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4783);
+    events.push_status_event(
+        channel_id,
+        StatusEvent::MachineTurnBusy {
+            reason: "subagent 완료 알림".to_string(),
+        },
+    );
+
+    assert_eq!(
+        status_for(&events, channel_id),
+        DerivedStatus::MachineTurnBusy {
+            reason: "subagent 완료 알림".to_string(),
+        }
+    );
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(
+        rendered.starts_with("🤖 백그라운드 완료 알림 처리 중 (subagent 완료 알림)"),
+        "machine turn activity: {rendered:?}"
+    );
+    assert!(!rendered.contains("🟢 진행 중"));
+}
+
+#[test]
 fn status_panel_absorbs_stale_and_final_into_the_activity_emoji() {
     // #3983 items 2 + B: the separate 신뢰도 line is retired; the freshness class is
     // absorbed into the activity emoji, and the following fields carry stable times.

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -517,6 +517,129 @@ fn idless_terminal_background_xml_clears_background_machine_turn_busy() {
 }
 
 #[test]
+fn machine_turn_busy_terminal_matrix_converges_after_real_xml_bridge() {
+    let terminal_statuses = ["completed", "failed"];
+    let nonterminal_statuses = [Some("running"), None];
+    let identities = [
+        ("id-bearing-matched", Some("known-background"), true),
+        ("id-bearing-unmatched", Some("unknown-background"), false),
+        ("idless", None, false),
+    ];
+
+    for status in terminal_statuses {
+        for (identity, tool_use_id, matched_slot) in identities {
+            let events = PlaceholderLiveEvents::default();
+            let channel_id =
+                ChannelId::new(4_783_100 + identity.len() as u64 + status.len() as u64);
+            if matched_slot {
+                events.push_status_events(
+                    channel_id,
+                    status_events_from_tool_use_with_id(
+                        "Bash",
+                        &json!({"command": "sleep 1", "run_in_background": true}).to_string(),
+                        tool_use_id,
+                    ),
+                );
+            }
+            events.push_status_event(
+                channel_id,
+                StatusEvent::MachineTurnBusy {
+                    reason: "background task 완료 알림".to_string(),
+                },
+            );
+            let tool_use_xml = tool_use_id
+                .map(|id| format!("<tool-use-id>{id}</tool-use-id>"))
+                .unwrap_or_default();
+            let raw = format!(
+                "<task-notification>{tool_use_xml}<status>{status}</status><summary>Background command \"wait\" {status}</summary></task-notification>"
+            );
+            events.bridge_task_notification_xml(channel_id, &raw);
+            assert!(
+                !matches!(
+                    status_for(&events, channel_id),
+                    DerivedStatus::MachineTurnBusy { .. }
+                ),
+                "terminal {status}, {identity} must converge after the XML bridge"
+            );
+        }
+    }
+
+    for status in nonterminal_statuses {
+        for (identity, tool_use_id, _) in identities {
+            let events = PlaceholderLiveEvents::default();
+            let channel_id = ChannelId::new(
+                4_783_200 + identity.len() as u64 + status.unwrap_or("").len() as u64,
+            );
+            let tool_use_xml = tool_use_id
+                .map(|id| format!("<tool-use-id>{id}</tool-use-id>"))
+                .unwrap_or_default();
+            let status_xml = status
+                .map(|value| format!("<status>{value}</status>"))
+                .unwrap_or_default();
+            let raw = format!(
+                "<task-notification>{tool_use_xml}{status_xml}<summary>Background command \"wait\" running</summary></task-notification>"
+            );
+            events.bridge_task_notification_xml(channel_id, &raw);
+            let busy = events
+                .status_by_channel
+                .get(&channel_id)
+                .is_some_and(|entry| {
+                    matches!(
+                        entry
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .status,
+                        DerivedStatus::MachineTurnBusy { .. }
+                    )
+                });
+            assert!(
+                !busy,
+                "non-terminal/malformed {identity} must never retain a busy state"
+            );
+        }
+    }
+
+    for status in terminal_statuses {
+        for (identity, tool_use_id, _) in identities {
+            let events = PlaceholderLiveEvents::default();
+            let channel_id =
+                ChannelId::new(4_783_300 + identity.len() as u64 + status.len() as u64);
+            events.push_status_event(
+                channel_id,
+                StatusEvent::MachineTurnBusy {
+                    reason: "subagent 완료 알림".to_string(),
+                },
+            );
+            let tool_use_xml = tool_use_id
+                .map(|id| format!("<tool-use-id>{id}</tool-use-id>"))
+                .unwrap_or_default();
+            let raw = format!(
+                "<task-notification>{tool_use_xml}<status>{status}</status><summary>Agent \"review\" {status}</summary></task-notification>"
+            );
+            events.bridge_task_notification_xml(channel_id, &raw);
+            assert!(matches!(
+                status_for(&events, channel_id),
+                DerivedStatus::MachineTurnBusy { .. }
+            ));
+            events.push_status_event(
+                channel_id,
+                StatusEvent::TurnCompleted {
+                    background: false,
+                    background_agent_pending: false,
+                },
+            );
+            assert!(
+                !matches!(
+                    status_for(&events, channel_id),
+                    DerivedStatus::MachineTurnBusy { .. }
+                ),
+                "subagent terminal {status}, {identity} must converge at TurnCompleted"
+            );
+        }
+    }
+}
+
+#[test]
 fn subagent_terminal_event_keeps_machine_turn_busy_until_turn_completed() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(4_783_002);

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -242,7 +242,7 @@ fn is_panel_header_status_marker(marker: char) -> bool {
     // for the spinner like every other leading status emoji.
     matches!(
         marker,
-        '🟢' | '💤' | '⏰' | '✅' | '🔧' | '🧵' | '🧬' | '🟡'
+        '🟢' | '💤' | '⏰' | '✅' | '🔧' | '🧵' | '🧬' | '🤖' | '🟡'
     )
 }
 

--- a/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
+++ b/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
@@ -68,6 +68,16 @@ impl InjectedPromptClass {
     pub(super) fn is_subagent_notification_event(self) -> bool {
         matches!(self, InjectedPromptClass::SubagentNotificationEvent)
     }
+
+    /// Read-only status text for a provider machine turn. This classification
+    /// intentionally does not participate in generic user-turn lifecycle state.
+    pub(super) fn machine_turn_busy_reason(self) -> Option<&'static str> {
+        match self {
+            Self::TaskNotificationEvent => Some("background task 완료 알림"),
+            Self::SubagentNotificationEvent => Some("subagent 완료 알림"),
+            Self::HumanTuiDirect | Self::SystemContinuation | Self::SlashCommandControl => None,
+        }
+    }
 }
 
 /// Pure classifier for injected TUI prompt text. Order is load-bearing:

--- a/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
+++ b/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
@@ -27,6 +27,14 @@ pub(super) fn observe(
 ) -> TaskPromptObservation {
     let start_anchored = matches!(injected_class, InjectedPromptClass::TaskNotificationEvent)
         && injected_prompt_policy::is_start_anchored_task_notification(&prompt.prompt);
+    if let Some(reason) = injected_class.machine_turn_busy_reason() {
+        shared.ui.placeholder_live_events.push_status_event(
+            channel_id,
+            crate::services::agent_protocol::StatusEvent::MachineTurnBusy {
+                reason: reason.to_string(),
+            },
+        );
+    }
     if start_anchored {
         shared
             .ui

--- a/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
+++ b/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
@@ -27,7 +27,9 @@ pub(super) fn observe(
 ) -> TaskPromptObservation {
     let start_anchored = matches!(injected_class, InjectedPromptClass::TaskNotificationEvent)
         && injected_prompt_policy::is_start_anchored_task_notification(&prompt.prompt);
-    if let Some(reason) = injected_class.machine_turn_busy_reason() {
+    let machine_turn_busy_reason =
+        machine_turn_busy_reason_for_prompt(injected_class, &prompt.prompt, start_anchored);
+    if let Some(reason) = machine_turn_busy_reason {
         shared.ui.placeholder_live_events.push_status_event(
             channel_id,
             crate::services::agent_protocol::StatusEvent::MachineTurnBusy {
@@ -68,6 +70,30 @@ pub(super) fn observe(
         start_anchored,
         event,
     }
+}
+
+/// Returns a display-only busy reason only when this machine event has a
+/// matching terminal lifecycle edge. Background task XML clears only from a
+/// terminal status; setting busy for a running or malformed payload would leave
+/// no completion event to clear it. Subagent notifications retain their normal
+/// machine-turn completion path.
+pub(super) fn machine_turn_busy_reason_for_prompt(
+    injected_class: InjectedPromptClass,
+    prompt: &str,
+    start_anchored_task_notification: bool,
+) -> Option<&'static str> {
+    let reason = injected_class.machine_turn_busy_reason()?;
+    if !matches!(injected_class, InjectedPromptClass::TaskNotificationEvent) {
+        return Some(reason);
+    }
+    let parsed = start_anchored_task_notification
+        .then(|| super::super::tui_task_card::parse_task_notification(prompt))?;
+    (parsed.kind() == "background"
+        && parsed
+            .status
+            .as_deref()
+            .is_some_and(super::super::placeholder_live_events::notification_is_terminal))
+    .then_some(reason)
 }
 
 pub(super) async fn resolve_gate(

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -909,6 +909,46 @@ fn classify_injected_prompt_task_notification_event() {
 // `<subagent_notification>{json}</subagent_notification>` envelopes. They are
 // neutral machine events, not human direct prompts.
 #[test]
+fn background_machine_turn_busy_set_requires_a_terminal_task_notification() {
+    for (label, status, expected_busy) in [
+        ("terminal success", Some("completed"), true),
+        ("terminal error", Some("failed"), true),
+        ("non-terminal", Some("running"), false),
+        ("missing status", None, false),
+    ] {
+        let prompt = status.map_or_else(
+            || "<task-notification><summary>Background command \"wait\"</summary></task-notification>".to_string(),
+            |status| format!(
+                "<task-notification><status>{status}</status><summary>Background command \"wait\"</summary></task-notification>"
+            ),
+        );
+        assert_eq!(
+            task_notification_prompt::machine_turn_busy_reason_for_prompt(
+                InjectedPromptClass::TaskNotificationEvent,
+                &prompt,
+                true,
+            ),
+            expected_busy.then_some("background task 완료 알림"),
+            "{label} background task notification busy-set decision"
+        );
+    }
+}
+
+#[test]
+fn subagent_machine_turn_busy_uses_its_turn_completed_lifecycle() {
+    let prompt =
+        r#"<subagent_notification>{"status":{"completed":"done"}}</subagent_notification>"#;
+    assert_eq!(
+        task_notification_prompt::machine_turn_busy_reason_for_prompt(
+            InjectedPromptClass::SubagentNotificationEvent,
+            prompt,
+            false,
+        ),
+        Some("subagent 완료 알림")
+    );
+}
+
+#[test]
 fn classify_injected_prompt_subagent_notification_event() {
     let unwrapped = r#"<subagent_notification>
 {"agent_path":"/tmp/agent","status":{"completed":"Read-only review complete."}}

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -899,6 +899,10 @@ fn classify_injected_prompt_task_notification_event() {
         "task-notification detection must honor tag boundaries",
     );
     assert!(!classify_injected_prompt(bare).is_human_active_turn());
+    assert_eq!(
+        classify_injected_prompt(bare).machine_turn_busy_reason(),
+        Some("background task 완료 알림")
+    );
 }
 
 // #3716: Codex subagent completions arrive as start-anchored
@@ -956,6 +960,10 @@ fn classify_injected_prompt_subagent_notification_event() {
     assert!(
         !super::injected_prompt_policy::is_start_anchored_subagent_notification(quoted),
         "mid-body quote must not pass the start-anchored detector"
+    );
+    assert_eq!(
+        classify_injected_prompt(unwrapped).machine_turn_busy_reason(),
+        Some("subagent 완료 알림")
     );
 }
 


### PR DESCRIPTION
## 요약
task/subagent 완료 notification을 `MachineTurnBusy` read-only derived status로 변환해, Discord 상태 카드/푸터가 `🤖 백그라운드 완료 알림 처리 중`을 표시하도록 한다. transcript busy 상태와 UI 표시를 일치시킨다.

## 결정
notification 분류 직후 기존 `PlaceholderLiveEvents` 상태 카드 경로에만 display event 주입. lifecycle 억제 설계와 주입 게이트 권위는 그대로 유지, UI 표시 불일치만 교정. generic user lifecycle/inflight/mailbox token 무변경.

## 검증
- cargo fmt/check 통과
- machine-turn 렌더링 + task/subagent 분류 focused test 4개 통과
- docs 게이트 통과

Closes #4783

🤖 Generated with [Claude Code](https://claude.com/claude-code)