### PR TITLE
fix(#4797): preserve FIFO for inflight follow-up retries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1188,6 +1188,7 @@ src/
 │   │   └── completion_scan.rs
 │   ├── turn_orchestrator/
 │   │   ├── active_source_dedup.rs
+│   │   ├── dispatch_cleanup.rs
 │   │   ├── dispatch_reservation.rs
 │   │   ├── episode_identity.rs
 │   │   ├── front_requeue.rs

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1190,6 +1190,7 @@ src/
 │   │   ├── active_source_dedup.rs
 │   │   ├── dispatch_reservation.rs
 │   │   ├── episode_identity.rs
+│   │   ├── front_requeue.rs
 │   │   ├── overflow.rs
 │   │   ├── pending_queue_persistence.rs
 │   │   ├── queue_cancellation.rs

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -668,6 +668,7 @@ src/
 │   │   │   │   │   ├── turn_watchdog.rs
 │   │   │   │   │   └── voice_intake.rs
 │   │   │   │   ├── attachments.rs
+│   │   │   │   ├── busy_retry.rs
 │   │   │   │   ├── control.rs
 │   │   │   │   ├── goal_lifecycle.rs
 │   │   │   │   ├── headless_turn.rs

--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -1,5 +1,7 @@
 # Discord Outbound Migration — Coverage Map (#1006 v3 / #1280 / #1436 / #1457)
 
+> Last refreshed: 2026-07-23 (#4797 round 4 — test gateway implementations thread the queued-dispatch capability required by the `TurnGateway` trait; outbound controller delivery verbs, production callsite coverage, and delivery semantics are unchanged).
+>
 > Last refreshed: 2026-07-21 (against #4706 lint-debt annotations only; outbound callsite coverage and delivery semantics are unchanged).
 
 > Last refreshed: 2026-07-03 (against #3874 dead-code removal — manual outbound callsite coverage map refreshed after removing permanently-None `Option<&Db>` threading; no delivery semantics change).

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -750,9 +750,11 @@ impl TurnGateway for DiscordGateway {
             {
                 router::QueuedAdmissionDisposition::Admitted(admitted) => admitted,
                 router::QueuedAdmissionDisposition::Deferred
-                | router::QueuedAdmissionDisposition::RejectedNonPortableAttachment
-                | router::QueuedAdmissionDisposition::RejectedRestore => {
+                | router::QueuedAdmissionDisposition::RejectedNonPortableAttachment => {
                     return Ok(());
+                }
+                router::QueuedAdmissionDisposition::RejectedRestore => {
+                    return Err("queued admission failed to restore dequeued head".to_string());
                 }
             };
 

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -182,6 +182,7 @@ pub(super) trait TurnGateway: Send + Sync {
         intervention: &'a Intervention,
         request_owner_name: &'a str,
         has_more_queued_turns: bool,
+        dispatch_lease: Option<std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>>,
     ) -> GatewayFuture<'a, Result<(), String>>;
 
     fn validate_live_routing<'a>(
@@ -697,6 +698,7 @@ impl TurnGateway for DiscordGateway {
         intervention: &'a Intervention,
         request_owner_name: &'a str,
         has_more_queued_turns: bool,
+        dispatch_lease: Option<std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>>,
     ) -> GatewayFuture<'a, Result<(), String>> {
         Box::pin(async move {
             // #4270 A — pre-drain hosted-TUI readiness gate: a busy TUI defers
@@ -708,6 +710,9 @@ impl TurnGateway for DiscordGateway {
                 &self.provider,
                 channel_id,
                 intervention,
+                dispatch_lease
+                    .clone()
+                    .ok_or_else(|| "queued dispatch is missing its dispatch lease".to_string())?,
             )
             .await
             {
@@ -739,12 +744,14 @@ impl TurnGateway for DiscordGateway {
                 has_more_queued_turns,
                 true,
                 "intake_admission_pre_drain_defer",
+                dispatch_lease.clone(),
             )
             .await
             {
                 router::QueuedAdmissionDisposition::Admitted(admitted) => admitted,
                 router::QueuedAdmissionDisposition::Deferred
-                | router::QueuedAdmissionDisposition::RejectedNonPortableAttachment => {
+                | router::QueuedAdmissionDisposition::RejectedNonPortableAttachment
+                | router::QueuedAdmissionDisposition::RejectedRestore => {
                     return Ok(());
                 }
             };
@@ -907,6 +914,7 @@ impl TurnGateway for HeadlessGateway {
         _intervention: &'a Intervention,
         _request_owner_name: &'a str,
         _has_more_queued_turns: bool,
+        _dispatch_lease: Option<std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>>,
     ) -> GatewayFuture<'a, Result<(), String>> {
         Box::pin(
             async move { Err("headless turns do not dispatch queued turns locally".to_string()) },
@@ -1018,6 +1026,9 @@ mod tests {
             _intervention: &'a Intervention,
             _request_owner_name: &'a str,
             _has_more_queued_turns: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             Box::pin(async { Ok(()) })
         }
@@ -1225,7 +1236,13 @@ mod tests {
                 .intervention
                 .unwrap_or_else(|| panic!("cycle {cycle}: the head must still be promotable"));
             let result = gateway
-                .dispatch_queued_turn(channel_id, &intervention, "tester", false)
+                .dispatch_queued_turn(
+                    channel_id,
+                    &intervention,
+                    "tester",
+                    false,
+                    taken.dispatch_lease,
+                )
                 .await;
             assert!(
                 result.is_ok(),
@@ -1302,7 +1319,13 @@ mod tests {
 
         let gateway = DiscordGateway::new(http.clone(), shared.clone(), provider.clone(), None);
         let result = gateway
-            .dispatch_queued_turn(channel_id, &intervention, "tester", false)
+            .dispatch_queued_turn(
+                channel_id,
+                &intervention,
+                "tester",
+                false,
+                taken.dispatch_lease,
+            )
             .await;
         let error = result.expect_err(
             "gate pass-through must continue into the dispatch body, which requires live context",

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -2563,21 +2563,7 @@ pub(super) fn make_shared_data_for_tests_with_storage(
     })
 }
 
-fn queue_persistence_context(
-    shared: &SharedData,
-    provider: &ProviderKind,
-    channel_id: ChannelId,
-) -> QueuePersistenceContext {
-    QueuePersistenceContext::new(
-        provider,
-        &shared.token_hash,
-        shared
-            .dispatch
-            .role_overrides
-            .get(&channel_id)
-            .map(|override_id| override_id.value().get()),
-    )
-}
+use queue_dispatch::persistence_context as queue_persistence_context;
 
 async fn mailbox_snapshot(shared: &SharedData, channel_id: ChannelId) -> ChannelMailboxSnapshot {
     match shared.mailbox_peek(channel_id) {
@@ -4224,11 +4210,7 @@ async fn kickoff_idle_queue_channel(
             return IdleQueueKickoffChannelOutcome::default();
         }
         router::QueuedAdmissionDisposition::RejectedRestore => {
-            tracing::error!(
-                provider = provider.as_str(),
-                channel_id = channel_id.get(),
-                "KICKOFF: queued admission failed to restore dequeued head"
-            );
+            queue_dispatch::log_kickoff_rejected_restore(provider, channel_id);
             drop(dispatch_lease);
             return IdleQueueKickoffChannelOutcome::default();
         }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -214,6 +214,7 @@ use prompt_builder::{RecoveryContextManifestInput, build_system_prompt_with_mani
 pub(in crate::services::discord) use queue_dispatch::MailboxEnqueueOutcome;
 use queue_dispatch::{
     MailboxTakeNextSoftOutcome, mailbox_abandon_unclaimed_dispatch_after_success,
+    mailbox_requeue_intervention_front, mailbox_restore_dequeued_head,
 };
 use recovery_engine::restore_inflight_turns;
 use restart_report::flush_restart_reports;
@@ -3660,36 +3661,6 @@ async fn idle_queue_take_next_soft_if_ready(
     mailbox_take_next_soft_intervention(shared, provider, channel_id).await
 }
 
-async fn mailbox_requeue_intervention_front(
-    shared: &SharedData,
-    provider: &ProviderKind,
-    channel_id: ChannelId,
-    intervention: Intervention,
-) -> MailboxEnqueueOutcome {
-    let result: RequeueInterventionResult = shared
-        .mailbox(channel_id)
-        .requeue_front(
-            intervention,
-            queue_persistence_context(shared, provider, channel_id),
-        )
-        .await;
-    apply_queue_exit_feedback(shared, channel_id, &result.queue_exit_events).await;
-    if let Some(error) = result.persistence_error.as_ref() {
-        tracing::warn!(
-            provider = provider.as_str(),
-            channel_id = channel_id.get(),
-            error = %error,
-            "mailbox requeue-front failed durable pending-queue persistence; pending dispatch marker remains the durable backstop"
-        );
-    }
-    MailboxEnqueueOutcome {
-        enqueued: result.enqueued && result.persistence_error.is_none(),
-        merged: false,
-        refusal_reason: result.refusal_reason,
-        persistence_error: result.persistence_error,
-    }
-}
-
 pub(in crate::services::discord) async fn mailbox_abandon_pending_dispatch(
     shared: &SharedData,
     provider: &ProviderKind,
@@ -4242,12 +4213,14 @@ async fn kickoff_idle_queue_channel(
         has_more,
         false,
         "intake_admission_pre_kickoff_defer",
+        dispatch_lease.clone(),
     )
     .await
     {
         router::QueuedAdmissionDisposition::Admitted(admitted) => admitted,
         router::QueuedAdmissionDisposition::Deferred
-        | router::QueuedAdmissionDisposition::RejectedNonPortableAttachment => {
+        | router::QueuedAdmissionDisposition::RejectedNonPortableAttachment
+        | router::QueuedAdmissionDisposition::RejectedRestore => {
             drop(dispatch_lease);
             return IdleQueueKickoffChannelOutcome::default();
         }
@@ -4285,7 +4258,29 @@ async fn kickoff_idle_queue_channel(
                 "  [{ts}]   ⚠ KICKOFF: failed to start turn for channel {}: {e}",
                 channel_id
             );
-            mailbox_requeue_intervention_front(shared, provider, channel_id, intervention).await;
+            let restored = mailbox_restore_dequeued_head(
+                shared,
+                provider,
+                channel_id,
+                intervention,
+                dispatch_lease
+                    .as_ref()
+                    .expect("dequeued kickoff intervention must carry its lease")
+                    .clone(),
+            )
+            .await;
+            if !restored.enqueued {
+                tracing::error!(
+                    provider = provider.as_str(),
+                    channel_id = channel_id.get(),
+                    refusal_reason = restored
+                        .refusal_reason
+                        .map(|reason| reason.as_str())
+                        .unwrap_or("none"),
+                    persistence_error = restored.persistence_error.as_deref().unwrap_or("none"),
+                    "KICKOFF: dequeued-head restore rejected after dispatch failure"
+                );
+            }
             drop(dispatch_lease);
             IdleQueueKickoffChannelOutcome { started: false }
         }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -4219,8 +4219,16 @@ async fn kickoff_idle_queue_channel(
     {
         router::QueuedAdmissionDisposition::Admitted(admitted) => admitted,
         router::QueuedAdmissionDisposition::Deferred
-        | router::QueuedAdmissionDisposition::RejectedNonPortableAttachment
-        | router::QueuedAdmissionDisposition::RejectedRestore => {
+        | router::QueuedAdmissionDisposition::RejectedNonPortableAttachment => {
+            drop(dispatch_lease);
+            return IdleQueueKickoffChannelOutcome::default();
+        }
+        router::QueuedAdmissionDisposition::RejectedRestore => {
+            tracing::error!(
+                provider = provider.as_str(),
+                channel_id = channel_id.get(),
+                "KICKOFF: queued admission failed to restore dequeued head"
+            );
             drop(dispatch_lease);
             return IdleQueueKickoffChannelOutcome::default();
         }
@@ -4290,6 +4298,10 @@ async fn kickoff_idle_queue_channel(
                 provider,
                 channel_id,
                 intervention.message_id,
+                dispatch_lease
+                    .as_ref()
+                    .expect("dequeued kickoff intervention must carry its lease")
+                    .clone(),
             )
             .await;
             drop(dispatch_lease);
@@ -5214,6 +5226,7 @@ mod idle_queue_background_supersede_tests {
                     &provider,
                     channel_id,
                     consumed.message_id,
+                    dispatch_lease.clone(),
                 )
                 .await;
 
@@ -5250,6 +5263,82 @@ mod idle_queue_background_supersede_tests {
                         .map(|(marker, _)| marker.message_id),
                     Some(next.message_id),
                     "next head receives the only remaining marker"
+                );
+            });
+    }
+
+    #[test]
+    fn stale_success_cleanup_cannot_abandon_same_identity_successor_lease() {
+        let _lock = crate::services::turn_orchestrator::test_support::lock_test_env();
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path().to_str().unwrap()) };
+        let _env_guard = EnvGuard;
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let shared = make_shared_data_for_tests();
+                let provider = ProviderKind::Claude;
+                let channel_id = ChannelId::new(4_797_904);
+                let intervention = user_intervention(4_797_905, "same identity successor");
+                let persistence = queue_persistence_context(&shared, &provider, channel_id);
+                shared
+                    .mailbox(channel_id)
+                    .replace_queue(vec![intervention.clone()], persistence.clone())
+                    .await;
+
+                let first = shared
+                    .mailbox(channel_id)
+                    .take_next_soft(persistence.clone())
+                    .await;
+                let stale_lease = first
+                    .dispatch_lease
+                    .expect("first dequeue must carry lease L1");
+                let restored = shared
+                    .mailbox(channel_id)
+                    .restore_dequeued_head(
+                        first.intervention.expect("first dequeue must return head"),
+                        persistence.clone(),
+                        stale_lease.clone(),
+                    )
+                    .await;
+                assert!(restored.enqueued);
+
+                let second = shared.mailbox(channel_id).take_next_soft(persistence).await;
+                let successor_lease = second
+                    .dispatch_lease
+                    .expect("successor dequeue must carry lease L2");
+                assert_eq!(
+                    second.intervention.as_ref().map(|item| item.message_id),
+                    Some(intervention.message_id)
+                );
+
+                mailbox_abandon_unclaimed_dispatch_after_success(
+                    &shared,
+                    &provider,
+                    channel_id,
+                    intervention.message_id,
+                    stale_lease,
+                )
+                .await;
+
+                let snapshot = mailbox_snapshot(&shared, channel_id).await;
+                assert_eq!(
+                    snapshot.pending_user_dispatch,
+                    Some(intervention.message_id)
+                );
+                assert_eq!(
+                    load_channel_pending_dispatch_marker(&provider, &shared.token_hash, channel_id)
+                        .map(|(marker, _)| marker.message_id),
+                    Some(intervention.message_id),
+                    "stale L1 cleanup must preserve L2's durable marker"
+                );
+                assert_eq!(
+                    Arc::strong_count(&successor_lease),
+                    2,
+                    "stale L1 cleanup must preserve the actor-held L2 reservation"
                 );
             });
     }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -3665,7 +3665,7 @@ async fn mailbox_requeue_intervention_front(
     provider: &ProviderKind,
     channel_id: ChannelId,
     intervention: Intervention,
-) -> RequeueInterventionResult {
+) -> MailboxEnqueueOutcome {
     let result: RequeueInterventionResult = shared
         .mailbox(channel_id)
         .requeue_front(
@@ -3682,7 +3682,12 @@ async fn mailbox_requeue_intervention_front(
             "mailbox requeue-front failed durable pending-queue persistence; pending dispatch marker remains the durable backstop"
         );
     }
-    result
+    MailboxEnqueueOutcome {
+        enqueued: result.enqueued && result.persistence_error.is_none(),
+        merged: false,
+        refusal_reason: result.refusal_reason,
+        persistence_error: result.persistence_error,
+    }
 }
 
 pub(in crate::services::discord) async fn mailbox_abandon_pending_dispatch(
@@ -3715,14 +3720,8 @@ async fn mailbox_clear_pending_dispatch_reservation(
         .await;
 }
 
-/// Re-queue the inflight message that a claude TUI follow-up could not submit
-/// because the pane was busy at submit time. The follow-up busy-timeout is
-/// PRE-submit (the prompt was never delivered), so retrying cannot double-send.
-/// Enqueues to the BACK of the channel mailbox so the message is retried after
-/// the in-flight turn frees the pane rather than hot-looping. No-op for
-/// anchorless (recovery) turns or empty text. Unlike the dequeued-head sibling
-/// `enqueue_busy_tui_followup_for_retry` (front-requeues for FIFO, #4795), this
-/// inflight-rebuild path still tail-enqueues; FIFO parity tracked in #4797.
+/// Front-restore an inflight Claude TUI follow-up that failed before submission;
+/// it predates queued interventions, and the deferred kickoff prevents hot loops.
 pub(in crate::services::discord) async fn mailbox_requeue_inflight_for_followup_retry(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
@@ -3770,7 +3769,7 @@ pub(in crate::services::discord) async fn mailbox_requeue_inflight_for_followup_
         pending_uploads: inflight_state.followup_pending_uploads.clone(),
         voice_announcement: inflight_state.followup_voice_announcement.clone(),
     };
-    mailbox_enqueue_intervention(shared, provider, channel_id, intervention).await
+    mailbox_requeue_intervention_front(shared, provider, channel_id, intervention).await
 }
 
 #[cfg(test)]
@@ -3920,7 +3919,7 @@ mod followup_retry_requeue_tests {
     }
 
     #[test]
-    fn pre_submit_requeue_reports_duplicate_refusal_outcome() {
+    fn inflight_retry_restores_earlier_message_without_reversing_fifo_4797() {
         let _lock = crate::config::shared_test_env_lock()
             .lock()
             .expect("shared env lock poisoned");
@@ -3937,21 +3936,50 @@ mod followup_retry_requeue_tests {
         rt.block_on(async {
             let shared = make_shared_data_for_tests();
             let provider = ProviderKind::Claude;
-            let channel_id = ChannelId::new(3_752_002);
-            let user_msg_id = MessageId::new(3_752_102);
-            let state = followup_inflight(channel_id, user_msg_id, false);
+            let channel_id = ChannelId::new(4_797_001);
+            let first_id = MessageId::new(4_797_101);
+            let later_id = MessageId::new(4_797_102);
+            let state = followup_inflight(channel_id, first_id, false);
+            let later = Intervention {
+                author_id: UserId::new(43),
+                author_is_bot: true,
+                message_id: later_id,
+                queued_generation: shared.restart.current_generation,
+                source_message_ids: vec![later_id],
+                source_message_queued_generations: Vec::new(),
+                source_text_segments: Vec::new(),
+                text: "later bot B".to_string(),
+                mode: crate::services::turn_orchestrator::InterventionMode::Soft,
+                created_at: std::time::Instant::now(),
+                reply_context: None,
+                has_reply_boundary: false,
+                merge_consecutive: false,
+                pending_uploads: Vec::new(),
+                voice_announcement: None,
+            };
+            mailbox_enqueue_intervention(&shared, &provider, channel_id, later.clone()).await;
 
-            let first =
+            let retry =
                 mailbox_requeue_inflight_for_followup_retry(&shared, &provider, channel_id, &state)
                     .await;
-            let second =
+            assert!(retry.enqueued);
+
+            let snapshot = mailbox_snapshot(&shared, channel_id).await;
+            let order: Vec<_> = snapshot
+                .intervention_queue
+                .iter()
+                .map(|item| item.message_id)
+                .collect();
+            assert_eq!(order, vec![first_id, later_id]);
+            assert!(!snapshot.intervention_queue[0].author_is_bot);
+            assert!(snapshot.intervention_queue[1].author_is_bot);
+
+            let duplicate =
                 mailbox_requeue_inflight_for_followup_retry(&shared, &provider, channel_id, &state)
                     .await;
-
-            assert!(first.enqueued);
-            assert!(!second.enqueued);
+            assert!(!duplicate.enqueued);
             assert_eq!(
-                second.refusal_reason,
+                duplicate.refusal_reason,
                 Some(
                     crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdAlreadyQueued
                 )
@@ -3959,8 +3987,8 @@ mod followup_retry_requeue_tests {
             let snapshot = mailbox_snapshot(&shared, channel_id).await;
             assert_eq!(
                 snapshot.intervention_queue.len(),
-                1,
-                "duplicate pre-submit requeue must not create a second queued prompt"
+                2,
+                "duplicate inflight retry must not create a second queued prompt"
             );
         });
     }

--- a/src/services/discord/outbound/turn_output_controller.rs
+++ b/src/services/discord/outbound/turn_output_controller.rs
@@ -1652,6 +1652,9 @@ mod tests {
             _i: &'a crate::services::discord::Intervention,
             _n: &'a str,
             _h: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             Box::pin(async move { Ok(()) })
         }
@@ -1960,6 +1963,9 @@ mod tests {
             _i: &'a crate::services::discord::Intervention,
             _n: &'a str,
             _h: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             Box::pin(async move { Ok(()) })
         }

--- a/src/services/discord/outbound/turn_output_controller/fresh_send_tests.rs
+++ b/src/services/discord/outbound/turn_output_controller/fresh_send_tests.rs
@@ -70,6 +70,7 @@ impl TurnGateway for CountingGateway {
         _intervention: &'a crate::services::discord::Intervention,
         _request_owner_name: &'a str,
         _has_more_queued_turns: bool,
+        _dispatch_lease: Option<std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>>,
     ) -> GatewayFuture<'a, Result<(), String>> {
         Box::pin(async { Ok(()) })
     }

--- a/src/services/discord/placeholder_controller.rs
+++ b/src/services/discord/placeholder_controller.rs
@@ -771,6 +771,9 @@ mod edit_retry_tests {
             _intervention: &'a crate::services::discord::Intervention,
             _request_owner_name: &'a str,
             _has_more_queued_turns: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             Box::pin(async { Ok(()) })
         }
@@ -1164,6 +1167,9 @@ mod live_events_tests {
             _intervention: &'a crate::services::discord::Intervention,
             _request_owner_name: &'a str,
             _has_more_queued_turns: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             Box::pin(async { Ok(()) })
         }

--- a/src/services/discord/queue_dispatch.rs
+++ b/src/services/discord/queue_dispatch.rs
@@ -103,12 +103,14 @@ pub(super) async fn mailbox_abandon_unclaimed_dispatch_after_success(
     provider: &ProviderKind,
     channel_id: ChannelId,
     user_message_id: MessageId,
+    dispatch_lease: DispatchLeaseHandle,
 ) {
-    let snapshot = super::mailbox_snapshot(shared, channel_id).await;
-    let active_identity_matches =
-        snapshot.cancel_token.is_some() && snapshot.active_user_message_id == Some(user_message_id);
-    if snapshot.pending_user_dispatch == Some(user_message_id) && !active_identity_matches {
-        super::mailbox_abandon_pending_dispatch(shared, provider, channel_id, user_message_id)
-            .await;
-    }
+    shared
+        .mailbox(channel_id)
+        .abandon_pending_dispatch_if_lease_matches(
+            user_message_id,
+            dispatch_lease,
+            super::queue_persistence_context(shared, provider, channel_id),
+        )
+        .await;
 }

--- a/src/services/discord/queue_dispatch.rs
+++ b/src/services/discord/queue_dispatch.rs
@@ -34,6 +34,70 @@ impl MailboxTakeNextSoftOutcome {
     }
 }
 
+pub(super) async fn mailbox_requeue_intervention_front(
+    shared: &SharedData,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    intervention: Intervention,
+) -> MailboxEnqueueOutcome {
+    mailbox_front_requeue_outcome(
+        shared,
+        provider,
+        channel_id,
+        shared.mailbox(channel_id).requeue_front(
+            intervention,
+            super::queue_persistence_context(shared, provider, channel_id),
+        ),
+    )
+    .await
+}
+
+pub(super) async fn mailbox_restore_dequeued_head(
+    shared: &SharedData,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    intervention: Intervention,
+    dispatch_lease: DispatchLeaseHandle,
+) -> MailboxEnqueueOutcome {
+    mailbox_front_requeue_outcome(
+        shared,
+        provider,
+        channel_id,
+        shared.mailbox(channel_id).restore_dequeued_head(
+            intervention,
+            super::queue_persistence_context(shared, provider, channel_id),
+            dispatch_lease,
+        ),
+    )
+    .await
+}
+
+async fn mailbox_front_requeue_outcome(
+    shared: &SharedData,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    request: impl std::future::Future<
+        Output = crate::services::turn_orchestrator::RequeueInterventionResult,
+    >,
+) -> MailboxEnqueueOutcome {
+    let result = request.await;
+    super::apply_queue_exit_feedback(shared, channel_id, &result.queue_exit_events).await;
+    if let Some(error) = result.persistence_error.as_ref() {
+        tracing::warn!(
+            provider = provider.as_str(),
+            channel_id = channel_id.get(),
+            error = %error,
+            "mailbox requeue-front failed durable pending-queue persistence; pending dispatch marker remains the durable backstop"
+        );
+    }
+    MailboxEnqueueOutcome {
+        enqueued: result.enqueued && result.persistence_error.is_none(),
+        merged: false,
+        refusal_reason: result.refusal_reason,
+        persistence_error: result.persistence_error,
+    }
+}
+
 pub(super) async fn mailbox_abandon_unclaimed_dispatch_after_success(
     shared: &SharedData,
     provider: &ProviderKind,

--- a/src/services/discord/queue_dispatch.rs
+++ b/src/services/discord/queue_dispatch.rs
@@ -2,6 +2,30 @@ use super::*;
 
 type DispatchLeaseHandle = Arc<crate::services::turn_orchestrator::DispatchLease>;
 
+pub(super) fn persistence_context(
+    shared: &SharedData,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+) -> crate::services::turn_orchestrator::QueuePersistenceContext {
+    crate::services::turn_orchestrator::QueuePersistenceContext::new(
+        provider,
+        &shared.token_hash,
+        shared
+            .dispatch
+            .role_overrides
+            .get(&channel_id)
+            .map(|override_id| override_id.value().get()),
+    )
+}
+
+pub(super) fn log_kickoff_rejected_restore(provider: &ProviderKind, channel_id: ChannelId) {
+    tracing::error!(
+        provider = provider.as_str(),
+        channel_id = channel_id.get(),
+        "KICKOFF: queued admission failed to restore dequeued head"
+    );
+}
+
 /// Outcome of `mailbox_enqueue_intervention`: exposes both the enqueue
 /// success and whether the incoming intervention was merged into the previous
 /// queue entry, so callers can pick a different reaction emoji for merged

--- a/src/services/discord/recovery_paths/controller_cutover.rs
+++ b/src/services/discord/recovery_paths/controller_cutover.rs
@@ -402,6 +402,9 @@ mod tests {
             _i: &'a crate::services::discord::Intervention,
             _o: &'a str,
             _h: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             panic!("unused TurnGateway method on the recovery short-replace path")
         }

--- a/src/services/discord/router/intake_dispatch/queued.rs
+++ b/src/services/discord/router/intake_dispatch/queued.rs
@@ -12,6 +12,7 @@ pub(crate) enum QueuedAdmissionDisposition {
     Admitted(AdmittedQueuedIntake),
     Deferred,
     RejectedNonPortableAttachment,
+    RejectedRestore,
 }
 
 pub(crate) struct AdmittedQueuedIntake {
@@ -30,6 +31,7 @@ pub(crate) async fn admit_queued_intake(
     defer_watcher_resume: bool,
     wait_for_completion: bool,
     backstop_reason: &'static str,
+    dispatch_lease: Option<std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>>,
 ) -> QueuedAdmissionDisposition {
     let submission = IntakeSubmission {
         provider,
@@ -78,16 +80,35 @@ pub(crate) async fn admit_queued_intake(
             return QueuedAdmissionDisposition::RejectedNonPortableAttachment;
         }
         IntakeAdmission::DeferredOpenRoute { .. } | IntakeAdmission::Blocked { .. } => {
-            // `requeue_front` also consumes the actor's pending-dispatch
-            // reservation, matching the existing hosted-TUI pre-drain defer.
-            // Both queue entrypoints call this before marker/card teardown.
-            super::super::super::mailbox_requeue_intervention_front(
+            let Some(dispatch_lease) = dispatch_lease else {
+                tracing::error!(
+                    provider = submission.provider.as_str(),
+                    channel_id = channel_id.get(),
+                    "queued admission defer is missing its dispatch lease"
+                );
+                return QueuedAdmissionDisposition::RejectedRestore;
+            };
+            let restored = super::super::super::mailbox_restore_dequeued_head(
                 deps.shared,
                 &submission.provider,
                 channel_id,
                 intervention.clone(),
+                dispatch_lease,
             )
             .await;
+            if !restored.enqueued {
+                tracing::error!(
+                    provider = submission.provider.as_str(),
+                    channel_id = channel_id.get(),
+                    refusal_reason = restored
+                        .refusal_reason
+                        .map(|reason| reason.as_str())
+                        .unwrap_or("none"),
+                    persistence_error = restored.persistence_error.as_deref().unwrap_or("none"),
+                    "queued admission defer rejected dequeued-head restore"
+                );
+                return QueuedAdmissionDisposition::RejectedRestore;
+            }
             super::super::super::arm_slow_idle_queue_backstop_if_queue_nonempty(
                 deps.shared,
                 &submission.provider,

--- a/src/services/discord/router/intake_dispatch/tests.rs
+++ b/src/services/discord/router/intake_dispatch/tests.rs
@@ -549,18 +549,31 @@ async fn distinct_open_route_requeues_queued_successor_pg() {
     .expect("predecessor forwards");
 
     let successor = queued_intervention(4_350_412, Vec::new());
+    let persistence = crate::services::discord::queue_persistence_context(
+        &shared,
+        &ProviderKind::Claude,
+        channel_id,
+    );
+    shared
+        .mailbox(channel_id)
+        .replace_queue(vec![successor.clone()], persistence.clone())
+        .await;
+    let dequeued = shared.mailbox(channel_id).take_next_soft(persistence).await;
+    let intervention = dequeued
+        .intervention
+        .expect("queued successor must be dequeued before admission");
     assert!(matches!(
         admit_queued_intake(
             &deps,
             ProviderKind::Claude,
             channel_id,
-            &successor,
-            successor.author_id,
+            &intervention,
+            intervention.author_id,
             "successor-owner".to_string(),
             false,
             false,
             "owner_affinity_open_route_test",
-            None,
+            dequeued.dispatch_lease,
         )
         .await,
         QueuedAdmissionDisposition::Deferred

--- a/src/services/discord/router/intake_dispatch/tests.rs
+++ b/src/services/discord/router/intake_dispatch/tests.rs
@@ -420,12 +420,14 @@ async fn queued_foreign_owner_forwards_without_local_body_pg() {
         false,
         false,
         "owner_affinity_queue_test",
+        None,
     )
     .await
     {
         QueuedAdmissionDisposition::Admitted(admitted) => admitted,
         QueuedAdmissionDisposition::Deferred
-        | QueuedAdmissionDisposition::RejectedNonPortableAttachment => {
+        | QueuedAdmissionDisposition::RejectedNonPortableAttachment
+        | QueuedAdmissionDisposition::RejectedRestore => {
             panic!("live foreign owner should forward")
         }
     };
@@ -483,6 +485,7 @@ async fn queued_foreign_attachment_is_rejected_without_requeue_pg() {
             false,
             false,
             "owner_affinity_attachment_test",
+            None,
         )
         .await,
         QueuedAdmissionDisposition::RejectedNonPortableAttachment
@@ -557,6 +560,7 @@ async fn distinct_open_route_requeues_queued_successor_pg() {
             false,
             false,
             "owner_affinity_open_route_test",
+            None,
         )
         .await,
         QueuedAdmissionDisposition::Deferred

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -43,6 +43,7 @@ use std::future::Future;
 use std::sync::Arc;
 use url::Url;
 mod attachments;
+mod busy_retry;
 mod control;
 mod goal_lifecycle;
 mod headless_turn;

--- a/src/services/discord/router/message_handler/busy_retry.rs
+++ b/src/services/discord/router/message_handler/busy_retry.rs
@@ -11,22 +11,37 @@ pub(super) fn present_or_accepted(outcome: &MailboxEnqueueOutcome) -> bool {
         )
 }
 
-#[allow(clippy::too_many_arguments)]
+pub(super) struct FinalizeEnqueueContext<'a> {
+    pub(super) shared: &'a Arc<SharedData>,
+    pub(super) http: &'a Arc<serenity::http::Http>,
+    pub(super) provider: &'a crate::services::provider::ProviderKind,
+    pub(super) channel_id: ChannelId,
+    pub(super) user_msg_id: MessageId,
+    pub(super) placeholder_msg_id: MessageId,
+    pub(super) turn_start_attempt:
+        Option<crate::services::discord::turn_view_reconciler::TurnStartAttempt>,
+    pub(super) session_retry_context:
+        Option<&'a crate::services::discord::router::turn_start::FormattedSessionRetryContext>,
+    pub(super) feedback_reminder: Option<&'a str>,
+    pub(super) wip_warning: Option<&'a str>,
+}
+
 pub(super) async fn finalize_enqueue(
-    shared: &Arc<SharedData>,
-    http: &Arc<serenity::http::Http>,
-    provider: &crate::services::provider::ProviderKind,
-    channel_id: ChannelId,
-    user_msg_id: MessageId,
-    placeholder_msg_id: MessageId,
-    turn_start_attempt: Option<crate::services::discord::turn_view_reconciler::TurnStartAttempt>,
-    session_retry_context: Option<
-        &crate::services::discord::router::turn_start::FormattedSessionRetryContext,
-    >,
-    feedback_reminder: Option<&str>,
-    wip_warning: Option<&str>,
+    context: FinalizeEnqueueContext<'_>,
     outcome: &MailboxEnqueueOutcome,
 ) -> bool {
+    let FinalizeEnqueueContext {
+        shared,
+        http,
+        provider,
+        channel_id,
+        user_msg_id,
+        placeholder_msg_id,
+        turn_start_attempt,
+        session_retry_context,
+        feedback_reminder,
+        wip_warning,
+    } = context;
     let accepted = present_or_accepted(outcome);
     if outcome.enqueued {
         super::intake_turn::race_loss::mailbox_reaction::note_busy_tui_pre_submit_queue_pending(

--- a/src/services/discord/router/message_handler/busy_retry.rs
+++ b/src/services/discord/router/message_handler/busy_retry.rs
@@ -1,0 +1,76 @@
+use super::*;
+
+pub(super) fn present_or_accepted(outcome: &MailboxEnqueueOutcome) -> bool {
+    outcome.enqueued
+        || matches!(
+            outcome.refusal_reason,
+            Some(
+                crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdAlreadyQueued
+                    | crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdPendingOrActive
+            )
+        )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn finalize_enqueue(
+    shared: &Arc<SharedData>,
+    http: &Arc<serenity::http::Http>,
+    provider: &crate::services::provider::ProviderKind,
+    channel_id: ChannelId,
+    user_msg_id: MessageId,
+    placeholder_msg_id: MessageId,
+    turn_start_attempt: Option<crate::services::discord::turn_view_reconciler::TurnStartAttempt>,
+    session_retry_context: Option<
+        &crate::services::discord::router::turn_start::FormattedSessionRetryContext,
+    >,
+    feedback_reminder: Option<&str>,
+    wip_warning: Option<&str>,
+    outcome: &MailboxEnqueueOutcome,
+) -> bool {
+    let accepted = present_or_accepted(outcome);
+    if outcome.enqueued {
+        super::intake_turn::race_loss::mailbox_reaction::note_busy_tui_pre_submit_queue_pending(
+            shared,
+            http,
+            channel_id,
+            user_msg_id,
+            outcome.merged,
+            turn_start_attempt,
+        )
+        .await;
+        let _ = channel_id.delete_message(http, placeholder_msg_id).await;
+    } else if accepted {
+        tracing::info!(
+            channel_id = channel_id.get(),
+            user_msg_id = user_msg_id.get(),
+            refusal_reason = outcome
+                .refusal_reason
+                .map(|reason| reason.as_str())
+                .unwrap_or("none"),
+            "claude_tui follow-up retry already queued or in progress"
+        );
+        let _ = channel_id.delete_message(http, placeholder_msg_id).await;
+    } else {
+        super::tui_followup::apply_tui_busy_enqueue_refusal(
+            shared,
+            http,
+            provider,
+            channel_id,
+            placeholder_msg_id,
+            session_retry_context,
+            feedback_reminder,
+            wip_warning,
+            outcome.refusal_reason,
+        )
+        .await;
+        crate::services::discord::turn_view_reconciler::note_intake_turn_cleared_current(
+            shared,
+            http,
+            channel_id,
+            user_msg_id,
+            "intake_busy_queue",
+        )
+        .await;
+    }
+    accepted
+}

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -9,7 +9,7 @@ use super::*;
 mod adk_thread;
 mod claim_bootstrap;
 pub(crate) mod inflight_create_log;
-mod race_loss;
+pub(super) mod race_loss;
 mod stale_dispatch_guard;
 mod steering_hook;
 mod turn_watchdog;
@@ -2185,35 +2185,23 @@ pub(super) async fn handle_text_message(
                 .await
                 .intervention_queue
                 .len();
+        let retry_present_or_accepted = busy_retry::finalize_enqueue(
+            shared,
+            http,
+            &provider,
+            channel_id,
+            user_msg_id,
+            placeholder_msg_id,
+            turn_start_attempt,
+            session_retry_context.as_ref(),
+            feedback_reminder.as_deref(),
+            wip_warning.as_deref(),
+            &enqueue_outcome,
+        )
+        .await;
         let queued_card_rendered = false;
-        if enqueue_outcome.enqueued {
-            race_loss::mailbox_reaction::note_busy_tui_pre_submit_queue_pending(
-                shared,
-                http,
-                channel_id,
-                user_msg_id,
-                enqueue_outcome.merged,
-                turn_start_attempt,
-            )
-            .await;
-            let _ = channel_id.delete_message(http, placeholder_msg_id).await;
-        } else {
-            apply_tui_busy_enqueue_refusal(
-                shared,
-                http,
-                &provider,
-                channel_id,
-                placeholder_msg_id,
-                session_retry_context.as_ref(),
-                feedback_reminder.as_deref(),
-                wip_warning.as_deref(),
-                enqueue_outcome.refusal_reason,
-            )
-            .await;
-            tv_clear_current(shared, http, channel_id, user_msg_id, "intake_busy_queue").await;
-        }
         let queue_kickoff_scheduled =
-            queue_kickoff_scheduled_by_release || enqueue_outcome.enqueued;
+            queue_kickoff_scheduled_by_release || retry_present_or_accepted;
         let mut diagnostic_json = diagnostic.to_json();
         if let Some(object) = diagnostic_json.as_object_mut() {
             object.insert(

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2186,16 +2186,18 @@ pub(super) async fn handle_text_message(
                 .intervention_queue
                 .len();
         let retry_present_or_accepted = busy_retry::finalize_enqueue(
-            shared,
-            http,
-            &provider,
-            channel_id,
-            user_msg_id,
-            placeholder_msg_id,
-            turn_start_attempt,
-            session_retry_context.as_ref(),
-            feedback_reminder.as_deref(),
-            wip_warning.as_deref(),
+            busy_retry::FinalizeEnqueueContext {
+                shared,
+                http,
+                provider: &provider,
+                channel_id,
+                user_msg_id,
+                placeholder_msg_id,
+                turn_start_attempt,
+                session_retry_context: session_retry_context.as_ref(),
+                feedback_reminder: feedback_reminder.as_deref(),
+                wip_warning: wip_warning.as_deref(),
+            },
             &enqueue_outcome,
         )
         .await;

--- a/src/services/discord/router/message_handler/intake_turn/race_loss.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(in crate::services::discord::router::message_handler::intake_turn) mod mailbox_reaction;
+pub(in crate::services::discord::router::message_handler) mod mailbox_reaction;
 
 async fn enqueue_race_loss_requeued_intervention(
     shared: &Arc<SharedData>,

--- a/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction.rs
@@ -18,7 +18,7 @@ pub(super) async fn clear_rejected_attempt_pending(
     .await;
 }
 
-pub(in crate::services::discord::router::message_handler::intake_turn) async fn note_busy_tui_pre_submit_queue_pending(
+pub(in crate::services::discord::router::message_handler) async fn note_busy_tui_pre_submit_queue_pending(
     shared: &Arc<SharedData>,
     http: &Arc<serenity::http::Http>,
     channel_id: ChannelId,

--- a/src/services/discord/router/message_handler/tui_followup.rs
+++ b/src/services/discord/router/message_handler/tui_followup.rs
@@ -875,7 +875,7 @@ pub(super) async fn enqueue_busy_tui_followup_for_retry(
     pending_uploads: Vec<String>,
     voice_announcement: Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
 ) -> MailboxEnqueueOutcome {
-    let result = super::super::super::mailbox_requeue_intervention_front(
+    super::super::super::mailbox_requeue_intervention_front(
         shared,
         provider,
         channel_id,
@@ -891,13 +891,7 @@ pub(super) async fn enqueue_busy_tui_followup_for_retry(
             voice_announcement,
         ),
     )
-    .await;
-    MailboxEnqueueOutcome {
-        enqueued: result.persistence_error.is_none(),
-        merged: false,
-        refusal_reason: None,
-        persistence_error: result.persistence_error,
-    }
+    .await
 }
 
 #[cfg(test)]

--- a/src/services/discord/router/message_handler/tui_followup.rs
+++ b/src/services/discord/router/message_handler/tui_followup.rs
@@ -829,17 +829,32 @@ pub(in crate::services::discord) async fn defer_promoted_dispatch_if_hosted_tui_
     provider: &ProviderKind,
     channel_id: serenity::ChannelId,
     intervention: &crate::services::turn_orchestrator::Intervention,
+    dispatch_lease: Arc<crate::services::turn_orchestrator::DispatchLease>,
 ) -> bool {
     if !hosted_tui_promote_readiness_blocked(shared, provider, channel_id).await {
         return false;
     }
-    super::super::super::mailbox_requeue_intervention_front(
+    let restored = super::super::super::mailbox_restore_dequeued_head(
         shared,
         provider,
         channel_id,
         intervention.clone(),
+        dispatch_lease,
     )
     .await;
+    if !restored.enqueued {
+        tracing::error!(
+            provider = provider.as_str(),
+            channel_id = channel_id.get(),
+            refusal_reason = restored
+                .refusal_reason
+                .map(|reason| reason.as_str())
+                .unwrap_or("none"),
+            persistence_error = restored.persistence_error.as_deref().unwrap_or("none"),
+            "hosted TUI promote defer rejected dequeued-head restore"
+        );
+        return false;
+    }
     super::super::super::arm_slow_idle_queue_backstop_if_queue_nonempty(
         shared,
         provider,

--- a/src/services/discord/router/message_handler/tui_followup.rs
+++ b/src/services/discord/router/message_handler/tui_followup.rs
@@ -13,9 +13,10 @@ pub(super) fn claude_tui_busy_followup_refusal_notice(
     reason: Option<crate::services::turn_orchestrator::EnqueueRefusalReason>,
 ) -> &'static str {
     match reason {
-        Some(crate::services::turn_orchestrator::EnqueueRefusalReason::AlreadyActiveTurn) => {
-            CLAUDE_TUI_BUSY_FOLLOWUP_ALREADY_ACTIVE_NOTICE
-        }
+        Some(
+            crate::services::turn_orchestrator::EnqueueRefusalReason::AlreadyActiveTurn
+            | crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdPendingOrActive,
+        ) => CLAUDE_TUI_BUSY_FOLLOWUP_ALREADY_ACTIVE_NOTICE,
         Some(crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdAlreadyQueued) => {
             CLAUDE_TUI_BUSY_FOLLOWUP_ALREADY_QUEUED_NOTICE
         }
@@ -961,6 +962,13 @@ mod busy_retry_fifo_tests {
             .intervention
             .expect("A is dequeued first");
         assert_eq!(dequeued.message_id, first.message_id);
+        crate::services::discord::mailbox_clear_pending_dispatch_reservation(
+            &shared,
+            &provider,
+            channel_id,
+            dequeued.message_id,
+        )
+        .await;
 
         let retry = enqueue_busy_tui_followup_for_retry(
             &shared,
@@ -1043,6 +1051,67 @@ mod busy_retry_fifo_tests {
             .expect("normal FIFO returns B");
         assert_eq!(normal_first.message_id, first.message_id);
         assert_eq!(normal_second.message_id, second.message_id);
+    }
+
+    #[test]
+    fn busy_retry_treats_pending_or_active_source_as_already_processing_4797() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = tempfile::tempdir().expect("temporary runtime root");
+        let _root_guard = RuntimeRootGuard(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+
+        runtime.block_on(async {
+            let shared = make_shared_data_for_tests();
+            let provider = ProviderKind::Claude;
+            let channel_id = serenity::ChannelId::new(4_797_301);
+            let first = intervention(4_797_302, 4_797_303, "pending A", false);
+            let persistence =
+                crate::services::discord::queue_persistence_context(&shared, &provider, channel_id);
+            shared
+                .mailbox(channel_id)
+                .replace_queue(vec![first.clone()], persistence.clone())
+                .await;
+            let dequeued = shared
+                .mailbox(channel_id)
+                .take_next_soft(persistence)
+                .await
+                .intervention
+                .expect("A is pending dispatch");
+
+            let retry = enqueue_busy_tui_followup_for_retry(
+                &shared,
+                &provider,
+                channel_id,
+                dequeued.author_id,
+                dequeued.message_id,
+                &dequeued.text,
+                dequeued.preserve_on_cancel(),
+                dequeued.reply_context,
+                dequeued.has_reply_boundary,
+                dequeued.merge_consecutive,
+                dequeued.pending_uploads,
+                dequeued.voice_announcement,
+            )
+            .await;
+
+            assert!(!retry.enqueued);
+            assert_eq!(
+                retry.refusal_reason,
+                Some(
+                    crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdPendingOrActive
+                )
+            );
+            assert!(super::super::busy_retry::present_or_accepted(&retry));
+            let snapshot = crate::services::discord::mailbox_snapshot(&shared, channel_id).await;
+            assert!(snapshot.intervention_queue.is_empty());
+            assert_eq!(snapshot.pending_user_dispatch, Some(first.message_id));
+        });
     }
 }
 

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -2951,6 +2951,9 @@ mod tests {
             _i: &'a super::super::Intervention,
             _o: &'a str,
             _h: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> super::super::gateway::GatewayFuture<'a, Result<(), String>> {
             panic!("unused TurnGateway method on the short-replace path")
         }

--- a/src/services/discord/standby_relay.rs
+++ b/src/services/discord/standby_relay.rs
@@ -1756,6 +1756,9 @@ mod tests {
                 _i: &'a crate::services::discord::Intervention,
                 _o: &'a str,
                 _h: bool,
+                _dispatch_lease: Option<
+                    std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+                >,
             ) -> GatewayFuture<'a, Result<(), String>> {
                 panic!("unused TurnGateway method on the standby short-replace path")
             }

--- a/src/services/discord/tmux_overload_retry.rs
+++ b/src/services/discord/tmux_overload_retry.rs
@@ -294,6 +294,9 @@ mod completion_release_tests {
             _intervention: &'a Intervention,
             _request_owner_name: &'a str,
             _has_more_queued_turns: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             Box::pin(async { Ok(()) })
         }

--- a/src/services/discord/tmux_watcher/tests.rs
+++ b/src/services/discord/tmux_watcher/tests.rs
@@ -4183,6 +4183,9 @@ mod watcher_short_replace_controller {
             _i: &'a crate::services::discord::Intervention,
             _o: &'a str,
             _h: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             panic!("unused on the short-replace path")
         }
@@ -4285,6 +4288,9 @@ mod watcher_short_replace_controller {
             _i: &'a crate::services::discord::Intervention,
             _o: &'a str,
             _h: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             panic!("unused on long chunks")
         }
@@ -4566,6 +4572,9 @@ mod watcher_short_replace_controller {
                 _i: &'a crate::services::discord::Intervention,
                 _o: &'a str,
                 _h: bool,
+                _dispatch_lease: Option<
+                    std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+                >,
             ) -> GatewayFuture<'a, Result<(), String>> {
                 panic!("unused")
             }

--- a/src/services/discord/tmux_watcher/turn_identity_tests.rs
+++ b/src/services/discord/tmux_watcher/turn_identity_tests.rs
@@ -534,6 +534,9 @@ async fn live_long_chunk_delivery_fingerprint_uses_raw_body_4081() {
             _intervention: &'a crate::services::discord::Intervention,
             _origin: &'a str,
             _include_history: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             panic!("long-chunk pin must not dispatch queued turns")
         }

--- a/src/services/discord/tui_prompt_relay/bridge_gateway.rs
+++ b/src/services/discord/tui_prompt_relay/bridge_gateway.rs
@@ -152,15 +152,27 @@ impl TurnGateway for TuiDirectBridgeGateway {
         intervention: &'a Intervention,
         _request_owner_name: &'a str,
         has_more_queued_turns: bool,
+        dispatch_lease: Option<std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>>,
     ) -> GatewayFuture<'a, Result<(), String>> {
         Box::pin(async move {
-            mailbox_requeue_intervention_front(
+            let restored = super::super::mailbox_restore_dequeued_head(
                 &self.shared,
                 &self.provider,
                 channel_id,
                 intervention.clone(),
+                dispatch_lease
+                    .ok_or_else(|| "queued bridge dispatch is missing its lease".to_string())?,
             )
             .await;
+            if !restored.enqueued {
+                return Err(format!(
+                    "queued bridge restore rejected: {}",
+                    restored
+                        .refusal_reason
+                        .map(|reason| reason.as_str())
+                        .unwrap_or("persistence_error")
+                ));
+            }
             schedule_deferred_idle_queue_kickoff(
                 self.shared.clone(),
                 self.provider.clone(),

--- a/src/services/discord/turn_bridge/finalize_epilogue.rs
+++ b/src/services/discord/turn_bridge/finalize_epilogue.rs
@@ -98,25 +98,44 @@ pub(super) async fn finalize_and_drain_queued_turns(
                             &intervention,
                             &request_owner_name,
                             has_more_queued_turns,
+                            dispatch_lease.clone(),
                         )
                         .await;
                     match dispatch_result {
                         Err(e) => {
                             let ts = chrono::Local::now().format("%H:%M:%S");
                             tracing::info!("  [{ts}]   ⚠ queued command failed: {e}");
-                            super::super::mailbox_requeue_intervention_front(
+                            let requeue = super::super::mailbox_restore_dequeued_head(
                                 &shared_owned,
                                 &bot_owner_provider,
                                 channel_id,
                                 intervention,
+                                dispatch_lease
+                                    .as_ref()
+                                    .expect("dequeued intervention must carry its dispatch lease")
+                                    .clone(),
                             )
                             .await;
-                            super::super::schedule_deferred_idle_queue_kickoff(
-                                shared_owned.clone(),
-                                bot_owner_provider.clone(),
-                                channel_id,
-                                "requeue-front after dispatch failure (finalize epilogue)",
-                            );
+                            if requeue.enqueued {
+                                super::super::schedule_deferred_idle_queue_kickoff(
+                                    shared_owned.clone(),
+                                    bot_owner_provider.clone(),
+                                    channel_id,
+                                    "requeue-front after dispatch failure (finalize epilogue)",
+                                );
+                            } else {
+                                tracing::error!(
+                                    provider = bot_owner_provider.as_str(),
+                                    channel_id = channel_id.get(),
+                                    refusal_reason = requeue
+                                        .refusal_reason
+                                        .map(|reason| reason.as_str())
+                                        .unwrap_or("none"),
+                                    persistence_error =
+                                        requeue.persistence_error.as_deref().unwrap_or("none"),
+                                    "queued command dispatch failed and dequeued-head restore was rejected"
+                                );
+                            }
                         }
                         Ok(()) => {
                             super::super::mailbox_abandon_unclaimed_dispatch_after_success(
@@ -209,6 +228,9 @@ mod tests {
             _intervention: &'a Intervention,
             _request_owner_name: &'a str,
             _has_more_queued_turns: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> TestGatewayFuture<'a, Result<(), String>> {
             Box::pin(async { Err("forced dispatch failure".to_string()) })
         }

--- a/src/services/discord/turn_bridge/finalize_epilogue.rs
+++ b/src/services/discord/turn_bridge/finalize_epilogue.rs
@@ -143,6 +143,10 @@ pub(super) async fn finalize_and_drain_queued_turns(
                                 &bot_owner_provider,
                                 channel_id,
                                 intervention.message_id,
+                                dispatch_lease
+                                    .as_ref()
+                                    .expect("dequeued intervention must carry its dispatch lease")
+                                    .clone(),
                             )
                             .await;
                         }

--- a/src/services/discord/turn_bridge/followup_requeue.rs
+++ b/src/services/discord/turn_bridge/followup_requeue.rs
@@ -3,7 +3,10 @@ use super::*;
 fn should_publish_queue_marker(outcome: &crate::services::discord::MailboxEnqueueOutcome) -> bool {
     !matches!(
         outcome.refusal_reason,
-        Some(crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdAlreadyQueued)
+        Some(
+            crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdAlreadyQueued
+                | crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdPendingOrActive
+        )
     )
 }
 
@@ -13,6 +16,7 @@ fn retry_present_or_accepted(outcome: &crate::services::discord::MailboxEnqueueO
             outcome.refusal_reason,
             Some(
                 crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdAlreadyQueued
+                    | crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdPendingOrActive
                     | crate::services::turn_orchestrator::EnqueueRefusalReason::LastItemDedup
             )
         )

--- a/src/services/discord/turn_bridge/status_panel_tests.rs
+++ b/src/services/discord/turn_bridge/status_panel_tests.rs
@@ -113,6 +113,7 @@ impl TurnGateway for StatusPanelFallbackGateway {
         _intervention: &'a super::super::Intervention,
         _request_owner_name: &'a str,
         _has_more_queued_turns: bool,
+        _dispatch_lease: Option<std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>>,
     ) -> TestGatewayFuture<'a, Result<(), String>> {
         Box::pin(async { Ok(()) })
     }

--- a/src/services/discord/turn_bridge/stream_tick.rs
+++ b/src/services/discord/turn_bridge/stream_tick.rs
@@ -843,6 +843,9 @@ mod provider_output_guard_tests {
             _intervention: &'a Intervention,
             _request_owner_name: &'a str,
             _has_more_queued_turns: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             Box::pin(async { Ok(()) })
         }

--- a/src/services/discord/turn_bridge/terminal_controller_cutover.rs
+++ b/src/services/discord/turn_bridge/terminal_controller_cutover.rs
@@ -1097,6 +1097,9 @@ mod tests {
                 _i: &'a crate::services::discord::Intervention,
                 _o: &'a str,
                 _h: bool,
+                _dispatch_lease: Option<
+                    std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+                >,
             ) -> GatewayFuture<'a, Result<(), String>> {
                 panic!("unused on the short-replace path")
             }
@@ -1322,6 +1325,9 @@ mod tests {
                 _i: &'a crate::services::discord::Intervention,
                 _o: &'a str,
                 _h: bool,
+                _dispatch_lease: Option<
+                    std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+                >,
             ) -> GatewayFuture<'a, Result<(), String>> {
                 panic!("unused on the long-chunk path")
             }

--- a/src/services/discord/turn_bridge/terminal_delivery.rs
+++ b/src/services/discord/turn_bridge/terminal_delivery.rs
@@ -852,6 +852,9 @@ mod tests {
             _intervention: &'a crate::services::discord::Intervention,
             _request_owner_name: &'a str,
             _has_more_queued_turns: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             Box::pin(async { Ok(()) })
         }

--- a/src/services/discord/turn_bridge/terminal_outcome_delivery/prompt_too_long_guidance.rs
+++ b/src/services/discord/turn_bridge/terminal_outcome_delivery/prompt_too_long_guidance.rs
@@ -75,6 +75,9 @@ mod tests {
             _intervention: &'a Intervention,
             _request_owner_name: &'a str,
             _has_more_queued_turns: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> TestGatewayFuture<'a, Result<(), String>> {
             panic!("prompt-too-long replacement must not dispatch a queued turn")
         }

--- a/src/services/discord/turn_bridge/two_message_panel.rs
+++ b/src/services/discord/turn_bridge/two_message_panel.rs
@@ -436,6 +436,9 @@ mod tests {
             _intervention: &'a super::super::Intervention,
             _request_owner_name: &'a str,
             _has_more_queued_turns: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             Box::pin(async { Ok(()) })
         }

--- a/src/services/discord/turn_bridge/watcher_orphan_cleanup.rs
+++ b/src/services/discord/turn_bridge/watcher_orphan_cleanup.rs
@@ -360,6 +360,9 @@ mod watcher_orphan_cleanup_tests {
             _intervention: &'a super::super::Intervention,
             _request_owner_name: &'a str,
             _has_more_queued_turns: bool,
+            _dispatch_lease: Option<
+                std::sync::Arc<crate::services::turn_orchestrator::DispatchLease>,
+            >,
         ) -> GatewayFuture<'a, Result<(), String>> {
             Box::pin(async { Ok(()) })
         }

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -14,6 +14,7 @@ use crate::services::provider::{CancelToken, ProviderKind};
 mod active_source_dedup;
 mod dispatch_reservation;
 mod episode_identity;
+mod front_requeue;
 mod overflow;
 mod pending_queue_persistence;
 mod queue_cancellation;
@@ -36,6 +37,7 @@ use dispatch_reservation::{
     record_valve_cleared_pending_dispatch, set_pending_user_dispatch,
 };
 use episode_identity::{TurnNonceGuard, turn_nonce_guard_matches};
+use front_requeue::requeue_intervention_front;
 pub(crate) use overflow::SoftInterventionProbe;
 use overflow::drain_head_overflow;
 #[cfg(test)]
@@ -443,53 +445,6 @@ pub(crate) fn enqueue_intervention(
 
     queue.push(intervention);
     queue_exit_events.extend(drain_head_overflow(queue));
-    EnqueueInterventionResult {
-        enqueued: true,
-        merged: false,
-        refusal_reason: None,
-        queue_exit_events,
-        persistence_error: None,
-    }
-}
-
-pub(crate) fn requeue_intervention_front(
-    queue: &mut Vec<Intervention>,
-    mut intervention: Intervention,
-    pending_user_dispatch: Option<MessageId>,
-    active_user_message_id: Option<MessageId>,
-) -> EnqueueInterventionResult {
-    let mut queue_exit_events = prune_interventions(queue);
-    ensure_source_message_ids(&mut intervention);
-    let source_id = intervention.message_id;
-    let refusal_reason =
-        if pending_user_dispatch == Some(source_id) || active_user_message_id == Some(source_id) {
-            Some(EnqueueRefusalReason::SourceIdPendingOrActive)
-        } else if queue
-            .iter()
-            .any(|item| item.source_message_ids.contains(&source_id))
-        {
-            Some(EnqueueRefusalReason::SourceIdAlreadyQueued)
-        } else {
-            None
-        };
-    if let Some(refusal_reason) = refusal_reason {
-        return EnqueueInterventionResult {
-            enqueued: false,
-            merged: false,
-            refusal_reason: Some(refusal_reason),
-            queue_exit_events,
-            persistence_error: None,
-        };
-    }
-    queue.insert(0, intervention);
-    if queue.len() > MAX_INTERVENTIONS_PER_CHANNEL {
-        // #4260: the tail drain here is a capacity evict too — genuine loss.
-        queue_exit_events.extend(
-            queue
-                .drain(MAX_INTERVENTIONS_PER_CHANNEL..)
-                .map(|intervention| QueueExitEvent::new(intervention, QueueExitKind::Overflow)),
-        );
-    }
     EnqueueInterventionResult {
         enqueued: true,
         merged: false,
@@ -1135,10 +1090,31 @@ impl ChannelMailboxHandle {
         intervention: Intervention,
         persistence: QueuePersistenceContext,
     ) -> RequeueInterventionResult {
+        self.requeue_front_inner(intervention, persistence, None)
+            .await
+    }
+
+    pub(crate) async fn restore_dequeued_head(
+        &self,
+        intervention: Intervention,
+        persistence: QueuePersistenceContext,
+        dispatch_lease: Arc<DispatchLease>,
+    ) -> RequeueInterventionResult {
+        self.requeue_front_inner(intervention, persistence, Some(dispatch_lease))
+            .await
+    }
+
+    async fn requeue_front_inner(
+        &self,
+        intervention: Intervention,
+        persistence: QueuePersistenceContext,
+        dispatch_lease: Option<Arc<DispatchLease>>,
+    ) -> RequeueInterventionResult {
         self.request(
             |reply| ChannelMailboxMsg::RequeueFront {
                 intervention,
                 persistence,
+                dispatch_lease,
                 reply,
             },
             RequeueInterventionResult {
@@ -1793,6 +1769,7 @@ enum ChannelMailboxMsg {
     RequeueFront {
         intervention: Intervention,
         persistence: QueuePersistenceContext,
+        dispatch_lease: Option<Arc<DispatchLease>>,
         reply: oneshot::Sender<RequeueInterventionResult>,
     },
     AbandonPendingDispatch {
@@ -2777,21 +2754,24 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                 ChannelMailboxMsg::RequeueFront {
                     intervention,
                     persistence,
+                    dispatch_lease,
                     reply,
                 } => {
                     state.last_persistence = Some(persistence.clone());
-                    // #3167 BLOCKER-2 — a failed dispatch requeues the reserved
-                    // head: clear the dequeue→claim reservation so the now
-                    // non-empty queue (not the stale reservation) governs the
-                    // Background gate, and reset the safety-valve counter.
-                    let requeued_id = intervention.message_id;
-                    let requeued_reserved = state.pending_user_dispatch == Some(requeued_id);
+                    let identity_ids = front_requeue::intervention_identity_ids(&intervention);
+                    let authorized_pending_restore = dispatch_lease.as_ref().and_then(|lease| {
+                        let pending = state.pending_user_dispatch?;
+                        let stored = state.pending_user_dispatch_lease.as_ref()?;
+                        (identity_ids.contains(&pending) && Arc::ptr_eq(lease, stored))
+                            .then_some(pending)
+                    });
                     let previous_queue = state.intervention_queue.clone();
                     let requeue_result = requeue_intervention_front(
                         &mut state.intervention_queue,
                         intervention,
                         state.pending_user_dispatch,
                         state.active_user_message_id,
+                        authorized_pending_restore,
                     );
                     let result = if !requeue_result.enqueued {
                         RequeueInterventionResult {
@@ -2807,9 +2787,6 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                         previous_queue,
                         "requeue_front",
                     ) {
-                        if requeued_reserved {
-                            clear_pending_user_dispatch(&mut state);
-                        }
                         RequeueInterventionResult {
                             enqueued: false,
                             refusal_reason: None,
@@ -2817,18 +2794,18 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                             persistence_error: Some(error),
                         }
                     } else {
-                        if requeued_reserved {
+                        if let Some(pending) = authorized_pending_restore {
                             consume_pending_dispatch_marker_if_matches(
                                 &mut state,
                                 channel_id,
-                                requeued_id,
-                                "requeue_front",
+                                pending,
+                                "restore_dequeued_head",
                             );
                             clear_pending_user_dispatch(&mut state);
                         }
                         RequeueInterventionResult {
-                            enqueued: requeue_result.enqueued,
-                            refusal_reason: requeue_result.refusal_reason,
+                            enqueued: true,
+                            refusal_reason: None,
                             queue_exit_events: requeue_result.queue_exit_events,
                             persistence_error: None,
                         }
@@ -5403,7 +5380,8 @@ mod no_ttl_evict_tests {
         let mut queue: Vec<Intervention> = (0..(MAX_INTERVENTIONS_PER_CHANNEL as u64))
             .map(|i| intervention_at(i + 2, now))
             .collect();
-        let result = requeue_intervention_front(&mut queue, intervention_at(1, now), None, None);
+        let result =
+            requeue_intervention_front(&mut queue, intervention_at(1, now), None, None, None);
         assert_eq!(
             result.queue_exit_events.len(),
             1,
@@ -5609,7 +5587,9 @@ mod persistence_tests {
             let marker_path = marker_file_path(tmp.path(), &provider, token_hash, channel_id);
             assert!(marker_path.exists());
 
-            let requeue = handle.requeue_front(intervention, persistence).await;
+            let requeue = handle
+                .restore_dequeued_head(intervention, persistence, dispatch_lease.clone())
+                .await;
 
             assert!(requeue.persistence_error.is_none());
             assert_eq!(
@@ -6227,6 +6207,107 @@ mod persistence_tests {
             let snapshot = handle.snapshot().await;
             assert!(snapshot.intervention_queue.is_empty());
             assert_eq!(snapshot.active_user_message_id, Some(head.message_id));
+        });
+    }
+
+    fn merged_intervention(primary: u64, source: u64) -> Intervention {
+        let mut intervention = make_intervention(primary, "merged retry", None);
+        intervention.source_message_ids = vec![MessageId::new(source), MessageId::new(primary)];
+        intervention
+    }
+
+    #[test]
+    fn requeue_front_rejects_merged_source_pending_4797() {
+        let _lock = lock_test_env();
+        let tmp = tempfile::tempdir().unwrap();
+        let _env_guard = EnvGuard::set_root(tmp.path());
+        run_async(async {
+            let provider = ProviderKind::Claude;
+            let channel_id = ChannelId::new(4_797_205);
+            let persistence = QueuePersistenceContext::new(&provider, "merged-pending", None);
+            let handle = ChannelMailboxRegistry::default().handle(channel_id);
+            let source = make_intervention(4_797_206, "source A", None);
+            handle
+                .replace_queue(vec![source.clone()], persistence.clone())
+                .await;
+            let _taken = handle.take_next_soft(persistence.clone()).await;
+
+            let result = handle
+                .requeue_front(
+                    merged_intervention(4_797_207, source.message_id.get()),
+                    persistence,
+                )
+                .await;
+
+            assert!(!result.enqueued);
+            assert_eq!(
+                result.refusal_reason,
+                Some(EnqueueRefusalReason::SourceIdPendingOrActive)
+            );
+            assert_eq!(
+                handle.snapshot().await.pending_user_dispatch,
+                Some(source.message_id)
+            );
+        });
+    }
+
+    #[test]
+    fn requeue_front_rejects_merged_source_active_4797() {
+        let _lock = lock_test_env();
+        let tmp = tempfile::tempdir().unwrap();
+        let _env_guard = EnvGuard::set_root(tmp.path());
+        run_async(async {
+            let provider = ProviderKind::Claude;
+            let channel_id = ChannelId::new(4_797_208);
+            let persistence = QueuePersistenceContext::new(&provider, "merged-active", None);
+            let handle = ChannelMailboxRegistry::default().handle(channel_id);
+            let source_id = MessageId::new(4_797_209);
+            assert!(
+                handle
+                    .try_start_turn(Arc::new(CancelToken::new()), UserId::new(1), source_id)
+                    .await
+            );
+
+            let result = handle
+                .requeue_front(merged_intervention(4_797_210, source_id.get()), persistence)
+                .await;
+
+            assert!(!result.enqueued);
+            assert_eq!(
+                result.refusal_reason,
+                Some(EnqueueRefusalReason::SourceIdPendingOrActive)
+            );
+        });
+    }
+
+    #[test]
+    fn requeue_front_rejects_merged_source_queued_4797() {
+        let _lock = lock_test_env();
+        let tmp = tempfile::tempdir().unwrap();
+        let _env_guard = EnvGuard::set_root(tmp.path());
+        run_async(async {
+            let provider = ProviderKind::Claude;
+            let channel_id = ChannelId::new(4_797_211);
+            let persistence = QueuePersistenceContext::new(&provider, "merged-queued", None);
+            let handle = ChannelMailboxRegistry::default().handle(channel_id);
+            let source = make_intervention(4_797_212, "queued A", None);
+            handle
+                .replace_queue(vec![source.clone()], persistence.clone())
+                .await;
+
+            let result = handle
+                .requeue_front(
+                    merged_intervention(4_797_213, source.message_id.get()),
+                    persistence,
+                )
+                .await;
+
+            assert!(!result.enqueued);
+            assert_eq!(
+                result.refusal_reason,
+                Some(EnqueueRefusalReason::SourceIdAlreadyQueued)
+            );
+            assert_eq!(handle.snapshot().await.intervention_queue.len(), 1);
         });
     }
 

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -454,9 +454,22 @@ pub(crate) fn enqueue_intervention(
 
 pub(crate) fn requeue_intervention_front(
     queue: &mut Vec<Intervention>,
-    intervention: Intervention,
-) -> Vec<QueueExitEvent> {
+    mut intervention: Intervention,
+) -> EnqueueInterventionResult {
     let mut queue_exit_events = prune_interventions(queue);
+    ensure_source_message_ids(&mut intervention);
+    if queue
+        .iter()
+        .any(|item| item.source_message_ids.contains(&intervention.message_id))
+    {
+        return EnqueueInterventionResult {
+            enqueued: false,
+            merged: false,
+            refusal_reason: Some(EnqueueRefusalReason::SourceIdAlreadyQueued),
+            queue_exit_events,
+            persistence_error: None,
+        };
+    }
     queue.insert(0, intervention);
     if queue.len() > MAX_INTERVENTIONS_PER_CHANNEL {
         // #4260: the tail drain here is a capacity evict too — genuine loss.
@@ -466,7 +479,13 @@ pub(crate) fn requeue_intervention_front(
                 .map(|intervention| QueueExitEvent::new(intervention, QueueExitKind::Overflow)),
         );
     }
-    queue_exit_events
+    EnqueueInterventionResult {
+        enqueued: true,
+        merged: false,
+        refusal_reason: None,
+        queue_exit_events,
+        persistence_error: None,
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -680,10 +699,9 @@ pub(crate) struct TakeNextSoftResult {
 }
 
 pub(crate) struct RequeueInterventionResult {
+    pub(crate) enqueued: bool,
+    pub(crate) refusal_reason: Option<EnqueueRefusalReason>,
     pub(crate) queue_exit_events: Vec<QueueExitEvent>,
-    // Uniform queue-mutation persistence-result surface, consumed by
-    // `enqueue_busy_tui_followup_for_retry` (#4795) to build its
-    // MailboxEnqueueOutcome. See `FinishTurnResult`.
     pub(crate) persistence_error: Option<String>,
 }
 
@@ -1109,6 +1127,8 @@ impl ChannelMailboxHandle {
                 reply,
             },
             RequeueInterventionResult {
+                enqueued: false,
+                refusal_reason: None,
                 queue_exit_events: Vec::new(),
                 persistence_error: None,
             },
@@ -2754,7 +2774,14 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                     let previous_queue = state.intervention_queue.clone();
                     let requeue_result =
                         requeue_intervention_front(&mut state.intervention_queue, intervention);
-                    let result = if let Err(error) = persist_queue_or_restore(
+                    let result = if !requeue_result.enqueued {
+                        RequeueInterventionResult {
+                            enqueued: false,
+                            refusal_reason: requeue_result.refusal_reason,
+                            queue_exit_events: requeue_result.queue_exit_events,
+                            persistence_error: None,
+                        }
+                    } else if let Err(error) = persist_queue_or_restore(
                         &mut state,
                         channel_id,
                         &persistence,
@@ -2765,6 +2792,8 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                             clear_pending_user_dispatch(&mut state);
                         }
                         RequeueInterventionResult {
+                            enqueued: false,
+                            refusal_reason: None,
                             queue_exit_events: Vec::new(),
                             persistence_error: Some(error),
                         }
@@ -2779,7 +2808,9 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                             clear_pending_user_dispatch(&mut state);
                         }
                         RequeueInterventionResult {
-                            queue_exit_events: requeue_result,
+                            enqueued: requeue_result.enqueued,
+                            refusal_reason: requeue_result.refusal_reason,
+                            queue_exit_events: requeue_result.queue_exit_events,
                             persistence_error: None,
                         }
                     };
@@ -5353,10 +5384,14 @@ mod no_ttl_evict_tests {
         let mut queue: Vec<Intervention> = (0..(MAX_INTERVENTIONS_PER_CHANNEL as u64))
             .map(|i| intervention_at(i + 2, now))
             .collect();
-        let exits = requeue_intervention_front(&mut queue, intervention_at(1, now));
-        assert_eq!(exits.len(), 1, "one tail entry must be evicted");
+        let result = requeue_intervention_front(&mut queue, intervention_at(1, now));
         assert_eq!(
-            exits[0].kind,
+            result.queue_exit_events.len(),
+            1,
+            "one tail entry must be evicted"
+        );
+        assert_eq!(
+            result.queue_exit_events[0].kind,
             QueueExitKind::Overflow,
             "requeue tail drain is a capacity evict — Overflow"
         );

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -12,6 +12,7 @@ use crate::services::provider::{CancelToken, ProviderKind};
 
 // #3293: non-creating registry lookup + operator-gated idle-entry purge.
 mod active_source_dedup;
+mod dispatch_cleanup;
 mod dispatch_reservation;
 mod episode_identity;
 mod front_requeue;
@@ -1125,63 +1126,6 @@ impl ChannelMailboxHandle {
             },
         )
         .await
-    }
-
-    pub(crate) async fn abandon_pending_dispatch(
-        &self,
-        user_message_id: MessageId,
-        persistence: QueuePersistenceContext,
-    ) {
-        let _ = self
-            .request(
-                |reply| ChannelMailboxMsg::AbandonPendingDispatch {
-                    user_message_id,
-                    dispatch_lease: None,
-                    persistence,
-                    consume_marker: true,
-                    reply,
-                },
-                false,
-            )
-            .await;
-    }
-
-    pub(crate) async fn abandon_pending_dispatch_if_lease_matches(
-        &self,
-        user_message_id: MessageId,
-        dispatch_lease: Arc<DispatchLease>,
-        persistence: QueuePersistenceContext,
-    ) -> bool {
-        self.request(
-            |reply| ChannelMailboxMsg::AbandonPendingDispatch {
-                user_message_id,
-                dispatch_lease: Some(dispatch_lease),
-                persistence,
-                consume_marker: true,
-                reply,
-            },
-            false,
-        )
-        .await
-    }
-
-    pub(crate) async fn clear_pending_dispatch_reservation(
-        &self,
-        user_message_id: MessageId,
-        persistence: QueuePersistenceContext,
-    ) {
-        let _ = self
-            .request(
-                |reply| ChannelMailboxMsg::AbandonPendingDispatch {
-                    user_message_id,
-                    dispatch_lease: None,
-                    persistence,
-                    consume_marker: false,
-                    reply,
-                },
-                false,
-            )
-            .await;
     }
 
     pub(crate) async fn cancel_queued_message(

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -455,17 +455,28 @@ pub(crate) fn enqueue_intervention(
 pub(crate) fn requeue_intervention_front(
     queue: &mut Vec<Intervention>,
     mut intervention: Intervention,
+    pending_user_dispatch: Option<MessageId>,
+    active_user_message_id: Option<MessageId>,
 ) -> EnqueueInterventionResult {
     let mut queue_exit_events = prune_interventions(queue);
     ensure_source_message_ids(&mut intervention);
-    if queue
-        .iter()
-        .any(|item| item.source_message_ids.contains(&intervention.message_id))
-    {
+    let source_id = intervention.message_id;
+    let refusal_reason =
+        if pending_user_dispatch == Some(source_id) || active_user_message_id == Some(source_id) {
+            Some(EnqueueRefusalReason::SourceIdPendingOrActive)
+        } else if queue
+            .iter()
+            .any(|item| item.source_message_ids.contains(&source_id))
+        {
+            Some(EnqueueRefusalReason::SourceIdAlreadyQueued)
+        } else {
+            None
+        };
+    if let Some(refusal_reason) = refusal_reason {
         return EnqueueInterventionResult {
             enqueued: false,
             merged: false,
-            refusal_reason: Some(EnqueueRefusalReason::SourceIdAlreadyQueued),
+            refusal_reason: Some(refusal_reason),
             queue_exit_events,
             persistence_error: None,
         };
@@ -640,6 +651,9 @@ pub(crate) enum EnqueueRefusalReason {
     /// `source_message_ids` — duplicate insert from a re-entry or rehydrated
     /// queue.
     SourceIdAlreadyQueued,
+    /// A front-restored source is already reserved for dispatch or active.
+    /// Re-inserting it would execute the same message again after that turn.
+    SourceIdPendingOrActive,
     /// The queue's last entry matches the incoming intervention on
     /// `(author_id, text, reply_context, has_reply_boundary)` within
     /// `INTERVENTION_DEDUP_WINDOW` — rapid-resend dedup.
@@ -657,6 +671,7 @@ impl EnqueueRefusalReason {
         match self {
             EnqueueRefusalReason::AlreadyActiveTurn => "already_active_turn",
             EnqueueRefusalReason::SourceIdAlreadyQueued => "source_id_already_queued",
+            EnqueueRefusalReason::SourceIdPendingOrActive => "source_id_pending_or_active",
             EnqueueRefusalReason::LastItemDedup => "last_item_dedup",
             EnqueueRefusalReason::ActorUnreachable => "actor_unreachable",
             EnqueueRefusalReason::MailboxClosed => "mailbox_closed",
@@ -2772,8 +2787,12 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                     let requeued_id = intervention.message_id;
                     let requeued_reserved = state.pending_user_dispatch == Some(requeued_id);
                     let previous_queue = state.intervention_queue.clone();
-                    let requeue_result =
-                        requeue_intervention_front(&mut state.intervention_queue, intervention);
+                    let requeue_result = requeue_intervention_front(
+                        &mut state.intervention_queue,
+                        intervention,
+                        state.pending_user_dispatch,
+                        state.active_user_message_id,
+                    );
                     let result = if !requeue_result.enqueued {
                         RequeueInterventionResult {
                             enqueued: false,
@@ -5384,7 +5403,7 @@ mod no_ttl_evict_tests {
         let mut queue: Vec<Intervention> = (0..(MAX_INTERVENTIONS_PER_CHANNEL as u64))
             .map(|i| intervention_at(i + 2, now))
             .collect();
-        let result = requeue_intervention_front(&mut queue, intervention_at(1, now));
+        let result = requeue_intervention_front(&mut queue, intervention_at(1, now), None, None);
         assert_eq!(
             result.queue_exit_events.len(),
             1,
@@ -6131,6 +6150,83 @@ mod persistence_tests {
                 marker_a.message_id.get(),
                 "dequeued restored head gets a fresh pending-dispatch marker"
             );
+        });
+    }
+
+    #[test]
+    fn requeue_front_rejects_pending_source_and_preserves_reservation_4797() {
+        let _lock = lock_test_env();
+        let tmp = tempfile::tempdir().unwrap();
+        let _env_guard = EnvGuard::set_root(tmp.path());
+
+        run_async(async {
+            let provider = ProviderKind::Claude;
+            let token_hash = "requeue-front-pending-4797";
+            let channel_id = ChannelId::new(4_797_201);
+            let persistence = QueuePersistenceContext::new(&provider, token_hash, None);
+            let registry = ChannelMailboxRegistry::default();
+            let handle = registry.handle(channel_id);
+            let head = make_intervention(4_797_202, "pending A", None);
+            handle
+                .replace_queue(vec![head.clone()], persistence.clone())
+                .await;
+            let taken = handle.take_next_soft(persistence.clone()).await;
+            assert_eq!(
+                taken.intervention.as_ref().map(|item| item.message_id),
+                Some(head.message_id)
+            );
+
+            let result = handle.requeue_front(head.clone(), persistence).await;
+
+            assert!(!result.enqueued);
+            assert_eq!(
+                result.refusal_reason,
+                Some(EnqueueRefusalReason::SourceIdPendingOrActive)
+            );
+            let snapshot = handle.snapshot().await;
+            assert!(snapshot.intervention_queue.is_empty());
+            assert_eq!(snapshot.pending_user_dispatch, Some(head.message_id));
+            assert!(
+                marker_file_path(tmp.path(), &provider, token_hash, channel_id).exists(),
+                "pending duplicate refusal must preserve the dispatch marker"
+            );
+        });
+    }
+
+    #[test]
+    fn requeue_front_rejects_active_source_4797() {
+        let _lock = lock_test_env();
+        let tmp = tempfile::tempdir().unwrap();
+        let _env_guard = EnvGuard::set_root(tmp.path());
+
+        run_async(async {
+            let provider = ProviderKind::Claude;
+            let token_hash = "requeue-front-active-4797";
+            let channel_id = ChannelId::new(4_797_203);
+            let persistence = QueuePersistenceContext::new(&provider, token_hash, None);
+            let registry = ChannelMailboxRegistry::default();
+            let handle = registry.handle(channel_id);
+            let head = make_intervention(4_797_204, "active A", None);
+            assert!(
+                handle
+                    .try_start_turn(
+                        Arc::new(CancelToken::new()),
+                        head.author_id,
+                        head.message_id
+                    )
+                    .await
+            );
+
+            let result = handle.requeue_front(head.clone(), persistence).await;
+
+            assert!(!result.enqueued);
+            assert_eq!(
+                result.refusal_reason,
+                Some(EnqueueRefusalReason::SourceIdPendingOrActive)
+            );
+            let snapshot = handle.snapshot().await;
+            assert!(snapshot.intervention_queue.is_empty());
+            assert_eq!(snapshot.active_user_message_id, Some(head.message_id));
         });
     }
 

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -1136,13 +1136,33 @@ impl ChannelMailboxHandle {
             .request(
                 |reply| ChannelMailboxMsg::AbandonPendingDispatch {
                     user_message_id,
+                    dispatch_lease: None,
                     persistence,
                     consume_marker: true,
                     reply,
                 },
-                (),
+                false,
             )
             .await;
+    }
+
+    pub(crate) async fn abandon_pending_dispatch_if_lease_matches(
+        &self,
+        user_message_id: MessageId,
+        dispatch_lease: Arc<DispatchLease>,
+        persistence: QueuePersistenceContext,
+    ) -> bool {
+        self.request(
+            |reply| ChannelMailboxMsg::AbandonPendingDispatch {
+                user_message_id,
+                dispatch_lease: Some(dispatch_lease),
+                persistence,
+                consume_marker: true,
+                reply,
+            },
+            false,
+        )
+        .await
     }
 
     pub(crate) async fn clear_pending_dispatch_reservation(
@@ -1154,11 +1174,12 @@ impl ChannelMailboxHandle {
             .request(
                 |reply| ChannelMailboxMsg::AbandonPendingDispatch {
                     user_message_id,
+                    dispatch_lease: None,
                     persistence,
                     consume_marker: false,
                     reply,
                 },
-                (),
+                false,
             )
             .await;
     }
@@ -1774,9 +1795,10 @@ enum ChannelMailboxMsg {
     },
     AbandonPendingDispatch {
         user_message_id: MessageId,
+        dispatch_lease: Option<Arc<DispatchLease>>,
         persistence: QueuePersistenceContext,
         consume_marker: bool,
-        reply: oneshot::Sender<()>,
+        reply: oneshot::Sender<bool>,
     },
     CancelQueuedMessage {
         message_id: MessageId,
@@ -2814,23 +2836,35 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                 }
                 ChannelMailboxMsg::AbandonPendingDispatch {
                     user_message_id,
+                    dispatch_lease,
                     persistence,
                     consume_marker,
                     reply,
                 } => {
                     state.last_persistence = Some(persistence);
-                    abandon_pending_dispatch_reservation(
-                        &mut state,
-                        channel_id,
-                        user_message_id,
-                        consume_marker,
-                        if consume_marker {
-                            "abandon_pending_dispatch"
-                        } else {
-                            "clear_pending_dispatch_reservation"
-                        },
-                    );
-                    let _ = reply.send(());
+                    let authorized = dispatch_lease.as_ref().is_none_or(|lease| {
+                        state.pending_user_dispatch == Some(user_message_id)
+                            && state
+                                .pending_user_dispatch_lease
+                                .as_ref()
+                                .is_some_and(|stored| Arc::ptr_eq(lease, stored))
+                    });
+                    if authorized {
+                        abandon_pending_dispatch_reservation(
+                            &mut state,
+                            channel_id,
+                            user_message_id,
+                            consume_marker,
+                            if dispatch_lease.is_some() {
+                                "abandon_pending_dispatch_if_lease_matches"
+                            } else if consume_marker {
+                                "abandon_pending_dispatch"
+                            } else {
+                                "clear_pending_dispatch_reservation"
+                            },
+                        );
+                    }
+                    let _ = reply.send(authorized);
                 }
                 ChannelMailboxMsg::CancelQueuedMessage {
                     message_id,

--- a/src/services/turn_orchestrator/dispatch_cleanup.rs
+++ b/src/services/turn_orchestrator/dispatch_cleanup.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use poise::serenity_prelude::MessageId;
+
+use super::{ChannelMailboxHandle, ChannelMailboxMsg, DispatchLease, QueuePersistenceContext};
+
+impl ChannelMailboxHandle {
+    pub(crate) async fn abandon_pending_dispatch(
+        &self,
+        user_message_id: MessageId,
+        persistence: QueuePersistenceContext,
+    ) {
+        let _ = self
+            .request(
+                |reply| ChannelMailboxMsg::AbandonPendingDispatch {
+                    user_message_id,
+                    dispatch_lease: None,
+                    persistence,
+                    consume_marker: true,
+                    reply,
+                },
+                false,
+            )
+            .await;
+    }
+
+    pub(crate) async fn abandon_pending_dispatch_if_lease_matches(
+        &self,
+        user_message_id: MessageId,
+        dispatch_lease: Arc<DispatchLease>,
+        persistence: QueuePersistenceContext,
+    ) -> bool {
+        self.request(
+            |reply| ChannelMailboxMsg::AbandonPendingDispatch {
+                user_message_id,
+                dispatch_lease: Some(dispatch_lease),
+                persistence,
+                consume_marker: true,
+                reply,
+            },
+            false,
+        )
+        .await
+    }
+
+    pub(crate) async fn clear_pending_dispatch_reservation(
+        &self,
+        user_message_id: MessageId,
+        persistence: QueuePersistenceContext,
+    ) {
+        let _ = self
+            .request(
+                |reply| ChannelMailboxMsg::AbandonPendingDispatch {
+                    user_message_id,
+                    dispatch_lease: None,
+                    persistence,
+                    consume_marker: false,
+                    reply,
+                },
+                false,
+            )
+            .await;
+    }
+}

--- a/src/services/turn_orchestrator/episode_identity.rs
+++ b/src/services/turn_orchestrator/episode_identity.rs
@@ -181,6 +181,8 @@ mod tests {
 
     #[tokio::test]
     async fn stale_episode_cannot_release_pre_cutoff_same_id_successor() {
+        let tmp = tempfile::tempdir().expect("isolated persistence root");
+        let _root_guard = crate::config::set_agentdesk_root_for_test(tmp.path());
         let registry = ChannelMailboxRegistry::default();
         let handle = registry.handle(ChannelId::new(4_595_001));
         let user_msg_id = MessageId::new(9_595);

--- a/src/services/turn_orchestrator/front_requeue.rs
+++ b/src/services/turn_orchestrator/front_requeue.rs
@@ -1,0 +1,66 @@
+use std::collections::HashSet;
+
+use poise::serenity_prelude::MessageId;
+
+use super::{
+    EnqueueInterventionResult, EnqueueRefusalReason, Intervention, MAX_INTERVENTIONS_PER_CHANNEL,
+    QueueExitEvent, QueueExitKind, drain_head_overflow, ensure_source_message_ids,
+    prune_interventions,
+};
+
+pub(super) fn intervention_identity_ids(intervention: &Intervention) -> HashSet<MessageId> {
+    let mut ids: HashSet<_> = intervention.source_message_ids.iter().copied().collect();
+    ids.insert(intervention.message_id);
+    ids
+}
+
+pub(super) fn requeue_intervention_front(
+    queue: &mut Vec<Intervention>,
+    mut intervention: Intervention,
+    pending_user_dispatch: Option<MessageId>,
+    active_user_message_id: Option<MessageId>,
+    authorized_pending_restore: Option<MessageId>,
+) -> EnqueueInterventionResult {
+    let mut queue_exit_events = prune_interventions(queue);
+    ensure_source_message_ids(&mut intervention);
+    let incoming_ids = intervention_identity_ids(&intervention);
+    let pending_conflict = pending_user_dispatch
+        .filter(|pending| incoming_ids.contains(pending))
+        .is_some_and(|pending| authorized_pending_restore != Some(pending));
+    let active_conflict =
+        active_user_message_id.is_some_and(|active| incoming_ids.contains(&active));
+    let queued_conflict = queue
+        .iter()
+        .any(|queued| !incoming_ids.is_disjoint(&intervention_identity_ids(queued)));
+    let refusal_reason = if pending_conflict || active_conflict {
+        Some(EnqueueRefusalReason::SourceIdPendingOrActive)
+    } else if queued_conflict {
+        Some(EnqueueRefusalReason::SourceIdAlreadyQueued)
+    } else {
+        None
+    };
+    if let Some(refusal_reason) = refusal_reason {
+        return EnqueueInterventionResult {
+            enqueued: false,
+            merged: false,
+            refusal_reason: Some(refusal_reason),
+            queue_exit_events,
+            persistence_error: None,
+        };
+    }
+    queue.insert(0, intervention);
+    if queue.len() > MAX_INTERVENTIONS_PER_CHANNEL {
+        queue_exit_events.extend(
+            queue
+                .drain(MAX_INTERVENTIONS_PER_CHANNEL..)
+                .map(|intervention| QueueExitEvent::new(intervention, QueueExitKind::Overflow)),
+        );
+    }
+    EnqueueInterventionResult {
+        enqueued: true,
+        merged: false,
+        refusal_reason: None,
+        queue_exit_events,
+        persistence_error: None,
+    }
+}


### PR DESCRIPTION
## 변경 요약
- pre-submit busy timeout으로 실패한 inflight 후속 메시지를 mailbox tail이 아니라 front로 복원해, 그 사이 큐에 들어온 메시지보다 먼저 재시도되도록 FIFO를 보존합니다.
- #4796의 dequeued-head 재시도와 #4797 inflight 재시도가 동일한 front-requeue 결과 변환 코어를 공유하도록 통합했습니다.
- front-requeue에 source-message 중복 거부를 추가해 inflight 재시도 호출자가 기존 `SourceIdAlreadyQueued` 의미를 유지합니다.

## 변경 파일
- `src/services/discord/mod.rs`
- `src/services/discord/router/message_handler/tui_followup.rs`
- `src/services/turn_orchestrator.rs`

## 검증 결과
- `cargo fmt --all --check`
- `cargo check --lib`
- `cargo test --lib inflight_retry_restores_earlier_message_without_reversing_fifo_4797`
- `cargo test --lib busy_retry_restores_dequeued_head_without_reversing_fifo_4795`
- 관련 pre-submit/context 및 overflow 테스트 통과
- `python3 scripts/generate_inventory_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate`
- `python3 scripts/audit_maintainability.py --check`
- `python3 scripts/check_await_holding_lock_ratchet.py` (54/54)

Closes #4797

🤖 Generated with [Claude Code](https://claude.com/claude-code)
