### PR TITLE
feat(relay): add discrete machine trigger markers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -757,6 +757,7 @@ src/
 │   │   │   ├── completion_gate_tests.rs
 │   │   │   ├── completion_producer.rs
 │   │   │   ├── controller_heartbeat.rs
+│   │   │   ├── discrete_trigger_marker.rs
 │   │   │   ├── entry.rs
 │   │   │   ├── jsonl_rotation.rs
 │   │   │   ├── liveness.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -331,7 +331,7 @@
     late-frame fresh row B is rejected; -576 from #3841 extracting placeholder
     suppression helpers to `tmux_placeholder_suppression/`;
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (frozen giant surface; #4229 S4
+  - `src/services/discord/tmux_watcher.rs` (frozen giant surface; #4799 adds thin suppressed-terminal wiring only: footer-owned background completions enqueue one semantic-event-keyed lifecycle marker, while card-owned subagents are deliberately excluded to prevent a duplicate card+marker surface; #4229 S4
     moved the turn stream collector (seed restore/first parse-forward/monitor
     auto-turn claim/active read-parse loop) verbatim to
     `src/services/discord/tmux_watcher/turn_stream_collector.rs` (frozen giant surface), ratcheting

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -446,6 +446,7 @@
   before merging.
 
 ### Audited touches
+- #4799 discrete machine-trigger markers: the watcher converts only footer-owned background terminal notifications into an idempotent lifecycle outbox marker keyed by channel plus semantic event identity; card-owned subagent notifications remain card-only, and monitor notices retain their existing offset-scoped aggregation. This adds no lease, owner, schema, or cross-node routing authority.
 - #4779 target preflight: added a pure fail-closed readiness report and transfer guard over worker-node capability evidence; owner mutation remains delegated to the generation-fenced handoff interface.
 
 - #4800 PostgreSQL pool-starvation fix: the existing `policy-tick` and

--- a/src/services/discord/task_notification_delivery/mod.rs
+++ b/src/services/discord/task_notification_delivery/mod.rs
@@ -130,6 +130,20 @@ impl TaskNotificationContext {
         &self.event_key
     }
 
+    /// Mirrors the footer-only eligibility used by the card policy: background
+    /// notifications need a stable task or tool identity to own a footer slot.
+    /// All other terminal notifications remain card-owned.
+    pub(super) fn footer_only_marker_event_key(&self) -> Option<&str> {
+        (matches!(self.routing_kind(), TaskNotificationKind::Background)
+            && (self.task_id.is_some() || self.tool_use_id.is_some()))
+        .then_some(self.event_key())
+    }
+
+    #[cfg(test)]
+    pub(super) fn footer_only_marker_event_key_for_test(&self) -> Option<&str> {
+        self.footer_only_marker_event_key()
+    }
+
     pub(super) fn to_event(
         &self,
         channel_id: u64,

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -666,6 +666,15 @@ pub(super) fn consume_monitor_auto_turn_preamble_once(injected: &mut bool) -> Op
     }
 }
 
+/// Stable outbox identity shared by prompt observation and watcher suppression
+/// for one footer-owned background completion.
+pub(in crate::services::discord) fn footer_background_marker_session_key(
+    channel_id: ChannelId,
+    event_key: &str,
+) -> String {
+    format!("footer_background:ch:{}:{event_key}", channel_id.get())
+}
+
 pub(super) fn suppressed_task_notification_marker(
     channel_id: ChannelId,
     tmux_session_name: &str,
@@ -686,11 +695,7 @@ pub(super) fn suppressed_task_notification_marker(
             )
         }
         TaskNotificationKind::Background => (
-            format!(
-                "footer_background:ch:{}:{}",
-                channel_id.get(),
-                footer_only_event_key?
-            ),
+            footer_background_marker_session_key(channel_id, footer_only_event_key?),
             "lifecycle.background_task_complete",
             "⚙️ Background complete".to_string(),
         ),
@@ -1535,7 +1540,7 @@ mod monitor_auto_turn_signal_tests {
 
 #[cfg(test)]
 mod suppressed_task_notification_marker_tests {
-    use super::suppressed_task_notification_marker;
+    use super::{footer_background_marker_session_key, suppressed_task_notification_marker};
     use crate::services::agent_protocol::TaskNotificationKind;
     use poise::serenity_prelude::ChannelId;
 
@@ -1567,6 +1572,11 @@ mod suppressed_task_notification_marker_tests {
         )
         .expect("same footer event remains marker eligible");
         assert_eq!(replay_at_new_offset.0, background_key);
+        assert_eq!(
+            footer_background_marker_session_key(channel_id, "event-identity"),
+            background_key,
+            "prompt and watcher paths must share one outbox identity"
+        );
         assert!(
             suppressed_task_notification_marker(
                 channel_id,

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -666,23 +666,68 @@ pub(super) fn consume_monitor_auto_turn_preamble_once(injected: &mut bool) -> Op
     }
 }
 
-fn enqueue_monitor_auto_turn_suppressed_notification(
+pub(super) fn suppressed_task_notification_marker(
+    channel_id: ChannelId,
+    tmux_session_name: &str,
+    data_start_offset: u64,
+    kind: TaskNotificationKind,
+    event_count: usize,
+    monitor_entry_keys: &[String],
+) -> (String, &'static str, String) {
+    match kind {
+        TaskNotificationKind::MonitorAutoTurn => {
+            let session_key = monitor_auto_turn_session_key(channel_id, data_start_offset);
+            let label = monitor_auto_turn_label(tmux_session_name);
+            (
+                session_key,
+                MONITOR_AUTO_TURN_REASON_CODE,
+                monitor_auto_turn_completion_notice(&label, event_count, monitor_entry_keys),
+            )
+        }
+        TaskNotificationKind::Background => (
+            format!(
+                "background_task_notification:ch:{}:off:{}",
+                channel_id.get(),
+                data_start_offset
+            ),
+            "lifecycle.background_task_complete",
+            "⚙️ Background complete".to_string(),
+        ),
+        TaskNotificationKind::Subagent => (
+            format!(
+                "subagent_notification:ch:{}:off:{}",
+                channel_id.get(),
+                data_start_offset
+            ),
+            "lifecycle.agent_message_arrived",
+            "🤖 Agent message arrived".to_string(),
+        ),
+    }
+}
+
+pub(super) fn enqueue_suppressed_task_notification(
     pg_pool: Option<&sqlx::PgPool>,
     channel_id: ChannelId,
     tmux_session_name: &str,
     data_start_offset: u64,
+    kind: TaskNotificationKind,
     event_count: usize,
-    entry_keys: &[String],
+    monitor_entry_keys: &[String],
 ) -> bool {
     let target = format!("channel:{}", channel_id.get());
-    let session_key = monitor_auto_turn_session_key(channel_id, data_start_offset);
-    let label = monitor_auto_turn_label(tmux_session_name);
-    let content = monitor_auto_turn_completion_notice(&label, event_count, entry_keys);
+    let (session_key, reason_code, content) = suppressed_task_notification_marker(
+        channel_id,
+        tmux_session_name,
+        data_start_offset,
+        kind,
+        event_count,
+        monitor_entry_keys,
+    );
     enqueue_lifecycle_notification_best_effort(
         pg_pool,
         target.as_str(),
         Some(session_key.as_str()),
-        MONITOR_AUTO_TURN_REASON_CODE,
+        reason_code,
         content.as_str(),
     )
 }
@@ -1486,6 +1531,44 @@ mod monitor_auto_turn_signal_tests {
         assert_eq!(shared.restart.global_active.load(Ordering::Relaxed), 0);
         let snapshot = shared.mailbox(channel_id).snapshot().await;
         assert_eq!(snapshot.active_user_message_id, None);
+    }
+}
+
+#[cfg(test)]
+mod suppressed_task_notification_marker_tests {
+    use super::suppressed_task_notification_marker;
+    use crate::services::agent_protocol::TaskNotificationKind;
+    use poise::serenity_prelude::ChannelId;
+
+    #[test]
+    fn background_and_subagent_markers_are_discrete_and_offset_deduped() {
+        let channel_id = ChannelId::new(4_799);
+        let (background_key, background_reason, background) = suppressed_task_notification_marker(
+            channel_id,
+            "AgentDesk-claude-4799",
+            44,
+            TaskNotificationKind::Background,
+            1,
+            &[],
+        );
+        assert_eq!(
+            background_key,
+            "background_task_notification:ch:4799:off:44"
+        );
+        assert_eq!(background_reason, "lifecycle.background_task_complete");
+        assert_eq!(background, "⚙️ Background complete");
+
+        let (subagent_key, subagent_reason, subagent) = suppressed_task_notification_marker(
+            channel_id,
+            "AgentDesk-claude-4799",
+            45,
+            TaskNotificationKind::Subagent,
+            1,
+            &[],
+        );
+        assert_eq!(subagent_key, "subagent_notification:ch:4799:off:45");
+        assert_eq!(subagent_reason, "lifecycle.agent_message_arrived");
+        assert_eq!(subagent, "🤖 Agent message arrived");
     }
 }
 

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -671,10 +671,11 @@ pub(super) fn suppressed_task_notification_marker(
     tmux_session_name: &str,
     data_start_offset: u64,
     kind: TaskNotificationKind,
+    footer_only_event_key: Option<&str>,
     event_count: usize,
     monitor_entry_keys: &[String],
-) -> (String, &'static str, String) {
-    match kind {
+) -> Option<(String, &'static str, String)> {
+    Some(match kind {
         TaskNotificationKind::MonitorAutoTurn => {
             let session_key = monitor_auto_turn_session_key(channel_id, data_start_offset);
             let label = monitor_auto_turn_label(tmux_session_name);
@@ -686,23 +687,17 @@ pub(super) fn suppressed_task_notification_marker(
         }
         TaskNotificationKind::Background => (
             format!(
-                "background_task_notification:ch:{}:off:{}",
+                "footer_background:ch:{}:{}",
                 channel_id.get(),
-                data_start_offset
+                footer_only_event_key?
             ),
             "lifecycle.background_task_complete",
             "⚙️ Background complete".to_string(),
         ),
-        TaskNotificationKind::Subagent => (
-            format!(
-                "subagent_notification:ch:{}:off:{}",
-                channel_id.get(),
-                data_start_offset
-            ),
-            "lifecycle.agent_message_arrived",
-            "🤖 Agent message arrived".to_string(),
-        ),
-    }
+        // Subagent completions are durable-card owned, so a suppressed watcher
+        // terminal must not add a duplicate discrete marker.
+        TaskNotificationKind::Subagent => return None,
+    })
 }
 
 pub(super) fn enqueue_suppressed_task_notification(
@@ -711,18 +706,22 @@ pub(super) fn enqueue_suppressed_task_notification(
     tmux_session_name: &str,
     data_start_offset: u64,
     kind: TaskNotificationKind,
+    footer_only_event_key: Option<&str>,
     event_count: usize,
     monitor_entry_keys: &[String],
 ) -> bool {
     let target = format!("channel:{}", channel_id.get());
-    let (session_key, reason_code, content) = suppressed_task_notification_marker(
+    let Some((session_key, reason_code, content)) = suppressed_task_notification_marker(
         channel_id,
         tmux_session_name,
         data_start_offset,
         kind,
+        footer_only_event_key,
         event_count,
         monitor_entry_keys,
-    );
+    ) else {
+        return false;
+    };
     enqueue_lifecycle_notification_best_effort(
         pg_pool,
         target.as_str(),
@@ -1541,34 +1540,46 @@ mod suppressed_task_notification_marker_tests {
     use poise::serenity_prelude::ChannelId;
 
     #[test]
-    fn background_and_subagent_markers_are_discrete_and_offset_deduped() {
+    fn background_marker_uses_event_identity_and_subagent_marker_is_skipped() {
         let channel_id = ChannelId::new(4_799);
         let (background_key, background_reason, background) = suppressed_task_notification_marker(
             channel_id,
             "AgentDesk-claude-4799",
             44,
             TaskNotificationKind::Background,
+            Some("event-identity"),
             1,
             &[],
-        );
-        assert_eq!(
-            background_key,
-            "background_task_notification:ch:4799:off:44"
-        );
+        )
+        .expect("footer-owned background completion gets a marker");
+        assert_eq!(background_key, "footer_background:ch:4799:event-identity");
         assert_eq!(background_reason, "lifecycle.background_task_complete");
         assert_eq!(background, "⚙️ Background complete");
 
-        let (subagent_key, subagent_reason, subagent) = suppressed_task_notification_marker(
+        let replay_at_new_offset = suppressed_task_notification_marker(
             channel_id,
             "AgentDesk-claude-4799",
-            45,
-            TaskNotificationKind::Subagent,
+            99,
+            TaskNotificationKind::Background,
+            Some("event-identity"),
             1,
             &[],
+        )
+        .expect("same footer event remains marker eligible");
+        assert_eq!(replay_at_new_offset.0, background_key);
+        assert!(
+            suppressed_task_notification_marker(
+                channel_id,
+                "AgentDesk-claude-4799",
+                45,
+                TaskNotificationKind::Subagent,
+                Some("subagent-event"),
+                1,
+                &[],
+            )
+            .is_none(),
+            "card-owned subagent completion must not duplicate its durable card"
         );
-        assert_eq!(subagent_key, "subagent_notification:ch:4799:off:45");
-        assert_eq!(subagent_reason, "lifecycle.agent_message_arrived");
-        assert_eq!(subagent, "🤖 Agent message arrived");
     }
 }
 

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -80,6 +80,9 @@ mod terminal_direct_fallback;
 #[path = "tmux_watcher/task_response_authority.rs"]
 mod task_response_authority;
 
+#[path = "tmux_watcher/discrete_trigger_marker.rs"]
+mod discrete_trigger_marker;
+
 // #3479 item-2: the watcher-direct orphan status-panel cleanup/completion/refresh
 // cluster extracted to a sibling submodule (pure move, zero logic change). Items
 // are `pub(super)` there and re-imported below so the watcher loop's call sites —
@@ -2149,38 +2152,16 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             )
             .await
         } else if relay_decision.suppressed {
-            let monitor_event_count = tool_state.transcript_events.len();
-            // #1009: Snapshot the channel's MonitoringStore entry keys ONCE so
-            // the lifecycle notify-outbox row uses a stable monitor summary for
-            // this suppressed terminal task-notification.
-            let monitor_entry_keys: Vec<String> = if matches!(
+            discrete_trigger_marker::enqueue_suppressed_machine_trigger_marker(
+                &shared,
+                channel_id,
+                &tmux_session_name,
+                data_start_offset,
                 task_notification_kind,
-                Some(TaskNotificationKind::MonitorAutoTurn)
-            ) {
-                let store_arc = crate::services::monitoring_store::global_monitoring_store();
-                let store = store_arc.lock().await;
-                store
-                    .list(channel_id.get())
-                    .into_iter()
-                    .map(|entry| entry.key)
-                    .collect()
-            } else {
-                Vec::new()
-            };
-            if let Some(kind @ (TaskNotificationKind::MonitorAutoTurn
-            | TaskNotificationKind::Background
-            | TaskNotificationKind::Subagent)) = task_notification_kind
-            {
-                let _ = enqueue_suppressed_task_notification(
-                    shared.pg_pool.as_ref(),
-                    channel_id,
-                    &tmux_session_name,
-                    data_start_offset,
-                    kind,
-                    monitor_event_count,
-                    &monitor_entry_keys,
-                );
-            }
+                task_notification_context.as_ref(),
+                tool_state.transcript_events.len(),
+            )
+            .await;
             let task_notification_detail = format!(
                 "{} kind={} offset={}",
                 tmux_session_name,

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -2167,15 +2167,16 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             } else {
                 Vec::new()
             };
-            if matches!(
-                task_notification_kind,
-                Some(TaskNotificationKind::MonitorAutoTurn)
-            ) {
-                let _ = enqueue_monitor_auto_turn_suppressed_notification(
+            if let Some(kind @ (TaskNotificationKind::MonitorAutoTurn
+            | TaskNotificationKind::Background
+            | TaskNotificationKind::Subagent)) = task_notification_kind
+            {
+                let _ = enqueue_suppressed_task_notification(
                     shared.pg_pool.as_ref(),
                     channel_id,
                     &tmux_session_name,
                     data_start_offset,
+                    kind,
                     monitor_event_count,
                     &monitor_entry_keys,
                 );

--- a/src/services/discord/tmux_watcher/discrete_trigger_marker.rs
+++ b/src/services/discord/tmux_watcher/discrete_trigger_marker.rs
@@ -1,0 +1,53 @@
+//! #4799: watcher-side discrete markers for suppressed machine triggers.
+//!
+//! Footer-owned background notifications receive a semantic-event-keyed lifecycle
+//! marker. Durable-card-owned subagent notifications deliberately remain silent
+//! here so the watcher never adds a second surface beside their task card.
+
+use super::*;
+use crate::services::discord::task_notification_delivery;
+
+pub(super) async fn enqueue_suppressed_machine_trigger_marker(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    tmux_session_name: &str,
+    data_start_offset: u64,
+    task_notification_kind: Option<TaskNotificationKind>,
+    task_notification_context: Option<&task_notification_delivery::TaskNotificationContext>,
+    monitor_event_count: usize,
+) {
+    let monitor_entry_keys: Vec<String> = if matches!(
+        task_notification_kind,
+        Some(TaskNotificationKind::MonitorAutoTurn)
+    ) {
+        let store_arc = crate::services::monitoring_store::global_monitoring_store();
+        let store = store_arc.lock().await;
+        store
+            .list(channel_id.get())
+            .into_iter()
+            .map(|entry| entry.key)
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let footer_only_event_key =
+        task_notification_context.and_then(|context| context.footer_only_marker_event_key());
+    let marker_kind = task_notification_kind.filter(|kind| {
+        matches!(
+            kind,
+            TaskNotificationKind::MonitorAutoTurn | TaskNotificationKind::Background
+        )
+    });
+    if let Some(kind) = marker_kind {
+        let _ = enqueue_suppressed_task_notification(
+            shared.pg_pool.as_ref(),
+            channel_id,
+            tmux_session_name,
+            data_start_offset,
+            kind,
+            footer_only_event_key,
+            monitor_event_count,
+            &monitor_entry_keys,
+        );
+    }
+}

--- a/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
+++ b/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
@@ -407,13 +407,10 @@ fn extract_local_command_stdout_body(prompt: &str) -> Option<String> {
     (!body.is_empty()).then_some(body)
 }
 
-pub(super) fn format_system_continuation_note(tmux_session_name: &str, prompt: &str) -> String {
-    let prompt = strip_terminal_controls(prompt);
-    let omitted_chars = format_count_with_commas(prompt.trim().chars().count());
+pub(super) fn format_system_continuation_note(tmux_session_name: &str, _prompt: &str) -> String {
     format!(
-        "🧩 세션 컨텍스트 이어가기 (tmux : `{}`) — 시스템 주입 (활성 턴 아님) (요약 {}자 생략 — 채널 기록과 동일 내용)",
+        "🧩 Session continued (compact/resume) · tmux: `{}`",
         sanitize_inline_code(tmux_session_name),
-        omitted_chars,
     )
 }
 

--- a/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
+++ b/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
@@ -105,6 +105,7 @@ pub(super) async fn resolve_gate(
             );
             return None;
         }
+        enqueue_footer_only_background_marker(shared, channel_id, event);
         clear_observed_external_turn_lease_if_current(prompt, channel_id, lease);
         return None;
     }
@@ -187,6 +188,26 @@ pub(super) async fn resolve_gate(
         notify_http: http,
         card_anchor: Some(MessageId::new(outcome.message_id)),
     })
+}
+
+/// Prompt observation remains a producer when the watcher cannot reach the
+/// terminal frame. It shares the watcher key, so observing the same semantic
+/// event through both paths still produces one outbox lifecycle notice.
+fn enqueue_footer_only_background_marker(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    event: &super::super::task_notification_delivery::TaskCardEvent,
+) {
+    let target = format!("channel:{}", channel_id.get());
+    let session_key =
+        super::super::tmux::footer_background_marker_session_key(channel_id, event.event_key());
+    let _ = crate::services::message_outbox::enqueue_lifecycle_notification_best_effort(
+        shared.pg_pool.as_ref(),
+        target.as_str(),
+        Some(session_key.as_str()),
+        "lifecycle.background_task_complete",
+        "⚙️ Background complete",
+    );
 }
 
 async fn legacy_notify_gate(

--- a/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
+++ b/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
@@ -105,7 +105,6 @@ pub(super) async fn resolve_gate(
             );
             return None;
         }
-        enqueue_footer_only_background_marker(shared, channel_id, event);
         clear_observed_external_turn_lease_if_current(prompt, channel_id, lease);
         return None;
     }
@@ -188,25 +187,6 @@ pub(super) async fn resolve_gate(
         notify_http: http,
         card_anchor: Some(MessageId::new(outcome.message_id)),
     })
-}
-
-/// Persist one discrete lifecycle marker for a footer-owned background
-/// completion. The event scope is the outbox idempotency key, so duplicate
-/// transcript observations coalesce without restoring the suppressed card body.
-fn enqueue_footer_only_background_marker(
-    shared: &Arc<SharedData>,
-    channel_id: ChannelId,
-    event: &super::super::task_notification_delivery::TaskCardEvent,
-) {
-    let target = format!("channel:{}", channel_id.get());
-    let session_key = format!("footer_background:{}", event.event_key());
-    let _ = crate::services::message_outbox::enqueue_lifecycle_notification_best_effort(
-        shared.pg_pool.as_ref(),
-        target.as_str(),
-        Some(session_key.as_str()),
-        "lifecycle.background_task_complete",
-        "⚙️ Background complete",
-    );
 }
 
 async fn legacy_notify_gate(

--- a/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
+++ b/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
@@ -105,6 +105,7 @@ pub(super) async fn resolve_gate(
             );
             return None;
         }
+        enqueue_footer_only_background_marker(shared, channel_id, event);
         clear_observed_external_turn_lease_if_current(prompt, channel_id, lease);
         return None;
     }
@@ -187,6 +188,25 @@ pub(super) async fn resolve_gate(
         notify_http: http,
         card_anchor: Some(MessageId::new(outcome.message_id)),
     })
+}
+
+/// Persist one discrete lifecycle marker for a footer-owned background
+/// completion. The event scope is the outbox idempotency key, so duplicate
+/// transcript observations coalesce without restoring the suppressed card body.
+fn enqueue_footer_only_background_marker(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    event: &super::super::task_notification_delivery::TaskCardEvent,
+) {
+    let target = format!("channel:{}", channel_id.get());
+    let session_key = format!("footer_background:{}", event.event_key());
+    let _ = crate::services::message_outbox::enqueue_lifecycle_notification_best_effort(
+        shared.pg_pool.as_ref(),
+        target.as_str(),
+        Some(session_key.as_str()),
+        "lifecycle.background_task_complete",
+        "⚙️ Background complete",
+    );
 }
 
 async fn legacy_notify_gate(

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -2207,13 +2207,12 @@ fn system_continuation_note_is_neutral_not_active_turn() {
     let prompt = "This session is being continued from a previous conversation. Summary: ...";
     let note = format_system_continuation_note("AgentDesk-claude-adk-cc", prompt);
     assert!(!note.contains("터미널에 직접 주입된 입력"));
-    assert!(note.contains("세션 컨텍스트 이어가기"));
-    assert!(note.contains("활성 턴 아님"));
-    assert!(note.contains("(tmux : `AgentDesk-claude-adk-cc`)"));
+    assert_eq!(
+        note,
+        "🧩 Session continued (compact/resume) · tmux: `AgentDesk-claude-adk-cc`"
+    );
     assert!(!note.contains("```text"));
     assert!(!note.contains("Summary:"));
-    assert!(note.contains(&format!("요약 {}자 생략", prompt.chars().count())));
-    assert!(note.contains("채널 기록과 동일 내용"));
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- relay footer-only background completions as idempotent `⚙️ Background complete` lifecycle markers
- add discrete background/subagent markers for suppressed tmux terminal notifications while preserving monitor notices
- replace verbose system-continuation content with `🧩 Session continued (compact/resume)`

## Policy
- `FooterOnly` remains footer-owned; the marker supplements it without restoring a task card or body relay.
- `CardRequired` remains card-owned and does not emit a duplicate marker.
- lifecycle outbox session keys include channel + terminal offset/event key for deduplication.

## Verification
- `cargo test --lib suppressed_task_notification_marker_tests -- --nocapture`
- `cargo test --lib system_continuation_note_is_neutral_not_active_turn -- --nocapture`
- `cargo test --lib tui_prompt_relay`
- `cargo test --lib tmux`
- `cargo fmt --all --check`
- `cargo check --lib`
- `python3 scripts/generate_inventory_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py --line-count-gate`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)