### PR TITLE
feat(#4777): PR-1 channel opt-in and planner telemetry

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -422,6 +422,8 @@ src/
 │   │   ├── intake_preflight.rs
 │   │   ├── intake_router_hook.rs
 │   │   ├── intake_routing.rs
+│   │   ├── intake_routing_config.rs
+│   │   ├── intake_routing_telemetry.rs
 │   │   ├── intake_worker.rs
 │   │   ├── intake_worker_capabilities.rs
 │   │   ├── mod.rs

--- a/agentdesk.example.yaml
+++ b/agentdesk.example.yaml
@@ -24,6 +24,9 @@ cluster:
   intake_routing:
     enabled: false
     mode: "observe"
+    # Raw top-level Discord channel IDs. PR-1 uses this allowlist only to tag
+    # planner telemetry; owner-authority enforcement remains unchanged.
+    owner_authority_channel_ids: []
     forward_pre_claim_timeout_secs: 12
     stale_claim_recovery_secs: 60
   # #4351. The gateway node is the node every conversational tmux session runs

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -446,6 +446,13 @@
   before merging.
 
 ### Audited touches
+- #4777 PR-1 channel owner-authority rollout scope: `owner_authority_channel_ids`
+  is a live-read, raw top-level Discord channel allowlist used only to tag the
+  leader-owned intake planner's structured telemetry. It does not activate the
+  dormant owner-record authority, mutate PG ownership, alter worker placement,
+  or change Observe/Enforce admission behavior; later rollout PRs own those
+  authority changes. The environment mode override cannot populate or bypass
+  this YAML-only channel scope.
 - #4799 discrete machine-trigger markers: the watcher converts only footer-owned background terminal notifications into an idempotent lifecycle outbox marker keyed by channel plus semantic event identity; card-owned subagent notifications remain card-only, and monitor notices retain their existing offset-scoped aggregation. This adds no lease, owner, schema, or cross-node routing authority.
 - #4779 target preflight: added a pure fail-closed readiness report and transfer guard over worker-node capability evidence; owner mutation remains delegated to the generation-fenced handoff interface.
 

--- a/docs/design/intake-node-routing.md
+++ b/docs/design/intake-node-routing.md
@@ -603,6 +603,11 @@ cluster:
     # observe: emit decision events but do NOT INSERT outbox rows.
     # enforce: actually forward.
     mode: "observe"
+    # Raw top-level Discord channel IDs selected for owner-authority rollout.
+    # PR-1 records this scope in planner telemetry only; authority behavior is
+    # unchanged until a later rollout PR consumes the allowlist.
+    owner_authority_channel_ids:
+      - "123456789012345678"
     # Pre-claim takeover threshold. After this many seconds without
     # reaching `claimed` (= worker SELECT FOR UPDATE), leader steals
     # and runs locally. Spawned/accepted rows are NEVER stolen.
@@ -617,10 +622,21 @@ Implemented authority (#3749): `cluster.intake_routing` is the primary
 source of truth. `ADK_INTAKE_ROUTING_MODE` remains as an emergency
 process override and wins over YAML when set (`disabled`/`off`/`false`/`0`,
 `observe`, `enforce`; invalid values fail closed to `disabled`). Operators
-can confirm the effective `mode`, `source`, YAML values, and warning count
-through `/api/health` or `/api/health/detail` under `intake_routing`.
+can confirm the effective `enabled`, `mode`, `source`, allowlist size, recent
+planner-decision count, YAML values, and warning count through `/api/health` or
+`/api/health/detail` under `intake_routing`.
 
-Operational reload note: worker consumers are spawned when the effective mode
+Every Disabled, Observe, and Enforce planner result emits an info-level structured
+`intake_routing_decision` event with stable `reason_code`, `would_assign_target`,
+`preferred_label_match`, `owner_resolution`, and `authority_channel_opted_in`
+fields. The allowlist tag is telemetry-only in PR-1. In particular,
+`ADK_INTAKE_ROUTING_MODE=enforce` can change the effective planner mode but cannot
+opt a channel into owner authority; only `owner_authority_channel_ids` controls
+that tag.
+
+Operational reload note: `owner_authority_channel_ids` is read from the runtime
+config snapshot for every intake decision, so allowlist edits are reflected by
+planner telemetry without a restart. Worker consumers are spawned when the effective mode
 is `observe` or `enforce`. Start from `enabled: true, mode: "observe"` and
 restart once to put consumers on standby; then observe→enforce rollback/promote
 changes are read by the hook and `/node` from the runtime config snapshot. A

--- a/src/config.rs
+++ b/src/config.rs
@@ -1110,6 +1110,10 @@ pub struct ClusterIntakeRoutingConfig {
     pub enabled: bool,
     #[serde(default, skip_serializing_if = "ClusterIntakeRoutingMode::is_default")]
     pub mode: ClusterIntakeRoutingMode,
+    /// Raw top-level Discord channel IDs opted into owner-authority planning.
+    /// PR-1 records this scope in telemetry only; it does not change enforcement.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub owner_authority_channel_ids: Vec<String>,
     #[serde(default = "default_intake_forward_pre_claim_timeout_secs")]
     pub forward_pre_claim_timeout_secs: u64,
     #[serde(default = "default_intake_stale_claim_recovery_secs")]
@@ -1121,6 +1125,7 @@ impl Default for ClusterIntakeRoutingConfig {
         Self {
             enabled: false,
             mode: ClusterIntakeRoutingMode::default(),
+            owner_authority_channel_ids: Vec::new(),
             forward_pre_claim_timeout_secs: default_intake_forward_pre_claim_timeout_secs(),
             stale_claim_recovery_secs: default_intake_stale_claim_recovery_secs(),
         }
@@ -1300,6 +1305,12 @@ dispatch_routing:
             12
         );
         assert_eq!(default_config.intake_routing.stale_claim_recovery_secs, 60);
+        assert!(
+            default_config
+                .intake_routing
+                .owner_authority_channel_ids
+                .is_empty()
+        );
 
         let config: ClusterConfig = serde_yaml::from_str(
             r#"
@@ -1307,6 +1318,9 @@ enabled: true
 intake_routing:
   enabled: true
   mode: enforce
+  owner_authority_channel_ids:
+    - "123456789012345678"
+    - "223456789012345678"
   forward_pre_claim_timeout_secs: 13
   stale_claim_recovery_secs: 61
 "#,
@@ -1317,6 +1331,10 @@ intake_routing:
         assert_eq!(
             config.intake_routing.mode,
             ClusterIntakeRoutingMode::Enforce
+        );
+        assert_eq!(
+            config.intake_routing.owner_authority_channel_ids,
+            ["123456789012345678", "223456789012345678"]
         );
         assert_eq!(config.intake_routing.forward_pre_claim_timeout_secs, 13);
         assert_eq!(config.intake_routing.stale_claim_recovery_secs, 61);

--- a/src/config_live_reload.rs
+++ b/src/config_live_reload.rs
@@ -280,8 +280,20 @@ pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str>
     if section_changed(&old.data, &new.data) {
         changed.push("data");
     }
-    // Cluster runtime and wait-queue snapshots are installed at boot.
-    if old.cluster != new.cluster {
+    // Most cluster runtime and wait-queue snapshots are installed at boot. The
+    // owner-authority channel allowlist is a planner telemetry scope read from
+    // `current()` per intake, so exclude only that field from the boot fingerprint.
+    let mut old_cluster = old.cluster.clone();
+    let mut new_cluster = new.cluster.clone();
+    old_cluster
+        .intake_routing
+        .owner_authority_channel_ids
+        .clear();
+    new_cluster
+        .intake_routing
+        .owner_authority_channel_ids
+        .clear();
+    if old_cluster != new_cluster {
         changed.push("cluster");
     }
     // The policy engine constructs its QuickJS runtime, directory watcher, and
@@ -653,6 +665,18 @@ mod tests {
         new = old.clone();
         new.policies.hook_timeout_ms = old.policies.hook_timeout_ms.wrapping_add(1);
         assert_eq!(restart_required_changes(&old, &new), vec!["policies"]);
+    }
+
+    #[test]
+    fn intake_owner_authority_allowlist_change_needs_no_restart() {
+        let old = Config::default();
+        let mut new = old.clone();
+        new.cluster
+            .intake_routing
+            .owner_authority_channel_ids
+            .push("123456789012345678".to_string());
+
+        assert!(restart_required_changes(&old, &new).is_empty());
     }
 
     // A hot-swappable-only change (routine tunable) reports no restart-required.

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -2625,11 +2625,15 @@ mod tests {
             "dashboard": true,
             "server_up": true,
             "intake_routing": {
+                "enabled": true,
                 "mode": "observe",
                 "source": "yaml",
+                "owner_authority_allowlist_size": 2,
+                "recent_decision_count": 17,
                 "yaml": {
                     "enabled": true,
                     "mode": "observe",
+                    "owner_authority_allowlist_size": 2,
                     "forward_pre_claim_timeout_secs": 12,
                     "stale_claim_recovery_secs": 60
                 },
@@ -2638,8 +2642,14 @@ mod tests {
                 "configuration_warnings": []
             }
         }));
+        assert_eq!(public["intake_routing"]["enabled"], json!(true));
         assert_eq!(public["intake_routing"]["mode"], json!("observe"));
         assert_eq!(public["intake_routing"]["source"], json!("yaml"));
+        assert_eq!(
+            public["intake_routing"]["owner_authority_allowlist_size"],
+            json!(2)
+        );
+        assert_eq!(public["intake_routing"]["recent_decision_count"], json!(17));
         assert_eq!(public["intake_routing"]["warning_count"], json!(0));
         assert_eq!(public["ok"], json!(true));
     }

--- a/src/services/cluster/intake_router_hook.rs
+++ b/src/services/cluster/intake_router_hook.rs
@@ -13,7 +13,6 @@
 //! observe / enforce mode. `ADK_INTAKE_ROUTING_MODE` remains as an
 //! emergency override and is surfaced in health.
 
-use crate::config::{ClusterIntakeRoutingConfig, ClusterIntakeRoutingMode};
 use crate::db::intake_outbox::{
     InsertPendingPayload, IntakeInsertConflict, classify_insert_pending_error, insert_pending,
 };
@@ -27,180 +26,28 @@ mod session_owner;
 
 use session_owner::SessionOwnerResolution;
 
-/// How aggressively to apply the Phase-2 routing decision in front of
-/// the existing leader intake path.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum IntakeRoutingMode {
-    /// Hook is a no-op; the leader runs every intake locally as today.
-    /// Default until Phase 5 flips the global flag — keeps prod
-    /// behaviour byte-identical while phases 1-4 land.
-    Disabled,
-    /// The hook does the full decision (label match, worker eligibility,
-    /// 23505 classification) but never INSERTs. Logs the decision so
-    /// operators can verify routing behaviour against real traffic
-    /// before promoting to `Enforce`.
-    Observe,
-    /// The hook actually INSERTs into `intake_outbox` and tells the
-    /// caller to skip local execution.
-    Enforce,
-}
-
-impl IntakeRoutingMode {
-    fn from_config(mode: ClusterIntakeRoutingMode) -> Self {
-        match mode {
-            ClusterIntakeRoutingMode::Disabled => Self::Disabled,
-            ClusterIntakeRoutingMode::Observe => Self::Observe,
-            ClusterIntakeRoutingMode::Enforce => Self::Enforce,
-        }
-    }
-
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::Disabled => "disabled",
-            Self::Observe => "observe",
-            Self::Enforce => "enforce",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum IntakeRoutingModeSource {
-    ConfigYaml,
-    EnvOverride,
-}
-
-impl IntakeRoutingModeSource {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::ConfigYaml => "yaml",
-            Self::EnvOverride => "env_override",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum IntakeRoutingEnvOverride {
-    Disabled,
-    Observe,
-    Enforce,
-    Invalid,
-}
-
-impl IntakeRoutingEnvOverride {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Disabled => "disabled",
-            Self::Observe => "observe",
-            Self::Enforce => "enforce",
-            Self::Invalid => "invalid",
-        }
-    }
-
-    fn mode(self) -> IntakeRoutingMode {
-        match self {
-            Self::Disabled | Self::Invalid => IntakeRoutingMode::Disabled,
-            Self::Observe => IntakeRoutingMode::Observe,
-            Self::Enforce => IntakeRoutingMode::Enforce,
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct EffectiveIntakeRoutingConfig {
-    pub(crate) mode: IntakeRoutingMode,
-    pub(crate) source: IntakeRoutingModeSource,
-    pub(crate) yaml_enabled: bool,
-    pub(crate) yaml_mode: ClusterIntakeRoutingMode,
-    pub(crate) env_override: Option<&'static str>,
-    pub(crate) warnings: Vec<&'static str>,
-    pub(crate) forward_pre_claim_timeout_secs: u64,
-    pub(crate) stale_claim_recovery_secs: u64,
-}
-
-impl EffectiveIntakeRoutingConfig {
-    pub(crate) fn mode_is_enforce(&self) -> bool {
-        matches!(self.mode, IntakeRoutingMode::Enforce)
-    }
-
-    pub(crate) fn worker_consumer_should_spawn(&self) -> bool {
-        !matches!(self.mode, IntakeRoutingMode::Disabled)
-    }
-
-    pub(crate) fn status_json(&self) -> serde_json::Value {
-        serde_json::json!({
-            "mode": self.mode.as_str(),
-            "source": self.source.as_str(),
-            "yaml": {
-                "enabled": self.yaml_enabled,
-                "mode": self.yaml_mode.as_str(),
-                "forward_pre_claim_timeout_secs": self.forward_pre_claim_timeout_secs,
-                "stale_claim_recovery_secs": self.stale_claim_recovery_secs,
-            },
-            "env_override": self.env_override,
-            "warning_count": self.warnings.len(),
-            "configuration_warnings": self.warnings,
-        })
-    }
-}
-
-fn parse_intake_routing_env_override(value: &str) -> IntakeRoutingEnvOverride {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "disabled" | "disable" | "off" | "false" | "0" => IntakeRoutingEnvOverride::Disabled,
-        "observe" => IntakeRoutingEnvOverride::Observe,
-        "enforce" => IntakeRoutingEnvOverride::Enforce,
-        _ => IntakeRoutingEnvOverride::Invalid,
-    }
-}
-
-fn effective_intake_routing_config_for(
-    config: &ClusterIntakeRoutingConfig,
-    env_override: Option<&str>,
-) -> EffectiveIntakeRoutingConfig {
-    let yaml_mode = if config.enabled {
-        IntakeRoutingMode::from_config(config.mode)
-    } else {
-        IntakeRoutingMode::Disabled
-    };
-    let parsed_env = env_override.map(parse_intake_routing_env_override);
-    let (mode, source) = match parsed_env {
-        Some(value) => (value.mode(), IntakeRoutingModeSource::EnvOverride),
-        None => (yaml_mode, IntakeRoutingModeSource::ConfigYaml),
-    };
-    let mut warnings = Vec::new();
-    if parsed_env == Some(IntakeRoutingEnvOverride::Invalid) {
-        warnings.push("invalid_ADK_INTAKE_ROUTING_MODE_fail_closed");
-    }
-    EffectiveIntakeRoutingConfig {
-        mode,
-        source,
-        yaml_enabled: config.enabled,
-        yaml_mode: config.mode,
-        env_override: parsed_env.map(IntakeRoutingEnvOverride::as_str),
-        warnings,
-        forward_pre_claim_timeout_secs: config.forward_pre_claim_timeout_secs,
-        stale_claim_recovery_secs: config.stale_claim_recovery_secs,
-    }
-}
-
-pub(crate) fn effective_intake_routing_config() -> EffectiveIntakeRoutingConfig {
-    let config = crate::config_live_reload::current()
-        .map(|config| config.cluster.intake_routing.clone())
-        .unwrap_or_else(|| crate::config::load_graceful().cluster.intake_routing);
-    let env_override = std::env::var("ADK_INTAKE_ROUTING_MODE").ok();
-    effective_intake_routing_config_for(&config, env_override.as_deref())
-}
-
-pub(crate) fn effective_intake_routing_mode() -> IntakeRoutingMode {
-    effective_intake_routing_config().mode
-}
-
-pub(crate) fn intake_routing_status_json() -> serde_json::Value {
-    effective_intake_routing_config().status_json()
-}
+pub(crate) use super::intake_routing_config::{
+    EffectiveIntakeRoutingConfig, IntakeRoutingMode, effective_intake_routing_config,
+    intake_routing_status_json,
+};
 
 /// What the hook decided. The intake gate uses this to choose between
 /// "skip local execution; the worker has the row" and "fall through
 /// to `handle_text_message` as today".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum IntakeRoutingBasis {
+    LiveForeignOwner,
+    NodeOverride,
+    PreferredLabels,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ResolvedSessionOwner {
+    NoOwner,
+    LiveLocal,
+    LiveForeign,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum IntakeRouterDecision {
     /// No forwarding happened (Disabled mode, a confirmed ownerless channel
@@ -216,6 +63,7 @@ pub(crate) enum IntakeRouterDecision {
     Forwarded {
         target_instance_id: String,
         outbox_id: i64,
+        basis: IntakeRoutingBasis,
     },
     /// At-most-once skip: Discord redelivered the same
     /// `(channel_id, user_msg_id)` and the 3-tuple unique constraint
@@ -223,11 +71,16 @@ pub(crate) enum IntakeRouterDecision {
     /// the message. Caller MUST NOT run the turn locally — running it
     /// would double-emit. Distinct from `RanLocal { DbErrorFellBack }`
     /// because the gate's response differs (skip vs run-local).
-    SkippedDuplicate,
+    SkippedDuplicate {
+        resolved_owner: ResolvedSessionOwner,
+    },
     /// A different message already owns the channel's single open outbox
     /// route. The producer must preserve/retry queued work and MUST NOT run it
     /// locally while the predecessor is open.
-    DeferredOpenRoute { target_instance_id: String },
+    DeferredOpenRoute {
+        target_instance_id: String,
+        resolved_owner: ResolvedSessionOwner,
+    },
     /// Ownership or placement could not be proven safe. Caller MUST NOT run
     /// the local execution body.
     Blocked { reason: IntakeBlockedReason },
@@ -236,12 +89,25 @@ pub(crate) enum IntakeRouterDecision {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ObservedIntakeOutcome {
     WouldKeepLocalExistingOwner,
-    WouldForwardLiveForeignOwner { target_instance_id: String },
-    WouldAssignNoOwnerToTarget { target_instance_id: String },
-    WouldKeepNoOwnerLocal { reason: RanLocalReason },
-    WouldSkipDuplicate,
-    WouldDeferOpenRoute { target_instance_id: String },
-    WouldBlock { reason: IntakeBlockedReason },
+    WouldForwardLiveForeignOwner {
+        target_instance_id: String,
+    },
+    WouldAssignNoOwnerToTarget {
+        target_instance_id: String,
+    },
+    WouldKeepNoOwnerLocal {
+        reason: RanLocalReason,
+    },
+    WouldSkipDuplicate {
+        resolved_owner: ResolvedSessionOwner,
+    },
+    WouldDeferOpenRoute {
+        target_instance_id: String,
+        resolved_owner: ResolvedSessionOwner,
+    },
+    WouldBlock {
+        reason: IntakeBlockedReason,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -434,15 +300,32 @@ pub(crate) async fn try_route_intake(
     }
 
     // The durable single-open-route fence surrounds every placement branch,
-    // including a local live owner and attachment-first placement.
+    // including a local live owner and attachment-first placement. Preserve the
+    // resolved owner classification for telemetry without changing the fence.
+    let resolved_owner = match &owner {
+        SessionOwnerResolution::NoOwner => ResolvedSessionOwner::NoOwner,
+        SessionOwnerResolution::LiveLocal { .. } => ResolvedSessionOwner::LiveLocal,
+        SessionOwnerResolution::LiveForeign { .. } => ResolvedSessionOwner::LiveForeign,
+        SessionOwnerResolution::StaleOwners { .. }
+        | SessionOwnerResolution::ConflictingLiveOwners { .. }
+        | SessionOwnerResolution::LiveForeignIncompatible { .. } => {
+            unreachable!("owner fail-safe outcomes return before the open-route fence")
+        }
+    };
     match existing_open_route(pool, ctx.channel_id).await {
         Ok(Some((_, existing_user_msg_id))) if existing_user_msg_id == ctx.user_msg_id => {
-            return apply_observe_mode(ctx.mode, IntakeRouterDecision::SkippedDuplicate);
+            return apply_observe_mode(
+                ctx.mode,
+                IntakeRouterDecision::SkippedDuplicate { resolved_owner },
+            );
         }
         Ok(Some((target_instance_id, _))) => {
             return apply_observe_mode(
                 ctx.mode,
-                IntakeRouterDecision::DeferredOpenRoute { target_instance_id },
+                IntakeRouterDecision::DeferredOpenRoute {
+                    target_instance_id,
+                    resolved_owner,
+                },
             );
         }
         Ok(None) => {}
@@ -650,7 +533,7 @@ async fn route_by_preferred_labels(
         &target,
         &preferred_labels,
         &agent_id,
-        ObserveTargetKind::NoOwnerPlacement,
+        ObserveTargetKind::PreferredLabels,
     )
     .await
 }
@@ -746,7 +629,7 @@ async fn route_node_override_without_owner(
         target,
         &required_labels,
         &agent_id,
-        ObserveTargetKind::NoOwnerPlacement,
+        ObserveTargetKind::NodeOverride,
     )
     .await
 }
@@ -754,7 +637,8 @@ async fn route_node_override_without_owner(
 #[derive(Clone, Copy)]
 enum ObserveTargetKind {
     LiveForeignOwner,
-    NoOwnerPlacement,
+    NodeOverride,
+    PreferredLabels,
 }
 
 fn apply_observe_mode(
@@ -772,10 +656,16 @@ fn apply_observe_mode(
         IntakeRouterDecision::RanLocal { reason } => {
             ObservedIntakeOutcome::WouldKeepNoOwnerLocal { reason }
         }
-        IntakeRouterDecision::SkippedDuplicate => ObservedIntakeOutcome::WouldSkipDuplicate,
-        IntakeRouterDecision::DeferredOpenRoute { target_instance_id } => {
-            ObservedIntakeOutcome::WouldDeferOpenRoute { target_instance_id }
+        IntakeRouterDecision::SkippedDuplicate { resolved_owner } => {
+            ObservedIntakeOutcome::WouldSkipDuplicate { resolved_owner }
         }
+        IntakeRouterDecision::DeferredOpenRoute {
+            target_instance_id,
+            resolved_owner,
+        } => ObservedIntakeOutcome::WouldDeferOpenRoute {
+            target_instance_id,
+            resolved_owner,
+        },
         IntakeRouterDecision::Blocked { reason } => ObservedIntakeOutcome::WouldBlock { reason },
         IntakeRouterDecision::Observed { .. } | IntakeRouterDecision::Forwarded { .. } => {
             unreachable!("observe conversion accepts only a mutation-free routing decision")
@@ -809,15 +699,25 @@ async fn route_to_instance(
     agent_id: &str,
     observe_target_kind: ObserveTargetKind,
 ) -> IntakeRouterDecision {
+    let resolved_owner = match observe_target_kind {
+        ObserveTargetKind::LiveForeignOwner => ResolvedSessionOwner::LiveForeign,
+        ObserveTargetKind::NodeOverride | ObserveTargetKind::PreferredLabels => {
+            ResolvedSessionOwner::NoOwner
+        }
+    };
     match existing_open_route(pool, ctx.channel_id).await {
         Ok(Some((_, existing_user_msg_id))) if existing_user_msg_id == ctx.user_msg_id => {
-            return apply_observe_mode(ctx.mode, IntakeRouterDecision::SkippedDuplicate);
+            return apply_observe_mode(
+                ctx.mode,
+                IntakeRouterDecision::SkippedDuplicate { resolved_owner },
+            );
         }
         Ok(Some((existing_target, _))) => {
             return apply_observe_mode(
                 ctx.mode,
                 IntakeRouterDecision::DeferredOpenRoute {
                     target_instance_id: existing_target,
+                    resolved_owner,
                 },
             );
         }
@@ -841,7 +741,7 @@ async fn route_to_instance(
                     target_instance_id: target.to_string(),
                 }
             }
-            ObserveTargetKind::NoOwnerPlacement => {
+            ObserveTargetKind::NodeOverride | ObserveTargetKind::PreferredLabels => {
                 ObservedIntakeOutcome::WouldAssignNoOwnerToTarget {
                     target_instance_id: target.to_string(),
                 }
@@ -864,6 +764,11 @@ async fn route_to_instance(
         Ok(outbox_id) => IntakeRouterDecision::Forwarded {
             target_instance_id: target.to_string(),
             outbox_id,
+            basis: match observe_target_kind {
+                ObserveTargetKind::LiveForeignOwner => IntakeRoutingBasis::LiveForeignOwner,
+                ObserveTargetKind::NodeOverride => IntakeRoutingBasis::NodeOverride,
+                ObserveTargetKind::PreferredLabels => IntakeRoutingBasis::PreferredLabels,
+            },
         },
         Err(error) => match classify_insert_pending_error(&error) {
             Some(IntakeInsertConflict::OpenRoutePerChannel) => {
@@ -871,13 +776,15 @@ async fn route_to_instance(
                     Ok(Some((_, existing_user_msg_id)))
                         if existing_user_msg_id == ctx.user_msg_id =>
                     {
-                        IntakeRouterDecision::SkippedDuplicate
+                        IntakeRouterDecision::SkippedDuplicate { resolved_owner }
                     }
                     Ok(Some((existing_target, _))) => IntakeRouterDecision::DeferredOpenRoute {
                         target_instance_id: existing_target,
+                        resolved_owner,
                     },
                     Ok(None) | Err(_) => IntakeRouterDecision::DeferredOpenRoute {
                         target_instance_id: target.to_string(),
+                        resolved_owner,
                     },
                 }
             }
@@ -887,7 +794,7 @@ async fn route_to_instance(
                     user_msg_id = ctx.user_msg_id,
                     "[intake_router] duplicate Discord message (node override) — existing row already covers it; skipping local execution"
                 );
-                IntakeRouterDecision::SkippedDuplicate
+                IntakeRouterDecision::SkippedDuplicate { resolved_owner }
             }
             None => IntakeRouterDecision::Blocked {
                 reason: IntakeBlockedReason::RoutingDependencyFailed {
@@ -978,49 +885,6 @@ async fn agent_preferred_labels_for_channel(
     Ok(agent_id_and_preferred_labels(pool, channel_id)
         .await?
         .map(|(_, _, labels)| labels))
-}
-
-#[cfg(test)]
-mod unit_tests {
-    use super::*;
-
-    #[test]
-    fn effective_intake_routing_config_resolves_yaml_and_env_override() {
-        let mut yaml = ClusterIntakeRoutingConfig::default();
-        assert_eq!(
-            effective_intake_routing_config_for(&yaml, None).mode,
-            IntakeRoutingMode::Disabled
-        );
-
-        yaml.enabled = true;
-        assert_eq!(
-            effective_intake_routing_config_for(&yaml, None).mode,
-            IntakeRoutingMode::Observe
-        );
-
-        yaml.mode = ClusterIntakeRoutingMode::Enforce;
-        let from_yaml = effective_intake_routing_config_for(&yaml, None);
-        assert_eq!(from_yaml.mode, IntakeRoutingMode::Enforce);
-        assert_eq!(from_yaml.source, IntakeRoutingModeSource::ConfigYaml);
-
-        let env_observe = effective_intake_routing_config_for(&yaml, Some("observe"));
-        assert_eq!(env_observe.mode, IntakeRoutingMode::Observe);
-        assert_eq!(env_observe.source, IntakeRoutingModeSource::EnvOverride);
-        assert_eq!(env_observe.env_override, Some("observe"));
-
-        let env_disabled = effective_intake_routing_config_for(&yaml, Some("OFF"));
-        assert_eq!(env_disabled.mode, IntakeRoutingMode::Disabled);
-        assert_eq!(env_disabled.env_override, Some("disabled"));
-
-        let invalid = effective_intake_routing_config_for(&yaml, Some("garbage"));
-        assert_eq!(invalid.mode, IntakeRoutingMode::Disabled);
-        assert_eq!(invalid.source, IntakeRoutingModeSource::EnvOverride);
-        assert_eq!(invalid.env_override, Some("invalid"));
-        assert_eq!(
-            invalid.warnings,
-            vec!["invalid_ADK_INTAKE_ROUTING_MODE_fail_closed"]
-        );
-    }
 }
 
 #[cfg(test)]
@@ -1460,6 +1324,7 @@ mod pg_tests {
             IntakeRouterDecision::Forwarded {
                 target_instance_id,
                 outbox_id,
+                ..
             } => {
                 assert_eq!(target_instance_id, "worker-enforce");
                 outbox_id
@@ -1614,6 +1479,7 @@ mod pg_tests {
             IntakeRouterDecision::Forwarded {
                 target_instance_id,
                 outbox_id,
+                ..
             } => {
                 assert_eq!(target_instance_id, "worker-owner");
                 outbox_id
@@ -2100,6 +1966,7 @@ mod pg_tests {
             IntakeRouterDecision::Forwarded {
                 target_instance_id,
                 outbox_id,
+                ..
             } => {
                 assert_eq!(target_instance_id, "worker-codex");
                 outbox_id
@@ -2468,6 +2335,7 @@ mod pg_tests {
             IntakeRouterDecision::Forwarded {
                 target_instance_id,
                 outbox_id,
+                ..
             } => {
                 assert_eq!(target_instance_id, "worker-selected");
                 outbox_id
@@ -2565,7 +2433,12 @@ mod pg_tests {
 
         // Second call (same Discord message) — must report SkippedDuplicate.
         let second = try_route_intake(&pool, &ctx).await;
-        assert_eq!(second, IntakeRouterDecision::SkippedDuplicate);
+        assert_eq!(
+            second,
+            IntakeRouterDecision::SkippedDuplicate {
+                resolved_owner: ResolvedSessionOwner::NoOwner
+            }
+        );
 
         pool.close().await;
         pg_db.drop().await;
@@ -2705,12 +2578,116 @@ mod pg_tests {
         assert_eq!(
             decision,
             IntakeRouterDecision::DeferredOpenRoute {
-                target_instance_id: "worker-conflict".to_string()
+                target_instance_id: "worker-conflict".to_string(),
+                resolved_owner: ResolvedSessionOwner::NoOwner,
             }
         );
 
         pool.close().await;
         pg_db.drop().await;
+    }
+
+    async fn seed_open_route(pool: &PgPool, channel_id: &str, target_instance_id: &str) {
+        sqlx::query(
+            "INSERT INTO intake_outbox (
+                target_instance_id, forwarded_by_instance_id, required_labels,
+                channel_id, user_msg_id, request_owner_id, user_text,
+                turn_kind, agent_id, status, attempt_no
+             ) VALUES ($1, 'leader-1', '[]'::JSONB, $2, 'msg-prior', '50',
+                'prior', 'foreground', 'agent-owner-telemetry', 'pending', 1)",
+        )
+        .bind(target_instance_id)
+        .bind(channel_id)
+        .execute(pool)
+        .await
+        .expect("seed open route");
+    }
+
+    async fn open_route_owner_telemetry_case(
+        channel_id: &str,
+        owner_instance_id: Option<&str>,
+        expected_owner: ResolvedSessionOwner,
+    ) {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        seed_open_route(&pool, channel_id, "worker-open-route").await;
+        if let Some(instance_id) = owner_instance_id {
+            if instance_id != "leader-1" {
+                seed_worker_node(&pool, instance_id, serde_json::json!([]), "online").await;
+            }
+            seed_session_owner(
+                &pool,
+                &format!("claude:{instance_id}:{channel_id}"),
+                "claude",
+                channel_id,
+                instance_id,
+                "turn_active",
+            )
+            .await;
+        }
+
+        let decision = try_route_intake(
+            &pool,
+            &ctx_for_channel(IntakeRoutingMode::Observe, channel_id),
+        )
+        .await;
+        assert!(matches!(
+            &decision,
+            IntakeRouterDecision::Observed {
+                outcome: ObservedIntakeOutcome::WouldDeferOpenRoute {
+                    resolved_owner: owner,
+                    ..
+                }
+            } if *owner == expected_owner
+        ));
+        assert_eq!(
+            super::super::intake_routing_telemetry::telemetry_for_decision(&decision)
+                .owner_resolution,
+            match expected_owner {
+                ResolvedSessionOwner::NoOwner => {
+                    super::super::intake_routing_telemetry::OwnerResolutionCode::NoOwner
+                }
+                ResolvedSessionOwner::LiveLocal => {
+                    super::super::intake_routing_telemetry::OwnerResolutionCode::LiveLocal
+                }
+                ResolvedSessionOwner::LiveForeign => {
+                    super::super::intake_routing_telemetry::OwnerResolutionCode::LiveForeign
+                }
+            }
+        );
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn open_route_telemetry_preserves_local_owner_pg() {
+        open_route_owner_telemetry_case(
+            "ch-open-route-local-owner",
+            Some("leader-1"),
+            ResolvedSessionOwner::LiveLocal,
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn open_route_telemetry_preserves_foreign_owner_pg() {
+        open_route_owner_telemetry_case(
+            "ch-open-route-foreign-owner",
+            Some("worker-live-owner"),
+            ResolvedSessionOwner::LiveForeign,
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn open_route_telemetry_preserves_no_owner_pg() {
+        open_route_owner_telemetry_case(
+            "ch-open-route-no-owner",
+            None,
+            ResolvedSessionOwner::NoOwner,
+        )
+        .await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2794,7 +2771,12 @@ mod pg_tests {
             &ctx_for_channel(IntakeRoutingMode::Enforce, "ch-dup"),
         )
         .await;
-        assert_eq!(second, IntakeRouterDecision::SkippedDuplicate);
+        assert_eq!(
+            second,
+            IntakeRouterDecision::SkippedDuplicate {
+                resolved_owner: ResolvedSessionOwner::NoOwner
+            }
+        );
 
         // CRITICAL: the family did NOT grow — only one row exists.
         let count: i64 = sqlx::query_scalar(

--- a/src/services/cluster/intake_routing_config.rs
+++ b/src/services/cluster/intake_routing_config.rs
@@ -1,0 +1,228 @@
+use crate::config::{ClusterIntakeRoutingConfig, ClusterIntakeRoutingMode};
+
+/// How aggressively to apply the Phase-2 routing decision in front of
+/// the existing leader intake path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum IntakeRoutingMode {
+    /// Hook is a no-op; the leader runs every intake locally as today.
+    /// Default until Phase 5 flips the global flag — keeps prod
+    /// behaviour byte-identical while phases 1-4 land.
+    Disabled,
+    /// The hook does the full decision (label match, worker eligibility,
+    /// 23505 classification) but never INSERTs. Logs the decision so
+    /// operators can verify routing behaviour against real traffic
+    /// before promoting to `Enforce`.
+    Observe,
+    /// The hook actually INSERTs into `intake_outbox` and tells the
+    /// caller to skip local execution.
+    Enforce,
+}
+
+impl IntakeRoutingMode {
+    fn from_config(mode: ClusterIntakeRoutingMode) -> Self {
+        match mode {
+            ClusterIntakeRoutingMode::Disabled => Self::Disabled,
+            ClusterIntakeRoutingMode::Observe => Self::Observe,
+            ClusterIntakeRoutingMode::Enforce => Self::Enforce,
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::Observe => "observe",
+            Self::Enforce => "enforce",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum IntakeRoutingModeSource {
+    ConfigYaml,
+    EnvOverride,
+}
+
+impl IntakeRoutingModeSource {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::ConfigYaml => "yaml",
+            Self::EnvOverride => "env_override",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IntakeRoutingEnvOverride {
+    Disabled,
+    Observe,
+    Enforce,
+    Invalid,
+}
+
+impl IntakeRoutingEnvOverride {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::Observe => "observe",
+            Self::Enforce => "enforce",
+            Self::Invalid => "invalid",
+        }
+    }
+
+    fn mode(self) -> IntakeRoutingMode {
+        match self {
+            Self::Disabled | Self::Invalid => IntakeRoutingMode::Disabled,
+            Self::Observe => IntakeRoutingMode::Observe,
+            Self::Enforce => IntakeRoutingMode::Enforce,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct EffectiveIntakeRoutingConfig {
+    pub(crate) mode: IntakeRoutingMode,
+    pub(crate) source: IntakeRoutingModeSource,
+    pub(crate) yaml_enabled: bool,
+    pub(crate) yaml_mode: ClusterIntakeRoutingMode,
+    pub(crate) env_override: Option<&'static str>,
+    pub(crate) warnings: Vec<&'static str>,
+    pub(crate) owner_authority_channel_ids: Vec<String>,
+    pub(crate) forward_pre_claim_timeout_secs: u64,
+    pub(crate) stale_claim_recovery_secs: u64,
+}
+
+impl EffectiveIntakeRoutingConfig {
+    pub(crate) fn mode_is_enforce(&self) -> bool {
+        matches!(self.mode, IntakeRoutingMode::Enforce)
+    }
+
+    pub(crate) fn worker_consumer_should_spawn(&self) -> bool {
+        !matches!(self.mode, IntakeRoutingMode::Disabled)
+    }
+
+    pub(crate) fn owner_authority_channel_opted_in(&self, channel_id: &str) -> bool {
+        self.owner_authority_channel_ids
+            .iter()
+            .any(|configured| configured.trim() == channel_id)
+    }
+
+    pub(crate) fn status_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "enabled": !matches!(self.mode, IntakeRoutingMode::Disabled),
+            "mode": self.mode.as_str(),
+            "source": self.source.as_str(),
+            "owner_authority_allowlist_size": self.owner_authority_channel_ids.len(),
+            "recent_decision_count": super::intake_routing_telemetry::recent_decision_count(),
+            "yaml": {
+                "enabled": self.yaml_enabled,
+                "mode": self.yaml_mode.as_str(),
+                "owner_authority_allowlist_size": self.owner_authority_channel_ids.len(),
+                "forward_pre_claim_timeout_secs": self.forward_pre_claim_timeout_secs,
+                "stale_claim_recovery_secs": self.stale_claim_recovery_secs,
+            },
+            "env_override": self.env_override,
+            "warning_count": self.warnings.len(),
+            "configuration_warnings": self.warnings,
+        })
+    }
+}
+
+fn parse_intake_routing_env_override(value: &str) -> IntakeRoutingEnvOverride {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "disabled" | "disable" | "off" | "false" | "0" => IntakeRoutingEnvOverride::Disabled,
+        "observe" => IntakeRoutingEnvOverride::Observe,
+        "enforce" => IntakeRoutingEnvOverride::Enforce,
+        _ => IntakeRoutingEnvOverride::Invalid,
+    }
+}
+
+fn effective_intake_routing_config_for(
+    config: &ClusterIntakeRoutingConfig,
+    env_override: Option<&str>,
+) -> EffectiveIntakeRoutingConfig {
+    let yaml_mode = if config.enabled {
+        IntakeRoutingMode::from_config(config.mode)
+    } else {
+        IntakeRoutingMode::Disabled
+    };
+    let parsed_env = env_override.map(parse_intake_routing_env_override);
+    let (mode, source) = match parsed_env {
+        Some(value) => (value.mode(), IntakeRoutingModeSource::EnvOverride),
+        None => (yaml_mode, IntakeRoutingModeSource::ConfigYaml),
+    };
+    let mut warnings = Vec::new();
+    if parsed_env == Some(IntakeRoutingEnvOverride::Invalid) {
+        warnings.push("invalid_ADK_INTAKE_ROUTING_MODE_fail_closed");
+    }
+    EffectiveIntakeRoutingConfig {
+        mode,
+        source,
+        yaml_enabled: config.enabled,
+        yaml_mode: config.mode,
+        env_override: parsed_env.map(IntakeRoutingEnvOverride::as_str),
+        warnings,
+        owner_authority_channel_ids: config.owner_authority_channel_ids.clone(),
+        forward_pre_claim_timeout_secs: config.forward_pre_claim_timeout_secs,
+        stale_claim_recovery_secs: config.stale_claim_recovery_secs,
+    }
+}
+
+pub(crate) fn effective_intake_routing_config() -> EffectiveIntakeRoutingConfig {
+    let config = crate::config_live_reload::current()
+        .map(|config| config.cluster.intake_routing.clone())
+        .unwrap_or_else(|| crate::config::load_graceful().cluster.intake_routing);
+    let env_override = std::env::var("ADK_INTAKE_ROUTING_MODE").ok();
+    effective_intake_routing_config_for(&config, env_override.as_deref())
+}
+
+pub(crate) fn intake_routing_status_json() -> serde_json::Value {
+    effective_intake_routing_config().status_json()
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn effective_intake_routing_config_resolves_yaml_and_env_override() {
+        let mut yaml = ClusterIntakeRoutingConfig::default();
+        assert_eq!(
+            effective_intake_routing_config_for(&yaml, None).mode,
+            IntakeRoutingMode::Disabled
+        );
+
+        yaml.enabled = true;
+        assert_eq!(
+            effective_intake_routing_config_for(&yaml, None).mode,
+            IntakeRoutingMode::Observe
+        );
+
+        yaml.mode = ClusterIntakeRoutingMode::Enforce;
+        yaml.owner_authority_channel_ids = vec!["123".into()];
+        let from_yaml = effective_intake_routing_config_for(&yaml, None);
+        assert_eq!(from_yaml.mode, IntakeRoutingMode::Enforce);
+        assert_eq!(from_yaml.source, IntakeRoutingModeSource::ConfigYaml);
+        assert!(from_yaml.owner_authority_channel_opted_in("123"));
+        assert!(!from_yaml.owner_authority_channel_opted_in("456"));
+
+        let env_observe = effective_intake_routing_config_for(&yaml, Some("observe"));
+        assert_eq!(env_observe.mode, IntakeRoutingMode::Observe);
+        assert_eq!(env_observe.source, IntakeRoutingModeSource::EnvOverride);
+        assert_eq!(env_observe.env_override, Some("observe"));
+        assert!(env_observe.owner_authority_channel_opted_in("123"));
+        assert!(!env_observe.owner_authority_channel_opted_in("456"));
+
+        let env_disabled = effective_intake_routing_config_for(&yaml, Some("OFF"));
+        assert_eq!(env_disabled.mode, IntakeRoutingMode::Disabled);
+        assert_eq!(env_disabled.env_override, Some("disabled"));
+
+        let invalid = effective_intake_routing_config_for(&yaml, Some("garbage"));
+        assert_eq!(invalid.mode, IntakeRoutingMode::Disabled);
+        assert_eq!(invalid.source, IntakeRoutingModeSource::EnvOverride);
+        assert_eq!(invalid.env_override, Some("invalid"));
+        assert_eq!(
+            invalid.warnings,
+            vec!["invalid_ADK_INTAKE_ROUTING_MODE_fail_closed"]
+        );
+    }
+}

--- a/src/services/cluster/intake_routing_telemetry.rs
+++ b/src/services/cluster/intake_routing_telemetry.rs
@@ -1,0 +1,470 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::intake_router_hook::{
+    IntakeBlockedReason, IntakeRouterDecision, IntakeRoutingBasis, IntakeRoutingMode,
+    ObservedIntakeOutcome, RanLocalReason, ResolvedSessionOwner,
+};
+
+static RECENT_DECISION_COUNT: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum IntakeRoutingReasonCode {
+    HookDisabled,
+    DisabledButPreferenceSet,
+    NoAgentForChannel,
+    AgentHasNoPreference,
+    NoEligibleWorker,
+    LeaderIsOnlyEligible,
+    DependencyFallback,
+    NodeOverrideIsLeader,
+    NodeOverrideRoutingDisabled,
+    LiveOwnerLocal,
+    LiveOwnerForeign,
+    NoOwnerTargetSelected,
+    DuplicateMessage,
+    OpenRouteDeferred,
+    OwnerLookupFailed,
+    StaleSessionOwners,
+    ConflictingLiveSessionOwners,
+    OwnerProtocolIncompatible,
+    OverrideUnavailable,
+    NonPortableAttachmentForeignOwner,
+    NonPortableAttachmentRoutedTarget,
+    RoutingDependencyFailed,
+}
+
+impl IntakeRoutingReasonCode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::HookDisabled => "hook_disabled",
+            Self::DisabledButPreferenceSet => "disabled_but_preference_set",
+            Self::NoAgentForChannel => "no_agent_for_channel",
+            Self::AgentHasNoPreference => "agent_has_no_preference",
+            Self::NoEligibleWorker => "no_eligible_worker",
+            Self::LeaderIsOnlyEligible => "leader_is_only_eligible",
+            Self::DependencyFallback => "dependency_fallback",
+            Self::NodeOverrideIsLeader => "node_override_is_leader",
+            Self::NodeOverrideRoutingDisabled => "node_override_routing_disabled",
+            Self::LiveOwnerLocal => "live_owner_local",
+            Self::LiveOwnerForeign => "live_owner_foreign",
+            Self::NoOwnerTargetSelected => "no_owner_target_selected",
+            Self::DuplicateMessage => "duplicate_message",
+            Self::OpenRouteDeferred => "open_route_deferred",
+            Self::OwnerLookupFailed => "owner_lookup_failed",
+            Self::StaleSessionOwners => "stale_session_owners",
+            Self::ConflictingLiveSessionOwners => "conflicting_live_session_owners",
+            Self::OwnerProtocolIncompatible => "owner_protocol_incompatible",
+            Self::OverrideUnavailable => "override_unavailable",
+            Self::NonPortableAttachmentForeignOwner => "nonportable_attachment_foreign_owner",
+            Self::NonPortableAttachmentRoutedTarget => "nonportable_attachment_routed_target",
+            Self::RoutingDependencyFailed => "routing_dependency_failed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OwnerResolutionCode {
+    NotEvaluated,
+    NoOwner,
+    LiveLocal,
+    LiveForeign,
+    Failed,
+    Stale,
+    Conflicting,
+    Incompatible,
+}
+
+impl OwnerResolutionCode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::NotEvaluated => "not_evaluated",
+            Self::NoOwner => "no_owner",
+            Self::LiveLocal => "live_local",
+            Self::LiveForeign => "live_foreign",
+            Self::Failed => "failed",
+            Self::Stale => "stale",
+            Self::Conflicting => "conflicting",
+            Self::Incompatible => "incompatible",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PreferredLabelMatchCode {
+    NotEvaluated,
+    NoPreference,
+    MatchedWorker,
+    LeaderOnly,
+    NoEligibleWorker,
+    LookupFailed,
+}
+
+impl PreferredLabelMatchCode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::NotEvaluated => "not_evaluated",
+            Self::NoPreference => "no_preference",
+            Self::MatchedWorker => "matched_worker",
+            Self::LeaderOnly => "leader_only",
+            Self::NoEligibleWorker => "no_eligible_worker",
+            Self::LookupFailed => "lookup_failed",
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct IntakeRoutingTelemetry<'a> {
+    pub(crate) reason_code: IntakeRoutingReasonCode,
+    pub(crate) would_assign_target: Option<&'a str>,
+    pub(crate) owner_resolution: OwnerResolutionCode,
+    pub(crate) preferred_label_match: PreferredLabelMatchCode,
+}
+
+fn blocked_reason_code(reason: &IntakeBlockedReason) -> IntakeRoutingReasonCode {
+    match reason {
+        IntakeBlockedReason::OwnerLookupFailed { .. } => IntakeRoutingReasonCode::OwnerLookupFailed,
+        IntakeBlockedReason::StaleSessionOwners { .. } => {
+            IntakeRoutingReasonCode::StaleSessionOwners
+        }
+        IntakeBlockedReason::ConflictingLiveSessionOwners { .. } => {
+            IntakeRoutingReasonCode::ConflictingLiveSessionOwners
+        }
+        IntakeBlockedReason::OwnerProtocolIncompatible { .. } => {
+            IntakeRoutingReasonCode::OwnerProtocolIncompatible
+        }
+        IntakeBlockedReason::OverrideUnavailable { .. } => {
+            IntakeRoutingReasonCode::OverrideUnavailable
+        }
+        IntakeBlockedReason::NonPortableAttachmentForeignOwner { .. } => {
+            IntakeRoutingReasonCode::NonPortableAttachmentForeignOwner
+        }
+        IntakeBlockedReason::NonPortableAttachmentRoutedTarget { .. } => {
+            IntakeRoutingReasonCode::NonPortableAttachmentRoutedTarget
+        }
+        IntakeBlockedReason::RoutingDependencyFailed { .. } => {
+            IntakeRoutingReasonCode::RoutingDependencyFailed
+        }
+    }
+}
+
+fn owner_resolution_code(owner: ResolvedSessionOwner) -> OwnerResolutionCode {
+    match owner {
+        ResolvedSessionOwner::NoOwner => OwnerResolutionCode::NoOwner,
+        ResolvedSessionOwner::LiveLocal => OwnerResolutionCode::LiveLocal,
+        ResolvedSessionOwner::LiveForeign => OwnerResolutionCode::LiveForeign,
+    }
+}
+
+fn ran_local_telemetry(reason: &RanLocalReason) -> IntakeRoutingTelemetry<'static> {
+    let (reason_code, owner_resolution, preferred_label_match) = match reason {
+        RanLocalReason::HookDisabled => (
+            IntakeRoutingReasonCode::HookDisabled,
+            OwnerResolutionCode::NotEvaluated,
+            PreferredLabelMatchCode::NoPreference,
+        ),
+        RanLocalReason::DisabledButPreferenceSet => (
+            IntakeRoutingReasonCode::DisabledButPreferenceSet,
+            OwnerResolutionCode::NotEvaluated,
+            PreferredLabelMatchCode::NotEvaluated,
+        ),
+        RanLocalReason::NoAgentForChannel => (
+            IntakeRoutingReasonCode::NoAgentForChannel,
+            OwnerResolutionCode::NoOwner,
+            PreferredLabelMatchCode::NoPreference,
+        ),
+        RanLocalReason::AgentHasNoPreference => (
+            IntakeRoutingReasonCode::AgentHasNoPreference,
+            OwnerResolutionCode::NoOwner,
+            PreferredLabelMatchCode::NoPreference,
+        ),
+        RanLocalReason::NoEligibleWorker => (
+            IntakeRoutingReasonCode::NoEligibleWorker,
+            OwnerResolutionCode::NoOwner,
+            PreferredLabelMatchCode::NoEligibleWorker,
+        ),
+        RanLocalReason::LeaderIsOnlyEligible => (
+            IntakeRoutingReasonCode::LeaderIsOnlyEligible,
+            OwnerResolutionCode::NoOwner,
+            PreferredLabelMatchCode::LeaderOnly,
+        ),
+        RanLocalReason::DbErrorFellBackToLocal { .. } => (
+            IntakeRoutingReasonCode::DependencyFallback,
+            OwnerResolutionCode::NoOwner,
+            PreferredLabelMatchCode::LookupFailed,
+        ),
+        RanLocalReason::NodeOverrideIsLeader => (
+            IntakeRoutingReasonCode::NodeOverrideIsLeader,
+            OwnerResolutionCode::NoOwner,
+            PreferredLabelMatchCode::NotEvaluated,
+        ),
+        RanLocalReason::NodeOverrideRoutingDisabled => (
+            IntakeRoutingReasonCode::NodeOverrideRoutingDisabled,
+            OwnerResolutionCode::NotEvaluated,
+            PreferredLabelMatchCode::NotEvaluated,
+        ),
+        RanLocalReason::LiveSessionOwnerIsLocal => (
+            IntakeRoutingReasonCode::LiveOwnerLocal,
+            OwnerResolutionCode::LiveLocal,
+            PreferredLabelMatchCode::NotEvaluated,
+        ),
+    };
+    IntakeRoutingTelemetry {
+        reason_code,
+        would_assign_target: None,
+        owner_resolution,
+        preferred_label_match,
+    }
+}
+
+pub(crate) fn telemetry_for_decision(
+    decision: &IntakeRouterDecision,
+) -> IntakeRoutingTelemetry<'_> {
+    match decision {
+        IntakeRouterDecision::RanLocal { reason } => ran_local_telemetry(reason),
+        IntakeRouterDecision::Observed { outcome } => match outcome {
+            ObservedIntakeOutcome::WouldKeepLocalExistingOwner => IntakeRoutingTelemetry {
+                reason_code: IntakeRoutingReasonCode::LiveOwnerLocal,
+                would_assign_target: None,
+                owner_resolution: OwnerResolutionCode::LiveLocal,
+                preferred_label_match: PreferredLabelMatchCode::NotEvaluated,
+            },
+            ObservedIntakeOutcome::WouldForwardLiveForeignOwner { target_instance_id } => {
+                IntakeRoutingTelemetry {
+                    reason_code: IntakeRoutingReasonCode::LiveOwnerForeign,
+                    would_assign_target: Some(target_instance_id),
+                    owner_resolution: OwnerResolutionCode::LiveForeign,
+                    preferred_label_match: PreferredLabelMatchCode::NotEvaluated,
+                }
+            }
+            ObservedIntakeOutcome::WouldAssignNoOwnerToTarget { target_instance_id } => {
+                IntakeRoutingTelemetry {
+                    reason_code: IntakeRoutingReasonCode::NoOwnerTargetSelected,
+                    would_assign_target: Some(target_instance_id),
+                    owner_resolution: OwnerResolutionCode::NoOwner,
+                    preferred_label_match: PreferredLabelMatchCode::MatchedWorker,
+                }
+            }
+            ObservedIntakeOutcome::WouldKeepNoOwnerLocal { reason } => ran_local_telemetry(reason),
+            ObservedIntakeOutcome::WouldSkipDuplicate { resolved_owner } => {
+                IntakeRoutingTelemetry {
+                    reason_code: IntakeRoutingReasonCode::DuplicateMessage,
+                    would_assign_target: None,
+                    owner_resolution: owner_resolution_code(*resolved_owner),
+                    preferred_label_match: PreferredLabelMatchCode::NotEvaluated,
+                }
+            }
+            ObservedIntakeOutcome::WouldDeferOpenRoute {
+                target_instance_id,
+                resolved_owner,
+            } => IntakeRoutingTelemetry {
+                reason_code: IntakeRoutingReasonCode::OpenRouteDeferred,
+                would_assign_target: Some(target_instance_id),
+                owner_resolution: owner_resolution_code(*resolved_owner),
+                preferred_label_match: PreferredLabelMatchCode::NotEvaluated,
+            },
+            ObservedIntakeOutcome::WouldBlock { reason } => blocked_telemetry(reason),
+        },
+        IntakeRouterDecision::Forwarded {
+            target_instance_id,
+            basis,
+            ..
+        } => match basis {
+            IntakeRoutingBasis::LiveForeignOwner => IntakeRoutingTelemetry {
+                reason_code: IntakeRoutingReasonCode::LiveOwnerForeign,
+                would_assign_target: Some(target_instance_id),
+                owner_resolution: OwnerResolutionCode::LiveForeign,
+                preferred_label_match: PreferredLabelMatchCode::NotEvaluated,
+            },
+            IntakeRoutingBasis::NodeOverride => IntakeRoutingTelemetry {
+                reason_code: IntakeRoutingReasonCode::NoOwnerTargetSelected,
+                would_assign_target: Some(target_instance_id),
+                owner_resolution: OwnerResolutionCode::NoOwner,
+                preferred_label_match: PreferredLabelMatchCode::NotEvaluated,
+            },
+            IntakeRoutingBasis::PreferredLabels => IntakeRoutingTelemetry {
+                reason_code: IntakeRoutingReasonCode::NoOwnerTargetSelected,
+                would_assign_target: Some(target_instance_id),
+                owner_resolution: OwnerResolutionCode::NoOwner,
+                preferred_label_match: PreferredLabelMatchCode::MatchedWorker,
+            },
+        },
+        IntakeRouterDecision::SkippedDuplicate { resolved_owner } => IntakeRoutingTelemetry {
+            reason_code: IntakeRoutingReasonCode::DuplicateMessage,
+            would_assign_target: None,
+            owner_resolution: owner_resolution_code(*resolved_owner),
+            preferred_label_match: PreferredLabelMatchCode::NotEvaluated,
+        },
+        IntakeRouterDecision::DeferredOpenRoute {
+            target_instance_id,
+            resolved_owner,
+        } => IntakeRoutingTelemetry {
+            reason_code: IntakeRoutingReasonCode::OpenRouteDeferred,
+            would_assign_target: Some(target_instance_id),
+            owner_resolution: owner_resolution_code(*resolved_owner),
+            preferred_label_match: PreferredLabelMatchCode::NotEvaluated,
+        },
+        IntakeRouterDecision::Blocked { reason } => blocked_telemetry(reason),
+    }
+}
+
+fn blocked_telemetry(reason: &IntakeBlockedReason) -> IntakeRoutingTelemetry<'_> {
+    let owner_resolution = match reason {
+        IntakeBlockedReason::OwnerLookupFailed { .. } => OwnerResolutionCode::Failed,
+        IntakeBlockedReason::StaleSessionOwners { .. } => OwnerResolutionCode::Stale,
+        IntakeBlockedReason::ConflictingLiveSessionOwners { .. } => {
+            OwnerResolutionCode::Conflicting
+        }
+        IntakeBlockedReason::OwnerProtocolIncompatible { .. } => OwnerResolutionCode::Incompatible,
+        IntakeBlockedReason::NonPortableAttachmentForeignOwner { .. } => {
+            OwnerResolutionCode::LiveForeign
+        }
+        IntakeBlockedReason::OverrideUnavailable { .. }
+        | IntakeBlockedReason::NonPortableAttachmentRoutedTarget { .. }
+        | IntakeBlockedReason::RoutingDependencyFailed { .. } => OwnerResolutionCode::NotEvaluated,
+    };
+    IntakeRoutingTelemetry {
+        reason_code: blocked_reason_code(reason),
+        would_assign_target: match reason {
+            IntakeBlockedReason::OverrideUnavailable { target_instance_id }
+            | IntakeBlockedReason::NonPortableAttachmentRoutedTarget { target_instance_id } => {
+                Some(target_instance_id)
+            }
+            IntakeBlockedReason::NonPortableAttachmentForeignOwner { owner_instance_id } => {
+                Some(owner_instance_id)
+            }
+            _ => None,
+        },
+        owner_resolution,
+        preferred_label_match: PreferredLabelMatchCode::NotEvaluated,
+    }
+}
+
+pub(crate) fn record_decision(
+    mode: IntakeRoutingMode,
+    channel_id: &str,
+    user_msg_id: &str,
+    authority_channel_opted_in: bool,
+    decision: &IntakeRouterDecision,
+) {
+    let telemetry = telemetry_for_decision(decision);
+    RECENT_DECISION_COUNT.fetch_add(1, Ordering::Relaxed);
+    tracing::info!(
+        event = "intake_routing_decision",
+        mode = mode.as_str(),
+        channel_id,
+        user_msg_id,
+        authority_channel_opted_in,
+        authority_scope = "telemetry_only",
+        would_assign_target = telemetry.would_assign_target,
+        owner_resolution = telemetry.owner_resolution.as_str(),
+        preferred_label_match = telemetry.preferred_label_match.as_str(),
+        reason_code = telemetry.reason_code.as_str(),
+        "[intake_router] routing decision"
+    );
+}
+
+pub(crate) fn recent_decision_count() -> u64 {
+    RECENT_DECISION_COUNT.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+
+    use tracing_subscriber::fmt::writer::MakeWriter;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct CapturingWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for CapturingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CapturingWriter {
+        type Writer = CapturingWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[test]
+    fn observe_planner_telemetry_is_stable_and_complete() {
+        let decision = IntakeRouterDecision::Observed {
+            outcome: ObservedIntakeOutcome::WouldAssignNoOwnerToTarget {
+                target_instance_id: "worker-mac".to_string(),
+            },
+        };
+        let telemetry = telemetry_for_decision(&decision);
+        assert_eq!(
+            telemetry,
+            IntakeRoutingTelemetry {
+                reason_code: IntakeRoutingReasonCode::NoOwnerTargetSelected,
+                would_assign_target: Some("worker-mac"),
+                owner_resolution: OwnerResolutionCode::NoOwner,
+                preferred_label_match: PreferredLabelMatchCode::MatchedWorker,
+            }
+        );
+        assert_eq!(telemetry.reason_code.as_str(), "no_owner_target_selected");
+    }
+
+    #[test]
+    fn observe_decision_emits_info_level_structured_fields() {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(CapturingWriter(buffer.clone()))
+            .finish();
+        let decision = IntakeRouterDecision::Observed {
+            outcome: ObservedIntakeOutcome::WouldAssignNoOwnerToTarget {
+                target_instance_id: "worker-mac".to_string(),
+            },
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            record_decision(IntakeRoutingMode::Observe, "123", "456", true, &decision);
+        });
+
+        let logs = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+        for field in [
+            "event=\"intake_routing_decision\"",
+            "mode=\"observe\"",
+            "authority_channel_opted_in=true",
+            "would_assign_target=\"worker-mac\"",
+            "owner_resolution=\"no_owner\"",
+            "preferred_label_match=\"matched_worker\"",
+            "reason_code=\"no_owner_target_selected\"",
+        ] {
+            assert!(logs.contains(field), "missing {field} in logs={logs}");
+        }
+    }
+
+    #[test]
+    fn owner_failure_uses_stable_reason_and_resolution_codes() {
+        let decision = IntakeRouterDecision::Observed {
+            outcome: ObservedIntakeOutcome::WouldBlock {
+                reason: IntakeBlockedReason::ConflictingLiveSessionOwners {
+                    instance_ids: vec!["worker-a".into(), "worker-b".into()],
+                },
+            },
+        };
+        let telemetry = telemetry_for_decision(&decision);
+        assert_eq!(
+            telemetry.reason_code.as_str(),
+            "conflicting_live_session_owners"
+        );
+        assert_eq!(telemetry.owner_resolution, OwnerResolutionCode::Conflicting);
+    }
+}

--- a/src/services/cluster/mod.rs
+++ b/src/services/cluster/mod.rs
@@ -12,6 +12,8 @@ pub(crate) mod capability_routing;
 pub(crate) mod intake_preflight;
 pub(crate) mod intake_router_hook;
 pub(crate) mod intake_routing;
+pub(crate) mod intake_routing_config;
+pub(crate) mod intake_routing_telemetry;
 pub(crate) mod intake_worker;
 pub(crate) mod intake_worker_capabilities;
 /// Worker-node registry + capability routing infrastructure. Relocated from

--- a/src/services/discord/commands/node.rs
+++ b/src/services/discord/commands/node.rs
@@ -454,9 +454,8 @@ pub(in crate::services::discord) async fn handle_node_picker_interaction(
 mod tests {
     use super::*;
     use crate::config::ClusterIntakeRoutingMode;
-    use crate::services::cluster::intake_router_hook::{
-        IntakeRoutingMode, IntakeRoutingModeSource,
-    };
+    use crate::services::cluster::intake_router_hook::IntakeRoutingMode;
+    use crate::services::cluster::intake_routing_config::IntakeRoutingModeSource;
 
     #[test]
     fn node_unavailable_message_reports_effective_mode_and_source() {
@@ -467,6 +466,7 @@ mod tests {
             yaml_mode: ClusterIntakeRoutingMode::Enforce,
             env_override: Some("observe"),
             warnings: Vec::new(),
+            owner_authority_channel_ids: Vec::new(),
             forward_pre_claim_timeout_secs: 12,
             stale_claim_recovery_secs: 60,
         };

--- a/src/services/discord/router/intake_dispatch.rs
+++ b/src/services/discord/router/intake_dispatch.rs
@@ -1,7 +1,6 @@
 use super::message_handler::{self, IntakeDeps, IntakeRequest};
 use crate::services::cluster::intake_router_hook::{
-    IntakeBlockedReason, IntakeRouterContext, IntakeRouterDecision, effective_intake_routing_mode,
-    try_route_intake,
+    IntakeBlockedReason, IntakeRouterContext, IntakeRouterDecision, try_route_intake,
 };
 use crate::services::provider::ProviderKind;
 
@@ -69,26 +68,55 @@ pub(crate) async fn admit_text_intake(
     deps: &IntakeDeps<'_>,
     submission: &IntakeSubmission,
 ) -> IntakeAdmission {
-    let mode = effective_intake_routing_mode();
+    let effective_config =
+        crate::services::cluster::intake_router_hook::effective_intake_routing_config();
+    let mode = effective_config.mode;
+    let channel_id = submission.request.channel_id.get().to_string();
+    let user_msg_id = submission.request.user_msg_id.get().to_string();
+    let authority_channel_opted_in = effective_config.owner_authority_channel_opted_in(&channel_id);
     let Some(pool) = deps.shared.pg_pool.as_ref() else {
-        if matches!(
+        let decision = if matches!(
             mode,
             crate::services::cluster::intake_router_hook::IntakeRoutingMode::Enforce
         ) {
-            return IntakeAdmission::Blocked {
+            IntakeRouterDecision::Blocked {
                 reason: IntakeBlockedReason::RoutingDependencyFailed {
                     detail: "Postgres pool unavailable for owner lookup".to_string(),
                 },
-            };
-        }
-        return IntakeAdmission::Local(LocalAdmissionPermit(()));
+            }
+        } else {
+            IntakeRouterDecision::RanLocal {
+                reason: if matches!(
+                    mode,
+                    crate::services::cluster::intake_router_hook::IntakeRoutingMode::Disabled
+                ) {
+                    crate::services::cluster::intake_router_hook::RanLocalReason::HookDisabled
+                } else {
+                    crate::services::cluster::intake_router_hook::RanLocalReason::DbErrorFellBackToLocal {
+                        detail: "Postgres pool unavailable for owner-aware planning".to_string(),
+                    }
+                },
+            }
+        };
+        crate::services::cluster::intake_routing_telemetry::record_decision(
+            mode,
+            &channel_id,
+            &user_msg_id,
+            authority_channel_opted_in,
+            &decision,
+        );
+        return match decision {
+            IntakeRouterDecision::Blocked { reason } => IntakeAdmission::Blocked { reason },
+            IntakeRouterDecision::RanLocal { .. } => {
+                IntakeAdmission::Local(LocalAdmissionPermit(()))
+            }
+            _ => unreachable!("dependency-free admission creates only blocked or local decisions"),
+        };
     };
 
     let request = &submission.request;
     let leader_instance_id =
         crate::services::cluster::node_registry::resolve_self_instance_id_without_config();
-    let channel_id = request.channel_id.get().to_string();
-    let user_msg_id = request.user_msg_id.get().to_string();
     let request_owner_id = request.request_owner.get().to_string();
     let node_override =
         super::super::commands::channel_node_override(deps.shared, request.channel_id);
@@ -120,36 +148,29 @@ pub(crate) async fn admit_text_intake(
     };
 
     let decision = try_route_intake(pool, &ctx).await;
+    crate::services::cluster::intake_routing_telemetry::record_decision(
+        mode,
+        &channel_id,
+        &user_msg_id,
+        authority_channel_opted_in,
+        &decision,
+    );
     let admission = match decision {
-        IntakeRouterDecision::RanLocal { reason } => {
-            tracing::debug!(
-                ?reason,
-                channel_id,
-                user_msg_id,
-                "[intake_dispatch] admitted local"
-            );
-            IntakeAdmission::Local(LocalAdmissionPermit(()))
-        }
-        IntakeRouterDecision::Observed { outcome } => {
-            tracing::info!(
-                ?outcome,
-                channel_id,
-                user_msg_id,
-                "[intake_dispatch] owner-aware observe route admitted local"
-            );
+        IntakeRouterDecision::RanLocal { .. } | IntakeRouterDecision::Observed { .. } => {
             IntakeAdmission::Local(LocalAdmissionPermit(()))
         }
         IntakeRouterDecision::Forwarded {
             target_instance_id,
             outbox_id,
+            ..
         } => IntakeAdmission::Forwarded {
             target_instance_id,
             outbox_id,
         },
-        IntakeRouterDecision::SkippedDuplicate => IntakeAdmission::SkippedDuplicate,
-        IntakeRouterDecision::DeferredOpenRoute { target_instance_id } => {
-            IntakeAdmission::DeferredOpenRoute { target_instance_id }
-        }
+        IntakeRouterDecision::SkippedDuplicate { .. } => IntakeAdmission::SkippedDuplicate,
+        IntakeRouterDecision::DeferredOpenRoute {
+            target_instance_id, ..
+        } => IntakeAdmission::DeferredOpenRoute { target_instance_id },
         IntakeRouterDecision::Blocked { reason } => IntakeAdmission::Blocked { reason },
     };
     log_nonlocal_admission(&admission, &channel_id, &user_msg_id);


### PR DESCRIPTION
## Summary
- add `cluster.intake_routing.owner_authority_channel_ids` as a live-reloaded raw top-level Discord channel allowlist with default `[]`
- emit one info-level structured `intake_routing_decision` event for Disabled, Observe, and Enforce outcomes, with stable reason, target, preferred-label, owner-resolution, and channel opt-in fields
- expose effective enabled/mode, allowlist size, and process-lifetime recent decision count in intake-routing health status
- document the config, environment override boundary, telemetry fields, and multinode audit classification

## Scope boundary
This PR-1 uses `owner_authority_channel_ids` for planner telemetry classification only. It does not activate `owner_record.rs`, change owner authority, mutate owner state, or alter Observe/Enforce admission behavior. Those authority changes remain for later #4777 PRs. `ADK_INTAKE_ROUTING_MODE` still overrides the effective planner mode, but it cannot populate or bypass the YAML channel allowlist.

## Verification
- `cargo fmt --all --check`
- `cargo check --lib`
- targeted config default/allowlist/env tests
- targeted live-reload classification test
- targeted Observe structured-log planner telemetry tests
- targeted health status preservation test
- `python3 scripts/generate_inventory_docs.py` with no post-commit tracked diff
- `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate`
- `python3 scripts/audit_maintainability.py --check`
- `python3 scripts/check_await_holding_lock_ratchet.py`

Closes #4777

Generated with Claude Code
