### PR TITLE
refactor(#4788): extract admitted attachment boundary

### DIFF
--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -848,7 +848,16 @@ pub(in crate::services::discord) async fn handle_event(
                         }
                     }
                 }
-                super::message_handler::handle_file_upload(ctx, new_message, &data.shared).await?
+                let attachments = super::message_handler::describe_attachments(new_message);
+                let permit = super::message_handler::LocalAttachmentPreparationPermit::preserving_existing_intake_order();
+                super::message_handler::prepare_admitted_local_attachment(
+                    ctx,
+                    channel_id,
+                    &attachments,
+                    &data.shared,
+                    &permit,
+                )
+                .await?
             } else {
                 Vec::new()
             };

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -142,7 +142,9 @@ async fn resolve_channel_tmux_names(
     (channel_name, tmux_session_name)
 }
 
-pub(super) use self::attachments::handle_file_upload;
+pub(super) use self::attachments::{
+    LocalAttachmentPreparationPermit, describe_attachments, prepare_admitted_local_attachment,
+};
 pub(super) use self::control::{handle_shell_command_raw, handle_text_command};
 #[allow(unused_imports)]
 pub(in crate::services::discord) use self::headless_turn::{

--- a/src/services/discord/router/message_handler/attachments.rs
+++ b/src/services/discord/router/message_handler/attachments.rs
@@ -28,14 +28,72 @@ pub(super) async fn download_discord_attachment(raw_url: &str) -> Result<Vec<u8>
         .map(|bytes| bytes.to_vec())
         .map_err(|error| format!("Download failed: {error}"))
 }
-/// Handle file uploads from Discord messages
-pub(in crate::services::discord::router) async fn handle_file_upload(
-    ctx: &serenity::Context,
-    msg: &serenity::Message,
-    shared: &Arc<SharedData>,
-) -> Result<Vec<String>, Error> {
-    let channel_id = msg.channel_id;
 
+/// Side-effect-free attachment metadata captured at Discord intake.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::services::discord::router) struct AttachmentDescriptor {
+    filename: String,
+    url: String,
+}
+
+impl From<&serenity::Attachment> for AttachmentDescriptor {
+    fn from(attachment: &serenity::Attachment) -> Self {
+        Self {
+            filename: attachment.filename.clone(),
+            url: attachment.url.clone(),
+        }
+    }
+}
+
+pub(in crate::services::discord::router) fn describe_attachments(
+    msg: &serenity::Message,
+) -> Vec<AttachmentDescriptor> {
+    msg.attachments.iter().map(Into::into).collect()
+}
+
+/// Opaque capability for the local attachment materialization boundary.
+///
+/// The current intake site issues this capability at its existing point so this
+/// preparatory slice preserves ordering. The admission coordinator can move
+/// issuance behind local admission without changing the download/save body.
+#[derive(Debug)]
+pub(in crate::services::discord::router) struct LocalAttachmentPreparationPermit(());
+
+impl LocalAttachmentPreparationPermit {
+    pub(in crate::services::discord::router) fn preserving_existing_intake_order() -> Self {
+        Self(())
+    }
+}
+
+fn persist_attachment(
+    save_dir: &Path,
+    descriptor: &AttachmentDescriptor,
+    bytes: &[u8],
+    timestamp_millis: i64,
+) -> std::io::Result<(std::path::PathBuf, String)> {
+    let safe_name = Path::new(&descriptor.filename)
+        .file_name()
+        .unwrap_or_else(|| std::ffi::OsStr::new("uploaded_file"));
+    let stamped_name = format!("{}_{}", timestamp_millis, safe_name.to_string_lossy());
+    let dest = save_dir.join(stamped_name);
+    fs::write(&dest, bytes)?;
+    let upload_record = format!(
+        "[File uploaded] {} → {} ({} bytes)",
+        descriptor.filename,
+        dest.display(),
+        bytes.len()
+    );
+    Ok((dest, upload_record))
+}
+
+/// Download and save attachments at the admitted-local side-effect boundary.
+pub(in crate::services::discord::router) async fn prepare_admitted_local_attachment(
+    ctx: &serenity::Context,
+    channel_id: serenity::ChannelId,
+    attachments: &[AttachmentDescriptor],
+    shared: &Arc<SharedData>,
+    _permit: &LocalAttachmentPreparationPermit,
+) -> Result<Vec<String>, Error> {
     // Always use the runtime uploads directory (works without session)
     let Some(save_dir) = channel_upload_dir(channel_id) else {
         rate_limit_wait(shared, channel_id).await;
@@ -57,7 +115,7 @@ pub(in crate::services::discord::router) async fn handle_file_upload(
     }
 
     let mut upload_records = Vec::new();
-    for attachment in &msg.attachments {
+    for attachment in attachments {
         let file_name = &attachment.filename;
 
         // Download only from Discord-owned attachment hosts.
@@ -77,21 +135,10 @@ pub(in crate::services::discord::router) async fn handle_file_upload(
             }
         };
 
-        // Save to session path (sanitize filename)
-        let safe_name = Path::new(file_name)
-            .file_name()
-            .unwrap_or_else(|| std::ffi::OsStr::new("uploaded_file"));
-        let ts = chrono::Utc::now().timestamp_millis();
-        let stamped_name = format!("{}_{}", ts, safe_name.to_string_lossy());
-        let dest = save_dir.join(stamped_name);
         let file_size = buf.len();
-
-        match fs::write(&dest, &buf) {
-            Ok(_) => {
-                let msg_text = format!("Saved: {}\n({} bytes)", dest.display(), file_size);
-                rate_limit_wait(shared, channel_id).await;
-                let _ = channel_id.say(&ctx.http, &msg_text).await;
-            }
+        let ts = chrono::Utc::now().timestamp_millis();
+        let (dest, upload_record) = match persist_attachment(&save_dir, attachment, &buf, ts) {
+            Ok(saved) => saved,
             Err(e) => {
                 rate_limit_wait(shared, channel_id).await;
                 let _ = channel_id
@@ -99,22 +146,21 @@ pub(in crate::services::discord::router) async fn handle_file_upload(
                     .await;
                 continue;
             }
-        }
+        };
 
-        let upload_record = format!(
-            "[File uploaded] {} → {} ({} bytes)",
-            file_name,
-            dest.display(),
-            file_size
-        );
+        let msg_text = format!("Saved: {}\n({} bytes)", dest.display(), file_size);
+        rate_limit_wait(shared, channel_id).await;
+        let _ = channel_id.say(&ctx.http, &msg_text).await;
+        debug_assert!(upload_record.starts_with(&format!("[File uploaded] {file_name} → ")));
         upload_records.push(upload_record);
     }
 
     Ok(upload_records)
 }
+
 #[cfg(test)]
-mod attachment_url_tests {
-    use super::is_allowed_discord_attachment_url;
+mod attachment_tests {
+    use super::{AttachmentDescriptor, is_allowed_discord_attachment_url, persist_attachment};
 
     #[test]
     fn discord_attachment_url_guard_allows_discord_cdn_hosts() {
@@ -138,5 +184,61 @@ mod attachment_url_tests {
             "https://127.0.0.1/attachments/1/2/file.txt"
         ));
         assert!(!is_allowed_discord_attachment_url("not a url"));
+    }
+
+    #[test]
+    fn attachment_persistence_seam_preserves_path_record_and_bytes() {
+        let root = tempfile::tempdir().expect("temporary upload root");
+        let descriptor = AttachmentDescriptor {
+            filename: "../report.txt".to_string(),
+            url: "https://cdn.discordapp.com/attachments/1/2/report.txt".to_string(),
+        };
+
+        let (path, record) = persist_attachment(root.path(), &descriptor, b"payload", 1234)
+            .expect("persist attachment");
+
+        assert_eq!(path, root.path().join("1234_report.txt"));
+        assert_eq!(std::fs::read(&path).expect("read saved file"), b"payload");
+        assert_eq!(
+            record,
+            format!(
+                "[File uploaded] ../report.txt → {} (7 bytes)",
+                path.display()
+            )
+        );
+    }
+
+    #[test]
+    fn attachment_materialization_requires_opaque_permit_and_keeps_existing_order() {
+        let source = include_str!("../intake_gate.rs");
+        let restore = source
+            .find("auto_restore_session_with_dm_hint(&data.shared, channel_id")
+            .expect("existing session restore");
+        let descriptor = source
+            .find("let attachments = super::message_handler::describe_attachments(new_message);")
+            .expect("descriptor capture");
+        let permit = source
+            .find("let permit = super::message_handler::LocalAttachmentPreparationPermit::preserving_existing_intake_order();")
+            .expect("opaque permit issuance");
+        let prepare = source
+            .find("super::message_handler::prepare_admitted_local_attachment(")
+            .expect("materialization boundary");
+        let history = source
+            .find("record_upload_history(&data.shared, channel_id, &upload_records).await;")
+            .expect("existing history update");
+        let admission = source
+            .find("super::dispatch_text_intake(&deps, submission).await?;")
+            .expect("central admission call");
+
+        assert!(restore < descriptor);
+        assert!(descriptor < permit && permit < prepare);
+        assert!(prepare < history && history < admission);
+        assert_eq!(
+            source
+                .matches("LocalAttachmentPreparationPermit::preserving_existing_intake_order()")
+                .count(),
+            1,
+            "only the compatibility intake site may issue the preparatory permit"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- capture Discord attachment metadata in a side-effect-free descriptor
- extract download/save/message effects behind `prepare_admitted_local_attachment` and an opaque local preparation permit
- preserve the current restore → materialize → history → central admission ordering with a regression test

## Scope
This is only the behavior-neutral preparatory slice recorded in issue #4788 for the #4777 PR sequence. It does not move attachment preparation behind admission, change intake routing, or modify `Intervention.pending_uploads`; those enforcement changes remain in #4777 PR-2.

## Validation
- `cargo fmt --all --check`
- `cargo check --lib`
- `cargo test --lib attachment_tests`
- `cargo test --lib intake_dispatch_invariant`
- `python3 scripts/generate_inventory_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py`
- generated-doc diff clean

Refs #4788
Part of #4777

🤖 Generated with [Claude Code](https://claude.com/claude-code)