### PR TITLE
fix(#4790): skip restart re-isolation for managed worktrees

### DIFF
--- a/src/services/discord/router/message_handler/provider_isolation.rs
+++ b/src/services/discord/router/message_handler/provider_isolation.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::services::discord::session_runtime::{is_linked_worktree, is_managed_worktree_path};
 
 pub(super) fn metadata_parent_channel_id(
     metadata: Option<&serde_json::Value>,
@@ -471,6 +472,10 @@ pub(super) struct ProviderWorktreeIsolationOutcome {
     stale_session_id: Option<String>,
 }
 
+fn should_skip_provider_worktree_isolation(already_isolated: bool, canonical: &str) -> bool {
+    already_isolated || (is_managed_worktree_path(canonical) && is_linked_worktree(canonical))
+}
+
 pub(super) async fn ensure_provider_worktree_isolation(
     shared: &Arc<SharedData>,
     channel_id: ChannelId,
@@ -516,7 +521,7 @@ pub(super) async fn ensure_provider_worktree_isolation(
         let conflict = detect_worktree_conflict(&data.sessions, &canonical, channel_id);
         (already_isolated, session_channel_name, conflict)
     };
-    if already_isolated {
+    if should_skip_provider_worktree_isolation(already_isolated, &canonical) {
         return ProviderWorktreeIsolationOutcome::default();
     }
 
@@ -605,6 +610,45 @@ pub(super) async fn reset_provider_session_after_worktree_isolation(
 #[cfg(test)]
 mod thread_role_inheritance_tests {
     use super::*;
+
+    #[test]
+    fn managed_linked_worktree_skips_provider_reisolation_without_session_state() {
+        let root = tempfile::tempdir().unwrap();
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
+        let repo = root.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+
+        let git = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .status()
+                .unwrap();
+            assert!(status.success(), "git command failed: {args:?}");
+        };
+        git(&["init", "-b", "main"]);
+        git(&["config", "user.email", "provider-isolation@test.invalid"]);
+        git(&["config", "user.name", "Provider Isolation Test"]);
+        std::fs::write(repo.join("README"), "test").unwrap();
+        git(&["add", "README"]);
+        git(&["commit", "-m", "initial"]);
+
+        let (worktree_path, _) = create_git_worktree(
+            repo.to_str().unwrap(),
+            "restart-reisolation",
+            "test-provider",
+        )
+        .unwrap();
+
+        assert!(is_managed_worktree_path(&worktree_path));
+        assert!(is_linked_worktree(&worktree_path));
+        assert!(should_skip_provider_worktree_isolation(
+            false,
+            &worktree_path
+        ));
+        assert!(!ProviderWorktreeIsolationOutcome::default().applied);
+    }
+
     fn bind_parent(
         root: &std::path::Path,
         id: ChannelId,

--- a/src/services/discord/router/message_handler/provider_isolation.rs
+++ b/src/services/discord/router/message_handler/provider_isolation.rs
@@ -643,12 +643,11 @@ mod thread_role_inheritance_tests {
         std::fs::create_dir(&repo).unwrap();
 
         let git = |args: &[&str]| {
-            let status = std::process::Command::new("git")
+            crate::services::git::GitCommand::new()
+                .repo(&repo)
                 .args(args)
-                .current_dir(&repo)
-                .status()
+                .run_output()
                 .unwrap();
-            assert!(status.success(), "git command failed: {args:?}");
         };
         git(&["init", "-b", "main"]);
         git(&["config", "user.email", "provider-isolation@test.invalid"]);

--- a/src/services/discord/router/message_handler/provider_isolation.rs
+++ b/src/services/discord/router/message_handler/provider_isolation.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::services::discord::session_runtime::{is_linked_worktree, is_managed_worktree_path};
+use crate::services::discord::session_runtime::reconstruct_managed_worktree_metadata;
 
 pub(super) fn metadata_parent_channel_id(
     metadata: Option<&serde_json::Value>,
@@ -472,8 +472,18 @@ pub(super) struct ProviderWorktreeIsolationOutcome {
     stale_session_id: Option<String>,
 }
 
-fn should_skip_provider_worktree_isolation(already_isolated: bool, canonical: &str) -> bool {
-    already_isolated || (is_managed_worktree_path(canonical) && is_linked_worktree(canonical))
+fn reconstruct_unowned_managed_worktree(
+    session: &mut DiscordSession,
+    conflict: Option<&str>,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    canonical: &str,
+) -> bool {
+    if conflict.is_some() {
+        return false;
+    }
+    reconstruct_managed_worktree_metadata(session, provider, channel_id, canonical);
+    session.worktree.is_some()
 }
 
 pub(super) async fn ensure_provider_worktree_isolation(
@@ -507,21 +517,35 @@ pub(super) async fn ensure_provider_worktree_isolation(
         .map(|path| path.display().to_string())
         .unwrap_or_else(|_| current_path.clone());
 
-    let (already_isolated, session_channel_name, conflict) = {
-        let data = shared.core.lock().await;
+    let (already_isolated, reconstructed, session_channel_name, conflict) = {
+        let mut data = shared.core.lock().await;
+        let conflict = detect_worktree_conflict(&data.sessions, &canonical, channel_id);
         let already_isolated = data
             .sessions
             .get(&channel_id)
             .and_then(|session| session.worktree.as_ref())
             .is_some();
+        let reconstructed = data.sessions.get_mut(&channel_id).is_some_and(|session| {
+            reconstruct_unowned_managed_worktree(
+                session,
+                conflict.as_deref(),
+                provider,
+                channel_id,
+                &canonical,
+            )
+        });
         let session_channel_name = data
             .sessions
             .get(&channel_id)
             .and_then(|session| session.channel_name.clone());
-        let conflict = detect_worktree_conflict(&data.sessions, &canonical, channel_id);
-        (already_isolated, session_channel_name, conflict)
+        (
+            already_isolated,
+            reconstructed,
+            session_channel_name,
+            conflict,
+        )
     };
-    if should_skip_provider_worktree_isolation(already_isolated, &canonical) {
+    if already_isolated || (conflict.is_none() && reconstructed) {
         return ProviderWorktreeIsolationOutcome::default();
     }
 
@@ -640,13 +664,57 @@ mod thread_role_inheritance_tests {
         )
         .unwrap();
 
-        assert!(is_managed_worktree_path(&worktree_path));
-        assert!(is_linked_worktree(&worktree_path));
-        assert!(should_skip_provider_worktree_isolation(
-            false,
-            &worktree_path
+        let mut session = DiscordSession {
+            session_id: Some("preserved-session".to_string()),
+            memento_context_loaded: true,
+            memento_reflected: false,
+            current_path: Some(worktree_path.clone()),
+            history: Vec::new(),
+            pending_uploads: Vec::new(),
+            cleared: false,
+            remote_profile_name: None,
+            channel_id: Some(43_170_001),
+            channel_name: Some("restart-reisolation".to_string()),
+            category_name: None,
+            last_active: tokio::time::Instant::now(),
+            worktree: None,
+            born_generation: 0,
+        };
+        reconstruct_managed_worktree_metadata(
+            &mut session,
+            &ProviderKind::Claude,
+            ChannelId::new(43_170_001),
+            &worktree_path,
+        );
+
+        assert!(session.worktree.is_some());
+        assert_eq!(session.session_id.as_deref(), Some("preserved-session"));
+
+        let mut conflicted_session = DiscordSession {
+            worktree: None,
+            ..session.clone()
+        };
+        assert!(!reconstruct_unowned_managed_worktree(
+            &mut conflicted_session,
+            Some("owner-channel"),
+            &ProviderKind::Claude,
+            ChannelId::new(43_170_003),
+            &worktree_path,
         ));
-        assert!(!ProviderWorktreeIsolationOutcome::default().applied);
+        assert!(conflicted_session.worktree.is_none());
+
+        git(&["-C", &worktree_path, "checkout", "--detach"]);
+        let mut detached_session = DiscordSession {
+            worktree: None,
+            ..session.clone()
+        };
+        reconstruct_managed_worktree_metadata(
+            &mut detached_session,
+            &ProviderKind::Claude,
+            ChannelId::new(43_170_002),
+            &worktree_path,
+        );
+        assert!(detached_session.worktree.is_none());
     }
 
     fn bind_parent(

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -24,11 +24,9 @@ pub(super) use self::restore_cwd::{
 };
 pub(super) use self::worktree::{
     WorktreeInfo, cleanup_git_worktree, create_git_worktree, detect_worktree_conflict,
-    resolve_reusable_worktree,
+    is_linked_worktree, is_managed_worktree_path, resolve_reusable_worktree,
 };
-use self::worktree::{
-    is_managed_worktree_path, reconstruct_managed_worktree_metadata, sync_inflight_worktree_context,
-};
+use self::worktree::{reconstruct_managed_worktree_metadata, sync_inflight_worktree_context};
 
 /// Per-channel session state
 #[derive(Clone)]

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -24,9 +24,9 @@ pub(super) use self::restore_cwd::{
 };
 pub(super) use self::worktree::{
     WorktreeInfo, cleanup_git_worktree, create_git_worktree, detect_worktree_conflict,
-    is_linked_worktree, is_managed_worktree_path, resolve_reusable_worktree,
+    reconstruct_managed_worktree_metadata, resolve_reusable_worktree,
 };
-use self::worktree::{reconstruct_managed_worktree_metadata, sync_inflight_worktree_context};
+use self::worktree::{is_managed_worktree_path, sync_inflight_worktree_context};
 
 /// Per-channel session state
 #[derive(Clone)]

--- a/src/services/discord/session_runtime/worktree.rs
+++ b/src/services/discord/session_runtime/worktree.rs
@@ -422,7 +422,7 @@ pub(super) fn restored_worktree_belongs_to_parent(parent_path: &str, worktree_pa
 /// worktree lives elsewhere and must NOT be treated as a disposable
 /// AgentDesk-owned worktree — otherwise idle session cleanup could remove the
 /// user's checkout and delete its branch (#3011 codex review P1).
-pub(in crate::services::discord) fn is_managed_worktree_path(path: &str) -> bool {
+pub(super) fn is_managed_worktree_path(path: &str) -> bool {
     let Some(root) = worktrees_root() else {
         return false;
     };
@@ -436,7 +436,7 @@ pub(in crate::services::discord) fn is_managed_worktree_path(path: &str) -> bool
 /// checkout. A linked worktree's per-worktree git dir
 /// (`<repo>/.git/worktrees/<name>`) differs from the shared common dir
 /// (`<repo>/.git`), whereas they are identical for the main checkout.
-pub(in crate::services::discord) fn is_linked_worktree(path: &str) -> bool {
+fn is_linked_worktree(path: &str) -> bool {
     let git_dir = git_command_stdout(path, &["rev-parse", "--path-format=absolute", "--git-dir"])
         .ok()
         .filter(|dir| !dir.is_empty());
@@ -547,7 +547,7 @@ pub(in crate::services::discord) fn resolve_reusable_worktree(
 /// checkout). Used by the auto-restore paths so a thread session that resumes
 /// after a dcserver restart regains its worktree metadata, inflight worktree
 /// context, and a stable cleanup root instead of silently dropping them (#3011).
-pub(super) fn reconstruct_managed_worktree_metadata(
+pub(in crate::services::discord) fn reconstruct_managed_worktree_metadata(
     session: &mut DiscordSession,
     provider: &ProviderKind,
     channel_id: ChannelId,

--- a/src/services/discord/session_runtime/worktree.rs
+++ b/src/services/discord/session_runtime/worktree.rs
@@ -422,7 +422,7 @@ pub(super) fn restored_worktree_belongs_to_parent(parent_path: &str, worktree_pa
 /// worktree lives elsewhere and must NOT be treated as a disposable
 /// AgentDesk-owned worktree — otherwise idle session cleanup could remove the
 /// user's checkout and delete its branch (#3011 codex review P1).
-pub(super) fn is_managed_worktree_path(path: &str) -> bool {
+pub(in crate::services::discord) fn is_managed_worktree_path(path: &str) -> bool {
     let Some(root) = worktrees_root() else {
         return false;
     };
@@ -436,7 +436,7 @@ pub(super) fn is_managed_worktree_path(path: &str) -> bool {
 /// checkout. A linked worktree's per-worktree git dir
 /// (`<repo>/.git/worktrees/<name>`) differs from the shared common dir
 /// (`<repo>/.git`), whereas they are identical for the main checkout.
-fn is_linked_worktree(path: &str) -> bool {
+pub(in crate::services::discord) fn is_linked_worktree(path: &str) -> bool {
     let git_dir = git_command_stdout(path, &["rev-parse", "--path-format=absolute", "--git-dir"])
         .ok()
         .filter(|dir| !dir.is_empty());


### PR DESCRIPTION
## Summary
- skip provider worktree isolation when the canonical cwd is already an AgentDesk-managed linked worktree
- expose the existing worktree predicates through `session_runtime`
- add a regression test for missing in-memory worktree state after restart

Root cause: dcserver restart clears `session.worktree`, so isolation relied solely on volatile state and nested a new worktree despite the cwd already being an existing managed linked worktree.

Closes #4790

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo check --lib`
- [x] `cargo test --lib managed_linked_worktree_skips_provider_reisolation_without_session_state`

🤖 Generated with [Claude Code](https://claude.com/claude-code)