### PR TITLE
ci(4747): remove duplicate lint from fast check

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -354,8 +354,15 @@ jobs:
       - name: Policy JS unit tests
         run: npm run test:policies
 
-      - name: just check
-        run: just check
+      # `lint` already runs the exact `fmt-check` + `lint` recipes in parallel
+      # and has its own required mirror. Repeating them through `just check`
+      # added 4-5 minutes to this critical-path job without adding coverage.
+      # Keep the compile check and every non-PG test here; branch protection
+      # still requires both this result and the independent Lint result.
+      - name: cargo check + non-PG tests
+        run: |
+          just cargo-check
+          just test-non-pg
         env:
           # Cold `cargo test --all-targets` on the 16GB ubuntu runner peaks over
           # RAM during codegen+link (SIGTERM/143). Two step-scoped levers keep

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -721,7 +721,9 @@ jobs:
   lint:
     name: Lint
     needs: changes
-    if: needs.changes.outputs.rust_or_policy == 'true'
+    # Match check_fast's composite gate so relay-contract-only changes retain
+    # fmt/clippy coverage after duplicate linting was removed from that job.
+    if: needs.changes.outputs.rust_or_policy == 'true' || needs.changes.outputs.relay_contract == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -774,8 +776,8 @@ jobs:
       - name: Mirror lint result for branch protection
         env:
           CHANGED_PATHS_RESULT: ${{ needs.changes.result }}
-          FILTER_NAME: rust_or_policy
-          FILTER_OUTPUT: ${{ needs.changes.outputs.rust_or_policy }}
+          FILTER_NAME: rust_or_policy_or_relay_contract
+          FILTER_OUTPUT: ${{ needs.changes.outputs.rust_or_policy == 'true' || needs.changes.outputs.relay_contract == 'true' }}
           UPSTREAM_JOB_NAME: lint
           UPSTREAM_RESULT: ${{ needs.lint.result }}
         run: ./scripts/required-check-mirror.sh


### PR DESCRIPTION
## Summary
- keep the required `Fast check (ubuntu-latest)` mirror and every existing compile/non-PG test unchanged
- stop rerunning `fmt-check` and the full Clippy lane inside `check_fast`; the separate required `Lint` job already runs those exact recipes in parallel
- preserve all required status context names and branch-protection wiring

## Measured impact
Five recent `ci-pr.yml` runs measured `Fast check + non-PG tests (ubuntu-latest)` at 13m21s–16m39s (median 14m43s, mean 15m03s). In run 29998313937, the duplicated Clippy phase alone took 5m01s while the parallel required `Lint` job completed in 4m09s. Removing that redundant serial phase should shorten the critical path by roughly 4–5 minutes (about 27–34%) without reducing test or lint coverage.

## Validation
- `./scripts/ci-script-checks.sh`
- `actionlint .github/workflows/ci-pr.yml`
- `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/ci-pr.yml'))\"`
- `git diff --check`
- branch protection contexts checked via GitHub API; names unchanged

Refs #4747

🤖 Generated with [Claude Code](https://claude.com/claude-code)