### PR TITLE
fix(#4549): reanchor compacted Claude transcript at EOF

### DIFF
--- a/src/services/discord/outbound/delivery_record.rs
+++ b/src/services/discord/outbound/delivery_record.rs
@@ -818,6 +818,41 @@ pub(in crate::services::discord) fn delivered_frontier_end_current_generation(
         .unwrap_or(0)
 }
 
+fn current_generation_frontier_exceeds_eof_at(
+    path: &Path,
+    current_gen_mtime: i64,
+    current_transcript_eof: u64,
+) -> bool {
+    read_record_at(path)
+        .and_then(|record| record.delivered_frontier)
+        .is_some_and(|frontier| {
+            durable_frontier_generation_current(frontier.generation_mtime_ns, current_gen_mtime)
+                && frontier.range.1 > current_transcript_eof
+        })
+}
+
+/// #4549: detect the exact same-generation frontier/EOF regression that the
+/// ordinary durable reader distrusts. The Claude idle scanner uses this signal
+/// only on an unchanged transcript path to re-anchor its scan cursor at EOF after
+/// an in-place `/compact` rewrite. A rotated UUID/path bypasses this predicate and
+/// keeps the fresh-transcript lookback path, so replacement-file prompts are not
+/// lost.
+pub(in crate::services::discord) fn delivered_frontier_exceeds_current_eof(
+    provider: &ProviderKind,
+    channel: ChannelId,
+    tmux_session_name: &str,
+    current_transcript_eof: u64,
+) -> bool {
+    let Some(path) = delivery_record_path(provider, channel.get()) else {
+        return false;
+    };
+    current_generation_frontier_exceeds_eof_at(
+        &path,
+        current_generation_mtime_ns(tmux_session_name),
+        current_transcript_eof,
+    )
+}
+
 /// #3089 B2b: the effective "already-committed" offset the dedup/skip gates read.
 /// Flag OFF (default) → the legacy in-memory `committed_relay_offset` verbatim
 /// (no record read → deploy no-op). Flag ON → `max(delivered_frontier.end,
@@ -2215,6 +2250,27 @@ mod tests {
             current_generation_durable_frontier_end_at(&path, gen_ns, None),
             None
         );
+    }
+
+    #[test]
+    fn current_generation_frontier_eof_regression_signal_is_exact_4549() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = delivery_record_path_in_root(dir.path(), &ProviderKind::Claude, 4549);
+        write_delivered_frontier_at(
+            &path,
+            DeliveredCommit {
+                range: (0, 900),
+                generation_mtime_ns: 700,
+                attempts: 1,
+                panel_msg_id: None,
+                panel_channel_id: None,
+            },
+        )
+        .unwrap();
+
+        assert!(current_generation_frontier_exceeds_eof_at(&path, 700, 250));
+        assert!(!current_generation_frontier_exceeds_eof_at(&path, 701, 250));
+        assert!(!current_generation_frontier_exceeds_eof_at(&path, 700, 900));
     }
 
     /// I3 conservatism: an absent or malformed record yields no durable floor

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -43,7 +43,7 @@ use self::observed_prompt_decision::{
 
 mod idle_transcript_scan;
 use self::idle_transcript_scan::{
-    ClaudeIdleTranscriptScan, CodexIdleRolloutScan,
+    ClaudeIdleTranscriptScan, CodexIdleRolloutScan, claude_idle_compaction_reanchor,
     claude_idle_prompt_observation_should_tail_response,
     codex_idle_prompt_observation_should_tail_response,
     scan_claude_idle_transcript_for_last_prompt, scan_claude_idle_transcript_for_prompt,

--- a/src/services/discord/tui_prompt_relay/claude_idle_runtime.rs
+++ b/src/services/discord/tui_prompt_relay/claude_idle_runtime.rs
@@ -152,10 +152,34 @@ pub(super) fn spawn_claude_idle_transcript_relay(shared: Arc<SharedData>) {
                 } else {
                     binding.last_offset
                 };
+                let transcript_eof = std::fs::metadata(&transcript_path)
+                    .ok()
+                    .map(|metadata| metadata.len());
+                // #4549: `/compact` rewrites the same UUID/path in place. When the
+                // current-generation durable frontier and binding cursor are both
+                // beyond the new EOF, re-anchor at EOF instead of scanning the
+                // compacted historical snapshot from zero. A real rotation changes
+                // path/session identity and stays on the bounded newest-prompt
+                // lookback below, so fresh replacement-file content is preserved.
+                let compaction_reanchor = transcript_eof.and_then(|eof| {
+                    claude_idle_compaction_reanchor(
+                        path_changed,
+                        binding.last_offset,
+                        eof,
+                        dr::delivered_frontier_exceeds_current_eof(
+                            &ProviderKind::Claude,
+                            channel_id,
+                            &tmux_session_name,
+                            eof,
+                        ),
+                    )
+                });
                 // #2843 (codex round-2 P1): the lookback can hold several finished
                 // turns — on a path change select the NEWEST prompt (the just-typed
                 // one); unchanged-path tailing keeps first-prompt semantics.
-                let scan_result = if path_changed {
+                let scan_result = if let Some(scan) = compaction_reanchor {
+                    Ok(scan)
+                } else if path_changed {
                     scan_claude_idle_transcript_for_last_prompt(&transcript_path, scan_offset)
                 } else {
                     scan_claude_idle_transcript_for_prompt(&transcript_path, scan_offset)
@@ -182,6 +206,21 @@ pub(super) fn spawn_claude_idle_transcript_relay(shared: Arc<SharedData>) {
                                 offset,
                             );
                         }
+                    }
+                    ClaudeIdleTranscriptScan::CompactionReanchor { offset } => {
+                        advance_claude_tmux_runtime_binding_offset(
+                            &tmux_session_name,
+                            &transcript_path,
+                            offset,
+                        );
+                        tracing::info!(
+                            tmux_session_name = %tmux_session_name,
+                            channel_id = channel_id.get(),
+                            transcript_path = %transcript_path.display(),
+                            previous_offset = binding.last_offset,
+                            reanchored_offset = offset,
+                            "Claude idle transcript relay fast-forwarded compacted history to current EOF"
+                        );
                     }
                     ClaudeIdleTranscriptScan::Prompt {
                         prompt,

--- a/src/services/discord/tui_prompt_relay/idle_transcript_scan.rs
+++ b/src/services/discord/tui_prompt_relay/idle_transcript_scan.rs
@@ -52,6 +52,9 @@ pub(super) enum ClaudeIdleTranscriptScan {
     NoPrompt {
         offset: u64,
     },
+    CompactionReanchor {
+        offset: u64,
+    },
     Prompt {
         prompt: String,
         prompt_start_offset: u64,
@@ -64,6 +67,23 @@ pub(super) enum ClaudeIdleTranscriptScan {
         /// the content-keyed recent-observed dedup (pre-#3540 behavior).
         entry_id: Option<String>,
     },
+}
+
+pub(super) fn claude_idle_compaction_reanchor(
+    path_changed: bool,
+    binding_offset: u64,
+    current_eof: u64,
+    durable_frontier_exceeds_eof: bool,
+) -> Option<ClaudeIdleTranscriptScan> {
+    // A real Claude session rotation changes the UUID/path and is handled by the
+    // bounded newest-prompt lookback. Only an unchanged-path, same-generation
+    // durable frontier beyond EOF proves an in-place `/compact` rewrite whose
+    // surviving bytes are historical and must be treated as already delivered.
+    (!path_changed && binding_offset > current_eof && durable_frontier_exceeds_eof).then_some(
+        ClaudeIdleTranscriptScan::CompactionReanchor {
+            offset: current_eof,
+        },
+    )
 }
 
 pub(super) fn scan_claude_idle_transcript_for_prompt(

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -4056,33 +4056,102 @@ fn claude_rehydrate_start_offset_uses_current_eof() {
     );
 }
 
-// U-17 Claude transcript scan must restart from offset 0 when the
-// recorded offset is past the current file length — this is the
-// /compact path, where Claude rewrites the transcript and our
-// previously-persisted offset would otherwise leak past the EOF and
-// skip all newly-written prompts.
+// #4549: `/compact` rewrites the same transcript path to a shorter historical
+// snapshot. The durable EOF-regression signal must fast-forward to the new EOF
+// instead of restarting at zero, which would mirror an old direct prompt again.
 #[test]
-fn claude_idle_transcript_scan_restarts_when_file_shrinks() {
+fn claude_idle_transcript_scan_fast_forwards_when_compaction_shrinks_file() {
+    assert_eq!(
+        claude_idle_compaction_reanchor(false, 99_999, 250, true),
+        Some(ClaudeIdleTranscriptScan::CompactionReanchor { offset: 250 })
+    );
+}
+
+#[test]
+fn claude_idle_transcript_scan_relays_prompt_appended_after_compaction_anchor() {
     let dir = tempfile::tempdir().expect("temp dir");
     let transcript = dir.path().join("transcript.jsonl");
-    let prompt = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"after compact\"}]},\"sessionId\":\"s1\"}\n";
-    std::fs::write(&transcript, prompt).expect("write transcript");
+    let compact = "{\"type\":\"system\",\"subtype\":\"compact\",\"sessionId\":\"s1\"}\n";
+    let historical_prompt = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"historical direct prompt\"}]},\"sessionId\":\"s1\"}\n";
+    let compacted = format!("{compact}{historical_prompt}");
+    std::fs::write(&transcript, &compacted).expect("write compacted transcript");
+    let anchored =
+        match claude_idle_compaction_reanchor(false, 99_999, compacted.len() as u64, true) {
+            Some(ClaudeIdleTranscriptScan::CompactionReanchor { offset }) => offset,
+            other => panic!("expected compaction anchor, got {other:?}"),
+        };
 
-    let scan = scan_claude_idle_transcript_for_prompt(&transcript, 99_999)
-        .expect("scan shrunken transcript");
-    match scan {
+    let fresh_prompt = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"fresh prompt after compact\"}]},\"sessionId\":\"s1\"}\n";
+    use std::io::Write;
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(&transcript)
+        .expect("open compacted transcript")
+        .write_all(fresh_prompt.as_bytes())
+        .expect("append fresh prompt");
+
+    assert_eq!(
+        scan_claude_idle_transcript_for_prompt(&transcript, anchored)
+            .expect("scan post-compact growth"),
         ClaudeIdleTranscriptScan::Prompt {
-            prompt: text,
-            line_end_offset,
-            prompt_start_offset,
-            ..
-        } => {
-            assert_eq!(text, "after compact");
-            assert_eq!(line_end_offset, prompt.len() as u64);
-            assert_eq!(prompt_start_offset, 0);
+            prompt: "fresh prompt after compact".to_string(),
+            prompt_start_offset: anchored,
+            line_end_offset: anchored + fresh_prompt.len() as u64,
+            entry_id: None,
         }
-        other => panic!("expected Prompt, got {other:?}"),
-    }
+    );
+}
+
+#[test]
+fn claude_idle_transcript_scan_preserves_normal_growth() {
+    assert_eq!(
+        claude_idle_compaction_reanchor(false, 100, 250, false),
+        None
+    );
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let transcript = dir.path().join("transcript.jsonl");
+    let before = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]},\"sessionId\":\"s1\"}\n";
+    let prompt = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"normally appended prompt\"}]},\"sessionId\":\"s1\"}\n";
+    std::fs::write(&transcript, format!("{before}{prompt}")).expect("write transcript");
+
+    assert_eq!(
+        scan_claude_idle_transcript_for_prompt(&transcript, before.len() as u64)
+            .expect("scan normal growth"),
+        ClaudeIdleTranscriptScan::Prompt {
+            prompt: "normally appended prompt".to_string(),
+            prompt_start_offset: before.len() as u64,
+            line_end_offset: (before.len() + prompt.len()) as u64,
+            entry_id: None,
+        }
+    );
+}
+
+#[test]
+fn claude_idle_transcript_rotation_lookback_still_observes_new_file_prompt() {
+    // A path/session rotation must never be mistaken for in-place compaction,
+    // even if the prior binding offset and durable frontier exceed the new EOF.
+    assert_eq!(
+        claude_idle_compaction_reanchor(true, 99_999, 250, true),
+        None
+    );
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let transcript = dir.path().join("new-session.jsonl");
+    let before = "{\"type\":\"system\",\"subtype\":\"init\",\"sessionId\":\"s2\"}\n";
+    let prompt = "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"fresh rotation prompt\"}]},\"sessionId\":\"s2\"}\n";
+    std::fs::write(&transcript, format!("{before}{prompt}")).expect("write transcript");
+
+    assert_eq!(
+        scan_claude_idle_transcript_for_last_prompt(&transcript, 0)
+            .expect("scan replacement transcript lookback"),
+        ClaudeIdleTranscriptScan::Prompt {
+            prompt: "fresh rotation prompt".to_string(),
+            prompt_start_offset: before.len() as u64,
+            line_end_offset: (before.len() + prompt.len()) as u64,
+            entry_id: None,
+        }
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## 변경 요약
- Claude TUI transcript가 `/compact`으로 같은 파일 경로에서 짧아졌고 current-generation `delivered_frontier.end`가 새 EOF를 초과하면 idle scanner를 현재 EOF로 fast-forward 합니다.
- 압축된 snapshot 안의 과거 `user` entry는 다시 관측하지 않으며, EOF 이후 append되는 진짜 신규 TUI-direct 입력은 다음 poll에서 정상 릴레이합니다.
- 파일 교체 rotation은 기존 UUID/path 변경 분기를 유지해 bounded lookback으로 새 transcript의 최신 prompt를 계속 관측합니다.

## 근본 원인 콜체인
1. `outbound::delivery_record::current_generation_durable_frontier_at`이 같은 wrapper generation의 `delivered_frontier.end > current transcript EOF`를 감지하고 `None`으로 distrust합니다.
2. `tui_prompt_relay::claude_idle_runtime::spawn_claude_idle_transcript_relay`는 unchanged path에서 `binding.last_offset`을 `scan_offset`으로 넘깁니다.
3. `/compact` 뒤 `binding.last_offset > EOF`이므로 `idle_transcript_scan::scan_claude_idle_transcript_for_prompt`가 기존 로직에서 offset을 `0`으로 재설정합니다.
4. scanner가 압축 snapshot에 살아 있는 과거 `user` entry를 반환하고 `observe_prompt_by_tmux_with_entry_id_at`이 TTL/identity ledger 밖의 entry를 `PublishedSshDirect`로 분류합니다.
5. `record_external_turn_lease_for_output` → synthetic-start/idle-tail 경로가 이를 새 외부 turn으로 미러링합니다.

## 수정 및 rotation/compaction 판별 근거
- `delivery_record`에 current-generation frontier가 실제 EOF를 초과하는지 읽는 정확한 predicate를 추가했습니다.
- compaction re-anchor는 다음 세 조건이 모두 참일 때만 수행합니다.
  1. resolved transcript path가 binding path와 동일함 (`path_changed == false`)
  2. 기존 binding cursor가 현재 EOF보다 큼
  3. 동일 wrapper generation의 durable frontier도 현재 EOF보다 큼
- Claude session rotation은 transcript UUID가 파일명/path 및 binding `session_id`로 바뀌며 resolver가 `path_changed == true`로 판별합니다. 이 경우 compaction fast-forward를 적용하지 않고 기존 `scan_claude_idle_transcript_for_last_prompt` bounded-lookback을 유지하므로 새 파일의 신규 prompt를 놓치지 않습니다.
- same-path shrink지만 durable evidence가 없거나 generation이 다르면 기존 fail-open scanner 동작을 유지합니다.

## 회귀 테스트
- compaction: frontier/cursor > EOF인 unchanged path는 `CompactionReanchor { offset: EOF }`로 끝나 과거 prompt를 반환하지 않음
- post-compaction: EOF re-anchor 이후 append된 신규 prompt는 정상 발견
- 정상 성장: 기존 offset부터 append된 prompt 발견 동작 불변
- rotation: path change에서는 re-anchor하지 않고 새 transcript lookback으로 신규 prompt 발견
- delivery record: same-generation + frontier>EOF일 때만 compaction evidence가 true

## 검증 결과
- `cargo fmt`: rc=0
- `cargo fmt --check`: rc=0
- `cargo check --lib`: rc=0
- `cargo test --lib tui_prompt_relay`: rc=0, 193 passed
- `cargo test --lib outbound`: rc=0, 170 passed
- `python3 scripts/generate_inventory_docs.py`: rc=0, generated outputs unchanged in git
- `python3 scripts/check_agent_maintenance_docs.py`: rc=0, `agent-maintenance freshness check passed`

Closes #4549

🤖 Generated with [Claude Code](https://claude.com/claude-code)
