### PR TITLE
fix(4181): persist redrive no-progress grace

### DIFF
--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -409,14 +409,17 @@ impl HealthRegistry {
         channel_id: ChannelId,
         now_unix_secs: i64,
     ) -> Result<bool, RelayRecoveryError> {
-        #[cfg(test)]
-        let _test_clock = stall_liveness::set_redrive_grace_test_clock(now_unix_secs);
         let Some(snapshot) = self
             .snapshot_watcher_state_for_shared(provider, shared.clone(), channel_id.get())
             .await
         else {
             return Ok(false);
         };
+        #[cfg(test)]
+        let _test_clock = stall_liveness::set_redrive_grace_test_clock(
+            now_unix_secs,
+            snapshot.inflight_identity.clone(),
+        );
 
         let token = shared.tmux_relay_coord(channel_id).frontier_token();
         if !should_redrive_undelivered_backlog(provider, channel_id, &snapshot, token) {
@@ -578,7 +581,10 @@ fn nudge_existing_watcher_for_backlog(
     token: RelayFrontierToken,
 ) -> bool {
     #[cfg(test)]
-    let _test_clock = stall_liveness::set_redrive_grace_test_clock(now_unix_secs);
+    let _test_clock = stall_liveness::set_redrive_grace_test_clock(
+        now_unix_secs,
+        snapshot.inflight_identity.clone(),
+    );
     if !should_redrive_undelivered_backlog(provider, channel_id, snapshot, token) {
         return false;
     }
@@ -1239,7 +1245,8 @@ mod tests {
         channel_id: ChannelId,
         now: i64,
     ) -> (bool, Option<u8>) {
-        let _test_clock = stall_liveness::set_redrive_grace_test_clock(now);
+        let _test_clock =
+            stall_liveness::set_redrive_grace_test_clock(now, snapshot.inflight_identity.clone());
         let token = shared.relay_frontier_token(channel_id);
         if !should_redrive_undelivered_backlog(provider, channel_id, snapshot, token)
             || !shared.relay_frontier_token_is_current(channel_id, token)

--- a/src/services/discord/health/stall_liveness/redrive_grace.rs
+++ b/src/services/discord/health/stall_liveness/redrive_grace.rs
@@ -25,7 +25,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use dashmap::mapref::entry::Entry;
 use poise::serenity_prelude::ChannelId;
@@ -96,12 +96,14 @@ impl RedriveClock for MonotonicRedriveClock {
 thread_local! {
     static TEST_CLOCK_OVERRIDE: std::cell::Cell<Option<i64>> = const { std::cell::Cell::new(None) };
     static TEST_DURABLE_CLOCK_OVERRIDE: std::cell::Cell<Option<i64>> = const { std::cell::Cell::new(None) };
+    static TEST_CANONICAL_EPISODE_OVERRIDE: std::cell::RefCell<Option<crate::services::discord::inflight::InflightTurnIdentity>> = const { std::cell::RefCell::new(None) };
 }
 
 #[cfg(test)]
 pub(in crate::services::discord::health) struct RedriveGraceTestClockGuard {
     previous: Option<i64>,
     previous_durable: Option<i64>,
+    previous_episode: Option<crate::services::discord::inflight::InflightTurnIdentity>,
 }
 
 #[cfg(test)]
@@ -109,6 +111,8 @@ impl Drop for RedriveGraceTestClockGuard {
     fn drop(&mut self) {
         TEST_CLOCK_OVERRIDE.with(|cell| cell.set(self.previous));
         TEST_DURABLE_CLOCK_OVERRIDE.with(|cell| cell.set(self.previous_durable));
+        TEST_CANONICAL_EPISODE_OVERRIDE
+            .with(|episode| *episode.borrow_mut() = self.previous_episode.clone());
     }
 }
 
@@ -117,12 +121,16 @@ impl Drop for RedriveGraceTestClockGuard {
 #[cfg(test)]
 pub(in crate::services::discord::health) fn set_redrive_grace_test_clock(
     mono_secs: i64,
+    episode_identity: Option<crate::services::discord::inflight::InflightTurnIdentity>,
 ) -> RedriveGraceTestClockGuard {
     let previous = TEST_CLOCK_OVERRIDE.with(|cell| cell.replace(Some(mono_secs)));
     let previous_durable = TEST_DURABLE_CLOCK_OVERRIDE.with(|cell| cell.replace(Some(mono_secs)));
+    let previous_episode =
+        TEST_CANONICAL_EPISODE_OVERRIDE.with(|episode| episode.replace(episode_identity));
     RedriveGraceTestClockGuard {
         previous,
         previous_durable,
+        previous_episode,
     }
 }
 
@@ -134,6 +142,7 @@ pub(in crate::services::discord::health) fn set_redrive_grace_test_clock(
 fn clear_redrive_grace_test_clock() {
     TEST_CLOCK_OVERRIDE.with(|cell| cell.set(None));
     TEST_DURABLE_CLOCK_OVERRIDE.with(|cell| cell.set(None));
+    TEST_CANONICAL_EPISODE_OVERRIDE.with(|episode| *episode.borrow_mut() = None);
 }
 
 /// Dedicated no-progress tracker, kept separate from the wall-clock
@@ -141,6 +150,8 @@ fn clear_redrive_grace_test_clock() {
 /// monotonic: the redrive lifecycle has zero wall dependence (#4181 item-2).
 #[derive(Clone, Debug)]
 struct NoProgressObservation {
+    episode_identity: Option<crate::services::discord::inflight::InflightTurnIdentity>,
+    turn_nonce: Option<String>,
     /// Highest committed relay offset observed for this key. A later snapshot
     /// reporting a LOWER offset is treated as stale and rejected, so a stale
     /// concurrent watchdog pass cannot rewind the freeze anchor (#4181 P3).
@@ -156,7 +167,7 @@ struct NoProgressObservation {
 static NO_PROGRESS_OBSERVATIONS: LazyLock<
     dashmap::DashMap<(StallLivenessKey, u64), NoProgressObservation>,
 > = LazyLock::new(dashmap::DashMap::new);
-static DURABLE_BASELINE_LOCKS: LazyLock<dashmap::DashMap<(String, u64), Mutex<()>>> =
+static DURABLE_BASELINE_LOCKS: LazyLock<dashmap::DashMap<(String, u64), Arc<Mutex<()>>>> =
     LazyLock::new(dashmap::DashMap::new);
 
 const REDRIVE_BASELINES_DIR: &str = "discord_redrive_baselines";
@@ -189,6 +200,8 @@ impl DurableNoProgressBaseline {
 
     fn observation(&self, mono_now: i64) -> NoProgressObservation {
         NoProgressObservation {
+            episode_identity: self.identity.clone(),
+            turn_nonce: self.turn_nonce.clone(),
             offset: self.offset,
             unchanged_since_mono_secs: self.unchanged_since_monotonic_secs.min(mono_now),
             last_seen_mono_secs: mono_now,
@@ -231,6 +244,80 @@ fn remove_durable_baseline_at(path: &Path) {
             error = %error,
             "redrive no-progress baseline cleanup failed"
         );
+    }
+}
+
+fn durable_baseline_lock(provider: &str, channel_id: u64) -> Arc<Mutex<()>> {
+    DURABLE_BASELINE_LOCKS
+        .entry((provider.to_string(), channel_id))
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
+fn load_canonical_episode(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+) -> Option<crate::services::discord::inflight::InflightTurnIdentity> {
+    crate::services::discord::inflight::load_inflight_state_read_only(provider, channel_id.get())
+        .map(|state| crate::services::discord::inflight::InflightTurnIdentity::from_state(&state))
+}
+
+#[cfg(not(test))]
+fn canonical_episode(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+) -> Option<crate::services::discord::inflight::InflightTurnIdentity> {
+    load_canonical_episode(provider, channel_id)
+}
+
+#[cfg(test)]
+fn canonical_episode(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+) -> Option<crate::services::discord::inflight::InflightTurnIdentity> {
+    TEST_CANONICAL_EPISODE_OVERRIDE.with(|override_episode| {
+        override_episode
+            .borrow()
+            .clone()
+            .or_else(|| load_canonical_episode(provider, channel_id))
+    })
+}
+
+fn canonical_episode_matches(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    identity: &crate::services::discord::inflight::InflightTurnIdentity,
+) -> bool {
+    canonical_episode(provider, channel_id).as_ref() == Some(identity)
+}
+
+fn clear_for_session_at(
+    probe: &StallLivenessKey,
+    requested_identity: Option<&crate::services::discord::inflight::InflightTurnIdentity>,
+    canonical: Option<&crate::services::discord::inflight::InflightTurnIdentity>,
+    path: Option<&Path>,
+) {
+    NO_PROGRESS_OBSERVATIONS.retain(|(key, _), observation| {
+        if !key.matches_session(probe) {
+            return true;
+        }
+        canonical.is_some_and(|identity| observation.episode_identity.as_ref() == Some(identity))
+    });
+    let Some(path) = path else {
+        return;
+    };
+    let Some(baseline) = load_durable_baseline_at(path) else {
+        return;
+    };
+    let owned_by_canonical =
+        canonical.is_some_and(|identity| baseline.identity.as_ref() == Some(identity));
+    let matches_request =
+        requested_identity.is_none_or(|requested| baseline.identity.as_ref() == Some(requested));
+    let matches_requested_session = baseline.identity.as_ref().is_some_and(|identity| {
+        identity.tmux_session_name.as_deref() == probe.tmux_session.as_deref()
+    });
+    if matches_request && matches_requested_session && !owned_by_canonical {
+        remove_durable_baseline_at(path);
     }
 }
 
@@ -331,6 +418,8 @@ fn relay_offset_stalled_past_grace(
         }
         Entry::Vacant(vacant) => {
             vacant.insert(NoProgressObservation {
+                episode_identity: None,
+                turn_nonce: None,
                 offset: observed_offset,
                 unchanged_since_mono_secs: mono_now,
                 last_seen_mono_secs: mono_now,
@@ -354,60 +443,75 @@ fn relay_offset_stalled_past_grace_durable(
     let Some(boot_id) = boot_id() else {
         return relay_offset_stalled_past_grace(key, token, mono_now);
     };
-    let lock_key = (provider.as_str().to_string(), channel_id.get());
-    let channel_lock = DURABLE_BASELINE_LOCKS
-        .entry(lock_key)
-        .or_insert_with(|| Mutex::new(()));
+    let channel_lock = durable_baseline_lock(provider.as_str(), channel_id.get());
     let _guard = channel_lock
         .lock()
         .unwrap_or_else(|poison| poison.into_inner());
-    let identity = snapshot.inflight_identity.as_ref();
+    let Some(identity) = snapshot.inflight_identity.as_ref() else {
+        return relay_offset_stalled_past_grace(key, token, mono_now);
+    };
     let turn_nonce = snapshot.mailbox_active_turn_nonce.as_deref();
+    if !canonical_episode_matches(provider, channel_id, identity) {
+        return false;
+    }
     let map_key = (key.clone(), token.reset_incarnation);
     let (stalled, observation) = match NO_PROGRESS_OBSERVATIONS.entry(map_key) {
         Entry::Occupied(mut occupied) => {
             let observation = occupied.get_mut();
-            observation.last_seen_mono_secs = mono_now;
-            if token.committed_offset > observation.offset {
-                observation.offset = token.committed_offset;
-                observation.unchanged_since_mono_secs = mono_now;
+            if observation.episode_identity.as_ref() != Some(identity)
+                || observation.turn_nonce.as_deref() != turn_nonce
+            {
+                *observation = NoProgressObservation {
+                    episode_identity: Some(identity.clone()),
+                    turn_nonce: turn_nonce.map(str::to_string),
+                    offset: token.committed_offset,
+                    unchanged_since_mono_secs: mono_now,
+                    last_seen_mono_secs: mono_now,
+                };
+            } else {
+                observation.last_seen_mono_secs = mono_now;
+                if token.committed_offset > observation.offset {
+                    observation.offset = token.committed_offset;
+                    observation.unchanged_since_mono_secs = mono_now;
+                }
             }
             (
                 token.committed_offset == observation.offset
                     && mono_now.saturating_sub(observation.unchanged_since_mono_secs)
                         >= STALL_WATCHDOG_BACKLOG_NO_PROGRESS_GRACE_SECS as i64,
-                NoProgressObservation {
-                    offset: observation.offset,
-                    unchanged_since_mono_secs: observation.unchanged_since_mono_secs,
-                    last_seen_mono_secs: observation.last_seen_mono_secs,
-                },
+                observation.clone(),
             )
         }
         Entry::Vacant(vacant) => {
             let observation = load_durable_baseline_at(&path)
-                .filter(|baseline| baseline.matches(identity, turn_nonce, token, &boot_id))
+                .filter(|baseline| baseline.matches(Some(identity), turn_nonce, token, &boot_id))
                 .map(|baseline| baseline.observation(mono_now))
                 .unwrap_or(NoProgressObservation {
+                    episode_identity: Some(identity.clone()),
+                    turn_nonce: turn_nonce.map(str::to_string),
                     offset: token.committed_offset,
                     unchanged_since_mono_secs: mono_now,
                     last_seen_mono_secs: mono_now,
                 });
             let stalled = mono_now.saturating_sub(observation.unchanged_since_mono_secs)
                 >= STALL_WATCHDOG_BACKLOG_NO_PROGRESS_GRACE_SECS as i64;
-            vacant.insert(NoProgressObservation {
-                offset: observation.offset,
-                unchanged_since_mono_secs: observation.unchanged_since_mono_secs,
-                last_seen_mono_secs: observation.last_seen_mono_secs,
-            });
+            vacant.insert(observation.clone());
             (stalled, observation)
         }
     };
 
-    if load_durable_baseline_at(&path).is_some_and(|baseline| {
-        !baseline.matches(identity, turn_nonce, token, &boot_id)
-            && baseline.last_seen_monotonic_secs > observation.last_seen_mono_secs
-    }) {
-        return stalled;
+    if !canonical_episode_matches(provider, channel_id, identity) {
+        let map_key = (key.clone(), token.reset_incarnation);
+        if NO_PROGRESS_OBSERVATIONS
+            .get(&map_key)
+            .is_some_and(|current| {
+                current.episode_identity.as_ref() == Some(identity)
+                    && current.turn_nonce.as_deref() == turn_nonce
+            })
+        {
+            NO_PROGRESS_OBSERVATIONS.remove(&map_key);
+        }
+        return false;
     }
     persist_durable_baseline_at(
         &path,
@@ -415,7 +519,7 @@ fn relay_offset_stalled_past_grace_durable(
             boot_id,
             offset: observation.offset,
             reset_incarnation: token.reset_incarnation,
-            identity: identity.cloned(),
+            identity: Some(identity.clone()),
             turn_nonce: turn_nonce.map(str::to_string),
             unchanged_since_monotonic_secs: observation.unchanged_since_mono_secs,
             last_seen_monotonic_secs: observation.last_seen_mono_secs,
@@ -492,17 +596,17 @@ fn stalled_undelivered_backlog_for_redrive_with_clock(
 /// Drop redrive no-progress observations for a cleared session. Called by the
 /// parent's `clear_stall_watchdog_liveness_state`.
 pub(super) fn clear_for_session(probe: &StallLivenessKey) {
-    let lock_key = (probe.provider.clone(), probe.channel_id);
-    let channel_lock = DURABLE_BASELINE_LOCKS
-        .entry(lock_key)
-        .or_insert_with(|| Mutex::new(()));
+    let Some(provider) = ProviderKind::from_str(&probe.provider) else {
+        return;
+    };
+    let channel_id = ChannelId::new(probe.channel_id);
+    let channel_lock = durable_baseline_lock(&probe.provider, probe.channel_id);
     let _guard = channel_lock
         .lock()
         .unwrap_or_else(|poison| poison.into_inner());
-    NO_PROGRESS_OBSERVATIONS.retain(|(key, _), _| !key.matches_session(probe));
-    if let Some(path) = durable_baseline_path(&probe.provider, ChannelId::new(probe.channel_id)) {
-        remove_durable_baseline_at(&path);
-    }
+    let canonical = canonical_episode(&provider, channel_id);
+    let path = durable_baseline_path(&probe.provider, channel_id);
+    clear_for_session_at(probe, None, canonical.as_ref(), path.as_deref());
 }
 
 /// TTL-GC on the MONOTONIC freshness anchor (production clock). Called by the
@@ -535,11 +639,28 @@ fn gc_durable_baselines_at(root: &Path, boot_id: &str, mono_now: i64) {
         return;
     };
     for provider in providers.flatten() {
+        let Some(provider_name) = provider.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
         let Ok(files) = fs::read_dir(provider.path()) else {
             continue;
         };
         for file in files.flatten() {
             let path = file.path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(channel_id) = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .and_then(|stem| stem.parse::<u64>().ok())
+            else {
+                continue;
+            };
+            let channel_lock = durable_baseline_lock(&provider_name, channel_id);
+            let _guard = channel_lock
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
             let keep = load_durable_baseline_at(&path).is_some_and(|baseline| {
                 baseline.boot_id == boot_id
                     && mono_now.saturating_sub(baseline.last_seen_monotonic_secs)
@@ -625,6 +746,37 @@ mod tests {
         fn durable_mono_secs(&self) -> Option<i64> {
             Some(self.mono.get())
         }
+    }
+
+    fn save_canonical_inflight(snapshot: &WatcherStateSnapshot, provider: &ProviderKind) {
+        let identity = snapshot
+            .inflight_identity
+            .as_ref()
+            .expect("snapshot identity");
+        let mut state = crate::services::discord::inflight::InflightTurnState::new(
+            provider.clone(),
+            snapshot.relay_health.channel_id,
+            None,
+            0,
+            identity.user_msg_id,
+            snapshot.inflight_current_msg_id.unwrap_or(0),
+            "redrive test".to_string(),
+            None,
+            identity.tmux_session_name.clone(),
+            snapshot.inflight_output_path.clone(),
+            None,
+            identity.turn_start_offset.unwrap_or(0),
+        );
+        state.started_at = identity.started_at.clone();
+        state.turn_start_offset = identity.turn_start_offset;
+        state.turn_nonce = snapshot.mailbox_active_turn_nonce.clone();
+        let root = runtime_store::runtime_root().expect("runtime root");
+        let path = root
+            .join("discord_inflight")
+            .join(provider.as_str())
+            .join(format!("{}.json", snapshot.relay_health.channel_id));
+        let json = serde_json::to_string_pretty(&state).expect("serialize canonical inflight");
+        runtime_store::atomic_write(&path, &json).expect("save canonical inflight");
     }
 
     /// A frozen, still-live undelivered backlog: unread bytes present, pane
@@ -1069,6 +1221,144 @@ mod tests {
     }
 
     #[test]
+    fn stale_clear_preserves_successor_episode_baseline_4181() {
+        let (_env, _root, _lock) = isolated_runtime_root();
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(4_181_010);
+        let old = frozen_backlog_snapshot(channel.get(), "AgentDesk-codex-4181-old-clear", 10, 20);
+        let mut successor =
+            frozen_backlog_snapshot(channel.get(), "AgentDesk-codex-4181-successor", 10, 20);
+        successor.inflight_identity.as_mut().unwrap().user_msg_id = 9003;
+        successor.mailbox_active_turn_nonce = Some("successor-nonce".to_string());
+        save_canonical_inflight(&successor, &provider);
+        let successor_identity = successor.inflight_identity.clone().unwrap();
+        let path = durable_baseline_path(provider.as_str(), channel).unwrap();
+        persist_durable_baseline_at(
+            &path,
+            &DurableNoProgressBaseline {
+                boot_id: "boot-a".to_string(),
+                offset: 10,
+                reset_incarnation: 0,
+                identity: Some(successor_identity.clone()),
+                turn_nonce: successor.mailbox_active_turn_nonce.clone(),
+                unchanged_since_monotonic_secs: 10,
+                last_seen_monotonic_secs: 10,
+            },
+        );
+        let successor_key = StallLivenessKey::from_snapshot(&provider, channel, &successor);
+        NO_PROGRESS_OBSERVATIONS.insert(
+            (successor_key.clone(), 0),
+            NoProgressObservation {
+                episode_identity: Some(successor_identity.clone()),
+                turn_nonce: successor.mailbox_active_turn_nonce.clone(),
+                offset: 10,
+                unchanged_since_mono_secs: 10,
+                last_seen_mono_secs: 10,
+            },
+        );
+
+        let stale_probe = StallLivenessKey::from_snapshot(&provider, channel, &old);
+        let channel_lock = durable_baseline_lock(provider.as_str(), channel.get());
+        let _guard = channel_lock
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let canonical = canonical_episode(&provider, channel);
+        clear_for_session_at(
+            &stale_probe,
+            old.inflight_identity.as_ref(),
+            canonical.as_ref(),
+            Some(&path),
+        );
+
+        assert_eq!(
+            load_durable_baseline_at(&path).and_then(|baseline| baseline.identity),
+            Some(successor_identity)
+        );
+        assert!(NO_PROGRESS_OBSERVATIONS.contains_key(&(successor_key, 0)));
+    }
+
+    #[test]
+    fn stale_identity_persist_cannot_overwrite_successor_baseline_4181() {
+        let (_env, _root, _lock) = isolated_runtime_root();
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(4_181_011);
+        let old = frozen_backlog_snapshot(channel.get(), "AgentDesk-codex-4181-shared", 10, 20);
+        let mut successor = old.clone();
+        successor.inflight_identity.as_mut().unwrap().user_msg_id = 9003;
+        successor
+            .inflight_identity
+            .as_mut()
+            .unwrap()
+            .turn_start_offset = Some(11);
+        successor.mailbox_active_turn_nonce = Some("successor-nonce".to_string());
+        save_canonical_inflight(&successor, &provider);
+        let token = RelayFrontierToken {
+            reset_incarnation: 0,
+            committed_offset: 10,
+        };
+        let path = durable_baseline_path(provider.as_str(), channel).unwrap();
+        let successor_baseline = DurableNoProgressBaseline {
+            boot_id: boot_id().expect("boot id"),
+            offset: 10,
+            reset_incarnation: 0,
+            identity: successor.inflight_identity.clone(),
+            turn_nonce: successor.mailbox_active_turn_nonce.clone(),
+            unchanged_since_monotonic_secs: 10,
+            last_seen_monotonic_secs: 10,
+        };
+        persist_durable_baseline_at(&path, &successor_baseline);
+
+        let old_key = StallLivenessKey::from_snapshot(&provider, channel, &old);
+        relay_offset_stalled_past_grace_durable(&provider, channel, &old_key, &old, token, 20);
+
+        assert_eq!(load_durable_baseline_at(&path), Some(successor_baseline));
+    }
+
+    #[test]
+    fn redrive_durable_gc_serializes_with_persist_and_ignores_staging_files_4181() {
+        let (_env, root, _lock) = isolated_runtime_root();
+        let records = root.path().join("records").join("codex");
+        fs::create_dir_all(&records).unwrap();
+        let channel_id = 4_181_012;
+        let path = records.join(format!("{channel_id}.json"));
+        let staging = records.join(format!(".{channel_id}.json.writer.tmp"));
+        fs::write(&staging, "staging").unwrap();
+        let stale = DurableNoProgressBaseline {
+            boot_id: "boot-b".to_string(),
+            offset: 10,
+            reset_incarnation: 0,
+            identity: None,
+            turn_nonce: None,
+            unchanged_since_monotonic_secs: 1,
+            last_seen_monotonic_secs: 1,
+        };
+        let fresh = DurableNoProgressBaseline {
+            boot_id: "boot-a".to_string(),
+            last_seen_monotonic_secs: 10_000,
+            unchanged_since_monotonic_secs: 10_000,
+            ..stale.clone()
+        };
+        persist_durable_baseline_at(&path, &stale);
+        let channel_lock = durable_baseline_lock("codex", channel_id);
+        let held = channel_lock
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let records_root = root.path().join("records");
+        let gc_thread =
+            std::thread::spawn(move || gc_durable_baselines_at(&records_root, "boot-a", 10_000));
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        persist_durable_baseline_at(&path, &fresh);
+        drop(held);
+        gc_thread.join().unwrap();
+
+        assert_eq!(load_durable_baseline_at(&path), Some(fresh));
+        assert!(
+            staging.exists(),
+            "GC must not touch atomic-write staging files"
+        );
+    }
+
+    #[test]
     fn redrive_durable_gc_removes_invalid_boot_malformed_and_stale_4181() {
         let (_env, root, _lock) = isolated_runtime_root();
         let records = root.path().join("records").join("codex");
@@ -1082,33 +1372,33 @@ mod tests {
             unchanged_since_monotonic_secs: last_seen,
             last_seen_monotonic_secs: last_seen,
         };
-        persist_durable_baseline_at(&records.join("fresh.json"), &sample("boot-a", 9_000));
-        persist_durable_baseline_at(&records.join("old-boot.json"), &sample("boot-b", 9_000));
-        persist_durable_baseline_at(&records.join("stale.json"), &sample("boot-a", 1));
-        fs::write(records.join("malformed.json"), "{").unwrap();
+        persist_durable_baseline_at(&records.join("101.json"), &sample("boot-a", 9_000));
+        persist_durable_baseline_at(&records.join("102.json"), &sample("boot-b", 9_000));
+        persist_durable_baseline_at(&records.join("103.json"), &sample("boot-a", 1));
+        fs::write(records.join("104.json"), "{").unwrap();
 
         gc_durable_baselines_at(&root.path().join("records"), "boot-a", 10_000);
 
-        assert!(records.join("fresh.json").exists());
-        assert!(!records.join("old-boot.json").exists());
-        assert!(!records.join("stale.json").exists());
-        assert!(!records.join("malformed.json").exists());
+        assert!(records.join("101.json").exists());
+        assert!(!records.join("102.json").exists());
+        assert!(!records.join("103.json").exists());
+        assert!(!records.join("104.json").exists());
     }
 
     #[test]
     fn scoped_test_clock_restores_nested_and_panicking_overrides_4181() {
         let _runtime = isolated_runtime_root();
         clear_redrive_grace_test_clock();
-        let outer = set_redrive_grace_test_clock(11);
+        let outer = set_redrive_grace_test_clock(11, None);
         assert_eq!(MonotonicRedriveClock.mono_secs(), 11);
         {
-            let _inner = set_redrive_grace_test_clock(22);
+            let _inner = set_redrive_grace_test_clock(22, None);
             assert_eq!(MonotonicRedriveClock.mono_secs(), 22);
         }
         assert_eq!(MonotonicRedriveClock.mono_secs(), 11);
 
         let panic = std::panic::catch_unwind(|| {
-            let _panicking = set_redrive_grace_test_clock(33);
+            let _panicking = set_redrive_grace_test_clock(33, None);
             assert_eq!(MonotonicRedriveClock.mono_secs(), 33);
             panic!("exercise panic-safe clock restoration");
         });

--- a/src/services/discord/health/stall_liveness/redrive_grace.rs
+++ b/src/services/discord/health/stall_liveness/redrive_grace.rs
@@ -25,7 +25,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
+use std::sync::{LazyLock, Mutex};
 
 use dashmap::mapref::entry::Entry;
 use poise::serenity_prelude::ChannelId;
@@ -139,7 +139,7 @@ fn clear_redrive_grace_test_clock() {
 /// Dedicated no-progress tracker, kept separate from the wall-clock
 /// `OFFSET_OBSERVATIONS` the liveness path uses. Every timestamp here is
 /// monotonic: the redrive lifecycle has zero wall dependence (#4181 item-2).
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct NoProgressObservation {
     /// Highest committed relay offset observed for this key. A later snapshot
     /// reporting a LOWER offset is treated as stale and rejected, so a stale
@@ -156,6 +156,8 @@ struct NoProgressObservation {
 static NO_PROGRESS_OBSERVATIONS: LazyLock<
     dashmap::DashMap<(StallLivenessKey, u64), NoProgressObservation>,
 > = LazyLock::new(dashmap::DashMap::new);
+static DURABLE_BASELINE_LOCKS: LazyLock<dashmap::DashMap<(String, u64), Mutex<()>>> =
+    LazyLock::new(dashmap::DashMap::new);
 
 const REDRIVE_BASELINES_DIR: &str = "discord_redrive_baselines";
 
@@ -164,21 +166,25 @@ struct DurableNoProgressBaseline {
     boot_id: String,
     offset: u64,
     reset_incarnation: u64,
-    tmux_session: Option<String>,
-    user_msg_id: Option<u64>,
-    started_at: Option<String>,
+    identity: Option<crate::services::discord::inflight::InflightTurnIdentity>,
+    turn_nonce: Option<String>,
     unchanged_since_monotonic_secs: i64,
     last_seen_monotonic_secs: i64,
 }
 
 impl DurableNoProgressBaseline {
-    fn matches(&self, key: &StallLivenessKey, token: RelayFrontierToken, boot_id: &str) -> bool {
+    fn matches(
+        &self,
+        identity: Option<&crate::services::discord::inflight::InflightTurnIdentity>,
+        turn_nonce: Option<&str>,
+        token: RelayFrontierToken,
+        boot_id: &str,
+    ) -> bool {
         self.boot_id == boot_id
             && self.offset == token.committed_offset
             && self.reset_incarnation == token.reset_incarnation
-            && self.tmux_session == key.tmux_session
-            && self.user_msg_id == key.user_msg_id
-            && self.started_at == key.started_at
+            && self.identity.as_ref() == identity
+            && self.turn_nonce.as_deref() == turn_nonce
     }
 
     fn observation(&self, mono_now: i64) -> NoProgressObservation {
@@ -338,6 +344,7 @@ fn relay_offset_stalled_past_grace_durable(
     provider: &ProviderKind,
     channel_id: ChannelId,
     key: &StallLivenessKey,
+    snapshot: &WatcherStateSnapshot,
     token: RelayFrontierToken,
     mono_now: i64,
 ) -> bool {
@@ -347,8 +354,17 @@ fn relay_offset_stalled_past_grace_durable(
     let Some(boot_id) = boot_id() else {
         return relay_offset_stalled_past_grace(key, token, mono_now);
     };
+    let lock_key = (provider.as_str().to_string(), channel_id.get());
+    let channel_lock = DURABLE_BASELINE_LOCKS
+        .entry(lock_key)
+        .or_insert_with(|| Mutex::new(()));
+    let _guard = channel_lock
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    let identity = snapshot.inflight_identity.as_ref();
+    let turn_nonce = snapshot.mailbox_active_turn_nonce.as_deref();
     let map_key = (key.clone(), token.reset_incarnation);
-    match NO_PROGRESS_OBSERVATIONS.entry(map_key) {
+    let (stalled, observation) = match NO_PROGRESS_OBSERVATIONS.entry(map_key) {
         Entry::Occupied(mut occupied) => {
             let observation = occupied.get_mut();
             observation.last_seen_mono_secs = mono_now;
@@ -356,35 +372,51 @@ fn relay_offset_stalled_past_grace_durable(
                 observation.offset = token.committed_offset;
                 observation.unchanged_since_mono_secs = mono_now;
             }
+            (
+                token.committed_offset == observation.offset
+                    && mono_now.saturating_sub(observation.unchanged_since_mono_secs)
+                        >= STALL_WATCHDOG_BACKLOG_NO_PROGRESS_GRACE_SECS as i64,
+                NoProgressObservation {
+                    offset: observation.offset,
+                    unchanged_since_mono_secs: observation.unchanged_since_mono_secs,
+                    last_seen_mono_secs: observation.last_seen_mono_secs,
+                },
+            )
         }
         Entry::Vacant(vacant) => {
             let observation = load_durable_baseline_at(&path)
-                .filter(|baseline| baseline.matches(key, token, &boot_id))
+                .filter(|baseline| baseline.matches(identity, turn_nonce, token, &boot_id))
                 .map(|baseline| baseline.observation(mono_now))
                 .unwrap_or(NoProgressObservation {
                     offset: token.committed_offset,
                     unchanged_since_mono_secs: mono_now,
                     last_seen_mono_secs: mono_now,
                 });
-            vacant.insert(observation);
+            let stalled = mono_now.saturating_sub(observation.unchanged_since_mono_secs)
+                >= STALL_WATCHDOG_BACKLOG_NO_PROGRESS_GRACE_SECS as i64;
+            vacant.insert(NoProgressObservation {
+                offset: observation.offset,
+                unchanged_since_mono_secs: observation.unchanged_since_mono_secs,
+                last_seen_mono_secs: observation.last_seen_mono_secs,
+            });
+            (stalled, observation)
         }
-    }
+    };
 
-    let observation = NO_PROGRESS_OBSERVATIONS
-        .get(&(key.clone(), token.reset_incarnation))
-        .expect("redrive observation inserted under entry lock");
-    let stalled = token.committed_offset == observation.offset
-        && mono_now.saturating_sub(observation.unchanged_since_mono_secs)
-            >= STALL_WATCHDOG_BACKLOG_NO_PROGRESS_GRACE_SECS as i64;
+    if load_durable_baseline_at(&path).is_some_and(|baseline| {
+        !baseline.matches(identity, turn_nonce, token, &boot_id)
+            && baseline.last_seen_monotonic_secs > observation.last_seen_mono_secs
+    }) {
+        return stalled;
+    }
     persist_durable_baseline_at(
         &path,
         &DurableNoProgressBaseline {
             boot_id,
             offset: observation.offset,
             reset_incarnation: token.reset_incarnation,
-            tmux_session: key.tmux_session.clone(),
-            user_msg_id: key.user_msg_id,
-            started_at: key.started_at.clone(),
+            identity: identity.cloned(),
+            turn_nonce: turn_nonce.map(str::to_string),
             unchanged_since_monotonic_secs: observation.unchanged_since_mono_secs,
             last_seen_monotonic_secs: observation.last_seen_mono_secs,
         },
@@ -426,11 +458,14 @@ fn stalled_undelivered_backlog_for_redrive_with_token_and_clock(
         return false;
     }
     let key = StallLivenessKey::from_snapshot(provider, channel_id, snapshot);
-    match clock.durable_mono_secs() {
-        Some(mono_now) => {
-            relay_offset_stalled_past_grace_durable(provider, channel_id, &key, token, mono_now)
-        }
-        None => relay_offset_stalled_past_grace(&key, token, clock.mono_secs()),
+    match (
+        clock.durable_mono_secs(),
+        snapshot.inflight_identity.as_ref(),
+    ) {
+        (Some(mono_now), Some(_)) => relay_offset_stalled_past_grace_durable(
+            provider, channel_id, &key, snapshot, token, mono_now,
+        ),
+        _ => relay_offset_stalled_past_grace(&key, token, clock.mono_secs()),
     }
 }
 
@@ -457,6 +492,13 @@ fn stalled_undelivered_backlog_for_redrive_with_clock(
 /// Drop redrive no-progress observations for a cleared session. Called by the
 /// parent's `clear_stall_watchdog_liveness_state`.
 pub(super) fn clear_for_session(probe: &StallLivenessKey) {
+    let lock_key = (probe.provider.clone(), probe.channel_id);
+    let channel_lock = DURABLE_BASELINE_LOCKS
+        .entry(lock_key)
+        .or_insert_with(|| Mutex::new(()));
+    let _guard = channel_lock
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
     NO_PROGRESS_OBSERVATIONS.retain(|(key, _), _| !key.matches_session(probe));
     if let Some(path) = durable_baseline_path(&probe.provider, ChannelId::new(probe.channel_id)) {
         remove_durable_baseline_at(&path);
@@ -472,13 +514,42 @@ pub(super) fn gc() {
 }
 
 fn gc_with_clock(clock: &dyn RedriveClock) {
-    let mono_now = clock
-        .durable_mono_secs()
-        .unwrap_or_else(|| clock.mono_secs());
+    let durable_now = clock.durable_mono_secs();
+    let mono_now = durable_now.unwrap_or_else(|| clock.mono_secs());
     NO_PROGRESS_OBSERVATIONS.retain(|_, observation| {
         mono_now.saturating_sub(observation.last_seen_mono_secs)
             <= STALL_LIVENESS_STATE_TTL_SECS as i64
     });
+    let Some(boot_id) = boot_id() else {
+        return;
+    };
+    let Some(root) = runtime_store::runtime_root().map(|root| root.join(REDRIVE_BASELINES_DIR))
+    else {
+        return;
+    };
+    gc_durable_baselines_at(&root, &boot_id, mono_now);
+}
+
+fn gc_durable_baselines_at(root: &Path, boot_id: &str, mono_now: i64) {
+    let Ok(providers) = fs::read_dir(root) else {
+        return;
+    };
+    for provider in providers.flatten() {
+        let Ok(files) = fs::read_dir(provider.path()) else {
+            continue;
+        };
+        for file in files.flatten() {
+            let path = file.path();
+            let keep = load_durable_baseline_at(&path).is_some_and(|baseline| {
+                baseline.boot_id == boot_id
+                    && mono_now.saturating_sub(baseline.last_seen_monotonic_secs)
+                        <= STALL_LIVENESS_STATE_TTL_SECS as i64
+            });
+            if !keep {
+                remove_durable_baseline_at(&path);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -595,7 +666,14 @@ mod tests {
             bound_output_path: None,
             bound_session_id: None,
             inflight_terminal_delivery_committed: false,
-            inflight_identity: None,
+            inflight_identity: Some(
+                crate::services::discord::inflight::InflightTurnIdentity {
+                    user_msg_id: 9001,
+                    started_at: "2026-06-12 00:00:00".to_string(),
+                    tmux_session_name: Some(tmux_session.to_string()),
+                    turn_start_offset: Some(relay_offset),
+                },
+            ),
             inflight_finalizer_turn_id: None,
             inflight_output_path: Some(format!("/tmp/{tmux_session}.jsonl")),
             relay_stall_state: RelayStallState::TmuxAliveRelayDead,
@@ -881,9 +959,8 @@ mod tests {
             boot_id: "boot-a".to_string(),
             offset: token.committed_offset,
             reset_incarnation: token.reset_incarnation,
-            tmux_session: key.tmux_session.clone(),
-            user_msg_id: key.user_msg_id,
-            started_at: key.started_at.clone(),
+            identity: snap.inflight_identity.clone(),
+            turn_nonce: None,
             unchanged_since_monotonic_secs: clock.mono.get(),
             last_seen_monotonic_secs: clock.mono.get(),
         };
@@ -893,9 +970,9 @@ mod tests {
         NO_PROGRESS_OBSERVATIONS.clear();
         clock.mono.set(10_000 + grace);
         let restored = load_durable_baseline_at(&path).expect("durable baseline");
-        assert!(restored.matches(&key, token, "boot-a"));
+        assert!(restored.matches(snap.inflight_identity.as_ref(), None, token, "boot-a"));
         assert!(
-            !restored.matches(&key, token, "boot-b"),
+            !restored.matches(snap.inflight_identity.as_ref(), None, token, "boot-b"),
             "a machine reboot must reject the prior boot's monotonic baseline"
         );
         NO_PROGRESS_OBSERVATIONS.insert(
@@ -938,22 +1015,84 @@ mod tests {
             reset_incarnation: 0,
             committed_offset: 10,
         };
-        let old_key = StallLivenessKey::from_snapshot(&provider, channel, &old);
         let new_key = StallLivenessKey::from_snapshot(&provider, channel, &new);
         let baseline = DurableNoProgressBaseline {
             boot_id: "boot-a".to_string(),
             offset: token.committed_offset,
             reset_incarnation: token.reset_incarnation,
-            tmux_session: old_key.tmux_session,
-            user_msg_id: old_key.user_msg_id,
-            started_at: old_key.started_at,
+            identity: old.inflight_identity.clone(),
+            turn_nonce: None,
             unchanged_since_monotonic_secs: 20_000,
             last_seen_monotonic_secs: 20_000,
         };
 
-        assert!(!baseline.matches(&new_key, token, "boot-a"));
+        assert!(!baseline.matches(new.inflight_identity.as_ref(), None, token, "boot-a"));
         assert!(!relay_offset_stalled_past_grace(&new_key, token, 20_180));
         NO_PROGRESS_OBSERVATIONS.remove(&(new_key, token.reset_incarnation));
+    }
+
+    #[test]
+    fn redrive_durable_baseline_rejects_same_second_synthetic_successor_4181() {
+        let _runtime = isolated_runtime_root();
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(4_181_009);
+        let snap = frozen_backlog_snapshot(channel.get(), "AgentDesk-codex-4181-synthetic", 10, 20);
+        let mut successor = snap.clone();
+        successor.inflight_identity.as_mut().unwrap().user_msg_id = 0;
+        successor
+            .inflight_identity
+            .as_mut()
+            .unwrap()
+            .turn_start_offset = Some(11);
+        let mut predecessor = successor.inflight_identity.clone().unwrap();
+        predecessor.turn_start_offset = Some(10);
+        let token = RelayFrontierToken {
+            reset_incarnation: 0,
+            committed_offset: 10,
+        };
+        let baseline = DurableNoProgressBaseline {
+            boot_id: "boot-a".to_string(),
+            offset: 10,
+            reset_incarnation: 0,
+            identity: Some(predecessor),
+            turn_nonce: Some("prior-turn".to_string()),
+            unchanged_since_monotonic_secs: 1,
+            last_seen_monotonic_secs: 1,
+        };
+
+        assert!(!baseline.matches(
+            successor.inflight_identity.as_ref(),
+            Some("successor-turn"),
+            token,
+            "boot-a",
+        ));
+    }
+
+    #[test]
+    fn redrive_durable_gc_removes_invalid_boot_malformed_and_stale_4181() {
+        let (_env, root, _lock) = isolated_runtime_root();
+        let records = root.path().join("records").join("codex");
+        fs::create_dir_all(&records).unwrap();
+        let sample = |boot_id: &str, last_seen: i64| DurableNoProgressBaseline {
+            boot_id: boot_id.to_string(),
+            offset: 10,
+            reset_incarnation: 0,
+            identity: None,
+            turn_nonce: None,
+            unchanged_since_monotonic_secs: last_seen,
+            last_seen_monotonic_secs: last_seen,
+        };
+        persist_durable_baseline_at(&records.join("fresh.json"), &sample("boot-a", 9_000));
+        persist_durable_baseline_at(&records.join("old-boot.json"), &sample("boot-b", 9_000));
+        persist_durable_baseline_at(&records.join("stale.json"), &sample("boot-a", 1));
+        fs::write(records.join("malformed.json"), "{").unwrap();
+
+        gc_durable_baselines_at(&root.path().join("records"), "boot-a", 10_000);
+
+        assert!(records.join("fresh.json").exists());
+        assert!(!records.join("old-boot.json").exists());
+        assert!(!records.join("stale.json").exists());
+        assert!(!records.join("malformed.json").exists());
     }
 
     #[test]

--- a/src/services/discord/health/stall_liveness/redrive_grace.rs
+++ b/src/services/discord/health/stall_liveness/redrive_grace.rs
@@ -16,14 +16,18 @@
 //! liveness observations in the parent module, and are updated under the
 //! DashMap entry lock so concurrent watchdog passes for the same key serialize.
 //!
-//! The clock is process-local (does not survive restart), which is correct for
-//! an in-process elapsed measurement; a restart-surviving baseline (#4181
-//! item-3) is a separate concern needing durable absolute time.
+//! The production clock uses OS boottime, which remains monotonic across a
+//! dcserver restart. The current episode baseline is stored outside inflight and
+//! restored only when provider/channel/turn/frontier identity matches, so a
+//! restart neither re-arms grace nor imports a stale episode.
 
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use dashmap::mapref::entry::Entry;
 use poise::serenity_prelude::ChannelId;
+use serde::{Deserialize, Serialize};
 
 use crate::services::provider::ProviderKind;
 
@@ -32,7 +36,7 @@ use super::{
     STALL_LIVENESS_STATE_TTL_SECS, STALL_WATCHDOG_BACKLOG_NO_PROGRESS_GRACE_SECS, StallLivenessKey,
     live_undelivered_backlog,
 };
-use crate::services::discord::RelayFrontierToken;
+use crate::services::discord::{RelayFrontierToken, runtime_store};
 
 /// Monotonic seconds source for the redrive no-progress lifecycle (grace + TTL
 /// GC). Injected — rather than `#[cfg]`-splitting a free function — so the
@@ -43,14 +47,19 @@ trait RedriveClock {
     /// wall-clock/NTP steps. There is deliberately NO wall-clock accessor — the
     /// entire redrive no-progress lifecycle must be free of wall dependence.
     fn mono_secs(&self) -> i64;
+
+    fn durable_mono_secs(&self) -> Option<i64> {
+        None
+    }
 }
 
-/// Process-start `Instant` anchor. Monotonic and unaffected by wall-clock/NTP
-/// steps. Always compiled (never `#[cfg]`-gated) so the production reader below
-/// is a real test target, not code that only exists in release builds.
+/// Process-start `Instant` fallback for platforms without an OS boottime clock.
+/// It remains wall-clock independent but cannot carry an elapsed baseline across
+/// process restart, so durable restore fails closed to a fresh grace there.
 static MONO_ANCHOR: LazyLock<std::time::Instant> = LazyLock::new(std::time::Instant::now);
 
-/// Production monotonic clock: seconds since the process-start `Instant`.
+/// Production monotonic clock. Grace and persistence use OS boottime when
+/// available; `mono_secs` stays as the injected/tested in-process reader.
 struct MonotonicRedriveClock;
 
 impl RedriveClock for MonotonicRedriveClock {
@@ -71,22 +80,33 @@ impl RedriveClock for MonotonicRedriveClock {
         }
         MONO_ANCHOR.elapsed().as_secs() as i64
     }
+
+    fn durable_mono_secs(&self) -> Option<i64> {
+        #[cfg(test)]
+        if let Some(secs) = TEST_DURABLE_CLOCK_OVERRIDE.with(|cell| cell.get()) {
+            return Some(secs);
+        }
+        process_boottime_secs()
+    }
 }
 
 #[cfg(test)]
 thread_local! {
     static TEST_CLOCK_OVERRIDE: std::cell::Cell<Option<i64>> = const { std::cell::Cell::new(None) };
+    static TEST_DURABLE_CLOCK_OVERRIDE: std::cell::Cell<Option<i64>> = const { std::cell::Cell::new(None) };
 }
 
 #[cfg(test)]
 pub(in crate::services::discord::health) struct RedriveGraceTestClockGuard {
     previous: Option<i64>,
+    previous_durable: Option<i64>,
 }
 
 #[cfg(test)]
 impl Drop for RedriveGraceTestClockGuard {
     fn drop(&mut self) {
         TEST_CLOCK_OVERRIDE.with(|cell| cell.set(self.previous));
+        TEST_DURABLE_CLOCK_OVERRIDE.with(|cell| cell.set(self.previous_durable));
     }
 }
 
@@ -97,7 +117,11 @@ pub(in crate::services::discord::health) fn set_redrive_grace_test_clock(
     mono_secs: i64,
 ) -> RedriveGraceTestClockGuard {
     let previous = TEST_CLOCK_OVERRIDE.with(|cell| cell.replace(Some(mono_secs)));
-    RedriveGraceTestClockGuard { previous }
+    let previous_durable = TEST_DURABLE_CLOCK_OVERRIDE.with(|cell| cell.replace(Some(mono_secs)));
+    RedriveGraceTestClockGuard {
+        previous,
+        previous_durable,
+    }
 }
 
 /// #4181 item-2 P3-2: clear the override so the production `Instant` reader runs.
@@ -107,6 +131,7 @@ pub(in crate::services::discord::health) fn set_redrive_grace_test_clock(
 #[cfg(test)]
 fn clear_redrive_grace_test_clock() {
     TEST_CLOCK_OVERRIDE.with(|cell| cell.set(None));
+    TEST_DURABLE_CLOCK_OVERRIDE.with(|cell| cell.set(None));
 }
 
 /// Dedicated no-progress tracker, kept separate from the wall-clock
@@ -130,6 +155,89 @@ static NO_PROGRESS_OBSERVATIONS: LazyLock<
     dashmap::DashMap<(StallLivenessKey, u64), NoProgressObservation>,
 > = LazyLock::new(dashmap::DashMap::new);
 
+const REDRIVE_BASELINES_DIR: &str = "discord_redrive_baselines";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct DurableNoProgressBaseline {
+    offset: u64,
+    reset_incarnation: u64,
+    tmux_session: Option<String>,
+    user_msg_id: Option<u64>,
+    started_at: Option<String>,
+    unchanged_since_boottime_secs: i64,
+    last_seen_boottime_secs: i64,
+}
+
+impl DurableNoProgressBaseline {
+    fn matches(&self, key: &StallLivenessKey, token: RelayFrontierToken) -> bool {
+        self.offset == token.committed_offset
+            && self.reset_incarnation == token.reset_incarnation
+            && self.tmux_session == key.tmux_session
+            && self.user_msg_id == key.user_msg_id
+            && self.started_at == key.started_at
+    }
+
+    fn observation(&self, mono_now: i64) -> NoProgressObservation {
+        NoProgressObservation {
+            offset: self.offset,
+            unchanged_since_mono_secs: self.unchanged_since_boottime_secs.min(mono_now),
+            last_seen_mono_secs: mono_now,
+        }
+    }
+}
+
+fn durable_baseline_path(provider: &str, channel_id: ChannelId) -> Option<PathBuf> {
+    runtime_store::runtime_root().map(|root| {
+        root.join(REDRIVE_BASELINES_DIR)
+            .join(provider)
+            .join(format!("{}.json", channel_id.get()))
+    })
+}
+
+fn load_durable_baseline_at(path: &Path) -> Option<DurableNoProgressBaseline> {
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn persist_durable_baseline_at(path: &Path, baseline: &DurableNoProgressBaseline) {
+    let result = serde_json::to_string(baseline)
+        .map_err(|error| error.to_string())
+        .and_then(|json| runtime_store::atomic_write(path, &json));
+    if let Err(error) = result {
+        tracing::warn!(
+            redrive_baseline_path = %path.display(),
+            error = %error,
+            "redrive no-progress baseline persistence failed; keeping process-local grace"
+        );
+    }
+}
+
+fn remove_durable_baseline_at(path: &Path) {
+    if let Err(error) = fs::remove_file(path)
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            redrive_baseline_path = %path.display(),
+            error = %error,
+            "redrive no-progress baseline cleanup failed"
+        );
+    }
+}
+
+fn process_boottime_secs() -> Option<i64> {
+    #[cfg(unix)]
+    {
+        let mut value = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        if unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut value) } == 0 {
+            return Some(value.tv_sec);
+        }
+    }
+    None
+}
+
 /// Returns `true` iff the observed committed relay offset has stayed UNCHANGED
 /// for at least `STALL_WATCHDOG_BACKLOG_NO_PROGRESS_GRACE_SECS` of MONOTONIC time.
 ///
@@ -151,16 +259,12 @@ fn relay_offset_stalled_past_grace(
             let observation = occupied.get_mut();
             observation.last_seen_mono_secs = mono_now;
             if observed_offset > observation.offset {
-                // Relay advanced: reset the freeze anchor.
                 observation.offset = observed_offset;
                 observation.unchanged_since_mono_secs = mono_now;
                 false
             } else if observed_offset < observation.offset {
-                // A lower value under one reset incarnation is a stale snapshot;
-                // a legitimate reset always obtains a distinct incarnation key.
                 false
             } else {
-                // Frozen at the same offset: measure the monotonic freeze age.
                 mono_now.saturating_sub(observation.unchanged_since_mono_secs)
                     >= STALL_WATCHDOG_BACKLOG_NO_PROGRESS_GRACE_SECS as i64
             }
@@ -171,10 +275,63 @@ fn relay_offset_stalled_past_grace(
                 unchanged_since_mono_secs: mono_now,
                 last_seen_mono_secs: mono_now,
             });
-            // The first observation can never be past the grace.
             false
         }
     }
+}
+
+fn relay_offset_stalled_past_grace_durable(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    key: &StallLivenessKey,
+    token: RelayFrontierToken,
+    mono_now: i64,
+) -> bool {
+    let Some(path) = durable_baseline_path(provider.as_str(), channel_id) else {
+        return relay_offset_stalled_past_grace(key, token, mono_now);
+    };
+    let map_key = (key.clone(), token.reset_incarnation);
+    match NO_PROGRESS_OBSERVATIONS.entry(map_key) {
+        Entry::Occupied(mut occupied) => {
+            let observation = occupied.get_mut();
+            observation.last_seen_mono_secs = mono_now;
+            if token.committed_offset > observation.offset {
+                observation.offset = token.committed_offset;
+                observation.unchanged_since_mono_secs = mono_now;
+            }
+        }
+        Entry::Vacant(vacant) => {
+            let observation = load_durable_baseline_at(&path)
+                .filter(|baseline| baseline.matches(key, token))
+                .map(|baseline| baseline.observation(mono_now))
+                .unwrap_or(NoProgressObservation {
+                    offset: token.committed_offset,
+                    unchanged_since_mono_secs: mono_now,
+                    last_seen_mono_secs: mono_now,
+                });
+            vacant.insert(observation);
+        }
+    }
+
+    let observation = NO_PROGRESS_OBSERVATIONS
+        .get(&(key.clone(), token.reset_incarnation))
+        .expect("redrive observation inserted under entry lock");
+    let stalled = token.committed_offset == observation.offset
+        && mono_now.saturating_sub(observation.unchanged_since_mono_secs)
+            >= STALL_WATCHDOG_BACKLOG_NO_PROGRESS_GRACE_SECS as i64;
+    persist_durable_baseline_at(
+        &path,
+        &DurableNoProgressBaseline {
+            offset: observation.offset,
+            reset_incarnation: token.reset_incarnation,
+            tmux_session: key.tmux_session.clone(),
+            user_msg_id: key.user_msg_id,
+            started_at: key.started_at.clone(),
+            unchanged_since_boottime_secs: observation.unchanged_since_mono_secs,
+            last_seen_boottime_secs: observation.last_seen_mono_secs,
+        },
+    );
+    stalled
 }
 
 /// #4181 item-2: a live undelivered backlog whose committed relay offset has
@@ -211,7 +368,12 @@ fn stalled_undelivered_backlog_for_redrive_with_token_and_clock(
         return false;
     }
     let key = StallLivenessKey::from_snapshot(provider, channel_id, snapshot);
-    relay_offset_stalled_past_grace(&key, token, clock.mono_secs())
+    match clock.durable_mono_secs() {
+        Some(mono_now) => {
+            relay_offset_stalled_past_grace_durable(provider, channel_id, &key, token, mono_now)
+        }
+        None => relay_offset_stalled_past_grace(&key, token, clock.mono_secs()),
+    }
 }
 
 #[cfg(test)]
@@ -238,6 +400,9 @@ fn stalled_undelivered_backlog_for_redrive_with_clock(
 /// parent's `clear_stall_watchdog_liveness_state`.
 pub(super) fn clear_for_session(probe: &StallLivenessKey) {
     NO_PROGRESS_OBSERVATIONS.retain(|(key, _), _| !key.matches_session(probe));
+    if let Some(path) = durable_baseline_path(&probe.provider, ChannelId::new(probe.channel_id)) {
+        remove_durable_baseline_at(&path);
+    }
 }
 
 /// TTL-GC on the MONOTONIC freshness anchor (production clock). Called by the
@@ -249,7 +414,9 @@ pub(super) fn gc() {
 }
 
 fn gc_with_clock(clock: &dyn RedriveClock) {
-    let mono_now = clock.mono_secs();
+    let mono_now = clock
+        .durable_mono_secs()
+        .unwrap_or_else(|| clock.mono_secs());
     NO_PROGRESS_OBSERVATIONS.retain(|_, observation| {
         mono_now.saturating_sub(observation.last_seen_mono_secs)
             <= STALL_LIVENESS_STATE_TTL_SECS as i64
@@ -291,6 +458,28 @@ mod tests {
     impl RedriveClock for FakeClock {
         fn mono_secs(&self) -> i64 {
             self.mono.get()
+        }
+    }
+
+    struct FakeDurableClock {
+        mono: Cell<i64>,
+    }
+
+    impl FakeDurableClock {
+        fn new(mono: i64) -> Self {
+            Self {
+                mono: Cell::new(mono),
+            }
+        }
+    }
+
+    impl RedriveClock for FakeDurableClock {
+        fn mono_secs(&self) -> i64 {
+            self.mono.get()
+        }
+
+        fn durable_mono_secs(&self) -> Option<i64> {
+            Some(self.mono.get())
         }
     }
 
@@ -591,6 +780,95 @@ mod tests {
         );
 
         super::super::clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
+    }
+
+    /// #4181 item-3: a fresh process-local map restores the same episode's freeze
+    /// anchor from the durable sidecar, so restart does not grant another grace.
+    #[test]
+    fn redrive_durable_baseline_survives_process_restart_4181() {
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(4_181_007);
+        let tmux_session = "AgentDesk-codex-4181-durable-baseline";
+        let snap = frozen_backlog_snapshot(channel.get(), tmux_session, 10, 301_613);
+        let token = RelayFrontierToken {
+            reset_incarnation: 0,
+            committed_offset: 10,
+        };
+        let grace = STALL_WATCHDOG_BACKLOG_NO_PROGRESS_GRACE_SECS as i64;
+        let clock = FakeDurableClock::new(10_000);
+        let key = StallLivenessKey::from_snapshot(&provider, channel, &snap);
+        let root = tempfile::tempdir().expect("temp runtime root");
+        let path = root.path().join("baseline.json");
+        let baseline = DurableNoProgressBaseline {
+            offset: token.committed_offset,
+            reset_incarnation: token.reset_incarnation,
+            tmux_session: key.tmux_session.clone(),
+            user_msg_id: key.user_msg_id,
+            started_at: key.started_at.clone(),
+            unchanged_since_boottime_secs: clock.mono.get(),
+            last_seen_boottime_secs: clock.mono.get(),
+        };
+        persist_durable_baseline_at(&path, &baseline);
+        assert_eq!(load_durable_baseline_at(&path), Some(baseline));
+
+        NO_PROGRESS_OBSERVATIONS.clear();
+        clock.mono.set(10_000 + grace);
+        let restored = load_durable_baseline_at(&path).expect("durable baseline");
+        assert!(restored.matches(&key, token));
+        NO_PROGRESS_OBSERVATIONS.insert(
+            (key.clone(), token.reset_incarnation),
+            restored.observation(clock.mono.get()),
+        );
+        assert!(relay_offset_stalled_past_grace(
+            &key,
+            token,
+            clock.mono.get(),
+        ));
+
+        remove_durable_baseline_at(&path);
+        assert!(
+            !path.exists(),
+            "session cleanup removes the durable baseline"
+        );
+    }
+
+    /// #4181 item-3 identity gate: a prior episode's durable baseline must not
+    /// shorten grace for a successor turn on the same provider/channel.
+    #[test]
+    fn redrive_durable_baseline_rejects_successor_episode_4181() {
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(4_181_008);
+        let old = frozen_backlog_snapshot(
+            channel.get(),
+            "AgentDesk-codex-4181-old-episode",
+            10,
+            301_613,
+        );
+        let new = frozen_backlog_snapshot(
+            channel.get(),
+            "AgentDesk-codex-4181-new-episode",
+            10,
+            301_613,
+        );
+        let token = RelayFrontierToken {
+            reset_incarnation: 0,
+            committed_offset: 10,
+        };
+        let old_key = StallLivenessKey::from_snapshot(&provider, channel, &old);
+        let new_key = StallLivenessKey::from_snapshot(&provider, channel, &new);
+        let baseline = DurableNoProgressBaseline {
+            offset: token.committed_offset,
+            reset_incarnation: token.reset_incarnation,
+            tmux_session: old_key.tmux_session,
+            user_msg_id: old_key.user_msg_id,
+            started_at: old_key.started_at,
+            unchanged_since_boottime_secs: 20_000,
+            last_seen_boottime_secs: 20_000,
+        };
+
+        assert!(!baseline.matches(&new_key, token));
+        assert!(!relay_offset_stalled_past_grace(&new_key, token, 20_180));
+        NO_PROGRESS_OBSERVATIONS.remove(&(new_key, token.reset_incarnation));
     }
 
     #[test]

--- a/src/services/discord/health/stall_liveness/redrive_grace.rs
+++ b/src/services/discord/health/stall_liveness/redrive_grace.rs
@@ -16,10 +16,12 @@
 //! liveness observations in the parent module, and are updated under the
 //! DashMap entry lock so concurrent watchdog passes for the same key serialize.
 //!
-//! The production clock uses OS boottime, which remains monotonic across a
-//! dcserver restart. The current episode baseline is stored outside inflight and
-//! restored only when provider/channel/turn/frontier identity matches, so a
-//! restart neither re-arms grace nor imports a stale episode.
+//! The production clock uses the OS `CLOCK_MONOTONIC` domain, which remains
+//! comparable across a dcserver restart within one machine boot (and excludes
+//! suspend time). The current episode baseline is stored outside inflight and
+//! restored only when boot/provider/channel/turn/frontier identity matches, so a
+//! process restart neither re-arms grace nor imports a stale episode or prior-boot
+//! timestamp.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -53,12 +55,12 @@ trait RedriveClock {
     }
 }
 
-/// Process-start `Instant` fallback for platforms without an OS boottime clock.
-/// It remains wall-clock independent but cannot carry an elapsed baseline across
+/// Process-start `Instant` fallback when `CLOCK_MONOTONIC` is unavailable. It
+/// remains wall-clock independent but cannot carry an elapsed baseline across a
 /// process restart, so durable restore fails closed to a fresh grace there.
 static MONO_ANCHOR: LazyLock<std::time::Instant> = LazyLock::new(std::time::Instant::now);
 
-/// Production monotonic clock. Grace and persistence use OS boottime when
+/// Production monotonic clock. Grace and persistence use `CLOCK_MONOTONIC` when
 /// available; `mono_secs` stays as the injected/tested in-process reader.
 struct MonotonicRedriveClock;
 
@@ -86,7 +88,7 @@ impl RedriveClock for MonotonicRedriveClock {
         if let Some(secs) = TEST_DURABLE_CLOCK_OVERRIDE.with(|cell| cell.get()) {
             return Some(secs);
         }
-        process_boottime_secs()
+        os_monotonic_secs()
     }
 }
 
@@ -159,18 +161,20 @@ const REDRIVE_BASELINES_DIR: &str = "discord_redrive_baselines";
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 struct DurableNoProgressBaseline {
+    boot_id: String,
     offset: u64,
     reset_incarnation: u64,
     tmux_session: Option<String>,
     user_msg_id: Option<u64>,
     started_at: Option<String>,
-    unchanged_since_boottime_secs: i64,
-    last_seen_boottime_secs: i64,
+    unchanged_since_monotonic_secs: i64,
+    last_seen_monotonic_secs: i64,
 }
 
 impl DurableNoProgressBaseline {
-    fn matches(&self, key: &StallLivenessKey, token: RelayFrontierToken) -> bool {
-        self.offset == token.committed_offset
+    fn matches(&self, key: &StallLivenessKey, token: RelayFrontierToken, boot_id: &str) -> bool {
+        self.boot_id == boot_id
+            && self.offset == token.committed_offset
             && self.reset_incarnation == token.reset_incarnation
             && self.tmux_session == key.tmux_session
             && self.user_msg_id == key.user_msg_id
@@ -180,7 +184,7 @@ impl DurableNoProgressBaseline {
     fn observation(&self, mono_now: i64) -> NoProgressObservation {
         NoProgressObservation {
             offset: self.offset,
-            unchanged_since_mono_secs: self.unchanged_since_boottime_secs.min(mono_now),
+            unchanged_since_mono_secs: self.unchanged_since_monotonic_secs.min(mono_now),
             last_seen_mono_secs: mono_now,
         }
     }
@@ -224,7 +228,7 @@ fn remove_durable_baseline_at(path: &Path) {
     }
 }
 
-fn process_boottime_secs() -> Option<i64> {
+fn os_monotonic_secs() -> Option<i64> {
     #[cfg(unix)]
     {
         let mut value = libc::timespec {
@@ -235,6 +239,56 @@ fn process_boottime_secs() -> Option<i64> {
             return Some(value.tv_sec);
         }
     }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn boot_id() -> Option<String> {
+    let mut size = 0usize;
+    let name = c"kern.bootsessionuuid";
+    if unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            std::ptr::null_mut(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    } != 0
+        || size <= 1
+    {
+        return None;
+    }
+    let mut buffer = vec![0u8; size];
+    if unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            buffer.as_mut_ptr().cast(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    } != 0
+    {
+        return None;
+    }
+    let end = buffer.iter().position(|byte| *byte == 0).unwrap_or(size);
+    std::str::from_utf8(&buffer[..end])
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(target_os = "linux")]
+fn boot_id() -> Option<String> {
+    fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn boot_id() -> Option<String> {
     None
 }
 
@@ -290,6 +344,9 @@ fn relay_offset_stalled_past_grace_durable(
     let Some(path) = durable_baseline_path(provider.as_str(), channel_id) else {
         return relay_offset_stalled_past_grace(key, token, mono_now);
     };
+    let Some(boot_id) = boot_id() else {
+        return relay_offset_stalled_past_grace(key, token, mono_now);
+    };
     let map_key = (key.clone(), token.reset_incarnation);
     match NO_PROGRESS_OBSERVATIONS.entry(map_key) {
         Entry::Occupied(mut occupied) => {
@@ -302,7 +359,7 @@ fn relay_offset_stalled_past_grace_durable(
         }
         Entry::Vacant(vacant) => {
             let observation = load_durable_baseline_at(&path)
-                .filter(|baseline| baseline.matches(key, token))
+                .filter(|baseline| baseline.matches(key, token, &boot_id))
                 .map(|baseline| baseline.observation(mono_now))
                 .unwrap_or(NoProgressObservation {
                     offset: token.committed_offset,
@@ -322,13 +379,14 @@ fn relay_offset_stalled_past_grace_durable(
     persist_durable_baseline_at(
         &path,
         &DurableNoProgressBaseline {
+            boot_id,
             offset: observation.offset,
             reset_incarnation: token.reset_incarnation,
             tmux_session: key.tmux_session.clone(),
             user_msg_id: key.user_msg_id,
             started_at: key.started_at.clone(),
-            unchanged_since_boottime_secs: observation.unchanged_since_mono_secs,
-            last_seen_boottime_secs: observation.last_seen_mono_secs,
+            unchanged_since_monotonic_secs: observation.unchanged_since_mono_secs,
+            last_seen_monotonic_secs: observation.last_seen_mono_secs,
         },
     );
     stalled
@@ -435,6 +493,21 @@ mod tests {
     use crate::services::provider::ProviderKind;
 
     use super::*;
+
+    #[must_use]
+    fn isolated_runtime_root() -> (
+        crate::config::TestEnvVarGuard,
+        tempfile::TempDir,
+        crate::config::test_env_lock::SharedTestEnvLockGuard,
+    ) {
+        let lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
+        let dir = tempfile::tempdir().expect("temp runtime root");
+        let env = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            dir.path(),
+        );
+        (env, dir, lock)
+    }
 
     /// Deterministic monotonic clock for tests, injected through the same
     /// `RedriveClock` trait the production `MonotonicRedriveClock` implements —
@@ -566,6 +639,7 @@ mod tests {
     /// frozen, or comparing against a different clock) flips step (2) or (3).
     #[test]
     fn redrive_no_progress_grace_is_monotonic_4181() {
+        let _runtime = isolated_runtime_root();
         let provider = ProviderKind::Codex;
         let channel = ChannelId::new(4_181_002);
         let tmux_session = "AgentDesk-codex-4181-mono-grace";
@@ -622,6 +696,7 @@ mod tests {
     /// comparison so it evicts inside the TTL flips the "survives" assertion.
     #[test]
     fn redrive_ttl_gc_is_monotonic_and_survives_wall_jumps_4181() {
+        let _runtime = isolated_runtime_root();
         let provider = ProviderKind::Codex;
         let channel = ChannelId::new(4_181_003);
         let tmux_session = "AgentDesk-codex-4181-mono-gc";
@@ -676,6 +751,7 @@ mod tests {
     /// measure ~1s of freeze and return `false`, failing.
     #[test]
     fn redrive_rejects_stale_lower_offset_4181() {
+        let _runtime = isolated_runtime_root();
         let provider = ProviderKind::Codex;
         let channel = ChannelId::new(4_181_004);
         let tmux_session = "AgentDesk-codex-4181-stale-offset";
@@ -729,6 +805,7 @@ mod tests {
     /// the final assertion fails.
     #[test]
     fn redrive_rotation_reset_rearms_grace_4181() {
+        let _runtime = isolated_runtime_root();
         let provider = ProviderKind::Codex;
         let channel = ChannelId::new(4_181_006);
         let tmux_session = "AgentDesk-codex-4181-rotation";
@@ -786,6 +863,7 @@ mod tests {
     /// anchor from the durable sidecar, so restart does not grant another grace.
     #[test]
     fn redrive_durable_baseline_survives_process_restart_4181() {
+        let _runtime = isolated_runtime_root();
         let provider = ProviderKind::Codex;
         let channel = ChannelId::new(4_181_007);
         let tmux_session = "AgentDesk-codex-4181-durable-baseline";
@@ -800,13 +878,14 @@ mod tests {
         let root = tempfile::tempdir().expect("temp runtime root");
         let path = root.path().join("baseline.json");
         let baseline = DurableNoProgressBaseline {
+            boot_id: "boot-a".to_string(),
             offset: token.committed_offset,
             reset_incarnation: token.reset_incarnation,
             tmux_session: key.tmux_session.clone(),
             user_msg_id: key.user_msg_id,
             started_at: key.started_at.clone(),
-            unchanged_since_boottime_secs: clock.mono.get(),
-            last_seen_boottime_secs: clock.mono.get(),
+            unchanged_since_monotonic_secs: clock.mono.get(),
+            last_seen_monotonic_secs: clock.mono.get(),
         };
         persist_durable_baseline_at(&path, &baseline);
         assert_eq!(load_durable_baseline_at(&path), Some(baseline));
@@ -814,7 +893,11 @@ mod tests {
         NO_PROGRESS_OBSERVATIONS.clear();
         clock.mono.set(10_000 + grace);
         let restored = load_durable_baseline_at(&path).expect("durable baseline");
-        assert!(restored.matches(&key, token));
+        assert!(restored.matches(&key, token, "boot-a"));
+        assert!(
+            !restored.matches(&key, token, "boot-b"),
+            "a machine reboot must reject the prior boot's monotonic baseline"
+        );
         NO_PROGRESS_OBSERVATIONS.insert(
             (key.clone(), token.reset_incarnation),
             restored.observation(clock.mono.get()),
@@ -836,6 +919,7 @@ mod tests {
     /// shorten grace for a successor turn on the same provider/channel.
     #[test]
     fn redrive_durable_baseline_rejects_successor_episode_4181() {
+        let _runtime = isolated_runtime_root();
         let provider = ProviderKind::Codex;
         let channel = ChannelId::new(4_181_008);
         let old = frozen_backlog_snapshot(
@@ -857,22 +941,24 @@ mod tests {
         let old_key = StallLivenessKey::from_snapshot(&provider, channel, &old);
         let new_key = StallLivenessKey::from_snapshot(&provider, channel, &new);
         let baseline = DurableNoProgressBaseline {
+            boot_id: "boot-a".to_string(),
             offset: token.committed_offset,
             reset_incarnation: token.reset_incarnation,
             tmux_session: old_key.tmux_session,
             user_msg_id: old_key.user_msg_id,
             started_at: old_key.started_at,
-            unchanged_since_boottime_secs: 20_000,
-            last_seen_boottime_secs: 20_000,
+            unchanged_since_monotonic_secs: 20_000,
+            last_seen_monotonic_secs: 20_000,
         };
 
-        assert!(!baseline.matches(&new_key, token));
+        assert!(!baseline.matches(&new_key, token, "boot-a"));
         assert!(!relay_offset_stalled_past_grace(&new_key, token, 20_180));
         NO_PROGRESS_OBSERVATIONS.remove(&(new_key, token.reset_incarnation));
     }
 
     #[test]
     fn scoped_test_clock_restores_nested_and_panicking_overrides_4181() {
+        let _runtime = isolated_runtime_root();
         clear_redrive_grace_test_clock();
         let outer = set_redrive_grace_test_clock(11);
         assert_eq!(MonotonicRedriveClock.mono_secs(), 11);
@@ -900,6 +986,7 @@ mod tests {
     /// not past the grace regardless of the clock's absolute value.
     #[test]
     fn redrive_production_monotonic_clock_path_runs_4181() {
+        let _runtime = isolated_runtime_root();
         let provider = ProviderKind::Codex;
         let channel = ChannelId::new(4_181_005);
         let tmux_session = "AgentDesk-codex-4181-prod-clock";


### PR DESCRIPTION
## Summary
- keep the destructive redrive grace on a wall-clock-independent monotonic source
- persist the active provider/channel/turn/frontier baseline in a dedicated runtime sidecar and restore it across dcserver restart
- reject stale successor-turn/reset baselines and remove the sidecar when session liveness state clears

## Verification
- `cargo fmt --all --check`
- `cargo check --lib`
- `cargo test --lib services::discord::health::stall_liveness::redrive_grace::tests -- --test-threads=1` (8 passed)
- `cargo test --lib services::discord::health::relay_auto_heal::tests -- --test-threads=1` (12 passed)
- `python3 scripts/generate_inventory_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py --line-count-gate`
- `git diff --check`

Closes #4181

🤖 Generated with [Claude Code](https://claude.com/claude-code)