### PR TITLE
ci(#4747): move non-PG tests off PR critical path

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -104,12 +104,13 @@ jobs:
       - name: Policy JS unit tests
         run: npm run test:policies
 
-      # `just check` wraps fmt, staged clippy, cargo check, and the same
-      # targeted non-PG subset that gates PRs in ci-pr.yml, with the same
-      # non-PG filters applied to every cargo test command since this lane has
-      # no Postgres service. PR #1306 (#1237) made production routes PG-only, so a
-      # `--all-targets` non-PG sweep panics in 169 SQLite-fixture tests
-      # that haven't been ported to PG fixtures yet. The PG migration is
+      # `just check` wraps fmt, staged clippy, cargo check, and the targeted
+      # non-PG subset. PR CI runs only the compile/policy portion to keep its
+      # critical path short; this main-push lane retains the test coverage.
+      # The same non-PG filters apply to every cargo test command since this
+      # lane has no Postgres service. PR #1306 (#1237) made production routes
+      # PG-only, so an `--all-targets` non-PG sweep panics in 169 SQLite-fixture
+      # tests that haven't been ported to PG fixtures yet. The PG migration is
       # tracked under #1238; once the bulk of the migration lands, this
       # lane can broaden again.
       - name: just check

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -297,7 +297,7 @@ jobs:
       - name: dashboard build/test
         run: ./scripts/verify-dashboard.sh
 
-  # Ubuntu Rust lane: canonical fast check. Gated on the broad rust_or_policy
+  # Ubuntu Rust lane: canonical fast compile check. Gated on the broad rust_or_policy
   # filter so a `policies/*.js`, `scripts/*.sh`, `.github/workflows/**`, or
   # Node package change still gets a Rust check on Linux.
   #
@@ -306,7 +306,7 @@ jobs:
   # job compiles the `relay_state_contract_refs` blocks, which is the only proof
   # that each contract symbol still exists.
   check_fast:
-    name: Fast check + non-PG tests (${{ matrix.os }})
+    name: Fast compile check (${{ matrix.os }})
     needs: changes
     if: needs.changes.outputs.rust_or_policy == 'true' || needs.changes.outputs.relay_contract == 'true'
     runs-on: ${{ matrix.os }}
@@ -354,31 +354,11 @@ jobs:
       - name: Policy JS unit tests
         run: npm run test:policies
 
-      # `lint` already runs the exact `fmt-check` + `lint` recipes in parallel
-      # and has its own required mirror. Repeating them through `just check`
-      # added 4-5 minutes to this critical-path job without adding coverage.
-      # Keep the compile check and every non-PG test here; branch protection
-      # still requires both this result and the independent Lint result.
-      - name: cargo check + non-PG tests
-        run: |
-          just cargo-check
-          just test-non-pg
-        env:
-          # Cold `cargo test --all-targets` on the 16GB ubuntu runner peaks over
-          # RAM during codegen+link (SIGTERM/143). Two step-scoped levers keep
-          # peak RSS under the ceiling; test semantics are unchanged (neither
-          # affects which tests run or their results). Step-scoped so no other
-          # Rust job's resource envelope is touched.
-          #   1. Cap parallel compile jobs at 2 (default = 4 vCPU) to bound
-          #      concurrent rustc/link.
-          CARGO_BUILD_JOBS: "2"
-          #   2. Drop debuginfo for the dev/test profiles. Linking many
-          #      `--all-targets` test binaries with full debuginfo is the
-          #      dominant peak-memory source; `-j2` alone still OOM'd on the
-          #      link phase, so strip it here. CI test failures still report
-          #      panics/asserts; only source-line debug data is omitted.
-          CARGO_PROFILE_DEV_DEBUG: "0"
-          CARGO_PROFILE_TEST_DEBUG: "0"
+      # `lint` owns fmt/clippy in its independent required mirror. Keep this
+      # required Ubuntu lane to compilation and policy tests; main and nightly
+      # retain the longer non-PG test coverage outside the PR critical path.
+      - name: cargo check
+        run: just cargo-check
 
       - name: sccache stats
         if: always()

--- a/docs/ci/release-gates.md
+++ b/docs/ci/release-gates.md
@@ -10,7 +10,7 @@
 
 | Gate | ci-main.yml job | ci-pr.yml job | ci-nightly.yml 대응 | 실행 조건 |
 | --- | --- | --- | --- | --- |
-| **Full tests** | `full_non_pg` (line 56) | `check_fast` + `test_fast` (line 79, 115) | `full_run` | 항상 실행 (path filter 없음). PR lane은 targeted 서브셋으로 replace. |
+| **Full tests** | `full_non_pg` | `check_fast` (compile/policy only) + `test_fast` | `full_macos` + `full_windows` | main/nightly always run non-PG tests; the path-filtered PR lane is compile/policy only. |
 | **PostgreSQL tests** | `postgres` (line 94) | `test_fast` PG 서비스 (line 115) | `postgres` | 항상 실행. main job은 `_pg` / `pg_` / `postgres` 필터 3회 직렬 실행. |
 | **High-risk recovery** | `high-risk-recovery` (line 151) | `high-risk-recovery` (line 173) | `high_risk_recovery_full` | path filter hit 시에만 실행. nightly full job은 무조건. |
 

--- a/docs/ci/rust-quality-gates.md
+++ b/docs/ci/rust-quality-gates.md
@@ -33,7 +33,12 @@ production-only, test-aware, or repo-wide before adding hard gates.
 ## Non-Postgres Test Scope
 
 `just test-non-pg` preserves the targeted non-Postgres subset already used by
-CI. A broader sweep was attempted with:
+CI on `main`: `ci-main.yml` runs it through `just check`, while the nightly
+macOS and Windows lanes run their broader non-Postgres sweeps. The required PR
+`check_fast` lane runs policy tests plus `just cargo-check` only, so this
+longer subset does not remain on the PR critical path.
+
+A broader sweep was attempted with:
 
 `cargo test --workspace --all-features --all-targets -- --skip _pg --skip pg_ --skip postgres --test-threads=1`
 

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -111,6 +111,9 @@ echo "=== CI timeout wrapper tests (#4413) ==="
 echo "=== Relay recovery targeted-lane wiring contract (#4423) ==="
 "$PYTHON" -m unittest tests.test_relay_recovery_ci_wiring
 
+echo "=== Fast compile check PR/main/nightly split contract (#4747) ==="
+"$PYTHON" -m unittest tests.test_fast_check_ci_wiring
+
 echo "=== Scheduled-message PG path-filter wiring contract ==="
 "$PYTHON" -m unittest tests.test_scheduled_messages_ci_wiring
 

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -12,6 +12,36 @@ PR_WORKFLOW = REPO_ROOT / ".github/workflows/ci-pr.yml"
 MAIN_WORKFLOW = REPO_ROOT / ".github/workflows/ci-main.yml"
 NIGHTLY_WORKFLOW = REPO_ROOT / ".github/workflows/ci-nightly.yml"
 
+# This manifest is intentionally exact: changing the retained test recipe must also
+# update this test deliberately. The duplication is a drift-prevention gate, not an
+# attempt to derive the expected coverage from the justfile under test.
+EXPECTED_TEST_NON_PG_COMMANDS = (
+    "cargo test --lib source_registry -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib task_notification -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib tui_task_card::tests -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib server::routes::message_outbox::tests -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib discord_thread_create -- --test-threads=1",
+    "cargo test --lib reaction_control::tests -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib intake_queue_transaction::tests -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib pending_reaction_failure_adapter_tests -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib intake_dispatch_invariant_queued_entrypoints_promote_markers -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib mailbox_reaction_tests -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib services::discord::outbound::serenity_reference::tests::lifecycle_notice_nonce_is_stable_and_semantic_event_scoped -- --exact",
+    "cargo test --lib services::discord::outbound::delivery::tests::v3_referenced_send_preserves_reference_and_dedupes -- --exact",
+    "cargo test --lib cli::args::tests::legacy_queue_help_directs_users_to_query_without_changing_compatibility_contract",
+    "cargo test --all-targets transition -- --skip _pg --skip pg_ --skip postgres --test-threads=1",
+    "cargo test --all-targets auto_queue -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres",
+    "python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres",
+    "env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --doc ClaudeBinary",
+)
+
 
 def job_block(workflow: str, job_name: str) -> str:
     marker = re.compile(rf"^  {re.escape(job_name)}:\n", re.MULTILINE)
@@ -22,6 +52,22 @@ def job_block(workflow: str, job_name: str) -> str:
         workflow, match.end()
     )
     return workflow[match.start() : next_job.start() if next_job else len(workflow)]
+
+
+def just_recipe_commands(justfile: str, recipe_name: str) -> tuple[str, ...]:
+    marker = re.compile(rf"^{re.escape(recipe_name)}:[ \t]*.*$", re.MULTILINE)
+    match = marker.search(justfile)
+    if match is None:
+        raise AssertionError(f"missing just recipe: {recipe_name}")
+
+    commands: list[str] = []
+    for line in justfile[match.end() :].splitlines():
+        if line and not line[0].isspace():
+            break
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            commands.append(" ".join(stripped.split()))
+    return tuple(commands)
 
 
 class FastCheckCiWiringTests(unittest.TestCase):
@@ -62,10 +108,38 @@ class FastCheckCiWiringTests(unittest.TestCase):
             lint_job,
         )
 
+    def test_required_targeted_context_mirrors_test_fast_pg_db_gate(self) -> None:
+        workflow = PR_WORKFLOW.read_text(encoding="utf-8")
+        job = job_block(workflow, "fast_targeted_tests_required_context")
+
+        self.assertIn("name: Fast targeted tests (ubuntu-latest)", job)
+        self.assertRegex(
+            job,
+            r"(?m)^    needs:\n      - changes\n      - test_fast\n    if: always\(\)$",
+        )
+        self.assertEqual(job.count("FILTER_NAME: pg_db"), 1)
+        self.assertEqual(
+            job.count("FILTER_OUTPUT: ${{ needs.changes.outputs.pg_db }}"), 1
+        )
+        self.assertEqual(job.count("UPSTREAM_JOB_NAME: test_fast"), 1)
+        self.assertEqual(
+            job.count("UPSTREAM_RESULT: ${{ needs.test_fast.result }}"), 1
+        )
+
+        test_job = job_block(workflow, "test_fast")
+        self.assertRegex(
+            test_job,
+            r"(?m)^    if: needs\.changes\.outputs\.pg_db == 'true'$",
+        )
+
     def test_main_and_nightly_retain_non_pg_test_coverage(self) -> None:
         justfile = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
         self.assertIn("check: fmt-check lint cargo-check test", justfile)
         self.assertIn("test: test-non-pg", justfile)
+        self.assertEqual(
+            just_recipe_commands(justfile, "test-non-pg"),
+            EXPECTED_TEST_NON_PG_COMMANDS,
+        )
 
         main_job = job_block(MAIN_WORKFLOW.read_text(encoding="utf-8"), "full_non_pg")
         self.assertIn("- name: just check\n        run: just check", main_job)

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -1,0 +1,92 @@
+"""Static contracts for the PR fast-compile and retained test lanes."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PR_WORKFLOW = REPO_ROOT / ".github/workflows/ci-pr.yml"
+MAIN_WORKFLOW = REPO_ROOT / ".github/workflows/ci-main.yml"
+NIGHTLY_WORKFLOW = REPO_ROOT / ".github/workflows/ci-nightly.yml"
+
+
+def job_block(workflow: str, job_name: str) -> str:
+    marker = re.compile(rf"^  {re.escape(job_name)}:\n", re.MULTILINE)
+    match = marker.search(workflow)
+    if match is None:
+        raise AssertionError(f"missing workflow job: {job_name}")
+    next_job = re.compile(r"^  [A-Za-z0-9_-]+:\n", re.MULTILINE).search(
+        workflow, match.end()
+    )
+    return workflow[match.start() : next_job.start() if next_job else len(workflow)]
+
+
+class FastCheckCiWiringTests(unittest.TestCase):
+    def test_pr_fast_check_is_compile_and_policy_only(self) -> None:
+        job = job_block(PR_WORKFLOW.read_text(encoding="utf-8"), "check_fast")
+
+        self.assertIn("name: Fast compile check (${{ matrix.os }})", job)
+        self.assertIn(
+            "if: needs.changes.outputs.rust_or_policy == 'true' || "
+            "needs.changes.outputs.relay_contract == 'true'",
+            job,
+        )
+        self.assertIn("os: [ubuntu-latest]", job)
+        self.assertIn("- name: Policy JS unit tests", job)
+        self.assertIn("- name: cargo check\n        run: just cargo-check", job)
+        self.assertNotIn("just test-non-pg", job)
+        self.assertNotRegex(job, r"(?m)^\s*cargo test\b")
+
+    def test_required_fast_check_context_mirrors_the_same_upstream_job(self) -> None:
+        workflow = PR_WORKFLOW.read_text(encoding="utf-8")
+        job = job_block(workflow, "fast_check_required_context")
+
+        self.assertIn("name: Fast check (ubuntu-latest)", job)
+        self.assertIn("- check_fast", job)
+        self.assertIn("if: always()", job)
+        self.assertEqual(job.count("UPSTREAM_JOB_NAME: check_fast"), 2)
+        self.assertIn(
+            "if: ${{ needs.changes.outputs.relay_contract != 'true' }}", job
+        )
+        self.assertIn(
+            "if: ${{ needs.changes.outputs.relay_contract == 'true' }}", job
+        )
+
+        lint_job = job_block(workflow, "lint")
+        self.assertIn(
+            "if: needs.changes.outputs.rust_or_policy == 'true' || "
+            "needs.changes.outputs.relay_contract == 'true'",
+            lint_job,
+        )
+
+    def test_main_and_nightly_retain_non_pg_test_coverage(self) -> None:
+        justfile = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
+        self.assertIn("check: fmt-check lint cargo-check test", justfile)
+        self.assertIn("test: test-non-pg", justfile)
+
+        main_job = job_block(MAIN_WORKFLOW.read_text(encoding="utf-8"), "full_non_pg")
+        self.assertIn("- name: just check\n        run: just check", main_job)
+
+        nightly = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+        for job_name in ("full_macos", "full_windows"):
+            with self.subTest(job=job_name):
+                job = job_block(nightly, job_name)
+                self.assertIn("- name: cargo test (non-PG)", job)
+                self.assertIn(
+                    "cargo test --all-targets -- --skip _pg_ --skip postgres_", job
+                )
+
+    def test_ci_script_checks_runs_this_contract(self) -> None:
+        script = (REPO_ROOT / "scripts/ci-script-checks.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            '"$PYTHON" -m unittest tests.test_fast_check_ci_wiring', script
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Slice

Implements the remaining #4747 option 2 long-pole split after excluding already-merged work:

- #4774 already unified Cargo dependency cache keys.
- #4823 already removed duplicate fmt/clippy work and aligned the lint composite gate.
- Merge queue support was reverted by #4757 because user-owned repositories cannot enable it.

This slice removes `just test-non-pg` from the PR-time `check_fast` job. The required Ubuntu lane still runs policy tests plus `just cargo-check`; `ci-main.yml` retains `just check` (including `test-non-pg`) on every main push, and nightly keeps the broader macOS/Windows non-PG sweeps.

## Expected wall-clock effect

Recent successful PR runs completed `Fast check + non-PG tests (ubuntu-latest)` in 11m15s–12m50s after #4823. In run 30010438202, the combined cargo step took 10m38s: `cargo check` completed after 3m02s, then the first test build alone took another 4m16s and the remaining targeted test sweep extended the step to 10m38s. Keeping only the compile portion is expected to remove roughly 7m36s from that observed step and reduce the required PR critical path from about 11–13 minutes toward about 4–5 minutes, subject to cache state.

## Required-check contract impact

- Branch-protection context names are unchanged, including `Fast check (ubuntu-latest)`.
- `fast_check_required_context` still runs `if: always()` and mirrors `check_fast` through both the ordinary and relay-contract paths.
- `check_fast` keeps the composite gate `rust_or_policy || relay_contract`, so relay-contract-only changes still compile the symbol-reference blocks.
- The #4823 lint gate remains exactly `rust_or_policy || relay_contract`.
- No path-filter/mirror condition mismatch is introduced, so expected skips continue to resolve rather than remain pending.

## Regression guard

Adds `tests/test_fast_check_ci_wiring.py`, wired into `scripts/ci-script-checks.sh`, to pin:

- compile/policy-only PR `check_fast` behavior;
- the required-context mirror wiring and lint composite gate;
- retained main/nightly non-PG coverage.

Mutation proof: restoring `just test-non-pg` to the PR lane makes the focused contract fail (`rc=1`); restoring the intended split passes (`rc=0`).

## Validation

- `bash -n scripts/ci-script-checks.sh scripts/required-check-mirror.sh scripts/check-ci-runner-hardening.sh`
- workflow YAML parse for `ci-pr.yml`, `ci-main.yml`, and `ci-nightly.yml`
- `actionlint` for all three workflows
- `python3 -m unittest tests.test_fast_check_ci_wiring`
- `bash tests/test_required_check_mirror.sh`
- `bash scripts/check-ci-runner-hardening.sh`
- `./scripts/ci-script-checks.sh`
- `python3 scripts/generate_inventory_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate`
- `git diff --check`

Refs #4747

🤖 Generated with [Claude Code](https://claude.com/claude-code)