### PR TITLE
fix(#4259): R1 guard stream-tick blind persistence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -850,6 +850,7 @@ src/
 │   │   │   │   │   ├── tui_error_classification.rs
 │   │   │   │   │   └── types.rs
 │   │   │   │   ├── content_arms.rs
+│   │   │   │   ├── expected_identity_tests.rs
 │   │   │   │   ├── message_conversion.rs
 │   │   │   │   └── tool_arms.rs
 │   │   │   ├── stream_tick/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -532,7 +532,8 @@ src/
 │   │   │   │   └── mod.rs
 │   │   │   ├── save_store/
 │   │   │   │   ├── identity_gate/
-│   │   │   │   │   └── claude_e_stamp.rs
+│   │   │   │   │   ├── claude_e_stamp.rs
+│   │   │   │   │   └── heartbeat.rs
 │   │   │   │   ├── delivery_rewind.rs
 │   │   │   │   ├── identity_gate.rs
 │   │   │   │   ├── post_loop_identity_guard_tests.rs
@@ -851,6 +852,8 @@ src/
 │   │   │   │   ├── content_arms.rs
 │   │   │   │   ├── message_conversion.rs
 │   │   │   │   └── tool_arms.rs
+│   │   │   ├── stream_tick/
+│   │   │   │   └── guarded_persist.rs
 │   │   │   ├── terminal_outcome_delivery/
 │   │   │   │   ├── empty_response_recovery/
 │   │   │   │   │   ├── guidance.rs

--- a/scripts/check_inflight_blind_save_ratchet.py
+++ b/scripts/check_inflight_blind_save_ratchet.py
@@ -78,7 +78,7 @@ from pathlib import Path
 # helper) still (re)write identity-pinned `tmux_session_name`, beyond what the
 # output-restamp variant tolerates, so each needs per-flow session-name-stability
 # verification or an adoption-aware variant before converting.
-BASELINE = 13
+BASELINE = 8
 
 SCAN_ROOT = Path("src") / "services" / "discord"
 

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -152,7 +152,7 @@ pub(in crate::services::discord) use self::save_store::{
     save_existing_inflight_rebind_adoption_with_offset_rebase_if_matches_identity,
     save_inflight_state_if_identity_matches_allow_output_restamp,
     save_inflight_state_if_identity_unchanged, save_inflight_state_if_matches_identity,
-    stamp_claude_e_process_if_matches_identity,
+    stamp_claude_e_process_if_matches_identity, touch_inflight_state_if_matches_identity,
 };
 // Explicit-root save seams reached only by the parent's / siblings' test modules.
 #[cfg(test)]

--- a/src/services/discord/inflight/save_store.rs
+++ b/src/services/discord/inflight/save_store.rs
@@ -30,7 +30,7 @@ pub(in crate::services::discord) use self::identity_gate::{
     recovery_anchor_msg_id_if_matches_identity,
     save_inflight_state_if_identity_matches_allow_output_restamp,
     save_inflight_state_if_identity_unchanged, save_inflight_state_if_matches_identity,
-    stamp_claude_e_process_if_matches_identity,
+    stamp_claude_e_process_if_matches_identity, touch_inflight_state_if_matches_identity,
 };
 pub(in crate::services::discord) use self::rebind_adoption::{
     save_existing_inflight_rebind_adoption_if_matches_episode,

--- a/src/services/discord/inflight/save_store/identity_gate.rs
+++ b/src/services/discord/inflight/save_store/identity_gate.rs
@@ -1,7 +1,10 @@
 use super::*;
 #[path = "identity_gate/claude_e_stamp.rs"]
 mod claude_e_stamp;
+#[path = "identity_gate/heartbeat.rs"]
+mod heartbeat;
 pub(in crate::services::discord) use claude_e_stamp::stamp_claude_e_process_if_matches_identity;
+pub(in crate::services::discord) use heartbeat::touch_inflight_state_if_matches_identity;
 
 pub(in crate::services::discord) fn save_inflight_state_if_identity_unchanged(
     state: &InflightTurnState,

--- a/src/services/discord/inflight/save_store/identity_gate/heartbeat.rs
+++ b/src/services/discord/inflight/save_store/identity_gate/heartbeat.rs
@@ -1,0 +1,78 @@
+use super::*;
+
+/// Bump only the durable row heartbeat while the caller still owns the turn.
+///
+/// Unlike a whole-row save, this locked patch never copies the caller's stale
+/// snapshot over fields that another component may have advanced. The durable
+/// row must retain the explicit identity captured before the stream tick began,
+/// and restart/rebind authority changes fail closed.
+pub(in crate::services::discord) fn touch_inflight_state_if_matches_identity(
+    provider: &ProviderKind,
+    channel_id: u64,
+    expected: &InflightTurnIdentity,
+    caller: &'static str,
+) -> GuardedSaveOutcome {
+    let Some(root) = inflight_runtime_root() else {
+        return GuardedSaveOutcome::IoError;
+    };
+    touch_inflight_state_if_matches_identity_in_root(&root, provider, channel_id, expected, caller)
+}
+
+fn touch_inflight_state_if_matches_identity_in_root(
+    root: &Path,
+    provider: &ProviderKind,
+    channel_id: u64,
+    expected: &InflightTurnIdentity,
+    caller: &'static str,
+) -> GuardedSaveOutcome {
+    let path = inflight_state_path(root, provider, channel_id);
+    let Ok(_lock) = lock_inflight_state_path(&path) else {
+        return GuardedSaveOutcome::IoError;
+    };
+    let Some(on_disk) = load_inflight_state_unlocked(&path) else {
+        return GuardedSaveOutcome::Missing;
+    };
+    if expected.user_msg_id == 0 && expected.turn_start_offset.is_none() {
+        tracing::info!(
+            provider = %provider.as_str(),
+            channel_id,
+            caller,
+            snapshot_identity = ?expected,
+            "inflight heartbeat skipped because offsetless id-0 identity cannot safely own a durable row"
+        );
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+    if on_disk.restart_mode.is_some() || on_disk.rebind_origin || !expected.matches_state(&on_disk)
+    {
+        tracing::info!(
+            provider = %provider.as_str(),
+            channel_id,
+            caller,
+            snapshot_identity = ?expected,
+            durable_identity = ?InflightTurnIdentity::from_state(&on_disk),
+            durable_restart_mode = ?on_disk.restart_mode,
+            durable_rebind_origin = on_disk.rebind_origin,
+            "inflight heartbeat skipped because durable row authority changed"
+        );
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+
+    match persist_under_lock(
+        root,
+        &path,
+        &on_disk,
+        "src/services/discord/inflight/save_store/identity_gate/heartbeat.rs:touch_inflight_state_if_matches_identity_in_root",
+    ) {
+        Ok(()) => GuardedSaveOutcome::Saved,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel_id,
+                caller,
+                error = %error,
+                "inflight heartbeat failed; leaving durable row untouched"
+            );
+            GuardedSaveOutcome::IoError
+        }
+    }
+}

--- a/src/services/discord/turn_bridge/runtime_handoff_loop.rs
+++ b/src/services/discord/turn_bridge/runtime_handoff_loop.rs
@@ -29,10 +29,8 @@ pub(super) enum RuntimeHandoffLoopMessage {
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum RuntimeHandoffLoopOutcome {
-    ContinueDraining,
-}
+pub(super) type RuntimeHandoffLoopOutcome =
+    Option<crate::services::discord::inflight::GuardedSaveOutcome>;
 
 pub(super) struct RuntimeHandoffLoopContext<'a> {
     pub(super) shared_owned: &'a Arc<SharedData>,
@@ -111,6 +109,7 @@ pub(super) async fn handle_runtime_handoff_loop_message(
     let mut state_dirty = *state.state_dirty;
     let mut terminal_control_drain_until = *state.terminal_control_drain_until;
     let mut last_activity_heartbeat_at = *state.last_activity_heartbeat_at;
+    let mut guarded_save_outcome = None;
 
     match message {
         RuntimeHandoffLoopMessage::TmuxReady {
@@ -455,6 +454,7 @@ pub(super) async fn handle_runtime_handoff_loop_message(
                 state_dirty,
                 tmux_ready_guarded_save_outcome,
             );
+            guarded_save_outcome = tmux_ready_guarded_save_outcome;
             if done {
                 terminal_control_drain_until = None;
             }
@@ -605,13 +605,15 @@ pub(super) async fn handle_runtime_handoff_loop_message(
                     // not stamped here.
                     let _ = session_name;
                     tmux_last_offset = Some(last_offset);
-                    state_dirty = claude_e::stamp_process_evidence(
+                    let (next_state_dirty, outcome) = claude_e::stamp_process_evidence(
                         inflight_state,
                         output_path,
                         last_offset,
                         pid,
                         state_dirty,
                     );
+                    state_dirty = next_state_dirty;
+                    guarded_save_outcome = Some(outcome);
                     if done {
                         terminal_control_drain_until = None;
                     }
@@ -676,7 +678,7 @@ pub(super) async fn handle_runtime_handoff_loop_message(
     *state.terminal_control_drain_until = terminal_control_drain_until;
     *state.last_activity_heartbeat_at = last_activity_heartbeat_at;
 
-    RuntimeHandoffLoopOutcome::ContinueDraining
+    guarded_save_outcome
 }
 
 fn handle_watcher_runtime_handoff(

--- a/src/services/discord/turn_bridge/runtime_handoff_loop/claude_e.rs
+++ b/src/services/discord/turn_bridge/runtime_handoff_loop/claude_e.rs
@@ -16,7 +16,7 @@ pub(super) fn stamp_process_evidence(
     last_offset: u64,
     pid: u32,
     state_dirty: bool,
-) -> bool {
+) -> (bool, crate::services::discord::inflight::GuardedSaveOutcome) {
     let expected_identity =
         crate::services::discord::inflight::InflightTurnIdentity::from_state(inflight_state);
     inflight_state.runtime_kind =
@@ -30,7 +30,10 @@ pub(super) fn stamp_process_evidence(
         inflight_state,
         &expected_identity,
     );
-    super::guarded_save::tmux_ready_state_dirty_after_guarded_save(state_dirty, Some(outcome))
+    (
+        super::guarded_save::tmux_ready_state_dirty_after_guarded_save(state_dirty, Some(outcome)),
+        outcome,
+    )
 }
 
 #[cfg(test)]

--- a/src/services/discord/turn_bridge/stream_loop.rs
+++ b/src/services/discord/turn_bridge/stream_loop.rs
@@ -29,8 +29,25 @@ use tool_arms::{
 };
 
 mod content_arms;
+#[cfg(test)]
+#[path = "stream_loop/expected_identity_tests.rs"]
+mod expected_identity_tests;
 mod message_conversion;
 mod tool_arms;
+
+fn refresh_stream_tick_expected_identity_after_handoff(
+    expected: &mut crate::services::discord::inflight::InflightTurnIdentity,
+    inflight_state: &InflightTurnState,
+    guarded_save_outcome: Option<crate::services::discord::inflight::GuardedSaveOutcome>,
+) {
+    if matches!(
+        guarded_save_outcome,
+        Some(crate::services::discord::inflight::GuardedSaveOutcome::Saved)
+    ) {
+        *expected =
+            crate::services::discord::inflight::InflightTurnIdentity::from_state(inflight_state);
+    }
+}
 
 pub(super) struct StreamLoopContext {
     pub(super) shared_owned: Arc<SharedData>,
@@ -253,7 +270,7 @@ pub(super) async fn run_stream_loop(
     // stream loop. Runtime handoff may mutate identity-bearing cursor fields
     // before a later tick, so deriving expected identity inside the tick would
     // authorize a mutated stale snapshot rather than the original owner.
-    let stream_tick_expected_identity =
+    let mut stream_tick_expected_identity =
         crate::services::discord::inflight::InflightTurnIdentity::from_state(&inflight_state);
 
     'outer: while !done
@@ -679,9 +696,11 @@ pub(super) async fn run_stream_loop(
                                 },
                             )
                             .await;
-                            match outcome {
-                                RuntimeHandoffLoopOutcome::ContinueDraining => {}
-                            }
+                            refresh_stream_tick_expected_identity_after_handoff(
+                                &mut stream_tick_expected_identity,
+                                &inflight_state,
+                                outcome,
+                            );
                         }
                         StreamMessage::RuntimeReady { handoff } => {
                             let outcome = handle_runtime_handoff_loop_message(
@@ -712,9 +731,11 @@ pub(super) async fn run_stream_loop(
                                 },
                             )
                             .await;
-                            match outcome {
-                                RuntimeHandoffLoopOutcome::ContinueDraining => {}
-                            }
+                            refresh_stream_tick_expected_identity_after_handoff(
+                                &mut stream_tick_expected_identity,
+                                &inflight_state,
+                                outcome,
+                            );
                         }
                         StreamMessage::ProcessReady {
                             output_path,
@@ -753,9 +774,11 @@ pub(super) async fn run_stream_loop(
                                 },
                             )
                             .await;
-                            match outcome {
-                                RuntimeHandoffLoopOutcome::ContinueDraining => {}
-                            }
+                            refresh_stream_tick_expected_identity_after_handoff(
+                                &mut stream_tick_expected_identity,
+                                &inflight_state,
+                                outcome,
+                            );
                         }
                         StreamMessage::OutputOffset { offset } => {
                             let outcome = handle_runtime_handoff_loop_message(
@@ -786,9 +809,11 @@ pub(super) async fn run_stream_loop(
                                 },
                             )
                             .await;
-                            match outcome {
-                                RuntimeHandoffLoopOutcome::ContinueDraining => {}
-                            }
+                            refresh_stream_tick_expected_identity_after_handoff(
+                                &mut stream_tick_expected_identity,
+                                &inflight_state,
+                                outcome,
+                            );
                         }
                     }
                 }

--- a/src/services/discord/turn_bridge/stream_loop.rs
+++ b/src/services/discord/turn_bridge/stream_loop.rs
@@ -249,6 +249,12 @@ pub(super) async fn run_stream_loop(
 
     let mut pending_long_running_open_after_state_save = None;
     let mut pending_long_running_retarget_after_state_save = None;
+    // The periodic flush must remain bound to the owner that entered this
+    // stream loop. Runtime handoff may mutate identity-bearing cursor fields
+    // before a later tick, so deriving expected identity inside the tick would
+    // authorize a mutated stale snapshot rather than the original owner.
+    let stream_tick_expected_identity =
+        crate::services::discord::inflight::InflightTurnIdentity::from_state(&inflight_state);
 
     'outer: while !done
         || terminal_control_drain_until.is_some_and(|deadline| std::time::Instant::now() < deadline)
@@ -818,6 +824,7 @@ pub(super) async fn run_stream_loop(
                 channel_id,
                 provider: &provider,
                 turn_id: turn_id.as_str(),
+                expected_identity: &stream_tick_expected_identity,
                 status_interval,
                 single_message_panel_footer_mode,
                 footer_owner,

--- a/src/services/discord/turn_bridge/stream_loop/expected_identity_tests.rs
+++ b/src/services/discord/turn_bridge/stream_loop/expected_identity_tests.rs
@@ -1,0 +1,141 @@
+use super::refresh_stream_tick_expected_identity_after_handoff;
+use crate::services::discord::inflight::{
+    GuardedSaveOutcome, InflightTurnIdentity, InflightTurnState, load_inflight_state,
+    save_inflight_state,
+};
+use crate::services::discord::turn_bridge::stream_tick::guarded_persist::persist_stream_tick_state;
+use crate::services::provider::ProviderKind;
+use serenity::model::id::ChannelId;
+
+fn owner_state(channel_id: u64, user_msg_id: u64, tmux_session: Option<&str>) -> InflightTurnState {
+    let mut state = InflightTurnState::new(
+        ProviderKind::Codex,
+        channel_id,
+        Some("adk-stream-handoff".to_string()),
+        343_742_347_365_974_026,
+        user_msg_id,
+        18,
+        "user prompt".to_string(),
+        Some("session".to_string()),
+        tmux_session.map(str::to_string),
+        Some("/tmp/AgentDesk-codex-stream-handoff.jsonl".to_string()),
+        Some("/tmp/AgentDesk-codex-stream-handoff.input".to_string()),
+        512,
+    );
+    state.last_offset = 512;
+    state
+}
+
+fn with_runtime_root(test: impl FnOnce()) {
+    let _lock = crate::config::shared_test_env_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    let temp = tempfile::TempDir::new().expect("runtime root");
+    let _env_reset = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+        "AGENTDESK_ROOT_DIR",
+        temp.path(),
+    );
+    test();
+}
+
+#[test]
+fn saved_tmux_ready_first_fill_recaptures_and_allows_next_stream_tick_flush() {
+    with_runtime_root(|| {
+        let channel = ChannelId::new(4_836_001);
+        let mut state = owner_state(channel.get(), 77_010, None);
+        let mut expected = InflightTurnIdentity::from_state(&state);
+
+        state.tmux_session_name = Some("AgentDesk-codex-handoff-ready".to_string());
+        save_inflight_state(&state).expect("seed successful handoff row");
+        refresh_stream_tick_expected_identity_after_handoff(
+            &mut expected,
+            &state,
+            Some(GuardedSaveOutcome::Saved),
+        );
+
+        state.full_response = "answer after handoff".to_string();
+        state.last_offset = 1_024;
+        assert_eq!(
+            persist_stream_tick_state(
+                &state,
+                &expected,
+                channel,
+                "turn_bridge::stream_loop::saved_handoff_test",
+            ),
+            GuardedSaveOutcome::Saved
+        );
+        let persisted =
+            load_inflight_state(&ProviderKind::Codex, channel.get()).expect("persisted row");
+        assert_eq!(persisted.full_response, "answer after handoff");
+        assert_eq!(persisted.last_offset, 1_024);
+    });
+}
+
+#[test]
+fn identity_mismatch_handoff_does_not_recapture_or_authorize_stream_tick_flush() {
+    with_runtime_root(|| {
+        let channel = ChannelId::new(4_836_002);
+        let mut stale = owner_state(channel.get(), 77_010, None);
+        let mut expected = InflightTurnIdentity::from_state(&stale);
+        stale.tmux_session_name = Some("AgentDesk-codex-stale-handoff".to_string());
+
+        let mut successor = owner_state(channel.get(), 99_999, Some("AgentDesk-codex-successor"));
+        successor.full_response = "successor answer".to_string();
+        successor.last_offset = 8_192;
+        save_inflight_state(&successor).expect("seed successor row");
+
+        refresh_stream_tick_expected_identity_after_handoff(
+            &mut expected,
+            &stale,
+            Some(GuardedSaveOutcome::IdentityMismatch),
+        );
+        assert_eq!(expected.tmux_session_name, None);
+
+        stale.full_response = "stale answer".to_string();
+        stale.last_offset = 1_024;
+        assert_eq!(
+            persist_stream_tick_state(
+                &stale,
+                &expected,
+                channel,
+                "turn_bridge::stream_loop::mismatched_handoff_test",
+            ),
+            GuardedSaveOutcome::IdentityMismatch
+        );
+        let persisted =
+            load_inflight_state(&ProviderKind::Codex, channel.get()).expect("persisted row");
+        assert_eq!(persisted.user_msg_id, 99_999);
+        assert_eq!(persisted.full_response, "successor answer");
+        assert_eq!(persisted.last_offset, 8_192);
+    });
+}
+
+#[test]
+fn no_handoff_keeps_original_expected_identity_and_stream_tick_behavior() {
+    with_runtime_root(|| {
+        let channel = ChannelId::new(4_836_003);
+        let mut state = owner_state(
+            channel.get(),
+            77_010,
+            Some("AgentDesk-codex-existing-session"),
+        );
+        save_inflight_state(&state).expect("seed owner row");
+        let expected = InflightTurnIdentity::from_state(&state);
+
+        state.full_response = "ordinary stream answer".to_string();
+        state.last_offset = 2_048;
+        assert_eq!(
+            persist_stream_tick_state(
+                &state,
+                &expected,
+                channel,
+                "turn_bridge::stream_loop::no_handoff_test",
+            ),
+            GuardedSaveOutcome::Saved
+        );
+        let persisted =
+            load_inflight_state(&ProviderKind::Codex, channel.get()).expect("persisted row");
+        assert_eq!(persisted.full_response, "ordinary stream answer");
+        assert_eq!(persisted.last_offset, 2_048);
+    });
+}

--- a/src/services/discord/turn_bridge/stream_tick.rs
+++ b/src/services/discord/turn_bridge/stream_tick.rs
@@ -5,6 +5,13 @@ use std::sync::Arc;
 
 use super::*;
 
+#[path = "stream_tick/guarded_persist.rs"]
+mod guarded_persist;
+use guarded_persist::{
+    GuardedSaveOutcome, dirty_after_guarded_save, persist_stream_tick_heartbeat,
+    persist_stream_tick_state,
+};
+
 pub(super) type LongRunningPlaceholderActive = Option<(
     super::super::placeholder_controller::PlaceholderKey,
     super::super::placeholder_controller::PlaceholderActiveInput,
@@ -74,6 +81,7 @@ pub(super) struct BridgeStreamTickContext<'a> {
     pub(super) channel_id: ChannelId,
     pub(super) provider: &'a ProviderKind,
     pub(super) turn_id: &'a str,
+    pub(super) expected_identity: &'a crate::services::discord::inflight::InflightTurnIdentity,
     pub(super) status_interval: std::time::Duration,
     pub(super) single_message_panel_footer_mode: bool,
     pub(super) footer_owner: super::super::footer_view_reconciler::CompletionFooterOwner,
@@ -188,6 +196,7 @@ pub(super) async fn run_bridge_stream_tick(
     let channel_id = ctx.channel_id;
     let provider = ProviderRef(ctx.provider);
     let turn_id = TurnIdRef(ctx.turn_id);
+    let stream_tick_expected = ctx.expected_identity;
     let status_interval = ctx.status_interval;
     let single_message_panel_footer_mode = ctx.single_message_panel_footer_mode;
     let footer_owner = ctx.footer_owner;
@@ -638,8 +647,15 @@ pub(super) async fn run_bridge_stream_tick(
         inflight_state.last_tool_name = last_tool_name.clone();
         inflight_state.last_tool_summary = last_tool_summary.clone();
         inflight_state.prev_tool_status = prev_tool_status.clone();
-        match save_inflight_state(&*inflight_state) {
-            Ok(()) => {
+        let flush_outcome = persist_stream_tick_state(
+            &*inflight_state,
+            stream_tick_expected,
+            channel_id,
+            "turn_bridge::stream_tick::dirty_flush",
+        );
+        state_dirty = dirty_after_guarded_save(flush_outcome);
+        match flush_outcome {
+            GuardedSaveOutcome::Saved => {
                 if let Some((key, snapshot, close_trigger, ack_consumed)) =
                     pending_long_running_open_after_state_save.take()
                 {
@@ -658,23 +674,23 @@ pub(super) async fn run_bridge_stream_tick(
                                 Some((key, snapshot, close_trigger, ack_consumed));
                         } else {
                             inflight_state.long_running_placeholder_active = false;
-                            if let Err(error) = save_inflight_state(&*inflight_state) {
-                                tracing::warn!(
-                                    "[turn_bridge] failed to persist long-running placeholder open failure in channel {}: {}",
-                                    channel_id,
-                                    error
-                                );
-                            }
+                            let outcome = persist_stream_tick_state(
+                                &*inflight_state,
+                                stream_tick_expected,
+                                channel_id,
+                                "turn_bridge::stream_tick::placeholder_open_failure",
+                            );
+                            state_dirty |= dirty_after_guarded_save(outcome);
                         }
                     } else {
                         inflight_state.long_running_placeholder_active = false;
-                        if let Err(error) = save_inflight_state(&*inflight_state) {
-                            tracing::warn!(
-                                "[turn_bridge] failed to persist stale long-running placeholder open drop in channel {}: {}",
-                                channel_id,
-                                error
-                            );
-                        }
+                        let outcome = persist_stream_tick_state(
+                            &*inflight_state,
+                            stream_tick_expected,
+                            channel_id,
+                            "turn_bridge::stream_tick::placeholder_open_drop",
+                        );
+                        state_dirty |= dirty_after_guarded_save(outcome);
                     }
                 }
                 if let Some((old_key, snapshot, close_trigger, ack_consumed, new_key)) =
@@ -702,23 +718,28 @@ pub(super) async fn run_bridge_stream_tick(
                             // normal handling.
                             long_running_placeholder_active = None;
                             inflight_state.long_running_placeholder_active = false;
-                            if let Err(error) = save_inflight_state(&*inflight_state) {
-                                tracing::warn!(
-                                    "[turn_bridge] failed to persist long-running placeholder retarget failure in channel {}: {}",
-                                    channel_id,
-                                    error
-                                );
-                            }
+                            let outcome = persist_stream_tick_state(
+                                &*inflight_state,
+                                stream_tick_expected,
+                                channel_id,
+                                "turn_bridge::stream_tick::placeholder_retarget_failure",
+                            );
+                            state_dirty |= dirty_after_guarded_save(outcome);
                         }
                     }
                 }
             }
-            Err(error) => {
+            GuardedSaveOutcome::IoError => {
                 tracing::warn!(
-                    "[turn_bridge] failed to persist inflight state before moving placeholder pin in channel {}: {}",
-                    channel_id,
-                    error
+                    "[turn_bridge] failed to persist inflight state before moving placeholder pin in channel {}",
+                    channel_id
                 );
+            }
+            GuardedSaveOutcome::Missing | GuardedSaveOutcome::IdentityMismatch => {
+                // Ownership was lost. Discard deferred placeholder actions so a
+                // stale tick cannot edit or retarget the successor turn's card.
+                pending_long_running_open_after_state_save = None;
+                pending_long_running_retarget_after_state_save = None;
             }
         }
     }
@@ -755,9 +776,11 @@ pub(super) async fn run_bridge_stream_tick(
     if long_running_placeholder_active.is_some()
         && last_inflight_long_run_heartbeat.elapsed() >= live_long_run_heartbeat_interval
     {
-        inflight_state.updated_at = chrono::Utc::now().to_rfc3339();
-        let _ = save_inflight_state(&*inflight_state);
-        last_inflight_long_run_heartbeat = std::time::Instant::now();
+        let heartbeat_outcome =
+            persist_stream_tick_heartbeat(&provider, channel_id, stream_tick_expected);
+        if matches!(heartbeat_outcome, GuardedSaveOutcome::Saved) {
+            last_inflight_long_run_heartbeat = std::time::Instant::now();
+        }
     }
 
     *state.state_dirty = state_dirty;

--- a/src/services/discord/turn_bridge/stream_tick.rs
+++ b/src/services/discord/turn_bridge/stream_tick.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use super::*;
 
 #[path = "stream_tick/guarded_persist.rs"]
-mod guarded_persist;
+pub(super) mod guarded_persist;
 use guarded_persist::{
     GuardedSaveOutcome, dirty_after_guarded_save, persist_stream_tick_heartbeat,
     persist_stream_tick_state,

--- a/src/services/discord/turn_bridge/stream_tick/guarded_persist.rs
+++ b/src/services/discord/turn_bridge/stream_tick/guarded_persist.rs
@@ -4,7 +4,7 @@ use super::super::*;
 
 pub(super) type GuardedSaveOutcome = crate::services::discord::inflight::GuardedSaveOutcome;
 
-pub(super) fn persist_stream_tick_state(
+pub(in crate::services::discord::turn_bridge) fn persist_stream_tick_state(
     inflight_state: &InflightTurnState,
     expected: &crate::services::discord::inflight::InflightTurnIdentity,
     channel_id: ChannelId,

--- a/src/services/discord/turn_bridge/stream_tick/guarded_persist.rs
+++ b/src/services/discord/turn_bridge/stream_tick/guarded_persist.rs
@@ -1,0 +1,186 @@
+//! Identity-guarded persistence helpers for the periodic stream tick (#4259 R1).
+
+use super::super::*;
+
+pub(super) type GuardedSaveOutcome = crate::services::discord::inflight::GuardedSaveOutcome;
+
+pub(super) fn persist_stream_tick_state(
+    inflight_state: &InflightTurnState,
+    expected: &crate::services::discord::inflight::InflightTurnIdentity,
+    channel_id: ChannelId,
+    caller: &'static str,
+) -> GuardedSaveOutcome {
+    use crate::services::discord::inflight::{
+        GuardedSaveOutcome, save_inflight_state_if_identity_matches_allow_output_restamp,
+    };
+    let outcome = save_inflight_state_if_identity_matches_allow_output_restamp(
+        inflight_state,
+        expected,
+        caller,
+    );
+    if matches!(
+        outcome,
+        GuardedSaveOutcome::Missing | GuardedSaveOutcome::IdentityMismatch
+    ) {
+        tracing::warn!(
+            channel_id = channel_id.get(),
+            caller,
+            ?outcome,
+            "stream tick guarded save skipped because durable row is no longer owned by this turn"
+        );
+    }
+    outcome
+}
+
+pub(super) fn persist_stream_tick_heartbeat(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    expected: &crate::services::discord::inflight::InflightTurnIdentity,
+) -> GuardedSaveOutcome {
+    crate::services::discord::inflight::touch_inflight_state_if_matches_identity(
+        provider,
+        channel_id.get(),
+        expected,
+        "turn_bridge::stream_tick::long_running_heartbeat",
+    )
+}
+
+pub(super) fn dirty_after_guarded_save(outcome: GuardedSaveOutcome) -> bool {
+    matches!(outcome, GuardedSaveOutcome::IoError)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::discord::inflight::{
+        GuardedSaveOutcome, load_inflight_state, save_inflight_state,
+    };
+
+    fn owner_state(channel_id: u64, user_msg_id: u64) -> InflightTurnState {
+        let mut state = InflightTurnState::new(
+            ProviderKind::Codex,
+            channel_id,
+            Some("adk-stream-tick".to_string()),
+            343_742_347_365_974_026,
+            user_msg_id,
+            18,
+            "user prompt".to_string(),
+            Some("session".to_string()),
+            Some("AgentDesk-codex-stream-tick".to_string()),
+            Some("/tmp/AgentDesk-codex-stream-tick.jsonl".to_string()),
+            Some("/tmp/AgentDesk-codex-stream-tick.input".to_string()),
+            512,
+        );
+        state.last_offset = 512;
+        state
+    }
+
+    fn with_runtime_root<T>(test: impl FnOnce() -> T) -> T {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = tempfile::TempDir::new().expect("runtime root");
+        let _env_reset = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            temp.path(),
+        );
+        test()
+    }
+
+    #[test]
+    fn same_owner_flush_persists_and_clears_dirty() {
+        with_runtime_root(|| {
+            let channel = ChannelId::new(4_259_101);
+            let mut state = owner_state(channel.get(), 77_010);
+            save_inflight_state(&state).expect("seed owner row");
+            let expected =
+                crate::services::discord::inflight::InflightTurnIdentity::from_state(&state);
+
+            state.full_response = "streamed answer".to_string();
+            state.last_offset = 1_024;
+            let outcome = persist_stream_tick_state(
+                &state,
+                &expected,
+                channel,
+                "turn_bridge::stream_tick::dirty_flush_test",
+            );
+
+            assert_eq!(outcome, GuardedSaveOutcome::Saved);
+            assert!(!dirty_after_guarded_save(outcome));
+            let persisted =
+                load_inflight_state(&ProviderKind::Codex, channel.get()).expect("persisted row");
+            assert_eq!(persisted.full_response, "streamed answer");
+            assert_eq!(persisted.last_offset, 1_024);
+        });
+    }
+
+    #[test]
+    fn reowned_flush_skips_without_clobbering_or_retrying_dirty() {
+        with_runtime_root(|| {
+            let channel = ChannelId::new(4_259_102);
+            let mut stale = owner_state(channel.get(), 77_010);
+            let expected =
+                crate::services::discord::inflight::InflightTurnIdentity::from_state(&stale);
+            stale.full_response = "stale answer".to_string();
+
+            let mut successor = owner_state(channel.get(), 99_999);
+            successor.full_response = "new owner answer".to_string();
+            successor.last_offset = 8_192;
+            save_inflight_state(&successor).expect("seed successor row");
+
+            let outcome = persist_stream_tick_state(
+                &stale,
+                &expected,
+                channel,
+                "turn_bridge::stream_tick::dirty_flush_test",
+            );
+
+            assert_eq!(outcome, GuardedSaveOutcome::IdentityMismatch);
+            assert!(!dirty_after_guarded_save(outcome));
+            let persisted =
+                load_inflight_state(&ProviderKind::Codex, channel.get()).expect("persisted row");
+            assert_eq!(persisted.user_msg_id, 99_999);
+            assert_eq!(persisted.full_response, "new owner answer");
+            assert_eq!(persisted.last_offset, 8_192);
+        });
+    }
+
+    #[test]
+    fn dirty_and_side_effect_transitions_follow_guarded_outcome() {
+        use GuardedSaveOutcome::*;
+        assert!(!dirty_after_guarded_save(Saved));
+        assert!(dirty_after_guarded_save(IoError));
+        assert!(!dirty_after_guarded_save(Missing));
+        assert!(!dirty_after_guarded_save(IdentityMismatch));
+        assert!(matches!(Saved, GuardedSaveOutcome::Saved));
+        assert!(!matches!(IoError, GuardedSaveOutcome::Saved));
+        assert!(!matches!(Missing, GuardedSaveOutcome::Saved));
+        assert!(!matches!(IdentityMismatch, GuardedSaveOutcome::Saved));
+    }
+
+    #[test]
+    fn heartbeat_touches_same_owner_but_skips_successor() {
+        with_runtime_root(|| {
+            let channel = ChannelId::new(4_259_103);
+            let owner = owner_state(channel.get(), 77_010);
+            save_inflight_state(&owner).expect("seed owner row");
+            let expected =
+                crate::services::discord::inflight::InflightTurnIdentity::from_state(&owner);
+
+            assert_eq!(
+                persist_stream_tick_heartbeat(&ProviderKind::Codex, channel, &expected),
+                GuardedSaveOutcome::Saved
+            );
+
+            let successor = owner_state(channel.get(), 99_999);
+            save_inflight_state(&successor).expect("seed successor row");
+            assert_eq!(
+                persist_stream_tick_heartbeat(&ProviderKind::Codex, channel, &expected),
+                GuardedSaveOutcome::IdentityMismatch
+            );
+            let persisted =
+                load_inflight_state(&ProviderKind::Codex, channel.get()).expect("persisted row");
+            assert_eq!(persisted.user_msg_id, 99_999);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- capture the stream-loop owner identity before runtime/tick mutations and thread it into every periodic stream-tick persist
- replace the five production blind saves in `stream_tick.rs` with explicit-expected guarded saves, including a narrow locked heartbeat touch
- stop deferred placeholder open/retarget side effects on missing or re-owned rows; retry dirty state only on I/O failure
- lower the blind-save ratchet from 13 to 8

Design: [#4259 R1 decomposition](https://github.com/itismyfield/AgentDesk/issues/4259#issuecomment-5059060466)

## Verification
- `cargo fmt --all` — rc 0
- `cargo fmt --all -- --check` — rc 0
- `cargo check --lib` — rc 0
- `cargo test --lib turn_bridge` — rc 0, 316 passed
- `cargo test --lib inflight` — rc 0, 386 passed
- `python3 scripts/check_inflight_blind_save_ratchet.py` — rc 0, 8 sites / baseline 8
- `python3 tests/test_inflight_blind_save_ratchet.py` — rc 0, 13 passed
- `python3 scripts/generate_inventory_docs.py` — rc 0
- `python3 scripts/check_agent_maintenance_docs.py` — rc 0

## Rollback
Revert this PR and restore the ratchet baseline from 8 to 13. No sidecar or schema migration is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)