### PR TITLE
fix(#4794): preserve resumed session id through launch

### DIFF
--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -122,16 +122,30 @@ fn stale_busy_context<'a>(
     (session_names[0], provider, session_names[1])
 }
 
-async fn resolve_channel_tmux_names(
+async fn resolve_channel_runtime_for_launch(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: serenity::ChannelId,
-) -> (Option<String>, Option<String>) {
-    let data = shared.core.lock().await;
+    mut current: (String, Option<String>, bool, &'static str),
+) -> (
+    String,
+    Option<String>,
+    bool,
+    &'static str,
+    Option<String>,
+    Option<String>,
+) {
+    let mut data = shared.core.lock().await;
     let channel_name = data
         .sessions
         .get(&channel_id)
         .and_then(|session| session.channel_name.clone());
+    if let Some((session_id, loaded, path)) =
+        load_session_runtime_state(&mut data.sessions, channel_id)
+        && (path != current.0 || session_id != current.1)
+    {
+        current = (path, session_id, loaded, "runtime_session_rebound");
+    }
     let tmux_session_name = if provider.uses_managed_tmux_backend() {
         channel_name
             .as_ref()
@@ -139,7 +153,14 @@ async fn resolve_channel_tmux_names(
     } else {
         None
     };
-    (channel_name, tmux_session_name)
+    (
+        current.0,
+        current.1,
+        current.2,
+        current.3,
+        channel_name,
+        tmux_session_name,
+    )
 }
 
 pub(super) use self::attachments::handle_file_upload;

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -140,11 +140,23 @@ async fn resolve_channel_runtime_for_launch(
         .sessions
         .get(&channel_id)
         .and_then(|session| session.channel_name.clone());
-    if let Some((session_id, loaded, path)) =
-        load_session_runtime_state(&mut data.sessions, channel_id)
-        && (path != current.0 || session_id != current.1)
-    {
-        current = (path, session_id, loaded, "runtime_session_rebound");
+    if let Some(session) = data.sessions.get_mut(&channel_id) {
+        let refreshed_path = session.validated_path(channel_id);
+        let session_changed = session.session_id != current.1;
+        let loaded_changed = session.memento_context_loaded != current.2;
+        let path_changed = refreshed_path
+            .as_deref()
+            .is_some_and(|path| path != current.0);
+        if session_changed || loaded_changed || path_changed {
+            current.0 = refreshed_path.unwrap_or(current.0);
+            current.3 = if current.1.is_some() && session.session_id.is_none() {
+                "explicit_provider_reset"
+            } else {
+                "runtime_session_rebound"
+            };
+            current.1 = session.session_id.clone();
+            current.2 = session.memento_context_loaded;
+        }
     }
     let tmux_session_name = if provider.uses_managed_tmux_backend() {
         channel_name

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -74,9 +74,12 @@ async fn try_start_turn_with_stale_busy_heal(
     cancel_token: Arc<CancelToken>,
     request_owner: serenity::UserId,
     user_msg_id: serenity::MessageId,
-    context: (Option<&str>, &ProviderKind, Option<&str>),
+    context: (
+        (Option<&str>, &ProviderKind, Option<&str>),
+        Option<LaunchState<'_>>,
+    ),
 ) -> bool {
-    let (session_key, provider, tmux_session_name) = context;
+    let ((session_key, provider, tmux_session_name), mut launch) = context;
     let started = mailbox_try_start_turn_with_terminal_marker_cleanup(
         shared,
         channel_id,
@@ -88,7 +91,7 @@ async fn try_start_turn_with_stale_busy_heal(
     .await;
 
     #[cfg(unix)]
-    if !started
+    let started = if !started
         && let Some(tmux_session_name) = tmux_session_name
         && heal_stale_busy_mailbox(
             shared,
@@ -99,7 +102,7 @@ async fn try_start_turn_with_stale_busy_heal(
         )
         .await
     {
-        return mailbox_try_start_turn_with_terminal_marker_cleanup(
+        mailbox_try_start_turn_with_terminal_marker_cleanup(
             shared,
             channel_id,
             cancel_token,
@@ -107,19 +110,65 @@ async fn try_start_turn_with_stale_busy_heal(
             user_msg_id,
             session_key,
         )
-        .await;
-    }
+        .await
+    } else {
+        started
+    };
 
     #[cfg(not(unix))]
     let _ = (provider, tmux_session_name);
+    if started && let Some(launch) = launch.take() {
+        refresh_claimed_runtime_for_launch(
+            shared,
+            provider,
+            channel_id,
+            true,
+            (launch.path, launch.session_id, launch.loaded, launch.reason),
+        )
+        .await;
+    }
     started
 }
 
-fn stale_busy_context<'a>(
+fn intake_claim_context<'a>(
+    session_key: Option<&'a str>,
     provider: &'a ProviderKind,
-    session_names: [Option<&'a str>; 2],
-) -> (Option<&'a str>, &'a ProviderKind, Option<&'a str>) {
-    (session_names[0], provider, session_names[1])
+    tmux_session_name: Option<&'a str>,
+    path: &'a mut String,
+    session_id: &'a mut Option<String>,
+    loaded: &'a mut bool,
+    reason: &'a mut &'static str,
+) -> (
+    (Option<&'a str>, &'a ProviderKind, Option<&'a str>),
+    Option<LaunchState<'a>>,
+) {
+    (
+        (session_key, provider, tmux_session_name),
+        Some(LaunchState::new(path, session_id, loaded, reason)),
+    )
+}
+
+impl<'a> LaunchState<'a> {
+    fn new(
+        path: &'a mut String,
+        session_id: &'a mut Option<String>,
+        loaded: &'a mut bool,
+        reason: &'a mut &'static str,
+    ) -> Self {
+        Self {
+            path,
+            session_id,
+            loaded,
+            reason,
+        }
+    }
+}
+
+struct LaunchState<'a> {
+    path: &'a mut String,
+    session_id: &'a mut Option<String>,
+    loaded: &'a mut bool,
+    reason: &'a mut &'static str,
 }
 
 async fn resolve_channel_runtime_for_launch(
@@ -147,15 +196,16 @@ async fn resolve_channel_runtime_for_launch(
         let path_changed = refreshed_path
             .as_deref()
             .is_some_and(|path| path != current.0);
-        if session_changed || loaded_changed || path_changed {
-            current.0 = refreshed_path.unwrap_or(current.0);
-            current.3 = if current.1.is_some() && session.session_id.is_none() {
-                "explicit_provider_reset"
-            } else {
-                "runtime_session_rebound"
-            };
+        let pending_reset = current.1.is_some() && session.session_id.is_none();
+        if pending_reset {
+            current.1 = None;
+            current.2 = session.memento_context_loaded;
+            current.3 = "explicit_provider_reset";
+        } else if refreshed_path.is_some() && (session_changed || loaded_changed || path_changed) {
+            current.0 = refreshed_path.expect("checked usable runtime path");
             current.1 = session.session_id.clone();
             current.2 = session.memento_context_loaded;
+            current.3 = "runtime_session_rebound";
         }
     }
     let tmux_session_name = if provider.uses_managed_tmux_backend() {
@@ -173,6 +223,30 @@ async fn resolve_channel_runtime_for_launch(
         channel_name,
         tmux_session_name,
     )
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+async fn refresh_claimed_runtime_for_launch(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: serenity::ChannelId,
+    started: bool,
+    state: (
+        &mut String,
+        &mut Option<String>,
+        &mut bool,
+        &mut &'static str,
+    ),
+) {
+    if !started {
+        return;
+    }
+    let current = (state.0.clone(), state.1.clone(), *state.2, *state.3);
+    let runtime = resolve_channel_runtime_for_launch(shared, provider, channel_id, current).await;
+    *state.0 = runtime.0;
+    *state.1 = runtime.1;
+    *state.2 = runtime.2;
+    *state.3 = runtime.3;
 }
 
 pub(super) use self::attachments::handle_file_upload;

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -1284,9 +1284,14 @@ pub(super) async fn handle_text_message(
         cancel_token.clone(),
         request_owner,
         user_msg_id,
-        stale_busy_context(
+        intake_claim_context(
+            adk_session_key.as_deref(),
             &provider,
-            [adk_session_key.as_deref(), tmux_session_name.as_deref()],
+            tmux_session_name.as_deref(),
+            &mut current_path,
+            &mut session_id,
+            &mut memento_context_loaded,
+            &mut session_strategy_reason,
         ),
     )
     .await;
@@ -1806,14 +1811,7 @@ pub(super) async fn handle_text_message(
     // #3813 Phase 1a: prompt prep complete — this mark sits INSIDE the
     // `[prompt-prep]` window below (overlaps it; do not sum — see latency_spans.rs).
     intake_latency.mark_prep_done();
-    let provider_label = match &provider {
-        ProviderKind::Claude => "claude",
-        ProviderKind::Codex => "codex",
-        ProviderKind::Gemini => "gemini",
-        ProviderKind::OpenCode => "opencode",
-        ProviderKind::Qwen => "qwen",
-        ProviderKind::Unsupported(_) => "unsupported",
-    };
+    let provider_label = provider.as_str();
     let ts = chrono::Local::now().format("%H:%M:%S");
     tracing::info!(
         "  [{ts}] [prompt-prep] channel={} provider={} dispatch={} memory_backend={} reused_session={} duration_ms={}",

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -1136,20 +1136,20 @@ pub(super) async fn handle_text_message(
         fast_mode_channel_id,
     )
     .await;
-    refresh_session_strategy_after_pending_reset(
-        shared,
-        channel_id,
-        &mut session_id,
-        &mut memento_context_loaded,
-        &mut session_strategy_reason,
-    )
-    .await;
     let prompt_prep_started = std::time::Instant::now();
 
-    // Resolve channel/tmux session name from current session state. We need the
-    // persisted provider session_id before recall so external memory can scope by run_id.
-    let (channel_name, tmux_session_name) =
-        resolve_channel_tmux_names(shared, &provider, channel_id).await;
+    let state = (
+        current_path,
+        session_id,
+        memento_context_loaded,
+        session_strategy_reason,
+    );
+    let runtime = resolve_channel_runtime_for_launch(shared, &provider, channel_id, state).await;
+    current_path = runtime.0;
+    session_id = runtime.1;
+    memento_context_loaded = runtime.2;
+    session_strategy_reason = runtime.3;
+    let (channel_name, tmux_session_name) = (runtime.4, runtime.5);
     let adk_session_key = build_adk_session_key(shared, channel_id, &provider, None).await;
     let turn_goal_kind = if !dispatch_reset_provider_state && !dispatch_recreate_tmux {
         classify_codex_goal_command_for_provider(

--- a/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
+++ b/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
@@ -12,6 +12,49 @@ fn lock_rollout_cache_test() -> std::sync::MutexGuard<'static, ()> {
     crate::services::codex_tui::rollout_index::lock_cache_for_tests()
 }
 
+#[tokio::test]
+async fn launch_runtime_refresh_preserves_pending_reset_when_path_is_stale() {
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    let channel_id = serenity::ChannelId::new(4_794_003);
+    {
+        let mut data = shared.core.lock().await;
+        data.sessions.insert(
+            channel_id,
+            DiscordSession {
+                session_id: None,
+                memento_context_loaded: false,
+                memento_reflected: false,
+                current_path: Some("/missing/resume-worktree".to_string()),
+                history: Vec::new(),
+                pending_uploads: Vec::new(),
+                cleared: false,
+                remote_profile_name: None,
+                channel_id: Some(channel_id.get()),
+                channel_name: Some("resume-reset".to_string()),
+                category_name: None,
+                last_active: tokio::time::Instant::now(),
+                worktree: None,
+                born_generation: 0,
+            },
+        );
+    }
+
+    let current = (
+        "/previous/launch-path".to_string(),
+        Some("01234567-89ab-cdef-0123-456789abcdef".to_string()),
+        true,
+        "runtime_cached_provider_session",
+    );
+    let runtime =
+        resolve_channel_runtime_for_launch(&shared, &ProviderKind::Claude, channel_id, current)
+            .await;
+
+    assert_eq!(runtime.0, "/previous/launch-path");
+    assert_eq!(runtime.1, None);
+    assert!(!runtime.2);
+    assert_eq!(runtime.3, "explicit_provider_reset");
+}
+
 #[test]
 fn session_strategy_lifecycle_event_records_fresh_and_resumed_details() {
     let fresh = session_strategy_lifecycle_event(None, "no_cached_provider_session", None);

--- a/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
+++ b/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
@@ -55,6 +55,146 @@ async fn launch_runtime_refresh_preserves_pending_reset_when_path_is_stale() {
     assert_eq!(runtime.3, "explicit_provider_reset");
 }
 
+#[tokio::test]
+async fn launch_runtime_refresh_rejects_rebound_session_when_target_path_is_stale() {
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    let channel_id = serenity::ChannelId::new(4_794_004);
+    let prior_session_id = "11111111-1111-1111-1111-111111111111";
+    let rebound_session_id = "22222222-2222-2222-2222-222222222222";
+    {
+        let mut data = shared.core.lock().await;
+        data.sessions.insert(
+            channel_id,
+            DiscordSession {
+                session_id: Some(rebound_session_id.to_string()),
+                memento_context_loaded: false,
+                memento_reflected: false,
+                current_path: Some("/removed/rebound-worktree".to_string()),
+                history: Vec::new(),
+                pending_uploads: Vec::new(),
+                cleared: false,
+                remote_profile_name: None,
+                channel_id: Some(channel_id.get()),
+                channel_name: Some("resume-stale-target".to_string()),
+                category_name: None,
+                last_active: tokio::time::Instant::now(),
+                worktree: None,
+                born_generation: 0,
+            },
+        );
+    }
+
+    let runtime = resolve_channel_runtime_for_launch(
+        &shared,
+        &ProviderKind::Claude,
+        channel_id,
+        (
+            "/prior/launch-path".to_string(),
+            Some(prior_session_id.to_string()),
+            true,
+            "runtime_cached_provider_session",
+        ),
+    )
+    .await;
+
+    assert_eq!(runtime.0, "/prior/launch-path");
+    assert_eq!(runtime.1.as_deref(), Some(prior_session_id));
+    assert_ne!(runtime.1.as_deref(), Some(rebound_session_id));
+}
+
+#[test]
+fn invalid_redirect_path_falls_back_without_pairing_redirect_session_id() {
+    let original_channel = serenity::ChannelId::new(4_794_005);
+    let redirect_channel = serenity::ChannelId::new(4_794_006);
+    let original_session_id = "33333333-3333-3333-3333-333333333333";
+    let redirect_session_id = "44444444-4444-4444-4444-444444444444";
+    let mut sessions = std::collections::HashMap::new();
+    sessions.insert(
+        redirect_channel,
+        DiscordSession {
+            session_id: Some(redirect_session_id.to_string()),
+            memento_context_loaded: false,
+            memento_reflected: false,
+            current_path: Some("/removed/redirect-worktree".to_string()),
+            history: Vec::new(),
+            pending_uploads: Vec::new(),
+            cleared: false,
+            remote_profile_name: None,
+            channel_id: Some(redirect_channel.get()),
+            channel_name: None,
+            category_name: None,
+            last_active: tokio::time::Instant::now(),
+            worktree: None,
+            born_generation: 0,
+        },
+    );
+    let original = (
+        Some(original_session_id.to_string()),
+        true,
+        "/prior/redirect-path".to_string(),
+    );
+
+    let resolved = session_runtime_state_after_redirect(
+        &mut sessions,
+        original_channel,
+        redirect_channel,
+        original.clone(),
+    );
+
+    assert_eq!(resolved, original);
+    assert_ne!(resolved.0.as_deref(), Some(redirect_session_id));
+}
+
+#[tokio::test]
+async fn claimed_runtime_refresh_adopts_late_resume_binding() {
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    let channel_id = serenity::ChannelId::new(4_794_007);
+    let prior_cwd = tempfile::tempdir().expect("prior cwd");
+    let rebound_cwd = tempfile::tempdir().expect("rebound cwd");
+    let prior_session_id = "55555555-5555-5555-5555-555555555555";
+    let rebound_session_id = "66666666-6666-6666-6666-666666666666";
+    {
+        let mut data = shared.core.lock().await;
+        data.sessions.insert(
+            channel_id,
+            DiscordSession {
+                session_id: Some(rebound_session_id.to_string()),
+                memento_context_loaded: false,
+                memento_reflected: false,
+                current_path: Some(rebound_cwd.path().display().to_string()),
+                history: Vec::new(),
+                pending_uploads: Vec::new(),
+                cleared: false,
+                remote_profile_name: None,
+                channel_id: Some(channel_id.get()),
+                channel_name: Some("resume-late-binding".to_string()),
+                category_name: None,
+                last_active: tokio::time::Instant::now(),
+                worktree: None,
+                born_generation: 0,
+            },
+        );
+    }
+    let mut current_path = prior_cwd.path().display().to_string();
+    let mut session_id = Some(prior_session_id.to_string());
+    let mut loaded = true;
+    let mut reason = "runtime_cached_provider_session";
+
+    refresh_claimed_runtime_for_launch(
+        &shared,
+        &ProviderKind::Claude,
+        channel_id,
+        true,
+        (&mut current_path, &mut session_id, &mut loaded, &mut reason),
+    )
+    .await;
+
+    assert_eq!(current_path, rebound_cwd.path().display().to_string());
+    assert_eq!(session_id.as_deref(), Some(rebound_session_id));
+    assert!(!loaded);
+    assert_eq!(reason, "runtime_session_rebound");
+}
+
 #[test]
 fn session_strategy_lifecycle_event_records_fresh_and_resumed_details() {
     let fresh = session_strategy_lifecycle_event(None, "no_cached_provider_session", None);

--- a/src/services/discord/router/mod.rs
+++ b/src/services/discord/router/mod.rs
@@ -24,6 +24,8 @@ pub(super) use message_handler::{
 };
 pub(crate) use message_handler::{IntakeRequest, execute_intake_turn_core};
 pub(in crate::services::discord) use queue_status_presentation::queue_status_card_enabled;
+#[cfg(test)]
+pub(super) use turn_start::load_session_runtime_state;
 pub(super) use turn_start::reserve_headless_turn;
 pub(crate) use turn_start::{
     HeadlessTurnReservation, HeadlessTurnStartError, HeadlessTurnStartOutcome,

--- a/src/services/discord/router/turn_start.rs
+++ b/src/services/discord/router/turn_start.rs
@@ -525,7 +525,7 @@ pub(super) async fn refresh_session_strategy_after_pending_reset(
     }
 }
 
-pub(super) fn load_session_runtime_state(
+pub(in crate::services::discord) fn load_session_runtime_state(
     sessions: &mut std::collections::HashMap<ChannelId, DiscordSession>,
     channel_id: ChannelId,
 ) -> Option<(Option<String>, bool, String)> {

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -153,6 +153,88 @@ pub(in crate::services::discord) async fn rebind_channel_session(
     (previous_path, previous_session_id)
 }
 
+#[cfg(test)]
+mod resume_launch_binding_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn rebound_session_binding_reaches_claude_resume_launch_args() {
+        let shared = super::super::make_shared_data_for_tests();
+        let channel_id = ChannelId::new(4_794_001);
+        let cwd_dir = tempfile::tempdir().expect("resume cwd");
+        let cwd = cwd_dir.path().to_str().expect("utf8 cwd");
+        let session_id = "01234567-89ab-cdef-0123-456789abcdef";
+
+        rebind_channel_session(&shared, &ProviderKind::Claude, channel_id, cwd, session_id).await;
+
+        let (launch_session_id, launch_cwd) = {
+            let mut data = shared.core.lock().await;
+            let (session_id, _, current_path) =
+                crate::services::discord::router::load_session_runtime_state(
+                    &mut data.sessions,
+                    channel_id,
+                )
+                .expect("rebound runtime state");
+            (session_id.expect("provider session id"), current_path)
+        };
+        let config = crate::services::claude_tui::session::ClaudeTuiLaunchConfig {
+            tmux_session_name: "AgentDesk-claude-resume-binding".to_string(),
+            working_dir: std::path::PathBuf::from(&launch_cwd),
+            claude_bin: crate::services::claude_command::ClaudeBinary::from_tmux_wrapper_argv(
+                "claude",
+            ),
+            agentdesk_exe: std::path::PathBuf::from("agentdesk"),
+            hook_endpoint: "http://127.0.0.1:49152".to_string(),
+            session_id: launch_session_id,
+            system_prompt: None,
+            model: None,
+            resume: true,
+            launch_env: crate::services::claude_command::ClaudeLaunchEnv::scrub_for_test(),
+        };
+        let args = crate::services::claude_tui::session::build_claude_tui_args(
+            &config,
+            std::path::Path::new("/runtime/settings.json"),
+        );
+
+        assert_eq!(config.working_dir, std::path::Path::new(cwd));
+        assert!(args.windows(2).any(|pair| pair == ["--resume", session_id]));
+    }
+
+    #[test]
+    fn absent_resume_binding_keeps_existing_launch_selection() {
+        let cwd_dir = tempfile::tempdir().expect("current cwd");
+        let expected_cwd = cwd_dir.path().display().to_string();
+        let mut sessions = std::collections::HashMap::new();
+        sessions.insert(
+            ChannelId::new(4_794_002),
+            DiscordSession {
+                session_id: None,
+                memento_context_loaded: false,
+                memento_reflected: false,
+                current_path: Some(expected_cwd.clone()),
+                history: Vec::new(),
+                pending_uploads: Vec::new(),
+                cleared: false,
+                remote_profile_name: None,
+                channel_id: Some(4_794_002),
+                channel_name: None,
+                category_name: None,
+                last_active: tokio::time::Instant::now(),
+                worktree: None,
+                born_generation: 0,
+            },
+        );
+
+        let (session_id, _, cwd) = crate::services::discord::router::load_session_runtime_state(
+            &mut sessions,
+            ChannelId::new(4_794_002),
+        )
+        .expect("existing runtime state");
+        assert_eq!(session_id, None);
+        assert_eq!(cwd, expected_cwd);
+    }
+}
+
 /// Auto-restore session from bot_settings.json if not in memory
 pub(super) async fn auto_restore_session(
     shared: &Arc<SharedData>,


### PR DESCRIPTION
## Summary
- refresh the channel runtime binding atomically at the final intake launch boundary
- keep `/resume`'s rebound cwd and provider session id paired through reset/isolation paths
- add regression coverage proving the rebound Claude id becomes `--resume <sid>` and the no-binding path stays fresh

## Verification
- `cargo fmt --all --check`
- `cargo check --workspace --all-targets`
- `cargo test --lib resume_launch_binding_tests -- --nocapture`
- generated-doc diff gate
- agent-maintenance docs line-count gate
- maintainability audit + hotfile ratchet
- `scripts/ci-script-checks.sh`

Closes #4794

🤖 Generated with [Claude Code](https://claude.com/claude-code)