### PR TITLE
fix: suppress healthy transcript growth desync alerts

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -1423,6 +1423,15 @@ class CoverageActivityProbe:
 
 
 @dataclass(frozen=True)
+class CoverageTranscriptProbe:
+    """Independent selected-transcript evidence for a desync judgment."""
+
+    growing: bool
+    blocks: int = 0
+    lost: int = 0
+
+
+@dataclass(frozen=True)
 class SelectorVerdict:
     state: str
     reason: str
@@ -2653,6 +2662,7 @@ def tick_coverage(
     ch: ChannelConfig,
     chs: dict[str, Any],
     now: float,
+    transcript_probe: CoverageTranscriptProbe | None = None,
 ) -> None:
     """Observe I2 only; never repair, return early from, or suppress gap checks."""
     expected_name = expected_tmux_session_name(ch)
@@ -2721,10 +2731,45 @@ def tick_coverage(
     # persistence before this alarms on its own. detached / watcher_state_404
     # keep the 2-tick behavior (different reason strings).
     if verdict.reason == "attached_but_desynced":
-        delivery_gap_active = bool(chs.get("gap_since") or chs.get("alerting"))
+        activity = probe.relay_activity
+        relay_ts = activity.last_relay_ts_ms if activity is not None else None
+        recent_relay = False
+        if (
+            activity is not None
+            and not activity.malformed
+            and isinstance(relay_ts, int)
+            and not isinstance(relay_ts, bool)
+            and relay_ts > 0
+        ):
+            relay_age_ms = int(now * 1000) - relay_ts
+            recent_relay = (
+                0 <= relay_age_ms < COVERAGE_ACTIVITY_FRESH_SECS * 1000
+            )
+        growing_without_loss = (
+            transcript_probe is not None
+            and transcript_probe.growing
+            and transcript_probe.blocks > 0
+            and transcript_probe.lost == 0
+        )
+        transcript_loss_active = bool(
+            transcript_probe is not None and transcript_probe.lost > 0
+        )
+        growing_relay_stall = bool(growing_without_loss and not recent_relay)
+        delivery_gap_active = bool(
+            chs.get("gap_since")
+            or chs.get("alerting")
+            or transcript_loss_active
+            or growing_relay_stall
+        )
         desync_for = (
             max(0.0, now - desync_since) if desync_since is not None else 0.0
         )
+        if not delivery_gap_active and growing_without_loss and recent_relay:
+            rt.log(
+                f"[{cid}] coverage desync classified as growth lag "
+                f"blocks={transcript_probe.blocks} lost=0 — not alarming"
+            )
+            return
         if (
             not delivery_gap_active
             and desync_for < COVERAGE_DESYNC_CONFIRM_SECS
@@ -2996,13 +3041,13 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     cid = ch.channel_id
     chs: dict[str, Any] = state.setdefault(cid, {})
 
-    # I2 is intentionally parallel to gap evaluation (#4424): this helper has
-    # no return value that can short-circuit the existing transcript/haystack
-    # verdict path and it owns a separate alert cooldown key.
-    try:
-        tick_coverage(rt, ch, chs, now)
-    except Exception as e:  # noqa: BLE001 — coverage must never suppress gap checks
-        rt.log(f"[{cid}] coverage tick error: {type(e).__name__}: {e}")
+    def observe_coverage(
+        transcript_probe: CoverageTranscriptProbe | None = None,
+    ) -> None:
+        try:
+            tick_coverage(rt, ch, chs, now, transcript_probe)
+        except Exception as e:  # noqa: BLE001 — coverage must never suppress gap checks
+            rt.log(f"[{cid}] coverage tick error: {type(e).__name__}: {e}")
 
     pattern = main_channel_project_re(ch.worktree_root, ch.worktree_prefix)
     project_root = projects_root()
@@ -3482,10 +3527,12 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             _clear_gap_alert_without_recovery(
                 rt, chs, cid, retired_pending_paths
             )
+        observe_coverage()
         return
 
     hay = rt.discord_haystack(cid)
     if hay is None:
+        observe_coverage()
         # A blind prober is itself a signal: persistent read failure means we
         # cannot vouch for the relay at all. Alert after N consecutive misses.
         fails = int(chs.get("read_failures", 0)) + 1
@@ -3637,6 +3684,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             _clear_gap_alert_without_recovery(
                 rt, chs, cid, retired_pending_paths
             )
+        observe_coverage()
         return
 
     # A cleared/restarted provider session creates a new transcript. Retire an
@@ -3730,6 +3778,24 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         ),
     )
     verdict_path = str(verdict_candidate.path)
+    selected_coverage = next(
+        (
+            verdict
+            for candidate, verdict in evaluated
+            if selected is not None and candidate.path == selected.path
+        ),
+        None,
+    )
+    coverage_transcript_probe = (
+        CoverageTranscriptProbe(
+            growing=f_growing,
+            blocks=selected_coverage.blocks,
+            lost=sum(verdict.lost for _, verdict in evaluated),
+        )
+        if selected_coverage is not None
+        else None
+    )
+    observe_coverage(coverage_transcript_probe)
     previous_gap_owners = _validated_gap_owner_transcripts(chs)
     evaluated_paths = {str(candidate.path) for candidate, _ in evaluated}
     incident_open = bool(

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -50,6 +50,7 @@ from scripts.relay_watchdog import (
     Config,
     ConfigError,
     CoverageActivityProbe,
+    CoverageTranscriptProbe,
     Runtime,
     TranscriptCandidate,
     WatcherStateProbe,
@@ -80,6 +81,7 @@ from scripts.relay_watchdog import (
     select_watch_transcript_with_reason,
     selector_divergence_confirmed,
     tick_channel,
+    tick_coverage,
     tick_pg_tunnel,
 )
 
@@ -2823,6 +2825,114 @@ class TickChannelTests(unittest.TestCase):
             any("커버리지 불변식 위반" in body for body, _ in rt.alerts)
         )
         self.assertIn("last_coverage_alert", state["999"])
+
+    def test_growth_lag_with_zero_loss_and_recent_relay_suppresses_alert(self):
+        rt = self.make_rt()
+        tick_at = self.now + COVERAGE_DESYNC_CONFIRM_SECS
+        probe = self.active_foreground_probe(
+            queue_depth=1,
+            last_outbound_activity_ms=None,
+            last_relay_ts_ms=int(tick_at * 1000) - 1,
+        )
+        self.arm_coverage(rt, probe)
+        state = {
+            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+            "coverage_desync_since": self.now,
+        }
+
+        tick_coverage(
+            rt,
+            TICK_CHANNEL,
+            state,
+            tick_at,
+            CoverageTranscriptProbe(growing=True, blocks=723, lost=0),
+        )
+
+        self.assertEqual(rt.alerts, [])
+        self.assertNotIn("last_coverage_alert", state)
+        self.assertTrue(any("growth lag" in line for line in rt.log_lines))
+
+    def test_growth_with_loss_still_alerts_desync_coverage(self):
+        rt = self.make_rt()
+        tick_at = self.now + COVERAGE_DESYNC_CONFIRM_SECS
+        probe = self.active_foreground_probe(
+            queue_depth=1,
+            last_outbound_activity_ms=None,
+            last_relay_ts_ms=int(tick_at * 1000) - 1,
+        )
+        self.arm_coverage(rt, probe)
+        state = {
+            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+            "coverage_desync_since": self.now,
+        }
+
+        tick_coverage(
+            rt,
+            TICK_CHANNEL,
+            state,
+            tick_at,
+            CoverageTranscriptProbe(growing=True, blocks=723, lost=1),
+        )
+
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("attached_but_desynced", rt.alerts[0][0])
+
+    def test_growth_with_stale_relay_timestamp_still_alerts(self):
+        rt = self.make_rt()
+        tick_at = self.now + COVERAGE_DESYNC_CONFIRM_SECS
+        stale_relay_ms = (
+            int(tick_at * 1000) - COVERAGE_ACTIVITY_FRESH_SECS * 1000
+        )
+        probe = self.active_foreground_probe(
+            queue_depth=1,
+            last_outbound_activity_ms=None,
+            last_relay_ts_ms=stale_relay_ms,
+        )
+        self.arm_coverage(rt, probe)
+        state = {
+            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+            "coverage_desync_since": self.now,
+        }
+
+        tick_coverage(
+            rt,
+            TICK_CHANNEL,
+            state,
+            tick_at,
+            CoverageTranscriptProbe(growing=True, blocks=723, lost=0),
+        )
+
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("attached_but_desynced", rt.alerts[0][0])
+
+    def test_tick_channel_wires_growth_lag_evidence_into_coverage(self):
+        self.write_transcript([(self.now - 30, "delivered initial")])
+        rt = self.make_rt(poll_secs=60)
+        rt.haystack = norm("delivered initial selector growth")
+        tick_at = self.now + COVERAGE_DESYNC_CONFIRM_SECS
+        self.arm_coverage(
+            rt,
+            self.active_foreground_probe(
+                queue_depth=1,
+                last_outbound_activity_ms=None,
+                last_relay_ts_ms=int(tick_at * 1000) - 1,
+            ),
+        )
+        transcript = self.proj_dir / "s.jsonl"
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(transcript),
+                "transcript_sizes": {str(transcript): transcript.stat().st_size},
+                "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+                "coverage_desync_since": self.now,
+            }
+        }
+        self._grow_selected_transcript()
+
+        tick_channel(rt, TICK_CHANNEL, state, tick_at)
+
+        self.assertEqual(rt.alerts, [])
+        self.assertTrue(any("growth lag" in line for line in rt.log_lines))
 
     def test_active_foreground_evidence_cannot_suppress_detached_alert(self):
         rt = self.make_rt()


### PR DESCRIPTION
## Summary
- defer watchdog coverage evaluation until transcript growth/loss evidence is available
- suppress `attached_but_desynced` only when the selected transcript is growing, aggregate `lost=0`, and `last_relay_ts_ms` is recent
- preserve immediate coverage alarms for actual loss and growing transcripts with a stale relay timestamp

## Tests
- `cargo fmt --all --check`
- `cargo check --lib`
- `python3 -m unittest tests.test_relay_watchdog tests.test_pg_tunnel`
- `python3 scripts/generate_inventory_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py`
- `python3 scripts/audit_maintainability.py --check`

Closes #4820

🤖 Generated with [Claude Code](https://claude.com/claude-code)