### PR TITLE
fix(cli): honor restart marker ownership

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,6 +39,7 @@ src/
 │   ├── client.rs
 │   ├── dcserver.rs
 │   ├── dcserver_pg_bootstrap.rs
+│   ├── dcserver_restart_marker.rs
 │   ├── direct.rs
 │   ├── discord.rs
 │   ├── discord_thread_create.rs

--- a/src/cli/dcserver.rs
+++ b/src/cli/dcserver.rs
@@ -659,15 +659,25 @@ pub fn handle_restart_dcserver(
     // turns survive and are rehydrated by the new process.
     const DEFERRED_TIMEOUT: Duration = Duration::from_secs(30);
     if let Some(root) = agentdesk_runtime_root() {
-        let marker = root.join("restart_pending");
-        if let Err(e) = fs::write(&marker, VERSION) {
-            eprintln!(
-                "   ⚠ Failed to write restart marker {}: {e} — falling back to force-kill",
-                marker.display()
-            );
-            kill_existing_dcserver_processes();
-            return;
-        }
+        let marker = match super::dcserver_restart_marker::create_quick_restart_marker(
+            &root, VERSION,
+        ) {
+            Ok(marker) => marker,
+            Err(super::dcserver_restart_marker::RestartMarkerCreateError::AlreadyOwned(owner)) => {
+                eprintln!(
+                    "   ⚠ restart already owned ({owner}); preserving the existing restart and refusing force-kill"
+                );
+                return;
+            }
+            Err(e) => {
+                eprintln!(
+                    "   ⚠ Failed to write restart marker {}: {e} — falling back to force-kill",
+                    root.join("restart_pending").display()
+                );
+                kill_existing_dcserver_processes();
+                return;
+            }
+        };
         println!(
             "   ⏳ Restart requested — waiting for dcserver quick-exit (max {}s)",
             DEFERRED_TIMEOUT.as_secs()
@@ -676,7 +686,7 @@ pub fn handle_restart_dcserver(
         let start = Instant::now();
         loop {
             // If marker file is gone, dcserver consumed it and exited
-            if !marker.exists() {
+            if !marker.path().exists() {
                 println!("   ✓ dcserver acknowledged restart marker");
                 break;
             }
@@ -706,13 +716,20 @@ pub fn handle_restart_dcserver(
                 };
                 if !process_alive {
                     println!("   ✓ dcserver process exited gracefully");
-                    let _ = fs::remove_file(&marker);
+                    marker.remove_if_owned();
                     break;
                 }
             }
             if start.elapsed() >= DEFERRED_TIMEOUT {
-                eprintln!("   ⚠ Deferred restart timeout — falling back to force kill");
-                let _ = fs::remove_file(&marker);
+                if marker.is_current_owner() {
+                    eprintln!("   ⚠ Deferred restart timeout — falling back to force kill");
+                    marker.remove_if_owned();
+                } else {
+                    eprintln!(
+                        "   ⚠ restart marker ownership changed while waiting; preserving the current owner and refusing force-kill"
+                    );
+                    return;
+                }
                 break;
             }
             std::thread::sleep(Duration::from_millis(500));

--- a/src/cli/dcserver.rs
+++ b/src/cli/dcserver.rs
@@ -684,18 +684,15 @@ pub fn handle_restart_dcserver(
         );
 
         let start = Instant::now();
-        loop {
-            // If marker file is gone, dcserver consumed it and exited
+        let ownership = loop {
             if !marker.path().exists() {
                 println!("   ✓ dcserver acknowledged restart marker");
-                break;
+                return;
             }
-            // Check if dcserver process is still running
             let pid_file = root.join("runtime").join("dcserver.pid");
             if let Ok(pid_str) = fs::read_to_string(&pid_file)
                 && let Ok(pid) = pid_str.trim().parse::<u32>()
             {
-                // Check if process still exists
                 let process_alive = {
                     #[cfg(unix)]
                     {
@@ -716,27 +713,39 @@ pub fn handle_restart_dcserver(
                 };
                 if !process_alive {
                     println!("   ✓ dcserver process exited gracefully");
-                    marker.remove_if_owned();
-                    break;
+                    return;
                 }
             }
             if start.elapsed() >= DEFERRED_TIMEOUT {
-                if marker.is_current_owner() {
-                    eprintln!("   ⚠ Deferred restart timeout — falling back to force kill");
-                    marker.remove_if_owned();
-                } else {
-                    eprintln!(
-                        "   ⚠ restart marker ownership changed while waiting; preserving the current owner and refusing force-kill"
-                    );
-                    return;
-                }
-                break;
+                break match marker.resolve_ownership(kill_existing_dcserver_processes) {
+                    Ok(ownership) => ownership,
+                    Err(error) => {
+                        eprintln!(
+                            "   ⚠ Failed to resolve restart marker ownership: {error}; refusing force-kill"
+                        );
+                        return;
+                    }
+                };
             }
             std::thread::sleep(Duration::from_millis(500));
+        };
+
+        match ownership {
+            super::dcserver_restart_marker::MarkerOwnership::RemovedOwned => {
+                eprintln!("   ⚠ Deferred restart timeout — force-kill fallback completed");
+            }
+            super::dcserver_restart_marker::MarkerOwnership::MissingCommitted => {
+                println!("   ✓ dcserver acknowledged restart marker");
+            }
+            super::dcserver_restart_marker::MarkerOwnership::Replaced(owner) => {
+                eprintln!(
+                    "   ⚠ restart already owned ({owner}); preserving the replacement and refusing force-kill"
+                );
+            }
         }
+        return;
     }
 
-    // Kill remaining dcserver processes (either timeout fallback or normal cleanup)
     kill_existing_dcserver_processes();
 
     let launchd_label = current_dcserver_launchd_label();

--- a/src/cli/dcserver_restart_marker.rs
+++ b/src/cli/dcserver_restart_marker.rs
@@ -185,16 +185,43 @@ pub(crate) fn create_quick_restart_marker(
     runtime_root: &Path,
     version: &str,
 ) -> Result<QuickRestartMarker, RestartMarkerCreateError> {
+    create_quick_restart_marker_inner(runtime_root, version, |file, body| {
+        file.write_all(body.as_bytes())?;
+        file.flush()
+    })
+}
+
+fn create_quick_restart_marker_inner(
+    runtime_root: &Path,
+    version: &str,
+    write_staging: impl FnOnce(&mut fs::File, &str) -> io::Result<()>,
+) -> Result<QuickRestartMarker, RestartMarkerCreateError> {
     let path = runtime_root.join("restart_pending");
+    let staging_path =
+        runtime_root.join(format!(".restart_pending.publish.{}", uuid::Uuid::new_v4()));
     let nonce = uuid::Uuid::new_v4();
     let body = format!(
         "nonce={nonce}\nsource={QUICK_RESTART_SOURCE}\nscope={QUICK_RESTART_SCOPE}\nversion={version}\nrequested_at={}\n",
         chrono::Utc::now().to_rfc3339()
     );
 
-    let mut file = match OpenOptions::new().write(true).create_new(true).open(&path) {
-        Ok(file) => file,
+    let mut staging = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&staging_path)
+        .map_err(RestartMarkerCreateError::Io)?;
+    if let Err(error) = write_staging(&mut staging, &body) {
+        let _ = fs::remove_file(&staging_path);
+        return Err(RestartMarkerCreateError::Io(error));
+    }
+    drop(staging);
+
+    match fs::hard_link(&staging_path, &path) {
+        Ok(()) => {
+            let _ = fs::remove_file(&staging_path);
+        }
         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            let _ = fs::remove_file(&staging_path);
             let owner = RestartMarkerOwner::from_path(&path).unwrap_or(RestartMarkerOwner {
                 nonce: None,
                 source: None,
@@ -202,12 +229,10 @@ pub(crate) fn create_quick_restart_marker(
             });
             return Err(RestartMarkerCreateError::AlreadyOwned(owner));
         }
-        Err(error) => return Err(RestartMarkerCreateError::Io(error)),
-    };
-
-    if let Err(error) = file.write_all(body.as_bytes()) {
-        let _ = fs::remove_file(&path);
-        return Err(RestartMarkerCreateError::Io(error));
+        Err(error) => {
+            let _ = fs::remove_file(&staging_path);
+            return Err(RestartMarkerCreateError::Io(error));
+        }
     }
 
     Ok(QuickRestartMarker {
@@ -254,6 +279,52 @@ mod tests {
         fs::write(&path, existing).unwrap();
 
         let result = create_quick_restart_marker(root.path(), "9.9.9");
+
+        assert!(matches!(
+            result,
+            Err(RestartMarkerCreateError::AlreadyOwned(RestartMarkerOwner {
+                nonce: Some(ref nonce),
+                source: Some(ref source),
+                scope: Some(ref scope),
+            })) if nonce == "owner-nonce" && source == "deploy-release" && scope == "release"
+        ));
+        assert_eq!(fs::read_to_string(path).unwrap(), existing);
+    }
+
+    #[test]
+    fn staging_write_failure_never_touches_canonical_marker() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("restart_pending");
+        let existing = "nonce=owner-nonce\nsource=deploy-release\nscope=release\n";
+        fs::write(&path, existing).unwrap();
+
+        let result = create_quick_restart_marker_inner(root.path(), "9.9.9", |file, body| {
+            file.write_all(&body.as_bytes()[..body.len() / 2])?;
+            Err(io::Error::other("injected staging write failure"))
+        });
+
+        assert!(matches!(result, Err(RestartMarkerCreateError::Io(_))));
+        assert_eq!(fs::read_to_string(path).unwrap(), existing);
+        assert!(fs::read_dir(root.path()).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".restart_pending.publish.")
+        }));
+    }
+
+    #[test]
+    fn staging_publish_eexist_preserves_existing_owner() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("restart_pending");
+        let existing = "nonce=owner-nonce\nsource=deploy-release\nscope=release\n";
+        fs::write(&path, existing).unwrap();
+
+        let result = create_quick_restart_marker_inner(root.path(), "9.9.9", |file, body| {
+            file.write_all(body.as_bytes())?;
+            file.flush()
+        });
 
         assert!(matches!(
             result,

--- a/src/cli/dcserver_restart_marker.rs
+++ b/src/cli/dcserver_restart_marker.rs
@@ -78,13 +78,14 @@ impl QuickRestartMarker {
         &self,
         on_removed_owned: impl FnOnce(),
     ) -> io::Result<MarkerOwnership> {
-        self.resolve_ownership_inner(|| {}, || {}, on_removed_owned)
+        self.resolve_ownership_inner(|| {}, || {}, append_force_kill_phase, on_removed_owned)
     }
 
     fn resolve_ownership_inner(
         &self,
         after_claim: impl FnOnce(),
         after_reservation: impl FnOnce(),
+        append_phase: impl FnOnce(&Path) -> io::Result<()>,
         on_removed_owned: impl FnOnce(),
     ) -> io::Result<MarkerOwnership> {
         let claimed_path = self
@@ -129,8 +130,8 @@ impl QuickRestartMarker {
             }
         }
 
-        if let Err(error) = append_force_kill_phase(&claimed_path) {
-            let _ = fs::remove_file(&self.path);
+        if let Err(error) = append_phase(&claimed_path) {
+            identity_safe_remove(&self.path, &self.nonce)?;
             restore_claimed_marker(&claimed_path, &self.path);
             return Err(error);
         }
@@ -139,7 +140,7 @@ impl QuickRestartMarker {
         // If this process dies during force-kill, the nonce-bound marker remains
         // for the next runtime to consume, so the interrupted fallback converges.
         on_removed_owned();
-        fs::remove_file(&self.path)?;
+        identity_safe_remove(&self.path, &self.nonce)?;
         fs::remove_file(claimed_path)?;
         Ok(MarkerOwnership::RemovedOwned)
     }
@@ -149,6 +150,30 @@ fn restore_claimed_marker(claimed_path: &Path, marker_path: &Path) {
     if fs::hard_link(claimed_path, marker_path).is_ok() {
         let _ = fs::remove_file(claimed_path);
     }
+}
+
+fn identity_safe_remove(marker_path: &Path, expected_nonce: &str) -> io::Result<()> {
+    let cleanup_path =
+        marker_path.with_file_name(format!(".restart_pending.cleanup.{}", uuid::Uuid::new_v4()));
+    match fs::rename(marker_path, &cleanup_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    }
+
+    let owner = match RestartMarkerOwner::from_path(&cleanup_path) {
+        Ok(owner) => owner,
+        Err(error) => {
+            restore_claimed_marker(&cleanup_path, marker_path);
+            return Err(error);
+        }
+    };
+    if owner.nonce.as_deref() == Some(expected_nonce) {
+        return fs::remove_file(cleanup_path);
+    }
+
+    restore_claimed_marker(&cleanup_path, marker_path);
+    Ok(())
 }
 
 fn append_force_kill_phase(path: &Path) -> io::Result<()> {
@@ -254,6 +279,7 @@ mod tests {
                     fs::write(marker.path(), replacement).unwrap();
                 },
                 || {},
+                append_force_kill_phase,
                 || force_kill_called.set(true),
             )
             .unwrap();
@@ -286,6 +312,7 @@ mod tests {
                         Err(RestartMarkerCreateError::AlreadyOwned(_))
                     ));
                 },
+                append_force_kill_phase,
                 || {},
             )
             .unwrap();
@@ -306,11 +333,61 @@ mod tests {
             .resolve_ownership_inner(
                 || fs::write(marker.path(), replacement).unwrap(),
                 || {},
+                append_force_kill_phase,
                 || force_kill_called.set(true),
             )
             .unwrap();
 
         assert!(matches!(outcome, MarkerOwnership::Replaced(_)));
+        assert!(!force_kill_called.get());
+        assert_eq!(fs::read_to_string(marker.path()).unwrap(), replacement);
+    }
+
+    #[test]
+    fn cleanup_preserves_replacement_after_runtime_consumes_reservation() {
+        let root = tempfile::tempdir().unwrap();
+        let marker = create_quick_restart_marker(root.path(), "1.2.3").unwrap();
+        let replacement = "nonce=replacement-owner\nsource=deploy-release\nscope=release\n";
+        let force_kill_called = std::cell::Cell::new(false);
+
+        let outcome = marker
+            .resolve_ownership_inner(
+                || {},
+                || {
+                    fs::remove_file(marker.path()).unwrap();
+                    fs::write(marker.path(), replacement).unwrap();
+                },
+                append_force_kill_phase,
+                || force_kill_called.set(true),
+            )
+            .unwrap();
+
+        assert_eq!(outcome, MarkerOwnership::RemovedOwned);
+        assert!(force_kill_called.get());
+        assert_eq!(fs::read_to_string(marker.path()).unwrap(), replacement);
+    }
+
+    #[test]
+    fn append_failure_rollback_preserves_replacement_after_runtime_consumes_reservation() {
+        let root = tempfile::tempdir().unwrap();
+        let marker = create_quick_restart_marker(root.path(), "1.2.3").unwrap();
+        let replacement = "nonce=replacement-owner\nsource=deploy-release\nscope=release\n";
+        let force_kill_called = std::cell::Cell::new(false);
+
+        let error = marker
+            .resolve_ownership_inner(
+                || {},
+                || {},
+                |_| {
+                    fs::remove_file(marker.path()).unwrap();
+                    fs::write(marker.path(), replacement).unwrap();
+                    Err(io::Error::other("injected append failure"))
+                },
+                || force_kill_called.set(true),
+            )
+            .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
         assert!(!force_kill_called.get());
         assert_eq!(fs::read_to_string(marker.path()).unwrap(), replacement);
     }

--- a/src/cli/dcserver_restart_marker.rs
+++ b/src/cli/dcserver_restart_marker.rs
@@ -78,12 +78,13 @@ impl QuickRestartMarker {
         &self,
         on_removed_owned: impl FnOnce(),
     ) -> io::Result<MarkerOwnership> {
-        self.resolve_ownership_inner(|| {}, on_removed_owned)
+        self.resolve_ownership_inner(|| {}, || {}, on_removed_owned)
     }
 
     fn resolve_ownership_inner(
         &self,
         after_claim: impl FnOnce(),
+        after_reservation: impl FnOnce(),
         on_removed_owned: impl FnOnce(),
     ) -> io::Result<MarkerOwnership> {
         let claimed_path = self
@@ -110,14 +111,36 @@ impl QuickRestartMarker {
             return Ok(MarkerOwnership::Replaced(claimed_owner));
         }
 
-        if self.path.exists() {
-            let replacement = RestartMarkerOwner::from_path(&self.path)?;
-            fs::remove_file(claimed_path)?;
-            return Ok(MarkerOwnership::Replaced(replacement));
+        match fs::hard_link(&claimed_path, &self.path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                let replacement =
+                    RestartMarkerOwner::from_path(&self.path).unwrap_or(RestartMarkerOwner {
+                        nonce: None,
+                        source: None,
+                        scope: None,
+                    });
+                fs::remove_file(claimed_path)?;
+                return Ok(MarkerOwnership::Replaced(replacement));
+            }
+            Err(error) => {
+                restore_claimed_marker(&claimed_path, &self.path);
+                return Err(error);
+            }
         }
 
-        fs::remove_file(claimed_path)?;
+        if let Err(error) = append_force_kill_phase(&claimed_path) {
+            let _ = fs::remove_file(&self.path);
+            restore_claimed_marker(&claimed_path, &self.path);
+            return Err(error);
+        }
+        after_reservation();
+        // Keep the canonical hard link occupied through the destructive callback.
+        // If this process dies during force-kill, the nonce-bound marker remains
+        // for the next runtime to consume, so the interrupted fallback converges.
         on_removed_owned();
+        fs::remove_file(&self.path)?;
+        fs::remove_file(claimed_path)?;
         Ok(MarkerOwnership::RemovedOwned)
     }
 }
@@ -126,6 +149,11 @@ fn restore_claimed_marker(claimed_path: &Path, marker_path: &Path) {
     if fs::hard_link(claimed_path, marker_path).is_ok() {
         let _ = fs::remove_file(claimed_path);
     }
+}
+
+fn append_force_kill_phase(path: &Path) -> io::Result<()> {
+    let mut file = OpenOptions::new().append(true).open(path)?;
+    file.write_all(b"phase=force_kill\n")
 }
 
 pub(crate) fn create_quick_restart_marker(
@@ -225,12 +253,64 @@ mod tests {
                 || {
                     fs::write(marker.path(), replacement).unwrap();
                 },
+                || {},
                 || force_kill_called.set(true),
             )
             .unwrap();
 
         assert!(matches!(outcome, MarkerOwnership::Replaced(_)));
         assert!(!outcome.permits_force_kill());
+        assert!(!force_kill_called.get());
+        assert_eq!(fs::read_to_string(marker.path()).unwrap(), replacement);
+    }
+
+    #[test]
+    fn reservation_blocks_new_exclusive_writer_during_force_kill() {
+        let root = tempfile::tempdir().unwrap();
+        let marker = create_quick_restart_marker(root.path(), "1.2.3").unwrap();
+        let writer_blocked = std::cell::Cell::new(false);
+        let phase_visible = std::cell::Cell::new(false);
+
+        let outcome = marker
+            .resolve_ownership_inner(
+                || {},
+                || {
+                    phase_visible.set(
+                        fs::read_to_string(marker.path())
+                            .unwrap()
+                            .lines()
+                            .any(|line| line == "phase=force_kill"),
+                    );
+                    writer_blocked.set(matches!(
+                        create_quick_restart_marker(root.path(), "2.0.0"),
+                        Err(RestartMarkerCreateError::AlreadyOwned(_))
+                    ));
+                },
+                || {},
+            )
+            .unwrap();
+
+        assert_eq!(outcome, MarkerOwnership::RemovedOwned);
+        assert!(phase_visible.get());
+        assert!(writer_blocked.get());
+    }
+
+    #[test]
+    fn reservation_race_returns_replaced_without_force_kill() {
+        let root = tempfile::tempdir().unwrap();
+        let marker = create_quick_restart_marker(root.path(), "1.2.3").unwrap();
+        let replacement = "nonce=replacement-owner\nsource=deploy-release\nscope=release\n";
+        let force_kill_called = std::cell::Cell::new(false);
+
+        let outcome = marker
+            .resolve_ownership_inner(
+                || fs::write(marker.path(), replacement).unwrap(),
+                || {},
+                || force_kill_called.set(true),
+            )
+            .unwrap();
+
+        assert!(matches!(outcome, MarkerOwnership::Replaced(_)));
         assert!(!force_kill_called.get());
         assert_eq!(fs::read_to_string(marker.path()).unwrap(), replacement);
     }

--- a/src/cli/dcserver_restart_marker.rs
+++ b/src/cli/dcserver_restart_marker.rs
@@ -14,13 +14,16 @@ pub(crate) struct RestartMarkerOwner {
 }
 
 impl RestartMarkerOwner {
-    fn from_path(path: &Path) -> Self {
-        let content = fs::read_to_string(path).unwrap_or_default();
+    fn from_content(content: &str) -> Self {
         Self {
-            nonce: marker_field(&content, "nonce"),
-            source: marker_field(&content, "source"),
-            scope: marker_field(&content, "scope"),
+            nonce: marker_field(content, "nonce"),
+            source: marker_field(content, "source"),
+            scope: marker_field(content, "scope"),
         }
+    }
+
+    fn from_path(path: &Path) -> io::Result<Self> {
+        fs::read_to_string(path).map(|content| Self::from_content(&content))
     }
 }
 
@@ -48,6 +51,19 @@ impl fmt::Display for RestartMarkerCreateError {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum MarkerOwnership {
+    RemovedOwned,
+    MissingCommitted,
+    Replaced(RestartMarkerOwner),
+}
+
+impl MarkerOwnership {
+    pub(crate) fn permits_force_kill(&self) -> bool {
+        matches!(self, Self::RemovedOwned)
+    }
+}
+
 pub(crate) struct QuickRestartMarker {
     path: PathBuf,
     nonce: String,
@@ -58,14 +74,57 @@ impl QuickRestartMarker {
         &self.path
     }
 
-    pub(crate) fn is_current_owner(&self) -> bool {
-        RestartMarkerOwner::from_path(&self.path).nonce.as_deref() == Some(self.nonce.as_str())
+    pub(crate) fn resolve_ownership(
+        &self,
+        on_removed_owned: impl FnOnce(),
+    ) -> io::Result<MarkerOwnership> {
+        self.resolve_ownership_inner(|| {}, on_removed_owned)
     }
 
-    pub(crate) fn remove_if_owned(&self) {
-        if self.is_current_owner() {
-            let _ = fs::remove_file(&self.path);
+    fn resolve_ownership_inner(
+        &self,
+        after_claim: impl FnOnce(),
+        on_removed_owned: impl FnOnce(),
+    ) -> io::Result<MarkerOwnership> {
+        let claimed_path = self
+            .path
+            .with_file_name(format!(".restart_pending.resolve.{}", uuid::Uuid::new_v4()));
+        match fs::rename(&self.path, &claimed_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Ok(MarkerOwnership::MissingCommitted);
+            }
+            Err(error) => return Err(error),
         }
+
+        after_claim();
+        let claimed_owner = match RestartMarkerOwner::from_path(&claimed_path) {
+            Ok(owner) => owner,
+            Err(error) => {
+                restore_claimed_marker(&claimed_path, &self.path);
+                return Err(error);
+            }
+        };
+        if claimed_owner.nonce.as_deref() != Some(self.nonce.as_str()) {
+            restore_claimed_marker(&claimed_path, &self.path);
+            return Ok(MarkerOwnership::Replaced(claimed_owner));
+        }
+
+        if self.path.exists() {
+            let replacement = RestartMarkerOwner::from_path(&self.path)?;
+            fs::remove_file(claimed_path)?;
+            return Ok(MarkerOwnership::Replaced(replacement));
+        }
+
+        fs::remove_file(claimed_path)?;
+        on_removed_owned();
+        Ok(MarkerOwnership::RemovedOwned)
+    }
+}
+
+fn restore_claimed_marker(claimed_path: &Path, marker_path: &Path) {
+    if fs::hard_link(claimed_path, marker_path).is_ok() {
+        let _ = fs::remove_file(claimed_path);
     }
 }
 
@@ -83,9 +142,12 @@ pub(crate) fn create_quick_restart_marker(
     let mut file = match OpenOptions::new().write(true).create_new(true).open(&path) {
         Ok(file) => file,
         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-            return Err(RestartMarkerCreateError::AlreadyOwned(
-                RestartMarkerOwner::from_path(&path),
-            ));
+            let owner = RestartMarkerOwner::from_path(&path).unwrap_or(RestartMarkerOwner {
+                nonce: None,
+                source: None,
+                scope: None,
+            });
+            return Err(RestartMarkerCreateError::AlreadyOwned(owner));
         }
         Err(error) => return Err(RestartMarkerCreateError::Io(error)),
     };
@@ -152,14 +214,69 @@ mod tests {
     }
 
     #[test]
-    fn quick_restart_cleanup_does_not_remove_replacement_owner() {
+    fn ownership_resolution_preserves_replacement_between_check_and_claim() {
         let root = tempfile::tempdir().unwrap();
         let marker = create_quick_restart_marker(root.path(), "1.2.3").unwrap();
         let replacement = "nonce=replacement-owner\nsource=deploy-release\nscope=release\n";
-        fs::write(marker.path(), replacement).unwrap();
 
-        marker.remove_if_owned();
+        let force_kill_called = std::cell::Cell::new(false);
+        let outcome = marker
+            .resolve_ownership_inner(
+                || {
+                    fs::write(marker.path(), replacement).unwrap();
+                },
+                || force_kill_called.set(true),
+            )
+            .unwrap();
 
+        assert!(matches!(outcome, MarkerOwnership::Replaced(_)));
+        assert!(!outcome.permits_force_kill());
+        assert!(!force_kill_called.get());
         assert_eq!(fs::read_to_string(marker.path()).unwrap(), replacement);
+    }
+
+    #[test]
+    fn only_removed_owned_permits_force_kill() {
+        let replacement = MarkerOwnership::Replaced(RestartMarkerOwner {
+            nonce: Some("other".to_string()),
+            source: None,
+            scope: None,
+        });
+
+        assert!(MarkerOwnership::RemovedOwned.permits_force_kill());
+        assert!(!MarkerOwnership::MissingCommitted.permits_force_kill());
+        assert!(!replacement.permits_force_kill());
+    }
+
+    #[test]
+    fn normal_owned_timeout_resolution_removes_marker() {
+        let root = tempfile::tempdir().unwrap();
+        let marker = create_quick_restart_marker(root.path(), "1.2.3").unwrap();
+
+        let force_kill_called = std::cell::Cell::new(false);
+        let outcome = marker
+            .resolve_ownership(|| force_kill_called.set(true))
+            .unwrap();
+
+        assert_eq!(outcome, MarkerOwnership::RemovedOwned);
+        assert!(outcome.permits_force_kill());
+        assert!(force_kill_called.get());
+        assert!(!marker.path().exists());
+    }
+
+    #[test]
+    fn normal_ack_resolution_reports_missing_committed() {
+        let root = tempfile::tempdir().unwrap();
+        let marker = create_quick_restart_marker(root.path(), "1.2.3").unwrap();
+        fs::remove_file(marker.path()).unwrap();
+
+        let force_kill_called = std::cell::Cell::new(false);
+        let outcome = marker
+            .resolve_ownership(|| force_kill_called.set(true))
+            .unwrap();
+
+        assert_eq!(outcome, MarkerOwnership::MissingCommitted);
+        assert!(!outcome.permits_force_kill());
+        assert!(!force_kill_called.get());
     }
 }

--- a/src/cli/dcserver_restart_marker.rs
+++ b/src/cli/dcserver_restart_marker.rs
@@ -1,0 +1,165 @@
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+const QUICK_RESTART_SOURCE: &str = "agentdesk-cli";
+const QUICK_RESTART_SCOPE: &str = "dcserver";
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct RestartMarkerOwner {
+    nonce: Option<String>,
+    source: Option<String>,
+    scope: Option<String>,
+}
+
+impl RestartMarkerOwner {
+    fn from_path(path: &Path) -> Self {
+        let content = fs::read_to_string(path).unwrap_or_default();
+        Self {
+            nonce: marker_field(&content, "nonce"),
+            source: marker_field(&content, "source"),
+            scope: marker_field(&content, "scope"),
+        }
+    }
+}
+
+impl fmt::Display for RestartMarkerOwner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let source = self.source.as_deref().unwrap_or("unknown");
+        let scope = self.scope.as_deref().unwrap_or("unknown");
+        let nonce = self.nonce.as_deref().unwrap_or("unknown");
+        write!(formatter, "source={source}, scope={scope}, nonce={nonce}")
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum RestartMarkerCreateError {
+    AlreadyOwned(RestartMarkerOwner),
+    Io(io::Error),
+}
+
+impl fmt::Display for RestartMarkerCreateError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AlreadyOwned(owner) => write!(formatter, "restart already owned ({owner})"),
+            Self::Io(error) => error.fmt(formatter),
+        }
+    }
+}
+
+pub(crate) struct QuickRestartMarker {
+    path: PathBuf,
+    nonce: String,
+}
+
+impl QuickRestartMarker {
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn is_current_owner(&self) -> bool {
+        RestartMarkerOwner::from_path(&self.path).nonce.as_deref() == Some(self.nonce.as_str())
+    }
+
+    pub(crate) fn remove_if_owned(&self) {
+        if self.is_current_owner() {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+pub(crate) fn create_quick_restart_marker(
+    runtime_root: &Path,
+    version: &str,
+) -> Result<QuickRestartMarker, RestartMarkerCreateError> {
+    let path = runtime_root.join("restart_pending");
+    let nonce = uuid::Uuid::new_v4();
+    let body = format!(
+        "nonce={nonce}\nsource={QUICK_RESTART_SOURCE}\nscope={QUICK_RESTART_SCOPE}\nversion={version}\nrequested_at={}\n",
+        chrono::Utc::now().to_rfc3339()
+    );
+
+    let mut file = match OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            return Err(RestartMarkerCreateError::AlreadyOwned(
+                RestartMarkerOwner::from_path(&path),
+            ));
+        }
+        Err(error) => return Err(RestartMarkerCreateError::Io(error)),
+    };
+
+    if let Err(error) = file.write_all(body.as_bytes()) {
+        let _ = fs::remove_file(&path);
+        return Err(RestartMarkerCreateError::Io(error));
+    }
+
+    Ok(QuickRestartMarker {
+        path,
+        nonce: nonce.to_string(),
+    })
+}
+
+fn marker_field(content: &str, name: &str) -> Option<String> {
+    content.lines().find_map(|line| {
+        line.strip_prefix(name)
+            .and_then(|value| value.strip_prefix('='))
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quick_restart_marker_contains_nonce_and_shell_protocol_fields() {
+        let root = tempfile::tempdir().unwrap();
+        let marker = create_quick_restart_marker(root.path(), "1.2.3").unwrap();
+        let content = fs::read_to_string(marker.path()).unwrap();
+
+        let nonce = marker_field(&content, "nonce").expect("nonce line");
+        assert!(uuid::Uuid::parse_str(&nonce).is_ok());
+        assert_eq!(
+            marker_field(&content, "source").as_deref(),
+            Some("agentdesk-cli")
+        );
+        assert_eq!(marker_field(&content, "scope").as_deref(), Some("dcserver"));
+        assert_eq!(marker_field(&content, "version").as_deref(), Some("1.2.3"));
+    }
+
+    #[test]
+    fn quick_restart_marker_create_new_preserves_existing_owner() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("restart_pending");
+        let existing = "nonce=owner-nonce\nsource=deploy-release\nscope=release\n";
+        fs::write(&path, existing).unwrap();
+
+        let result = create_quick_restart_marker(root.path(), "9.9.9");
+
+        assert!(matches!(
+            result,
+            Err(RestartMarkerCreateError::AlreadyOwned(RestartMarkerOwner {
+                nonce: Some(ref nonce),
+                source: Some(ref source),
+                scope: Some(ref scope),
+            })) if nonce == "owner-nonce" && source == "deploy-release" && scope == "release"
+        ));
+        assert_eq!(fs::read_to_string(path).unwrap(), existing);
+    }
+
+    #[test]
+    fn quick_restart_cleanup_does_not_remove_replacement_owner() {
+        let root = tempfile::tempdir().unwrap();
+        let marker = create_quick_restart_marker(root.path(), "1.2.3").unwrap();
+        let replacement = "nonce=replacement-owner\nsource=deploy-release\nscope=release\n";
+        fs::write(marker.path(), replacement).unwrap();
+
+        marker.remove_if_owned();
+
+        assert_eq!(fs::read_to_string(marker.path()).unwrap(), replacement);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod args;
 pub(crate) mod client;
 pub(crate) mod dcserver;
 pub(crate) mod dcserver_pg_bootstrap;
+pub(crate) mod dcserver_restart_marker;
 pub(crate) mod direct;
 pub(crate) mod discord;
 pub(crate) mod discord_thread_create;


### PR DESCRIPTION
## Summary
- move CLI quick-restart marker creation into an isolated nonce-bound helper
- publish `restart_pending` with `create_new(true)` and the shell-compatible `nonce`/`source`/`scope` fields
- preserve an existing or replacement owner instead of overwriting it

## Safety decision
When `restart_pending` is already owned, or ownership changes while the CLI waits, the CLI reports `restart already owned`, preserves the marker, and exits without force-killing dcserver. A foreign marker represents an in-progress restart whose admission/persistence handoff must remain authoritative; force-killing at that point could interrupt the other owner and violate the nonce discipline. Unrelated marker-creation I/O failures and timeouts while the CLI still owns the marker retain the existing force-kill fallback.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --lib`
- `cargo test --lib cli::dcserver_restart_marker::tests:: -- --test-threads=1`
- `cargo test --lib cli:: -- --test-threads=1`
- `cargo test --lib gateway_lease -- --test-threads=1`
- `python3 scripts/generate_inventory_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate`

Closes #4816

🤖 Generated with [Claude Code](https://claude.com/claude-code)