### PR TITLE
fix: Windows 컴파일 — footer marker key 헬퍼 크로스플랫폼 이동

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -237,7 +237,10 @@
     `TmuxDeathLifecycleDecision` plumbing; +25 from #4455 adding the explicit
     force-replace claim action used only when Codex rebind proves that a live
     same-output watcher still belongs to an earlier provider turn).
-  - `src/services/discord/tmux.rs` (frozen giant surface; test-only #4104 pins
+  - `src/services/discord/tmux.rs` (frozen giant surface; -9 from the #4804
+    Windows-compile hotfix moving `footer_background_marker_session_key` into
+    the cross-platform `task_notification_delivery::terminal_identity` (tmux.rs
+    keeps a `use` of the shared helper; key format unchanged); test-only #4104 pins
     watcher tool-hold progress persistence before both silent-render suppression
     and unchanged-render early returns; runtime wiring lives in the non-giant
     `tmux_watcher/streaming_status_tick.rs`; test-only #4253 wires the

--- a/src/services/discord/task_notification_delivery/mod.rs
+++ b/src/services/discord/task_notification_delivery/mod.rs
@@ -21,6 +21,7 @@ use crate::services::agent_protocol::TaskNotificationKind;
 use crate::services::session_backend::{StreamLineState, classify_task_notification_kind};
 
 use self::card_post::deliver_card_post_claim;
+pub(in crate::services::discord) use self::terminal_identity::footer_background_marker_session_key;
 pub(super) use gateway::{
     CardBot, CardDeliveryClients, CardPostReconcile, DiscordTaskCardTransport, TaskCardTransport,
     TaskCardTransportError,

--- a/src/services/discord/task_notification_delivery/terminal_identity.rs
+++ b/src/services/discord/task_notification_delivery/terminal_identity.rs
@@ -1,6 +1,17 @@
 //! Provider-entry identity for terminal task cards (#4295).
 
+use poise::serenity_prelude::ChannelId;
+
 use super::*;
+
+/// Stable outbox identity shared by prompt observation and watcher suppression
+/// for one footer-owned background completion.
+pub(in crate::services::discord) fn footer_background_marker_session_key(
+    channel_id: ChannelId,
+    event_key: &str,
+) -> String {
+    format!("footer_background:ch:{}:{event_key}", channel_id.get())
+}
 
 impl TaskCardEvent {
     pub(in crate::services::discord) fn from_task_prompt(

--- a/src/services/discord/task_notification_delivery/tests.rs
+++ b/src/services/discord/task_notification_delivery/tests.rs
@@ -24,6 +24,17 @@ fn terminal_task_card_includes_shared_completion_metadata_4806() {
 }
 
 #[test]
+fn footer_background_marker_key_is_stable_across_delivery_paths() {
+    assert_eq!(
+        footer_background_marker_session_key(
+            poise::serenity_prelude::ChannelId::new(4_799),
+            "event-identity",
+        ),
+        "footer_background:ch:4799:event-identity"
+    );
+}
+
+#[test]
 fn response_turn_key_is_stable_and_separates_offsets() {
     let first = response_turn_key(4055, "2026-07-11T01:37:00Z", Some(10));
     assert_eq!(first.len(), 64);

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -35,6 +35,7 @@ use super::settings::{
     channel_supports_provider, load_last_session_path, resolve_role_binding,
     validate_bot_channel_routing_with_provider_channel,
 };
+use super::task_notification_delivery::footer_background_marker_session_key;
 use super::tmux_error_detect::{
     detect_provider_overload_message, is_auth_error_message, is_prompt_too_long_message,
 };
@@ -664,15 +665,6 @@ pub(super) fn consume_monitor_auto_turn_preamble_once(injected: &mut bool) -> Op
         *injected = true;
         Some(MONITOR_AUTO_TURN_PREAMBLE_HINT)
     }
-}
-
-/// Stable outbox identity shared by prompt observation and watcher suppression
-/// for one footer-owned background completion.
-pub(in crate::services::discord) fn footer_background_marker_session_key(
-    channel_id: ChannelId,
-    event_key: &str,
-) -> String {
-    format!("footer_background:ch:{}:{event_key}", channel_id.get())
 }
 
 pub(super) fn suppressed_task_notification_marker(

--- a/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
+++ b/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
@@ -200,7 +200,10 @@ fn enqueue_footer_only_background_marker(
 ) {
     let target = format!("channel:{}", channel_id.get());
     let session_key =
-        super::super::tmux::footer_background_marker_session_key(channel_id, event.event_key());
+        super::super::task_notification_delivery::footer_background_marker_session_key(
+            channel_id,
+            event.event_key(),
+        );
     let _ = crate::services::message_outbox::enqueue_lifecycle_notification_best_effort(
         shared.pg_pool.as_ref(),
         target.as_str(),


### PR DESCRIPTION
## 변경 요약
- #4804(8cb56b09a)에서 도입된 footer background marker key 포매터를 Unix 전용 `tmux` 모듈에서 양 플랫폼 공통 `task_notification_delivery` 모듈로 이동했습니다.
- prompt observation 경로와 Unix watcher 경로가 같은 헬퍼를 사용하므로 키 문자열과 dedup 동작은 그대로 유지됩니다.
- Windows에서 `#[cfg(unix)] mod tmux`를 참조하던 E0433 회귀를 제거했습니다.

## 검증
- `cargo fmt --all --check`
- `cargo check --lib`
- `cargo test --lib tui_prompt_relay`
- `cargo test --lib tmux`
- docs generation + maintenance freshness check
- maintainability audit `--check`
- hotfile / inflight blind-save / await-holding-lock / clippy-allow ratchets

CI Windows job 실행 확인

회귀: #4804