### PR TITLE
fix(#4756): offload runtime directory walks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -314,6 +314,7 @@ src/
 │   ├── cluster.rs
 │   ├── cluster_session_routing.rs
 │   ├── cron_catalog.rs
+│   ├── dashboard_provision.rs
 │   ├── issue_specs.rs
 │   ├── mod.rs
 │   ├── multinode_regression.rs

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -446,6 +446,7 @@
   before merging.
 
 ### Audited touches
+- #4756 blocking filesystem isolation: routine script reload scans remain inside the existing worker-local routine runtime and per-request validation paths, while startup dashboard provisioning and session-resume discovery retain their existing node-local paths. Moving those synchronous directory walks to Tokio's blocking pool changes no leader election, PG lease, worker placement, durable ownership, or cross-node routing authority.
 - #4777 PR-1 channel owner-authority rollout scope: `owner_authority_channel_ids`
   is a live-read, raw top-level Discord channel allowlist used only to tag the
   leader-owned intake planner's structured telemetry. It does not activate the

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -252,8 +252,8 @@
 | `POST` | `/api/routines/{id}/resume` | `routines::resume_routine` | `src/server/routes/routines/handlers.rs:253` | `src/server/routes/domains/ops.rs:259` |
 | `POST` | `/api/routines/{id}/run-now` | `routines::run_routine_now` | `src/server/routes/routines/handlers.rs:337` | `src/server/routes/domains/ops.rs:261` |
 | `GET` | `/api/routines/{id}/runs` | `routines::list_routine_runs` | `src/server/routes/routines/handlers.rs:116` | `src/server/routes/domains/ops.rs:257` |
-| `POST` | `/api/routines/{id}/session/kill` | `routines::kill_routine_session` | `src/server/routes/routines/handlers.rs:424` | `src/server/routes/domains/ops.rs:266` |
-| `POST` | `/api/routines/{id}/session/reset` | `routines::reset_routine_session` | `src/server/routes/routines/handlers.rs:417` | `src/server/routes/domains/ops.rs:262` |
+| `POST` | `/api/routines/{id}/session/kill` | `routines::kill_routine_session` | `src/server/routes/routines/handlers.rs:433` | `src/server/routes/domains/ops.rs:266` |
+| `POST` | `/api/routines/{id}/session/reset` | `routines::reset_routine_session` | `src/server/routes/routines/handlers.rs:426` | `src/server/routes/domains/ops.rs:262` |
 | `GET` | `/api/scheduled-messages` | `scheduled_messages::list_scheduled_messages` | `src/server/routes/scheduled_messages.rs:454` | `src/server/routes/domains/ops.rs:270` |
 | `POST` | `/api/scheduled-messages` | `scheduled_messages::create_scheduled_message` | `src/server/routes/scheduled_messages.rs:104` | `src/server/routes/domains/ops.rs:270` |
 | `DELETE` | `/api/scheduled-messages/{id}` | `scheduled_messages::cancel_scheduled_message` | `src/server/routes/scheduled_messages.rs:782` | `src/server/routes/domains/ops.rs:275` |
@@ -300,4 +300,4 @@
 | `GET` | `/api/v1/tokens` | `tokens` | `src/server/routes/v1.rs:202` | `src/server/routes/v1.rs:119` |
 | `GET` | `/api/voice/config` | `voice_config::get_voice_config` | `src/server/routes/voice_config.rs:110` | `src/server/routes/domains/admin.rs:68` |
 | `PUT` | `/api/voice/config` | `voice_config::put_voice_config` | `src/server/routes/voice_config.rs:120` | `src/server/routes/domains/admin.rs:68` |
-| `GET` | `/ws` | `ws::ws_handler` | `src/server/ws.rs:24` | `src/server/mod.rs:424` |
+| `GET` | `/ws` | `ws::ws_handler` | `src/server/ws.rs:24` | `src/server/mod.rs:399` |

--- a/src/server/dashboard_provision.rs
+++ b/src/server/dashboard_provision.rs
@@ -1,0 +1,137 @@
+use std::path::{Path, PathBuf};
+
+pub(super) async fn provision_off_runtime(dashboard_dir: PathBuf) {
+    let dashboard_dir_for_task = dashboard_dir.clone();
+    match tokio::task::spawn_blocking(move || provision(&dashboard_dir_for_task)).await {
+        Ok(ProvisionResult::AlreadyPresent) => {}
+        Ok(ProvisionResult::Copied {
+            workspace_dist,
+            files,
+        }) => tracing::info!(
+            dashboard_dir = %dashboard_dir.display(),
+            workspace_dist = %workspace_dist.display(),
+            files,
+            "dashboard dist copied"
+        ),
+        Ok(ProvisionResult::SourceMissing { workspace_dist }) => tracing::warn!(
+            dashboard_dir = %dashboard_dir.display(),
+            workspace_dist = %workspace_dist.display(),
+            "dashboard dist unavailable"
+        ),
+        Ok(ProvisionResult::CopyFailed {
+            workspace_dist,
+            error,
+        }) => tracing::warn!(
+            dashboard_dir = %dashboard_dir.display(),
+            workspace_dist = %workspace_dist.display(),
+            error,
+            "failed to copy dashboard dist"
+        ),
+        Err(error) => tracing::warn!(
+            dashboard_dir = %dashboard_dir.display(),
+            error = %error,
+            "dashboard provisioning blocking task failed"
+        ),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ProvisionResult {
+    AlreadyPresent,
+    Copied {
+        workspace_dist: PathBuf,
+        files: usize,
+    },
+    SourceMissing {
+        workspace_dist: PathBuf,
+    },
+    CopyFailed {
+        workspace_dist: PathBuf,
+        error: String,
+    },
+}
+
+#[cfg(test)]
+static PROVISION_THREAD_OBSERVER: std::sync::Mutex<
+    Option<std::sync::mpsc::Sender<std::thread::ThreadId>>,
+> = std::sync::Mutex::new(None);
+
+fn provision(dashboard_dir: &Path) -> ProvisionResult {
+    #[cfg(test)]
+    if let Some(observer) = PROVISION_THREAD_OBSERVER
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .as_ref()
+    {
+        let _ = observer.send(std::thread::current().id());
+    }
+    if dashboard_dir.join("index.html").exists() {
+        return ProvisionResult::AlreadyPresent;
+    }
+    let workspace_dist = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("dashboard/dist");
+    if !workspace_dist.join("index.html").exists() {
+        return ProvisionResult::SourceMissing { workspace_dist };
+    }
+    if let Some(parent) = dashboard_dir.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::remove_dir_all(dashboard_dir);
+    match copy_dir_recursive(&workspace_dist, dashboard_dir) {
+        Ok(files) => ProvisionResult::Copied {
+            workspace_dist,
+            files,
+        },
+        Err(error) => ProvisionResult::CopyFailed {
+            workspace_dist,
+            error: error.to_string(),
+        },
+    }
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<usize> {
+    std::fs::create_dir_all(dst)?;
+    let mut count = 0;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        let dest_path = dst.join(entry.file_name());
+        if ty.is_dir() {
+            count += copy_dir_recursive(&entry.path(), &dest_path)?;
+        } else {
+            std::fs::copy(entry.path(), &dest_path)?;
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn existing_dashboard_is_preserved_off_runtime() {
+        let root = tempfile::tempdir().unwrap();
+        let dashboard = root.path().join("dashboard/dist");
+        std::fs::create_dir_all(&dashboard).unwrap();
+        std::fs::write(dashboard.join("index.html"), "existing").unwrap();
+        let runtime_thread = std::thread::current().id();
+        let (sender, receiver) = mpsc::channel();
+        *PROVISION_THREAD_OBSERVER
+            .lock()
+            .unwrap_or_else(|error| error.into_inner()) = Some(sender);
+
+        provision_off_runtime(dashboard.clone()).await;
+        let provision_thread = receiver.recv().unwrap();
+        *PROVISION_THREAD_OBSERVER
+            .lock()
+            .unwrap_or_else(|error| error.into_inner()) = None;
+
+        assert_ne!(provision_thread, runtime_thread);
+        assert_eq!(
+            std::fs::read_to_string(dashboard.join("index.html")).unwrap(),
+            "existing"
+        );
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod cluster;
 pub(crate) mod cluster_session_routing;
 pub(crate) mod cron_catalog;
+mod dashboard_provision;
 pub mod dto;
 pub(crate) mod issue_specs;
 pub(crate) mod maintenance;
@@ -375,33 +376,7 @@ pub(crate) async fn run(
         .map(|r| r.join("dashboard/dist"))
         .unwrap_or_else(|| std::path::PathBuf::from("dashboard/dist"));
 
-    // Auto-provision: if runtime dist is missing, copy from workspace source
-    if !dashboard_dir.join("index.html").exists() {
-        let workspace_dist =
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("dashboard/dist");
-        if workspace_dist.join("index.html").exists() {
-            tracing::info!(
-                "Dashboard dist missing at {:?}, copying from workspace {:?}",
-                dashboard_dir,
-                workspace_dist
-            );
-            if let Some(parent) = dashboard_dir.parent() {
-                let _ = std::fs::create_dir_all(parent);
-            }
-            // Remove stale dist dir if it exists but is incomplete
-            let _ = std::fs::remove_dir_all(&dashboard_dir);
-            match copy_dir_recursive(&workspace_dist, &dashboard_dir) {
-                Ok(n) => tracing::info!("Dashboard dist copied ({n} files)"),
-                Err(e) => tracing::warn!("Failed to copy dashboard dist: {e}"),
-            }
-        } else {
-            tracing::warn!(
-                "Dashboard dist not found at {:?} or {:?} — dashboard will be unavailable",
-                dashboard_dir,
-                workspace_dist
-            );
-        }
-    }
+    dashboard_provision::provision_off_runtime(dashboard_dir.clone()).await;
 
     tracing::info!("Serving dashboard from {:?}", dashboard_dir);
 
@@ -1993,24 +1968,6 @@ async fn github_sync_loop(pg_pool: Arc<PgPool>, interval_minutes: u64) {
     }
 }
 
-/// Recursively copy a directory tree. Returns the number of files copied.
-fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<usize> {
-    std::fs::create_dir_all(dst)?;
-    let mut count = 0;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let ty = entry.file_type()?;
-        let dest_path = dst.join(entry.file_name());
-        if ty.is_dir() {
-            count += copy_dir_recursive(&entry.path(), &dest_path)?;
-        } else {
-            std::fs::copy(entry.path(), &dest_path)?;
-            count += 1;
-        }
-    }
-    Ok(count)
-}
-
 /// Async worker that drains the message_outbox table via the in-process Discord delivery path (#120).
 /// Runs every 2 seconds, processes up to 10 messages per tick.
 #[derive(Clone, Debug)]
@@ -3119,18 +3076,28 @@ async fn routine_runtime_loop(
     let _routine_action_validator: fn(serde_json::Value) -> anyhow::Result<RoutineAction> =
         crate::services::routines::validate_routine_action;
 
-    let script_loader = match RoutineScriptLoader::new() {
-        Ok(loader) => loader,
+    let routine_script_dirs = routines_config.script_dirs();
+    let initial_script_dirs = routine_script_dirs.clone();
+    let script_loader = match tokio::task::spawn_blocking(move || {
+        let loader = Arc::new(RoutineScriptLoader::new()?);
+        let count = loader.load_dirs(&initial_script_dirs)?;
+        Ok::<_, anyhow::Error>((loader, count))
+    })
+    .await
+    {
+        Ok(Ok((loader, count))) => {
+            tracing::info!(count, "routine script registry initialized");
+            loader
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "routine runtime not started: script registry initialization failed");
+            return;
+        }
         Err(e) => {
-            tracing::warn!(error = %e, "routine runtime not started: script loader init failed");
+            tracing::warn!(error = %e, "routine runtime not started: script registry blocking task failed");
             return;
         }
     };
-    let routine_script_dirs = routines_config.script_dirs();
-    match script_loader.load_dirs(&routine_script_dirs) {
-        Ok(count) => tracing::info!(count, "routine script registry initialized"),
-        Err(e) => tracing::warn!(error = %e, "routine script registry initialization failed"),
-    }
 
     let store = RoutineStore::new_with_timezone_and_checkpoint_limit(
         pg_pool.clone(),
@@ -3199,12 +3166,20 @@ async fn routine_runtime_loop(
             Err(e) => tracing::warn!(error = %e, "routine periodic recovery failed"),
         }
         if routines_config.hot_reload {
-            match script_loader.load_dirs(&routine_script_dirs) {
-                Ok(count) if count > 0 => {
+            let reload_dirs = routine_script_dirs.clone();
+            let loader = Arc::clone(&script_loader);
+            match tokio::task::spawn_blocking(move || loader.load_dirs(&reload_dirs)).await {
+                Ok(Ok(count)) if count > 0 => {
                     tracing::debug!(count, "routine script registry hot-reload pass complete")
                 }
-                Ok(_) => {}
-                Err(e) => tracing::warn!(error = %e, "routine script registry hot-reload failed"),
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => {
+                    tracing::warn!(error = %e, "routine script registry hot-reload failed")
+                }
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    "routine script registry hot-reload blocking task failed"
+                ),
             }
         }
         // #3564: surface routines that have been stuck in `paused` past the

--- a/src/server/routes/routines/handlers.rs
+++ b/src/server/routes/routines/handlers.rs
@@ -267,7 +267,7 @@ pub async fn resume_routine(
             "paused routine {routine_id} not found"
         )));
     }
-    let metadata = migrated_launchd_metadata_for_state(&state, &routine.script_ref)?;
+    let metadata = migrated_launchd_metadata_for_state(&state, &routine.script_ref).await?;
     let routine_script_dirs = state.config.routines.script_dirs();
     validate_migrated_launchd_activation(
         &routine.script_ref,
@@ -348,24 +348,33 @@ pub async fn run_routine_now(
         )));
     };
 
-    let loader = RoutineScriptLoader::new().map_err(|error| {
-        AppError::internal(format!("routine script loader init failed: {error}"))
-            .with_code(ErrorCode::Internal)
-    })?;
     let routine_script_dirs = state.config.routines.script_dirs();
-    loader.load_dirs(&routine_script_dirs).map_err(|error| {
-        AppError::internal(format!("routine script registry load failed: {error}"))
-            .with_code(ErrorCode::Config)
-    })?;
-    let metadata = if is_migrated_launchd_script_ref(&routine.script_ref) {
-        let Some(script) = loader.get_script(&routine.script_ref).map_err(|error| {
-            AppError::internal(format!("routine script lookup failed: {error}"))
-                .with_code(ErrorCode::Config)
-        })?
-        else {
+    let script_dirs_for_task = routine_script_dirs.clone();
+    let requested_script_ref = routine.script_ref.clone();
+    let script_ref_for_task = requested_script_ref.clone();
+    let (loader, script) = tokio::task::spawn_blocking(move || {
+        let loader = RoutineScriptLoader::new()
+            .map_err(|error| format!("routine script loader init failed: {error}"))?;
+        loader
+            .load_dirs(&script_dirs_for_task)
+            .map_err(|error| format!("routine script registry load failed: {error}"))?;
+        let script = loader
+            .get_script(&script_ref_for_task)
+            .map_err(|error| format!("routine script lookup failed: {error}"))?;
+        Ok::<_, String>((loader, script))
+    })
+    .await
+    .map_err(|error| {
+        AppError::internal(format!(
+            "routine script registry blocking task failed: {error}"
+        ))
+        .with_code(ErrorCode::Internal)
+    })?
+    .map_err(|error| AppError::internal(error).with_code(ErrorCode::Config))?;
+    let metadata = if is_migrated_launchd_script_ref(&requested_script_ref) {
+        let Some(script) = script else {
             return Err(AppError::conflict(format!(
-                "migrated routine {} is invalid: routine script not loaded",
-                routine.script_ref
+                "migrated routine {requested_script_ref} is invalid: routine script not loaded"
             )));
         };
         Some(script.metadata)

--- a/src/server/routes/routines/helpers.rs
+++ b/src/server/routes/routines/helpers.rs
@@ -32,29 +32,37 @@ pub(super) fn ensure_routine_runtime_runnable(
     Ok(())
 }
 
-pub(super) fn migrated_launchd_metadata_for_state(
+pub(super) async fn migrated_launchd_metadata_for_state(
     state: &AppState,
     script_ref: &str,
 ) -> AppResult<Option<Value>> {
     if !is_migrated_launchd_script_ref(script_ref) {
         return Ok(None);
     }
-    let loader = RoutineScriptLoader::new().map_err(|error| {
-        AppError::internal(format!("routine script loader init failed: {error}"))
-            .with_code(ErrorCode::Internal)
-    })?;
     let routine_script_dirs = state.config.routines.script_dirs();
-    loader.load_dirs(&routine_script_dirs).map_err(|error| {
-        AppError::internal(format!("routine script registry load failed: {error}"))
-            .with_code(ErrorCode::Config)
-    })?;
-    let Some(script) = loader.get_script(script_ref).map_err(|error| {
-        AppError::internal(format!("routine script lookup failed: {error}"))
-            .with_code(ErrorCode::Config)
+    let requested_script_ref = script_ref.to_string();
+    let script_ref_for_task = requested_script_ref.clone();
+    let script = tokio::task::spawn_blocking(move || {
+        let loader = RoutineScriptLoader::new()
+            .map_err(|error| format!("routine script loader init failed: {error}"))?;
+        loader
+            .load_dirs(&routine_script_dirs)
+            .map_err(|error| format!("routine script registry load failed: {error}"))?;
+        loader
+            .get_script(&script_ref_for_task)
+            .map_err(|error| format!("routine script lookup failed: {error}"))
+    })
+    .await
+    .map_err(|error| {
+        AppError::internal(format!(
+            "routine script registry blocking task failed: {error}"
+        ))
+        .with_code(ErrorCode::Internal)
     })?
-    else {
+    .map_err(|error| AppError::internal(error).with_code(ErrorCode::Config))?;
+    let Some(script) = script else {
         return Err(AppError::conflict(format!(
-            "migrated routine {script_ref} is invalid: routine script not loaded"
+            "migrated routine {requested_script_ref} is invalid: routine script not loaded"
         )));
     };
     Ok(Some(script.metadata))

--- a/src/services/maintenance/jobs/target_sweep.rs
+++ b/src/services/maintenance/jobs/target_sweep.rs
@@ -98,7 +98,22 @@ pub async fn run(config: Config) -> Result<()> {
 /// Split out for unit-testability — returns the structured report.
 pub async fn collect_and_sweep(config: Config) -> Result<SweepReport> {
     let target_dir = config.workspace_root.join("target");
-    let target_exists = target_dir.exists();
+    let disk_threshold_bytes = config.disk_threshold_bytes;
+    let dry_run = config.dry_run;
+    let (target_exists, disk_usage_bytes, cargo_sweep_available) =
+        tokio::task::spawn_blocking(move || {
+            let target_exists = target_dir.exists();
+            let disk_usage_bytes = target_exists
+                .then(|| measure_dir_size(&target_dir).unwrap_or(0))
+                .unwrap_or(0);
+            (
+                target_exists,
+                disk_usage_bytes,
+                which::which("cargo-sweep").is_ok(),
+            )
+        })
+        .await
+        .map_err(|error| anyhow::anyhow!("target sweep filesystem task failed: {error}"))?;
 
     if !target_exists {
         return Ok(SweepReport {
@@ -107,12 +122,9 @@ pub async fn collect_and_sweep(config: Config) -> Result<SweepReport> {
         });
     }
 
-    let disk_usage_bytes = measure_dir_size(&target_dir).unwrap_or(0);
-    let threshold_triggered = disk_usage_bytes >= config.disk_threshold_bytes;
+    let threshold_triggered = disk_usage_bytes >= disk_threshold_bytes;
 
-    let cargo_sweep_available = which::which("cargo-sweep").is_ok();
-
-    if config.dry_run || !cargo_sweep_available {
+    if dry_run || !cargo_sweep_available {
         return Ok(SweepReport {
             target_exists: true,
             disk_usage_bytes,
@@ -152,7 +164,20 @@ pub async fn collect_and_sweep(config: Config) -> Result<SweepReport> {
 /// Recursively sum file sizes under `dir`. Best-effort: fs errors are swallowed
 /// per-entry (we don't want a single permission-denied to abort the whole
 /// maintenance tick).
+#[cfg(test)]
+static MEASURE_THREAD_OBSERVER: std::sync::Mutex<
+    Option<std::sync::mpsc::Sender<std::thread::ThreadId>>,
+> = std::sync::Mutex::new(None);
+
 fn measure_dir_size(dir: &Path) -> Result<u64> {
+    #[cfg(test)]
+    if let Some(observer) = MEASURE_THREAD_OBSERVER
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .as_ref()
+    {
+        let _ = observer.send(std::thread::current().id());
+    }
     let mut total = 0u64;
     let mut stack: Vec<PathBuf> = vec![dir.to_path_buf()];
     while let Some(path) = stack.pop() {
@@ -197,4 +222,42 @@ fn parse_cargo_sweep_output(stdout: &str) -> (u64, u64) {
         }
     }
     (removed_files, removed_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn target_walk_runs_off_runtime_and_preserves_report() {
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("target");
+        std::fs::create_dir_all(target.join("nested")).unwrap();
+        std::fs::write(target.join("nested/artifact"), vec![0u8; 17]).unwrap();
+        let runtime_thread = std::thread::current().id();
+        let (sender, receiver) = mpsc::channel();
+        *MEASURE_THREAD_OBSERVER
+            .lock()
+            .unwrap_or_else(|error| error.into_inner()) = Some(sender);
+
+        let report = collect_and_sweep(Config {
+            workspace_root: root.path().to_path_buf(),
+            sweep_time_days: 30,
+            disk_threshold_bytes: 10,
+            dry_run: true,
+        })
+        .await
+        .unwrap();
+        let walk_thread = receiver.recv().unwrap();
+        *MEASURE_THREAD_OBSERVER
+            .lock()
+            .unwrap_or_else(|error| error.into_inner()) = None;
+
+        assert_ne!(walk_thread, runtime_thread);
+        assert!(report.target_exists);
+        assert_eq!(report.disk_usage_bytes, 17);
+        assert!(report.threshold_triggered);
+        assert!(!report.invoked_sweep);
+    }
 }

--- a/src/services/session_resume.rs
+++ b/src/services/session_resume.rs
@@ -92,6 +92,7 @@ pub(crate) enum ResumeRebindError {
     /// Auto-selection is only wired for Claude transcripts.
     AutoUnsupportedProvider(String),
     Database(String),
+    Filesystem(String),
 }
 
 impl ResumeRebindError {
@@ -131,7 +132,7 @@ impl ResumeRebindError {
                     )
                 })),
             ),
-            ResumeRebindError::Database(error) => (
+            ResumeRebindError::Database(error) | ResumeRebindError::Filesystem(error) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": error})),
             ),
@@ -356,12 +357,13 @@ pub(crate) async fn perform_resume_rebind(
             let live_bound = dispatched_sessions_db::load_live_bound_session_ids_pg(pool)
                 .await
                 .map_err(ResumeRebindError::Database)?;
-            let candidate = discover_previous_claude_session_scoped(
-                current_cwd.as_deref(),
-                current_session_id.as_deref(),
-                &live_bound,
+            let candidate = discover_previous_claude_session_off_runtime(
+                current_cwd.clone(),
+                current_session_id.clone(),
+                live_bound,
                 None,
             )
+            .await?
             .ok_or(ResumeRebindError::NoPreviousSession)?;
             (candidate.session_id, candidate.cwd, true)
         }
@@ -486,6 +488,26 @@ fn worktree_lineage_stem(dir_name: &str) -> &str {
 /// `claude_home` is injectable for tests; production passes `None`.
 ///
 /// Returns `None` when no distinct, unbound prior transcript exists in-lineage.
+async fn discover_previous_claude_session_off_runtime(
+    current_cwd: Option<String>,
+    current_session_id: Option<String>,
+    live_bound: std::collections::HashSet<String>,
+    claude_home: Option<std::path::PathBuf>,
+) -> Result<Option<PreviousSessionCandidate>, ResumeRebindError> {
+    tokio::task::spawn_blocking(move || {
+        discover_previous_claude_session_scoped(
+            current_cwd.as_deref(),
+            current_session_id.as_deref(),
+            &live_bound,
+            claude_home.as_deref(),
+        )
+    })
+    .await
+    .map_err(|error| {
+        ResumeRebindError::Filesystem(format!("previous-session discovery task failed: {error}"))
+    })
+}
+
 pub(crate) fn discover_previous_claude_session_scoped(
     current_cwd: Option<&str>,
     current_session_id: Option<&str>,
@@ -564,6 +586,42 @@ pub(crate) fn discover_previous_claude_session_scoped(
 mod tests {
     use super::*;
     use filetime::{FileTime, set_file_mtime};
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn off_runtime_discovery_preserves_selection_and_runtime_progress() {
+        let tmp = unique_tmp("off-runtime");
+        let claude_home = tmp.join(".claude");
+        let parent = tmp.join("worktrees");
+        let cwd = parent.join("claude-adk-cc-20260101-000001");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let prior = "22222222-2222-2222-2222-222222222222";
+        write_transcript(&claude_home, &cwd, prior, 2_000);
+
+        let expected = discover_previous_claude_session_scoped(
+            Some(cwd.to_str().unwrap()),
+            None,
+            &no_live_bound(),
+            Some(&claude_home),
+        );
+        let selected = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            discover_previous_claude_session_off_runtime(
+                Some(cwd.to_string_lossy().to_string()),
+                None,
+                no_live_bound(),
+                Some(claude_home),
+            ),
+        )
+        .await
+        .expect("blocking discovery must complete")
+        .expect("blocking task must not fail")
+        .expect("prior session must be selected");
+
+        assert_eq!(Some(selected.clone()), expected);
+        assert_eq!(selected.session_id, prior);
+        assert_eq!(selected.cwd, cwd.to_string_lossy());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 
     #[test]
     fn discover_returns_none_without_current_cwd() {


### PR DESCRIPTION
Closes #4756

## 요약

런타임 async 경로에서 동기 디렉터리 순회와 재귀 파일시스템 작업을 실행하던 호출자를 추적하고 Tokio blocking pool로 격리했습니다. 기존 결과 순서, fail-closed 처리, 에러 매핑을 유지합니다.

중요한 인과 교정: incident dump의 `com.apple.main-thread`는 604/604 샘플에서 `pthread_cond_wait`였고, `readdir` 표본은 별도 `hook-relay-recovery` 스레드였습니다. 따라서 이 PR은 readdir가 main thread hang의 직접 원인이었다고 주장하지 않으며, 실제 main-thread condition wait 추적은 #4770 범위입니다.

## 호출자 스카우트

| 호출자 | async/runtime 콜체인 | 확인 결과 | 조치 |
|---|---|---|---|
| Routine script registry recursive scan | `server::run` → `SupervisedWorkerRegistry::start_after_boot_reconcile` → worker-local `routine_runtime_loop` → `RoutineScriptLoader::load_dirs` → recursive `collect_routine_script_paths` → `std::fs::read_dir`; HTTP `resume_routine`/`run_routine_now`도 Axum async handler에서 동일 loader 호출 | Tokio worker에서 동기 recursive scan + script reads + QuickJS metadata evaluation | 초기화/주기 hot reload/HTTP validation 전체를 `spawn_blocking`으로 이동. loader와 registry 결과를 그대로 반환 |
| Claude previous-session discovery | HTTP `/resume-previous` 또는 Discord `/resume` → `dispatch_resume_previous` → async `perform_resume_rebind` → `discover_previous_claude_session_scoped` → sibling worktree `read_dir` + per-worktree transcript `read_dir`/metadata | worktree 수 및 transcript 수에 비례하는 sync discovery가 async handler에서 실행 | discovery 전체를 단일 `spawn_blocking`으로 이동; newest-mtime, lineage, live-binding 제외 시맨틱 보존 |
| Monthly target size walk | leader maintenance scheduler → `StorageTargetSweepJob::run` → async `target_sweep::collect_and_sweep` → recursive `measure_dir_size` → `read_dir`/metadata | `target/` 파일 수에 비례하는 recursive walk가 Tokio worker에서 실행 | existence/size/`which` probe를 한 blocking task로 이동; report/threshold 동등성 유지 |
| Startup dashboard provisioning | `launch::run` → Tokio `Runtime::block_on` → async `server::run` → missing-dist path → recursive `copy_dir_recursive` → `read_dir`/copy/remove | startup runtime future에서 recursive sync copy | 새 `server/dashboard_provision.rs`로 추출하고 provisioning 전체를 `spawn_blocking`으로 이동 |
| Worktree orphan sweep | maintenance scheduler → `tokio::spawn(run_job_and_record)` → `worktree_orphan_sweep::run_inner` | PR #4772에서 root stats, enumeration, metadata, cleanup/remove가 이미 blocking pool로 격리됨 | 추가 변경 없음 |
| Zombie reconcile filesystem sweeps | async `reconcile_zombie_resources` → `spawn_blocking(sweep_stale_inflight_files / sweep_stale_discord_uploads)` | 이미 격리됨 | 추가 변경 없음 |
| tmux enumeration | production paths use async process APIs or explicit blocking/thread isolation; no worktree-count recursive directory walk found in tmux enumeration | incident의 `readdir` 호출자와 불일치 | 추가 변경 없음 |
| QuickJS local worktree inventory | `local-worktree-gc.js` only dispatches a fresh agent turn; Node helper `local_worktree_inventory.js` runs in the provider child process, not in dcserver QuickJS/runtime thread | dcserver main-thread caller 아님 | 추가 변경 없음 |
| Dump의 `hook-relay-recovery` readdir | dedicated named OS thread `start_ordered_hook_relay_recovery_owner` → `scan_ordered_hook_relay_queues_once` | main/Tokio runtime thread가 아님; 비용/retention은 #4770에 기록됨 | 본 PR 변경 없음 |

## 테스트

- `cargo fmt --all` — rc 0
- `cargo fmt --all --check` — rc 0
- `cargo check --lib` (build token, `set -o pipefail`) — rc 0
- `cargo test --lib services::session_resume` — rc 0, 7 passed
- `cargo test --lib services::maintenance::jobs::target_sweep` — rc 0, 1 passed
- `cargo test --lib services::routines::loader` — rc 0, 31 passed
- `cargo test --lib server::routes::routines` — rc 0, 17 passed
- `cargo test --lib server::dashboard_provision` — rc 0, 1 passed
- `python3 scripts/generate_inventory_docs.py` — rc 0
- `python3 scripts/check_agent_maintenance_docs.py` — rc 0, `agent-maintenance freshness check passed`

새 회귀 테스트는 single-thread Tokio runtime에서 blocking task가 별도 thread에서 실행되는지 검증하고, target report 및 session selection 결과 동등성을 확인합니다.

## 별도 트랙

- Ask 3 worktree GC: 디스크에 누적되는 stale worktree 정리 정책과 destructive GC 확대는 본 PR에서 변경하지 않았습니다. 기존 `worktree_orphan_sweep` 안전 가드와 별도 운영 트랙을 유지합니다.
- Ask 4 restart gap: Tailscale/PG tunnel partition, launchd throttle, 18~26분 intake-open 지연은 본 PR에서 변경하지 않았습니다.
- Main-thread wait: dump의 실제 main thread는 `pthread_cond_wait`; holder/park-vs-shutdown-join 규명과 queue retention/backoff는 #4770에서 계측 후 처리해야 합니다.

## 멀티노드 영향

Routine reload는 기존 worker-local routine runtime 및 요청 처리 경계 안에 유지됩니다. leader election, PG lease, worker placement, durable ownership, cross-node forwarding authority는 변경하지 않았고 `multinode-transition.md`에 audited touch를 기록했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
