### PR TITLE
fix(tui): background-agent 대기 문구가 foreground idle 주입을 veto함 (B1)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -407,6 +407,7 @@ src/
 │   │   ├── input.rs
 │   │   ├── memento_feedback.rs
 │   │   ├── mod.rs
+│   │   ├── prompt_readiness.rs
 │   │   ├── session.rs
 │   │   ├── startup_dialog.rs
 │   │   ├── transcript_tail.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1879,7 +1879,11 @@ these contextual numbers to match ordinary LoC churn.
   MCP-authentication-required cold-boot welcome screen during readiness and fail
   fast with an actionable, non-timeout reason instead of false-submitting then
   blind-waiting/retrying the full timeout; gate every ready-return path —
-  including the recorded-turn idle-transcript fallbacks — on the MCP-auth check.)
+  including the recorded-turn idle-transcript fallbacks — on the MCP-auth check;
+  #4785 keeps the giant root wiring thin by extracting transcript-aware foreground
+  busy/timeout policy to `claude_tui/prompt_readiness.rs`; authoritative Idle may
+  exclude background-agent-only chrome while Streaming/UserSubmitted keeps the
+  conservative pane veto.)
 - `src/services/tmux_common.rs` (frozen giant surface) — Claude/Codex TUI pane-capture
   heuristics: ready-for-input, prompt-draft vs idle-suggestion-ghost, active-work
   streaming, MCP-auth banner, and `/effort` selector detection, plus session

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -448,6 +448,10 @@
 ### Audited touches
 
 - #4781 text-only routed attachment contract: leader-side `intake_router_hook.rs` rejects gateway-local attachment paths before a foreign-owner, `/node`, or preferred-label outbox insert. Queued nonportable uploads are notice-and-drop rather than indefinitely requeued; this changes no leader election, worker lease, or durable owner authority.
+- #4785 Claude TUI readiness classification is worker-local to one session-bound
+  pane/transcript pair. Extracting foreground busy evidence and transcript-aware
+  timeout diagnostics changes no leader election, PG lease, cross-node routing,
+  durable ownership, or provider-session placement behavior.
 - #4706 structural lint debt backfill: item-level Clippy annotations and their checked-in occurrence ratchet change no runtime ownership, leader election, PG lease, or multinode routing behavior.
 - #4515 worker-local recovery supervision: `src/server/worker_recovery.rs` owns
   bounded restart handling for the worker-local dispatch-outbox and session-discovery

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -1363,9 +1363,7 @@ fn wait_for_prompt_ready_inner(
         }
         // #3889/#4528: only proven warm reuse may treat this banner as stale.
         // Every path still honors the live draft and busy state below.
-        if snapshot_allows_prompt_readiness(readiness, &snapshot)
-            && transcript_idle_confirms_prompt_ready(&snapshot, transcript_path)
-        {
+        if transcript_idle_snapshot_confirms_prompt_ready(readiness, &snapshot, transcript_path) {
             check_prompt_cancel(cancel_token)?;
             let drained_buffered_stop = claude_registry_stop_already_buffered(session_name);
             tracing::info!(
@@ -1652,9 +1650,7 @@ fn wait_for_prompt_ready_polling(
         }
         // #3889/#4528: apply the same provenance-aware auth policy to the
         // transcript-idle fallback; draft and busy state still veto every kind.
-        if snapshot_allows_prompt_readiness(readiness, &snapshot)
-            && transcript_idle_confirms_prompt_ready(&snapshot, transcript_path)
-        {
+        if transcript_idle_snapshot_confirms_prompt_ready(readiness, &snapshot, transcript_path) {
             tracing::info!(
                 tmux_session_name = session_name,
                 readiness = readiness.label(),
@@ -1677,10 +1673,10 @@ fn wait_for_prompt_ready_polling(
             // Idle/Unknown read does NOT extend), keep waiting up to the absolute
             // ceiling — the prompt returns once the turn finishes, so the
             // follow-up is delivered sequentially instead of dropped.
-            let transcript_turn_active = transcript_path.is_some_and(|path| {
+            let transcript_turn_state = transcript_path.map(|path| {
                 crate::services::claude_tui::transcript_tail::observe_transcript_turn_state(path)
-                    .is_busy()
             });
+            let transcript_turn_active = transcript_turn_state.is_some_and(|state| state.is_busy());
             if active_turn_warrants_wait_extension(
                 snapshot.tmux_pane_alive,
                 transcript_turn_active,
@@ -1702,7 +1698,19 @@ fn wait_for_prompt_ready_polling(
                 wait_interval = std::cmp::min(wait_interval * 2, Duration::from_millis(1000));
                 continue;
             }
-            log_prompt_ready_timeout(session_name, readiness, timeout, &snapshot);
+            let previous_tui_turn_still_running =
+                crate::services::claude_tui::prompt_readiness::previous_turn_still_running(
+                    snapshot.tmux_pane_alive,
+                    snapshot.prompt_marker_detected,
+                    transcript_turn_state,
+                );
+            log_prompt_ready_timeout(
+                session_name,
+                readiness,
+                timeout,
+                &snapshot,
+                previous_tui_turn_still_running,
+            );
             if prompt_ready_timeout_should_clear_followup_draft(
                 readiness,
                 &snapshot,
@@ -1726,13 +1734,10 @@ fn wait_for_prompt_ready_polling(
                 readiness.label(),
                 timeout.as_secs(),
                 prompt_ready_timeout_reason(&snapshot),
-                // Mirror the computed value the debug log already records
-                // (`log_prompt_ready_timeout`) instead of the legacy hardcoded
-                // `true`: the pane is known alive here (a dead pane returned
-                // above), so this is `true` only when the pane never looked
-                // ready — i.e. a turn that is plausibly still running. An unsent
-                // draft means the turn ended, so it reports `false`.
-                snapshot.tmux_pane_alive && !snapshot.prompt_marker_detected,
+                // Mirror the transcript-aware value recorded by the debug log.
+                // A conclusive Idle state reports false even when pane marker
+                // scraping is confused by persistent background-agent chrome.
+                previous_tui_turn_still_running,
                 snapshot.prompt_marker_detected,
                 snapshot.prompt_draft_detected,
                 snapshot.capture_available
@@ -1825,8 +1830,11 @@ fn proven_warm_followup_revalidates_prompt_ready(
 ) -> bool {
     let readiness = PromptReadinessKind::ProvenWarmFollowup;
     prompt_marker_confirms_prompt_ready(readiness, snapshot)
-        || (snapshot_allows_prompt_readiness(readiness, snapshot)
-            && transcript_idle_confirms_prompt_ready(snapshot, Some(transcript_path)))
+        || transcript_idle_snapshot_confirms_prompt_ready(
+            readiness,
+            snapshot,
+            Some(transcript_path),
+        )
 }
 
 /// #3889/#4528: an MCP-auth warning blocks readiness unless the caller proves
@@ -1838,12 +1846,22 @@ fn snapshot_allows_prompt_readiness(
     readiness: PromptReadinessKind,
     snapshot: &PromptReadinessSnapshot,
 ) -> bool {
+    snapshot_allows_prompt_readiness_for_turn(readiness, snapshot, None)
+}
+
+fn snapshot_allows_prompt_readiness_for_turn(
+    readiness: PromptReadinessKind,
+    snapshot: &PromptReadinessSnapshot,
+    transcript_turn_state: Option<crate::services::tui_turn_state::TuiTurnState>,
+) -> bool {
     if snapshot.prompt_draft_detected {
         return false;
     }
-    if snapshot.capture_available
-        && crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(&snapshot.pane_tail)
-    {
+    if crate::services::claude_tui::prompt_readiness::pane_has_foreground_busy_evidence(
+        &snapshot.pane_tail,
+        snapshot.capture_available,
+        transcript_turn_state,
+    ) {
         return false;
     }
     readiness.allows_stale_mcp_auth_warning() || !snapshot_indicates_mcp_auth_block(snapshot)
@@ -1868,7 +1886,11 @@ fn snapshot_indicates_mcp_auth_block(snapshot: &PromptReadinessSnapshot) -> bool
 /// auth warning; draft or busy evidence still blocks it. A blind capture cannot
 /// assert a draft, busy frame, or auth block.
 fn pane_allows_prompt_readiness(session_name: &str, readiness: PromptReadinessKind) -> bool {
-    snapshot_allows_prompt_readiness(readiness, &prompt_readiness_snapshot(session_name))
+    snapshot_allows_prompt_readiness_for_turn(
+        readiness,
+        &prompt_readiness_snapshot(session_name),
+        Some(crate::services::tui_turn_state::TuiTurnState::Idle),
+    )
 }
 
 /// Actionable, NON-timeout error for a cold-boot stranded on the
@@ -2059,6 +2081,19 @@ fn transcript_idle_confirms_prompt_ready(
     })
 }
 
+fn transcript_idle_snapshot_confirms_prompt_ready(
+    readiness: PromptReadinessKind,
+    snapshot: &PromptReadinessSnapshot,
+    transcript_path: Option<&std::path::Path>,
+) -> bool {
+    transcript_idle_confirms_prompt_ready(snapshot, transcript_path)
+        && snapshot_allows_prompt_readiness_for_turn(
+            readiness,
+            snapshot,
+            Some(crate::services::tui_turn_state::TuiTurnState::Idle),
+        )
+}
+
 fn log_startup_dialog_dismiss(
     session_name: &str,
     readiness: PromptReadinessKind,
@@ -2107,6 +2142,7 @@ fn log_prompt_ready_timeout(
     readiness: PromptReadinessKind,
     timeout: Duration,
     snapshot: &PromptReadinessSnapshot,
+    previous_tui_turn_still_running: bool,
 ) {
     tracing::debug!(
         tmux_session_name = session_name,
@@ -2114,7 +2150,7 @@ fn log_prompt_ready_timeout(
         timeout_secs = timeout.as_secs(),
         prompt_marker_detected = snapshot.prompt_marker_detected,
         prompt_draft_detected = snapshot.prompt_draft_detected,
-        previous_tui_turn_still_running = snapshot.tmux_pane_alive && !snapshot.prompt_marker_detected,
+        previous_tui_turn_still_running,
         tmux_pane_alive = snapshot.tmux_pane_alive,
         capture_available = snapshot.capture_available,
         pane_tail = %snapshot.pane_tail,
@@ -2129,7 +2165,7 @@ fn log_prompt_ready_timeout(
             timeout.as_secs(),
             snapshot.prompt_marker_detected,
             snapshot.prompt_draft_detected,
-            snapshot.tmux_pane_alive && !snapshot.prompt_marker_detected,
+            previous_tui_turn_still_running,
             snapshot.tmux_pane_alive,
             snapshot.capture_available,
             snapshot.pane_tail
@@ -3238,13 +3274,19 @@ line 13";
         assert!(transcript_idle);
         assert!(snapshot_indicates_mcp_auth_block(&blocked));
         assert!(
-            !(snapshot_allows_prompt_readiness(PromptReadinessKind::FreshTurn, &blocked)
-                && transcript_idle),
+            !(snapshot_allows_prompt_readiness_for_turn(
+                PromptReadinessKind::FreshTurn,
+                &blocked,
+                Some(crate::services::tui_turn_state::TuiTurnState::Idle)
+            ) && transcript_idle),
             "MCP-auth welcome pane must not confirm FreshTurn via idle transcript"
         );
         assert!(
-            !(snapshot_allows_prompt_readiness(PromptReadinessKind::ProvenWarmFollowup, &blocked)
-                && transcript_idle),
+            !(snapshot_allows_prompt_readiness_for_turn(
+                PromptReadinessKind::ProvenWarmFollowup,
+                &blocked,
+                Some(crate::services::tui_turn_state::TuiTurnState::Idle)
+            ) && transcript_idle),
             "an unsent draft must block proven warm reuse despite an idle transcript"
         );
 
@@ -3253,13 +3295,19 @@ line 13";
             ..blocked.clone()
         };
         assert!(
-            !(snapshot_allows_prompt_readiness(PromptReadinessKind::Followup, &warm_idle)
-                && transcript_idle),
+            !(snapshot_allows_prompt_readiness_for_turn(
+                PromptReadinessKind::Followup,
+                &warm_idle,
+                Some(crate::services::tui_turn_state::TuiTurnState::Idle)
+            ) && transcript_idle),
             "Followup intent alone must not bypass a genuine cold auth block"
         );
         assert!(
-            snapshot_allows_prompt_readiness(PromptReadinessKind::ProvenWarmFollowup, &warm_idle,)
-                && transcript_idle,
+            snapshot_allows_prompt_readiness_for_turn(
+                PromptReadinessKind::ProvenWarmFollowup,
+                &warm_idle,
+                Some(crate::services::tui_turn_state::TuiTurnState::Idle)
+            ) && transcript_idle,
             "recorded-turn warm provenance may ignore a stale warning only when idle"
         );
 
@@ -3274,31 +3322,76 @@ line 13";
         };
         assert!(!snapshot_indicates_mcp_auth_block(&ready));
         assert!(
-            snapshot_allows_prompt_readiness(PromptReadinessKind::FreshTurn, &ready)
-                && transcript_idle_confirms_prompt_ready(&ready, Some(file.path())),
+            snapshot_allows_prompt_readiness_for_turn(
+                PromptReadinessKind::FreshTurn,
+                &ready,
+                Some(crate::services::tui_turn_state::TuiTurnState::Idle)
+            ) && transcript_idle_confirms_prompt_ready(&ready, Some(file.path())),
             "a normal recorded-turn idle pane must still confirm ready (no regression)"
         );
     }
 
     #[test]
-    fn non_idle_transcript_does_not_confirm_readiness() {
+    fn idle_terminator_with_background_agents_and_composer_allows_readiness() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            concat!(
+                r#"{"type":"assistant","message":{"stop_reason":"end_turn"}}"#,
+                "\n",
+                r#"{"type":"system","subtype":"stop_hook_summary"}"#,
+                "\n",
+                r#"{"type":"system","subtype":"turn_duration","pendingBackgroundAgentCount":3}"#,
+            ),
+        )
+        .unwrap();
+        let pane = "\
+⏺ Foreground answer complete
+✻ Waiting for 3 background agents to finish
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  ◆ Opus(M) │ Tools: 224 done
+  ⏵⏵ bypass permissions on · 2 shells
+
+  ⏺ main
+  ◯ reviewer       Watching CI                         6m 13s
+  ◯ implementer    Updating tests                      3m 52s";
+        let snapshot = prompt_readiness_snapshot_from_capture(Some(pane), true);
+
+        assert!(snapshot.prompt_marker_detected);
+        assert!(transcript_idle_snapshot_confirms_prompt_ready(
+            PromptReadinessKind::Followup,
+            &snapshot,
+            Some(file.path()),
+        ));
+    }
+
+    #[test]
+    fn foreground_streaming_with_background_agents_still_vetoes_readiness() {
         let file = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(
             file.path(),
             r#"{"type":"assistant","message":{"content":[{"type":"text","text":"still streaming"}]}}"#,
         )
         .unwrap();
-        let snapshot = PromptReadinessSnapshot {
-            prompt_marker_detected: false,
-            prompt_draft_detected: false,
-            tmux_pane_alive: true,
-            capture_available: true,
-            pane_tail: "streaming turn".to_string(),
-        };
+        let pane = "\
+✻ Waiting for 3 background agents to finish
+✳ Architecting… (12s · esc to interrupt)
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  ◯ reviewer       Watching CI                         6m 13s";
+        let snapshot = prompt_readiness_snapshot_from_capture(Some(pane), true);
 
-        assert!(!transcript_idle_confirms_prompt_ready(
+        assert!(!transcript_idle_snapshot_confirms_prompt_ready(
+            PromptReadinessKind::Followup,
             &snapshot,
-            Some(file.path())
+            Some(file.path()),
+        ));
+        assert!(!prompt_marker_confirms_prompt_ready(
+            PromptReadinessKind::Followup,
+            &snapshot,
         ));
     }
 

--- a/src/services/claude_tui/mod.rs
+++ b/src/services/claude_tui/mod.rs
@@ -12,6 +12,7 @@ mod hook_server_memento_tests;
 pub(crate) mod hosting;
 pub mod input;
 pub(crate) mod memento_feedback;
+pub(super) mod prompt_readiness;
 pub mod session;
 pub(crate) mod startup_dialog;
 pub mod transcript_tail;

--- a/src/services/claude_tui/prompt_readiness.rs
+++ b/src/services/claude_tui/prompt_readiness.rs
@@ -57,9 +57,16 @@ fn claude_tui_background_agent_footer_before_composer(
     if !is_claude_tui_horizontal_separator(lines[separator_index]) {
         return None;
     }
-    let footer_index = lines[..separator_index]
+    const MAX_FOOTER_BLANK_LINES: usize = 1;
+    let blank_lines = lines[..separator_index]
         .iter()
-        .rposition(|line| !line.trim().is_empty())?;
+        .rev()
+        .take_while(|line| line.trim().is_empty())
+        .count();
+    if blank_lines > MAX_FOOTER_BLANK_LINES {
+        return None;
+    }
+    let footer_index = separator_index.checked_sub(blank_lines + 1)?;
     is_claude_tui_background_agent_footer(lines[footer_index]).then_some(footer_index)
 }
 
@@ -218,6 +225,20 @@ mod tests {
             claude_tui_background_agent_status_line_indexes(pane),
             vec![3, 10, 11],
         );
+    }
+
+    #[test]
+    fn background_agent_footer_rejects_assistant_footer_separated_by_many_blanks() {
+        let pane = "\
+✻ Waiting for 3 background agents to finish
+
+
+
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  ◆ Opus(M) │ Tools: 224 done";
+        assert!(claude_tui_background_agent_status_line_indexes(pane).is_empty());
     }
 
     #[test]

--- a/src/services/claude_tui/prompt_readiness.rs
+++ b/src/services/claude_tui/prompt_readiness.rs
@@ -1,5 +1,83 @@
 use crate::services::tui_turn_state::TuiTurnState;
 
+/// Return line indexes occupied by authenticated Claude TUI background-agent
+/// chrome. The three shapes deliberately include their TUI-only placement:
+/// a spinner footer, an indented management affordance, or a contiguous task
+/// table headed by `⏺ main`. Text in an assistant response may use the same
+/// words or `◯` bullet, but it cannot satisfy these structural anchors.
+pub(crate) fn claude_tui_background_agent_status_line_indexes(pane: &str) -> Vec<usize> {
+    let lines = pane.lines().collect::<Vec<_>>();
+    let mut statuses = Vec::new();
+    let mut task_table_open = false;
+
+    for (index, line) in lines.iter().enumerate() {
+        if is_claude_tui_background_agent_footer(line)
+            || is_claude_tui_background_agent_management_line(line)
+        {
+            statuses.push(index);
+            task_table_open = false;
+            continue;
+        }
+
+        if line == &"  ⏺ main" {
+            task_table_open = true;
+            continue;
+        }
+
+        if task_table_open && is_claude_tui_background_agent_task_row(line) {
+            statuses.push(index);
+            continue;
+        }
+
+        task_table_open = false;
+    }
+
+    statuses
+}
+
+fn is_claude_tui_background_agent_footer(line: &str) -> bool {
+    let line = line.trim();
+    let Some(count) = line.strip_prefix("✻ Waiting for ") else {
+        return false;
+    };
+    let count = count
+        .strip_suffix(" background agent to finish")
+        .or_else(|| count.strip_suffix(" background agents to finish"));
+    count.is_some_and(|count| !count.is_empty() && count.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+fn is_claude_tui_background_agent_management_line(line: &str) -> bool {
+    let Some(affordance) = line.strip_prefix("  ⎿  Backgrounded agent (") else {
+        return false;
+    };
+    affordance.ends_with(')') && affordance.contains("↓ to manage · ctrl+o to expand")
+}
+
+fn is_claude_tui_background_agent_task_row(line: &str) -> bool {
+    let Some(columns) = line.strip_prefix("  ◯ ") else {
+        return false;
+    };
+    let columns = columns
+        .split("  ")
+        .filter(|column| !column.trim().is_empty())
+        .collect::<Vec<_>>();
+    columns.len() == 3 && is_claude_tui_elapsed_duration(columns[2].trim())
+}
+
+fn is_claude_tui_elapsed_duration(value: &str) -> bool {
+    let components = value.split_whitespace().collect::<Vec<_>>();
+    !components.is_empty()
+        && components.iter().all(|component| {
+            let Some(unit) = component.chars().last() else {
+                return false;
+            };
+            matches!(unit, 's' | 'm' | 'h')
+                && component.strip_suffix(unit).is_some_and(|digits| {
+                    !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+                })
+        })
+}
+
 /// Return foreground live-turn evidence from a Claude TUI pane.
 ///
 /// A completed foreground turn may leave detached background-agent chrome on
@@ -18,11 +96,11 @@ pub(super) fn pane_has_foreground_busy_evidence(
         return crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(pane);
     }
 
+    let background_status_lines = claude_tui_background_agent_status_line_indexes(pane);
     let foreground_only = pane
         .lines()
-        .filter(|line| {
-            !crate::services::tmux_common::tmux_line_is_claude_tui_background_agent_status(line)
-        })
+        .enumerate()
+        .filter_map(|(index, line)| (!background_status_lines.contains(&index)).then_some(line))
         .collect::<Vec<_>>()
         .join("\n");
     crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(&foreground_only)
@@ -59,6 +137,20 @@ mod tests {
   ⏺ main
   ◯ reviewer       Watching CI                         6m 13s
   ◯ implementer    Updating tests                      3m 52s";
+
+    #[test]
+    fn task_list_background_agent_rows_require_main_header_and_columns() {
+        assert_eq!(
+            claude_tui_background_agent_status_line_indexes(BACKGROUND_WAITING_PANE),
+            vec![1, 9, 10],
+        );
+        let assistant_body = "\
+◯ reviewer       Watching CI                         6m 13s
+◯ implementer    Updating tests                      3m 52s
+I am waiting for 3 background agents to finish.
+⎿ Backgrounded agent (↓ to manage · ctrl+o to expand)";
+        assert!(claude_tui_background_agent_status_line_indexes(assistant_body).is_empty());
+    }
 
     #[test]
     fn authoritative_idle_excludes_background_agent_status_from_busy_evidence() {

--- a/src/services/claude_tui/prompt_readiness.rs
+++ b/src/services/claude_tui/prompt_readiness.rs
@@ -7,10 +7,19 @@ use crate::services::tui_turn_state::TuiTurnState;
 /// words or `◯` bullet, but it cannot satisfy these structural anchors.
 pub(crate) fn claude_tui_background_agent_status_line_indexes(pane: &str) -> Vec<usize> {
     let lines = pane.lines().collect::<Vec<_>>();
+    let Some(prompt_index) = lines.iter().rposition(|line| line.trim() == "❯") else {
+        return Vec::new();
+    };
+    // Claude's persistent chrome is painted around the active bottom composer:
+    // its waiting/management footer is immediately above the separator and
+    // composer, while its task table is below it. Restrict matching to that
+    // bottom zone so identical lines in the assistant transcript are never
+    // promoted to live status.
+    let chrome_start = prompt_index.saturating_sub(2);
     let mut statuses = Vec::new();
     let mut task_table_open = false;
 
-    for (index, line) in lines.iter().enumerate() {
+    for (index, line) in lines.iter().enumerate().skip(chrome_start) {
         if is_claude_tui_background_agent_footer(line)
             || is_claude_tui_background_agent_management_line(line)
         {
@@ -36,7 +45,6 @@ pub(crate) fn claude_tui_background_agent_status_line_indexes(pane: &str) -> Vec
 }
 
 fn is_claude_tui_background_agent_footer(line: &str) -> bool {
-    let line = line.trim();
     let Some(count) = line.strip_prefix("✻ Waiting for ") else {
         return false;
     };
@@ -139,17 +147,42 @@ mod tests {
   ◯ implementer    Updating tests                      3m 52s";
 
     #[test]
-    fn task_list_background_agent_rows_require_main_header_and_columns() {
+    fn background_agent_chrome_requires_bottom_prompt_zone() {
         assert_eq!(
             claude_tui_background_agent_status_line_indexes(BACKGROUND_WAITING_PANE),
             vec![1, 9, 10],
         );
-        let assistant_body = "\
-◯ reviewer       Watching CI                         6m 13s
-◯ implementer    Updating tests                      3m 52s
-I am waiting for 3 background agents to finish.
-⎿ Backgrounded agent (↓ to manage · ctrl+o to expand)";
-        assert!(claude_tui_background_agent_status_line_indexes(assistant_body).is_empty());
+        assert_eq!(
+            claude_tui_background_agent_status_line_indexes(
+                "⏺ Agent(read story)\n  ⎿  Backgrounded agent (↓ to manage · ctrl+o to expand)\n❯"
+            ),
+            vec![1],
+        );
+
+        let quoted_assistant_output = "\
+```text
+✻ Waiting for 3 background agents to finish
+  ⎿  Backgrounded agent (↓ to manage · ctrl+o to expand)
+  ⏺ main
+  ◯ reviewer       Watching CI                         6m 13s
+```
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  ◆ Opus(M) │ Tools: 224 done";
+        assert!(
+            claude_tui_background_agent_status_line_indexes(quoted_assistant_output).is_empty()
+        );
+    }
+
+    #[test]
+    fn background_agent_footer_rejects_indented_assistant_text() {
+        let pane = "  ✻ Waiting for 3 background agents to finish\n\
+────────────────────────────────────────────────────\n\
+❯\n\
+────────────────────────────────────────────────────\n\
+  ◆ Opus(M) │ Tools: 224 done";
+        assert!(claude_tui_background_agent_status_line_indexes(pane).is_empty());
     }
 
     #[test]

--- a/src/services/claude_tui/prompt_readiness.rs
+++ b/src/services/claude_tui/prompt_readiness.rs
@@ -1,0 +1,95 @@
+use crate::services::tui_turn_state::TuiTurnState;
+
+/// Return foreground live-turn evidence from a Claude TUI pane.
+///
+/// A completed foreground turn may leave detached background-agent chrome on
+/// screen. That chrome is ignored only when the session-bound transcript has
+/// authoritatively reached `Idle`; busy or unknown transcripts keep the full,
+/// conservative pane classifier.
+pub(super) fn pane_has_foreground_busy_evidence(
+    pane: &str,
+    capture_available: bool,
+    transcript_turn_state: Option<TuiTurnState>,
+) -> bool {
+    if !capture_available {
+        return false;
+    }
+    if transcript_turn_state != Some(TuiTurnState::Idle) {
+        return crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(pane);
+    }
+
+    let foreground_only = pane
+        .lines()
+        .filter(|line| {
+            !crate::services::tmux_common::tmux_line_is_claude_tui_background_agent_status(line)
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(&foreground_only)
+}
+
+/// Derive the timeout diagnostic from the transcript when it is conclusive.
+/// Unknown/no transcript retains the legacy pane-marker fallback.
+pub(super) fn previous_turn_still_running(
+    pane_alive: bool,
+    prompt_marker_detected: bool,
+    transcript_turn_state: Option<TuiTurnState>,
+) -> bool {
+    pane_alive
+        && match transcript_turn_state {
+            Some(TuiTurnState::Idle) => false,
+            Some(TuiTurnState::Streaming | TuiTurnState::UserSubmitted) => true,
+            Some(TuiTurnState::Unknown) | None => !prompt_marker_detected,
+        }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BACKGROUND_WAITING_PANE: &str = "\
+⏺ Foreground answer complete
+✻ Waiting for 3 background agents to finish
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  ◆ Opus(M) │ Tools: 224 done
+  ⏵⏵ bypass permissions on · 2 shells
+
+  ⏺ main
+  ◯ reviewer       Watching CI                         6m 13s
+  ◯ implementer    Updating tests                      3m 52s";
+
+    #[test]
+    fn authoritative_idle_excludes_background_agent_status_from_busy_evidence() {
+        assert!(!pane_has_foreground_busy_evidence(
+            BACKGROUND_WAITING_PANE,
+            true,
+            Some(TuiTurnState::Idle),
+        ));
+    }
+
+    #[test]
+    fn foreground_streaming_still_vetoes_with_background_agent_status_present() {
+        let pane = format!("{BACKGROUND_WAITING_PANE}\n✳ Architecting… (12s · esc to interrupt)");
+        assert!(pane_has_foreground_busy_evidence(
+            &pane,
+            true,
+            Some(TuiTurnState::Streaming),
+        ));
+    }
+
+    #[test]
+    fn idle_transcript_never_reports_previous_turn_running() {
+        assert!(!previous_turn_still_running(
+            true,
+            false,
+            Some(TuiTurnState::Idle),
+        ));
+        assert!(previous_turn_still_running(
+            true,
+            true,
+            Some(TuiTurnState::Streaming),
+        ));
+    }
+}

--- a/src/services/claude_tui/prompt_readiness.rs
+++ b/src/services/claude_tui/prompt_readiness.rs
@@ -7,7 +7,10 @@ use crate::services::tui_turn_state::TuiTurnState;
 /// words or `◯` bullet, but it cannot satisfy these structural anchors.
 pub(crate) fn claude_tui_background_agent_status_line_indexes(pane: &str) -> Vec<usize> {
     let lines = pane.lines().collect::<Vec<_>>();
-    let Some(prompt_index) = lines.iter().rposition(|line| line.trim() == "❯") else {
+    let Some(prompt_index) = lines
+        .iter()
+        .rposition(|line| line.trim_start().starts_with('❯'))
+    else {
         return Vec::new();
     };
     // Claude's persistent chrome is painted around the active bottom composer.
@@ -16,11 +19,10 @@ pub(crate) fn claude_tui_background_agent_status_line_indexes(pane: &str) -> Vec
     // Require these adjacent structures so transcript text quoting exact chrome
     // cannot become a keep-alive signal.
     let mut statuses = Vec::new();
-    if prompt_index >= 2
-        && is_claude_tui_background_agent_footer(lines[prompt_index - 2])
-        && is_claude_tui_horizontal_separator(lines[prompt_index - 1])
+    if let Some(footer_index) =
+        claude_tui_background_agent_footer_before_composer(&lines, prompt_index)
     {
-        statuses.push(prompt_index - 2);
+        statuses.push(footer_index);
     }
     if prompt_index >= 2
         && is_claude_tui_background_agent_management_header(lines[prompt_index - 2])
@@ -31,18 +33,34 @@ pub(crate) fn claude_tui_background_agent_status_line_indexes(pane: &str) -> Vec
 
     let mut task_table_open = false;
     for (index, line) in lines.iter().enumerate().skip(prompt_index + 1) {
-        if line == &"  ⏺ main" {
+        if line.starts_with("  ⏺ main") {
             task_table_open = true;
             continue;
         }
-        if task_table_open && is_claude_tui_background_agent_task_row(line) {
-            statuses.push(index);
-            continue;
+        if task_table_open {
+            if is_claude_tui_background_agent_task_row(line) {
+                statuses.push(index);
+                continue;
+            }
+            break;
         }
-        task_table_open = false;
     }
 
     statuses
+}
+
+fn claude_tui_background_agent_footer_before_composer(
+    lines: &[&str],
+    prompt_index: usize,
+) -> Option<usize> {
+    let separator_index = prompt_index.checked_sub(1)?;
+    if !is_claude_tui_horizontal_separator(lines[separator_index]) {
+        return None;
+    }
+    let footer_index = lines[..separator_index]
+        .iter()
+        .rposition(|line| !line.trim().is_empty())?;
+    is_claude_tui_background_agent_footer(lines[footer_index]).then_some(footer_index)
 }
 
 fn is_claude_tui_horizontal_separator(line: &str) -> bool {
@@ -71,28 +89,17 @@ fn is_claude_tui_background_agent_management_line(line: &str) -> bool {
 }
 
 fn is_claude_tui_background_agent_task_row(line: &str) -> bool {
-    let Some(columns) = line.strip_prefix("  ◯ ") else {
-        return false;
-    };
-    let columns = columns
-        .split("  ")
-        .filter(|column| !column.trim().is_empty())
-        .collect::<Vec<_>>();
-    columns.len() == 3 && is_claude_tui_elapsed_duration(columns[2].trim())
-}
-
-fn is_claude_tui_elapsed_duration(value: &str) -> bool {
-    let components = value.split_whitespace().collect::<Vec<_>>();
-    !components.is_empty()
-        && components.iter().all(|component| {
-            let Some(unit) = component.chars().last() else {
+    line.strip_prefix("  ◯ ").is_some_and(|row| {
+        row.split_whitespace().any(|value| {
+            let Some(unit) = value.chars().last() else {
                 return false;
             };
             matches!(unit, 's' | 'm' | 'h')
-                && component.strip_suffix(unit).is_some_and(|digits| {
+                && value.strip_suffix(unit).is_some_and(|digits| {
                     !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
                 })
         })
+    })
 }
 
 /// Return foreground live-turn evidence from a Claude TUI pane.
@@ -190,6 +197,27 @@ mod tests {
         ] {
             assert!(claude_tui_background_agent_status_line_indexes(pane).is_empty());
         }
+    }
+
+    #[test]
+    fn captured_background_agent_frame_with_draft_composer_is_detected() {
+        let pane = "\
+원하는 대로 할게:
+  어느 쪽?
+
+✻ Waiting for 5 background agents to finish
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯ a로 확정짓고 4:22 타임라인 떠서 처리해
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  🤖 Opus(H) │ ███░░░░░░░ │ 26% │ 265K/1.0M │ 5h: 8% (3h0m) │ 7d: 55% (1d23h)
+  ⏺ main                                                                                        ↑/↓ to select · Enter to view
+  ◯ general-purpose  Fix #3207 turn-stop + resume                                                    16m 5s · ↓ 159.5k tokens
+  ◯ general-purpose  Implement #3154 A converged design                                             10m 53s · ↓ 110.5k tokens";
+        assert_eq!(
+            claude_tui_background_agent_status_line_indexes(pane),
+            vec![3, 10, 11],
+        );
     }
 
     #[test]

--- a/src/services/claude_tui/prompt_readiness.rs
+++ b/src/services/claude_tui/prompt_readiness.rs
@@ -10,38 +10,43 @@ pub(crate) fn claude_tui_background_agent_status_line_indexes(pane: &str) -> Vec
     let Some(prompt_index) = lines.iter().rposition(|line| line.trim() == "❯") else {
         return Vec::new();
     };
-    // Claude's persistent chrome is painted around the active bottom composer:
-    // its waiting/management footer is immediately above the separator and
-    // composer, while its task table is below it. Restrict matching to that
-    // bottom zone so identical lines in the assistant transcript are never
-    // promoted to live status.
-    let chrome_start = prompt_index.saturating_sub(2);
+    // Claude's persistent chrome is painted around the active bottom composer.
+    // A waiting footer has its own separator/composer block; a management
+    // affordance directly precedes the composer; and a task table is below it.
+    // Require these adjacent structures so transcript text quoting exact chrome
+    // cannot become a keep-alive signal.
     let mut statuses = Vec::new();
+    if prompt_index >= 2
+        && is_claude_tui_background_agent_footer(lines[prompt_index - 2])
+        && is_claude_tui_horizontal_separator(lines[prompt_index - 1])
+    {
+        statuses.push(prompt_index - 2);
+    }
+    if prompt_index >= 2
+        && is_claude_tui_background_agent_management_header(lines[prompt_index - 2])
+        && is_claude_tui_background_agent_management_line(lines[prompt_index - 1])
+    {
+        statuses.push(prompt_index - 1);
+    }
+
     let mut task_table_open = false;
-
-    for (index, line) in lines.iter().enumerate().skip(chrome_start) {
-        if is_claude_tui_background_agent_footer(line)
-            || is_claude_tui_background_agent_management_line(line)
-        {
-            statuses.push(index);
-            task_table_open = false;
-            continue;
-        }
-
+    for (index, line) in lines.iter().enumerate().skip(prompt_index + 1) {
         if line == &"  ⏺ main" {
             task_table_open = true;
             continue;
         }
-
         if task_table_open && is_claude_tui_background_agent_task_row(line) {
             statuses.push(index);
             continue;
         }
-
         task_table_open = false;
     }
 
     statuses
+}
+
+fn is_claude_tui_horizontal_separator(line: &str) -> bool {
+    line.chars().count() >= 8 && line.chars().all(|character| character == '─')
 }
 
 fn is_claude_tui_background_agent_footer(line: &str) -> bool {
@@ -52,6 +57,10 @@ fn is_claude_tui_background_agent_footer(line: &str) -> bool {
         .strip_suffix(" background agent to finish")
         .or_else(|| count.strip_suffix(" background agents to finish"));
     count.is_some_and(|count| !count.is_empty() && count.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+fn is_claude_tui_background_agent_management_header(line: &str) -> bool {
+    line.starts_with("⏺ Agent(") && line.ends_with(')')
 }
 
 fn is_claude_tui_background_agent_management_line(line: &str) -> bool {
@@ -147,7 +156,7 @@ mod tests {
   ◯ implementer    Updating tests                      3m 52s";
 
     #[test]
-    fn background_agent_chrome_requires_bottom_prompt_zone() {
+    fn background_agent_chrome_requires_composer_adjacency() {
         assert_eq!(
             claude_tui_background_agent_status_line_indexes(BACKGROUND_WAITING_PANE),
             vec![1, 9, 10],
@@ -173,6 +182,23 @@ mod tests {
         assert!(
             claude_tui_background_agent_status_line_indexes(quoted_assistant_output).is_empty()
         );
+
+        for pane in [
+            "❯\n✻ Waiting for 3 background agents to finish",
+            "❯\n  ⎿  Backgrounded agent (↓ to manage · ctrl+o to expand)",
+            "✻ Waiting for 3 background agents to finish\n❯",
+        ] {
+            assert!(claude_tui_background_agent_status_line_indexes(pane).is_empty());
+        }
+    }
+
+    #[test]
+    fn background_agent_footer_requires_separator_before_composer() {
+        let pane = "\
+✻ Waiting for 3 background agents to finish
+not a Claude TUI separator
+❯";
+        assert!(claude_tui_background_agent_status_line_indexes(pane).is_empty());
     }
 
     #[test]

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -367,11 +367,20 @@ pub(crate) fn tmux_capture_indicates_claude_tui_background_agent_pending(capture
         return false;
     }
     let start = non_empty.len().saturating_sub(CLAUDE_TUI_ACTIVE_SCAN_LINES);
-    non_empty[start..].iter().any(|line| {
-        let lower = line.to_ascii_lowercase();
-        (lower.contains("waiting for") && lower.contains("background agent"))
-            || lower.contains("backgrounded agent")
-    })
+    non_empty[start..]
+        .iter()
+        .any(|line| tmux_line_is_claude_tui_background_agent_status(line))
+}
+
+/// Identify background-agent-only TUI chrome, including task-list rows. This is
+/// shared by completion pending detection and foreground readiness filtering so
+/// the two consumers cannot drift onto different status-line shapes.
+pub(crate) fn tmux_line_is_claude_tui_background_agent_status(line: &str) -> bool {
+    let line = trim_prompt_line(line);
+    let lower = line.to_ascii_lowercase();
+    (lower.contains("waiting for") && lower.contains("background agent"))
+        || lower.contains("backgrounded agent")
+        || line.starts_with('◯')
 }
 
 /// Shared producer for the Claude TUI background-agent pending bit.

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -367,20 +367,11 @@ pub(crate) fn tmux_capture_indicates_claude_tui_background_agent_pending(capture
         return false;
     }
     let start = non_empty.len().saturating_sub(CLAUDE_TUI_ACTIVE_SCAN_LINES);
-    non_empty[start..]
-        .iter()
-        .any(|line| tmux_line_is_claude_tui_background_agent_status(line))
-}
-
-/// Identify background-agent-only TUI chrome, including task-list rows. This is
-/// shared by completion pending detection and foreground readiness filtering so
-/// the two consumers cannot drift onto different status-line shapes.
-pub(crate) fn tmux_line_is_claude_tui_background_agent_status(line: &str) -> bool {
-    let line = trim_prompt_line(line);
-    let lower = line.to_ascii_lowercase();
-    (lower.contains("waiting for") && lower.contains("background agent"))
-        || lower.contains("backgrounded agent")
-        || line.starts_with('◯')
+    let recent = non_empty[start..].join("\n");
+    !crate::services::claude_tui::prompt_readiness::claude_tui_background_agent_status_line_indexes(
+        &recent,
+    )
+    .is_empty()
 }
 
 /// Shared producer for the Claude TUI background-agent pending bit.
@@ -2177,6 +2168,11 @@ another line of prior output";
         ));
         assert!(!tmux_capture_indicates_claude_tui_background_agent_pending(
             "I will hand that to the background agent.\n❯ "
+        ));
+        assert!(!tmux_capture_indicates_claude_tui_background_agent_pending(
+            "◯ reviewer       Watching CI                         6m 13s\n\
+             ◯ quoted agent status                         3m 52s\n\
+             I am waiting for 3 background agents to finish."
         ));
     }
 

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -2158,7 +2158,7 @@ another line of prior output";
         // foreground-idle panes and assistant prose merely mentioning a background
         // agent are NOT (no false keep-alive → no stuck turn).
         assert!(tmux_capture_indicates_claude_tui_background_agent_pending(
-            "⏺ reading docs\n✻ Waiting for 1 background agent to finish\n❯ "
+            "⏺ reading docs\n✻ Waiting for 1 background agent to finish\n────────────────────────────────────────────────────\n❯ "
         ));
         assert!(tmux_capture_indicates_claude_tui_background_agent_pending(
             "⏺ Agent(read story)\n  ⎿  Backgrounded agent (↓ to manage · ctrl+o to expand)\n❯ "


### PR DESCRIPTION
## 요약
Claude TUI transcript가 확정 Idle terminator(result/turn_duration/stop_hook_summary)로 끝나 실제 입력 가능(pane에 `❯` composer)인데도, 하위 readiness 루프가 pane의 `✻ Waiting for N background agents to finish` 문자열을 live busy로 오판해 transcript Idle을 veto → 45초 timeout → 사용자 메시지 requeue하던 버그(B1) 수정.

## 근본원인
상위 pre-submit 게이트(tui_followup.rs)는 Idle 통과시키나, 실제 전송 단계 readiness 루프(claude_tui/input.rs)가 background-agent 상태 문구를 foreground busy로 취급해 확정 Idle을 뒤집음. background agent 대기는 foreground turn과 무관한데도.

## 변경
- session-bound transcript가 확정 `Idle`이면 `Waiting for N background agents`/`Backgrounded agent`/`◯` task-list 행을 foreground busy 증거에서 제외. Streaming/UserSubmitted/불확실이면 기존 보수적 veto 유지.
- `previous_tui_turn_still_running`을 transcript-aware로: Idle→false, Streaming/UserSubmitted→true, Unknown/no-transcript→기존 pane-marker fallback.
- giant input.rs엔 얇은 배선만, 판정 정책은 신규 prompt_readiness.rs(95줄) sibling 추출. tmux_common.rs에 background-agent status 행 판정 DRY 중앙화.

## 검증
- cargo fmt/check 통과
- 회귀 테스트: 정상 terminator+background agents+visible composer→주입 허용(1 passed), 실제 foreground streaming→veto 유지(1 passed), 추출 정책 테스트 3 passed
- change-surfaces.md + multinode-transition.md audited-touch 갱신, docs 게이트 통과

Closes #4785

🤖 Generated with [Claude Code](https://claude.com/claude-code)