### PR TITLE
fix(#4259): R2 guard runtime-handoff persistence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -534,7 +534,8 @@ src/
 │   │   │   ├── save_store/
 │   │   │   │   ├── identity_gate/
 │   │   │   │   │   ├── claude_e_stamp.rs
-│   │   │   │   │   └── heartbeat.rs
+│   │   │   │   │   ├── heartbeat.rs
+│   │   │   │   │   └── runtime_stamp.rs
 │   │   │   │   ├── delivery_rewind.rs
 │   │   │   │   ├── identity_gate.rs
 │   │   │   │   ├── post_loop_identity_guard_tests.rs
@@ -844,7 +845,8 @@ src/
 │   │   │   │   └── channel_writeback.rs
 │   │   │   ├── runtime_handoff_loop/
 │   │   │   │   ├── claude_e.rs
-│   │   │   │   └── guarded_save.rs
+│   │   │   │   ├── guarded_save.rs
+│   │   │   │   └── tests.rs
 │   │   │   ├── stream_loop/
 │   │   │   │   ├── content_arms/
 │   │   │   │   │   ├── provider_error_presentation.rs

--- a/scripts/check_inflight_blind_save_ratchet.py
+++ b/scripts/check_inflight_blind_save_ratchet.py
@@ -53,32 +53,21 @@ from pathlib import Path
 # to the identity-guarded variant; never raise it casually.
 #
 # #4259 PR-1 baseline = 29; PR-2a lowered to 26; #4596 lowered to 25;
-# the post-loop-finalize slice lowered to 21. Track decomposition
-# (convert + lower per PR-2..N):
-#   turn_bridge/runtime_handoff_loop.rs .. 5  (#4596 converted ClaudeEAdapter)
-#   turn_bridge/stream_tick.rs .......... 5
-#   turn_bridge/stream_loop.rs .......... 2
-#   turn_bridge/post_loop_finalize.rs ... 0  (#4259 post-loop slice converted 4)
-#   turn_bridge/mod.rs (hotfile, solo) .. 1
-#   external (router/session/tui) ....... 0  (#4259 slice 1 converted 8)
-#     (headless_turn, intake_turn, provider_isolation, watchdog,
-#      session_runtime/worktree, tui_prompt_relay/synthetic_start x2,
-#      tui_prompt_relay/codex_idle_rollout)
+# post-loop-finalize lowered to 21; external writers lowered to 13; R1 stream
+# tick lowered to 8; R2 runtime-handoff atomic stamps lower to 3. Remaining:
+#   turn_bridge/runtime_handoff_loop.rs .. 0  (R2 field-scoped locked stamp)
+#   turn_bridge/stream_tick.rs .......... 0  (R1)
+#   turn_bridge/stream_loop.rs .......... 2  (R3)
+#   turn_bridge/post_loop_finalize.rs ... 0
+#   turn_bridge/mod.rs (hotfile, solo) .. 1  (R4)
+#   external (router/session/tui) ....... 0
 #
-# #4259 PR-2a: the 3 converted runtime_handoff_loop sites are the legacy
-# tmux-wrapper `TmuxReady` stamps, converted to
-# `save_inflight_state_if_identity_matches_allow_output_restamp` (codex r1):
-# the 4-field turn identity is stable across the stamp (declines only on
-# concurrent re-own), while `output_path` may legitimately restamp to the
-# resolved legacy /tmp session path on a warm follow-up
-# (`resolve_session_temp_path`). #4596 additionally converted ClaudeEAdapter
-# to a dedicated locked identity-gated RMW that may clear `tmux_session_name`
-# without overwriting a newer turn. The 5 that REMAIN blind (RuntimeReady
-# ProcessBackend/ClaudeTui/CodexTui + ProcessReady + the watcher-handoff
-# helper) still (re)write identity-pinned `tmux_session_name`, beyond what the
-# output-restamp variant tolerates, so each needs per-flow session-name-stability
-# verification or an adoption-aware variant before converting.
-BASELINE = 8
+# R2 converts RuntimeReady ProcessBackend, ProcessReady, and the shared watcher
+# handoff's standby/spawn/handoff saves. The store-side locked RMW accepts a
+# first `tmux_session_name` population only after the pre-mutation durable
+# identity and authority match, pins an established session against changes,
+# and patches only runtime/session/output/owner evidence.
+BASELINE = 3
 
 SCAN_ROOT = Path("src") / "services" / "discord"
 

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -152,7 +152,8 @@ pub(in crate::services::discord) use self::save_store::{
     save_existing_inflight_rebind_adoption_with_offset_rebase_if_matches_identity,
     save_inflight_state_if_identity_matches_allow_output_restamp,
     save_inflight_state_if_identity_unchanged, save_inflight_state_if_matches_identity,
-    stamp_claude_e_process_if_matches_identity, touch_inflight_state_if_matches_identity,
+    stamp_claude_e_process_if_matches_identity, stamp_runtime_handoff_if_matches_identity,
+    touch_inflight_state_if_matches_identity,
 };
 // Explicit-root save seams reached only by the parent's / siblings' test modules.
 #[cfg(test)]

--- a/src/services/discord/inflight/model.rs
+++ b/src/services/discord/inflight/model.rs
@@ -393,16 +393,14 @@ pub(in crate::services::discord) struct InflightTurnState {
     /// live, progressing re-adopted turn (matching `user_msg_id`, not committed)
     /// still yields reclaim-reason `None`.
     ///
-    /// NOTE (#4370): this marker IS persisted on a DrainRestart-preserved row. The
-    /// BROAD identity-refresh save (`save_inflight_state_if_identity_unchanged`)
-    /// refuses any row still carrying `restart_mode`, which is precisely why the
-    /// marker is written through the NARROW single-field patch
+    /// NOTE (#4370/#4810): this marker is written through the NARROW adoption patch
     /// `mark_readopted_from_inflight_if_identity_unchanged`
-    /// (`inflight/save_store/identity_gate.rs`) instead: it re-reads under the
-    /// sidecar flock, pins the turn identity, flips only this additive bit, and
-    /// preserves `restart_mode`. Test `readopted_marker_lands_on_restart_preserved_row_and_never_resurrects`
-    /// pins that behavior. So the present-row (Path A) reclaim DOES cover
-    /// restart-preserved rows.
+    /// (`inflight/save_store/identity_gate.rs`), not the broad identity-refresh
+    /// save. The patch re-reads under the sidecar flock, pins the turn identity,
+    /// flips this additive bit, and atomically consumes any planned-restart marker
+    /// so replacement-process authority is durable before runtime handoff. Test
+    /// `readopted_marker_lands_on_restart_preserved_row_and_never_resurrects` pins
+    /// the restart-preserved adoption and no-resurrection behavior.
     ///
     /// The ROW-ABSENT reclaim (Path B) still does not consult this field — there is
     /// no row left to read — and uses the in-memory

--- a/src/services/discord/inflight/save_store.rs
+++ b/src/services/discord/inflight/save_store.rs
@@ -30,7 +30,8 @@ pub(in crate::services::discord) use self::identity_gate::{
     recovery_anchor_msg_id_if_matches_identity,
     save_inflight_state_if_identity_matches_allow_output_restamp,
     save_inflight_state_if_identity_unchanged, save_inflight_state_if_matches_identity,
-    stamp_claude_e_process_if_matches_identity, touch_inflight_state_if_matches_identity,
+    stamp_claude_e_process_if_matches_identity, stamp_runtime_handoff_if_matches_identity,
+    touch_inflight_state_if_matches_identity,
 };
 pub(in crate::services::discord) use self::rebind_adoption::{
     save_existing_inflight_rebind_adoption_if_matches_episode,

--- a/src/services/discord/inflight/save_store/identity_gate.rs
+++ b/src/services/discord/inflight/save_store/identity_gate.rs
@@ -3,8 +3,11 @@ use super::*;
 mod claude_e_stamp;
 #[path = "identity_gate/heartbeat.rs"]
 mod heartbeat;
+#[path = "identity_gate/runtime_stamp.rs"]
+mod runtime_stamp;
 pub(in crate::services::discord) use claude_e_stamp::stamp_claude_e_process_if_matches_identity;
 pub(in crate::services::discord) use heartbeat::touch_inflight_state_if_matches_identity;
+pub(in crate::services::discord) use runtime_stamp::stamp_runtime_handoff_if_matches_identity;
 
 pub(in crate::services::discord) fn save_inflight_state_if_identity_unchanged(
     state: &InflightTurnState,
@@ -41,18 +44,13 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_un
 /// session path that differs from the intake seed
 /// (`resolve_session_temp_path`; claude.rs/codex.rs/qwen.rs follow-up arms), so
 /// the strict `output_path` equality of the `_if_identity_unchanged` variant
-/// would refuse a legitimate same-turn stamp. Use THIS variant for
-/// runtime-handoff (re)stamp sites; it still refuses rows re-owned by another
-/// turn. The expected identity is captured before the caller mutates its
-/// restamp cursor, so the durable row must still have the loaded birth offset;
-/// the written state may then advance that cursor. The held-back blind sites in
-/// `turn_bridge/runtime_handoff_loop.rs`
-/// (RuntimeReady ProcessBackend/ClaudeEAdapter/ClaudeTui/CodexTui,
-/// ProcessReady, and the watcher-handoff helper — see
-/// `scripts/check_inflight_blind_save_ratchet.py`) are expected to convert to
-/// this variant too, once each site's identity-pinned fields (notably
-/// `tmux_session_name`, which some of them first-populate or clear) are
-/// verified stable across the stamp.
+/// would refuse a legitimate same-turn stamp. Use THIS variant for handoffs
+/// whose session identity was already established before the mutation; it still
+/// refuses rows re-owned by another turn. Handoffs that first-populate
+/// `tmux_session_name` use the field-scoped `runtime_stamp` RMW instead. The
+/// expected identity is captured before the caller mutates its restamp cursor,
+/// so the durable row must still have the loaded birth offset; the written state
+/// may then advance that cursor.
 pub(in crate::services::discord) fn save_inflight_state_if_identity_matches_allow_output_restamp(
     state: &InflightTurnState,
     expected: &InflightTurnIdentity,

--- a/src/services/discord/inflight/save_store/identity_gate/runtime_stamp.rs
+++ b/src/services/discord/inflight/save_store/identity_gate/runtime_stamp.rs
@@ -1,0 +1,365 @@
+use super::*;
+
+pub(in crate::services::discord) fn stamp_runtime_handoff_if_matches_identity(
+    state: &InflightTurnState,
+    expected: &InflightTurnIdentity,
+    caller: &'static str,
+) -> GuardedSaveOutcome {
+    let Some(root) = inflight_runtime_root() else {
+        return GuardedSaveOutcome::IoError;
+    };
+    stamp_runtime_handoff_if_matches_identity_in_root(&root, state, expected, caller)
+}
+
+pub(in crate::services::discord::inflight) fn stamp_runtime_handoff_if_matches_identity_in_root(
+    root: &Path,
+    state: &InflightTurnState,
+    expected: &InflightTurnIdentity,
+    caller: &'static str,
+) -> GuardedSaveOutcome {
+    let Some(provider) = state.provider_kind() else {
+        return GuardedSaveOutcome::IoError;
+    };
+    let path = inflight_state_path(root, &provider, state.channel_id);
+    let Ok(_lock) = lock_inflight_state_path(&path) else {
+        return GuardedSaveOutcome::IoError;
+    };
+    let Some(mut on_disk) = load_inflight_state_unlocked(&path) else {
+        return GuardedSaveOutcome::Missing;
+    };
+    let durable = InflightTurnIdentity::from_state(&on_disk);
+    if expected.user_msg_id == 0 && expected.turn_start_offset.is_none() {
+        tracing::info!(
+            provider = %provider.as_str(),
+            channel_id = state.channel_id,
+            caller,
+            snapshot_identity = ?expected,
+            durable_identity = ?durable,
+            "runtime-handoff stamp skipped because offsetless id-0 snapshot cannot safely match a durable row"
+        );
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+    if on_disk.restart_mode.is_some() || on_disk.rebind_origin || !expected.matches_state(&on_disk)
+    {
+        tracing::info!(
+            provider = %provider.as_str(),
+            channel_id = state.channel_id,
+            caller,
+            snapshot_identity = ?expected,
+            durable_identity = ?durable,
+            durable_restart_mode = ?on_disk.restart_mode,
+            durable_rebind_origin = on_disk.rebind_origin,
+            "runtime-handoff stamp skipped because durable row authority changed"
+        );
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+    if expected.tmux_session_name.is_some() && state.tmux_session_name != expected.tmux_session_name
+    {
+        tracing::info!(
+            provider = %provider.as_str(),
+            channel_id = state.channel_id,
+            caller,
+            snapshot_tmux_session_name = ?expected.tmux_session_name,
+            requested_tmux_session_name = ?state.tmux_session_name,
+            "runtime-handoff stamp skipped because an established runtime session changed"
+        );
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+
+    on_disk.runtime_kind = state.runtime_kind;
+    on_disk.tmux_session_name = state.tmux_session_name.clone();
+    on_disk.output_path = state.output_path.clone();
+    on_disk.input_fifo_path = state.input_fifo_path.clone();
+    on_disk.session_id = state.session_id.clone();
+    on_disk.last_offset = state.last_offset;
+    on_disk.watcher_owner_channel_id = state.watcher_owner_channel_id;
+    on_disk.set_relay_owner_kind(state.effective_relay_owner_kind());
+    match persist_under_lock(
+        root,
+        &path,
+        &on_disk,
+        "src/services/discord/inflight.rs:stamp_runtime_handoff_if_matches_identity_in_root",
+    ) {
+        Ok(()) => GuardedSaveOutcome::Saved,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel_id = state.channel_id,
+                caller,
+                error = %error,
+                "runtime-handoff stamp failed; leaving durable row untouched"
+            );
+            GuardedSaveOutcome::IoError
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn runtime_seed(
+        provider: ProviderKind,
+        channel_id: u64,
+        tmux_session_name: Option<&str>,
+    ) -> InflightTurnState {
+        InflightTurnState::new(
+            provider,
+            channel_id,
+            Some("adk-4259-r2".to_string()),
+            343_742_347_365_974_026,
+            77_010,
+            18,
+            "runtime handoff".to_string(),
+            Some("provider-session-before-handoff".to_string()),
+            tmux_session_name.map(str::to_string),
+            Some("/seeded/runtime-output.jsonl".to_string()),
+            None,
+            512,
+        )
+    }
+
+    fn load(root: &Path, provider: &ProviderKind, channel_id: u64) -> InflightTurnState {
+        let path = inflight_state_path(root, provider, channel_id);
+        serde_json::from_str(&std::fs::read_to_string(path).expect("read inflight row"))
+            .expect("parse inflight row")
+    }
+
+    #[test]
+    fn runtime_first_stamp_supports_process_claude_tui_and_codex_tui() {
+        for (index, provider, runtime_kind, session_name) in [
+            (
+                0,
+                ProviderKind::Claude,
+                RuntimeHandoffKind::ProcessBackend,
+                "claude-process-session",
+            ),
+            (
+                1,
+                ProviderKind::Claude,
+                RuntimeHandoffKind::ClaudeTui,
+                "AgentDesk-claude-adk-4259-r2",
+            ),
+            (
+                2,
+                ProviderKind::Codex,
+                RuntimeHandoffKind::CodexTui,
+                "AgentDesk-codex-adk-4259-r2",
+            ),
+        ] {
+            let root = tempfile::tempdir().expect("runtime root");
+            let channel_id = 42_592_100 + index;
+            let seed = runtime_seed(provider.clone(), channel_id, None);
+            save_inflight_state_in_root(root.path(), &seed).expect("seed owner row");
+            let expected = InflightTurnIdentity::from_state(&seed);
+
+            let mut stamp = seed.clone();
+            stamp.runtime_kind = Some(runtime_kind);
+            stamp.tmux_session_name = Some(session_name.to_string());
+            stamp.output_path = Some(format!("/runtime/{session_name}.jsonl"));
+            stamp.input_fifo_path = matches!(runtime_kind, RuntimeHandoffKind::ClaudeTui)
+                .then(|| format!("/runtime/{session_name}.input"));
+            stamp.session_id = Some(format!("provider-session-{index}"));
+            stamp.last_offset = 4096;
+            stamp.watcher_owner_channel_id = Some(channel_id + 100);
+            stamp.set_relay_owner_kind(RelayOwnerKind::Watcher);
+
+            assert_eq!(
+                stamp_runtime_handoff_if_matches_identity_in_root(
+                    root.path(),
+                    &stamp,
+                    &expected,
+                    "test::runtime_first_stamp",
+                ),
+                GuardedSaveOutcome::Saved,
+            );
+            let persisted = load(root.path(), &provider, channel_id);
+            assert_eq!(persisted.runtime_kind, Some(runtime_kind));
+            assert_eq!(persisted.tmux_session_name.as_deref(), Some(session_name));
+            assert_eq!(persisted.output_path, stamp.output_path);
+            assert_eq!(persisted.input_fifo_path, stamp.input_fifo_path);
+            assert_eq!(persisted.session_id, stamp.session_id);
+            assert_eq!(persisted.last_offset, 4096);
+            assert_eq!(persisted.watcher_owner_channel_id, Some(channel_id + 100));
+            assert_eq!(
+                persisted.effective_relay_owner_kind(),
+                RelayOwnerKind::Watcher
+            );
+        }
+    }
+
+    #[test]
+    fn runtime_stamp_accepts_same_session_restamp_and_rejects_changed_session() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let provider = ProviderKind::Codex;
+        let channel_id = 42_592_200;
+        let seed = runtime_seed(provider.clone(), channel_id, Some("AgentDesk-codex-stable"));
+        save_inflight_state_in_root(root.path(), &seed).expect("seed owner row");
+        let expected = InflightTurnIdentity::from_state(&seed);
+
+        let mut same_session = seed.clone();
+        same_session.runtime_kind = Some(RuntimeHandoffKind::CodexTui);
+        same_session.output_path = Some("/runtime/restamped-rollout.jsonl".to_string());
+        same_session.last_offset = 2048;
+        assert_eq!(
+            stamp_runtime_handoff_if_matches_identity_in_root(
+                root.path(),
+                &same_session,
+                &expected,
+                "test::same_session_restamp",
+            ),
+            GuardedSaveOutcome::Saved,
+        );
+
+        let persisted = load(root.path(), &provider, channel_id);
+        let persisted_expected = InflightTurnIdentity::from_state(&persisted);
+        let mut changed_session = persisted.clone();
+        changed_session.tmux_session_name = Some("AgentDesk-codex-different".to_string());
+        changed_session.output_path = Some("/runtime/should-not-land.jsonl".to_string());
+        assert_eq!(
+            stamp_runtime_handoff_if_matches_identity_in_root(
+                root.path(),
+                &changed_session,
+                &persisted_expected,
+                "test::changed_session_rejected",
+            ),
+            GuardedSaveOutcome::IdentityMismatch,
+        );
+        let preserved = load(root.path(), &provider, channel_id);
+        assert_eq!(
+            preserved.tmux_session_name.as_deref(),
+            Some("AgentDesk-codex-stable")
+        );
+        assert_eq!(
+            preserved.output_path.as_deref(),
+            Some("/runtime/restamped-rollout.jsonl")
+        );
+    }
+
+    #[test]
+    fn runtime_stamp_never_creates_or_overwrites_unowned_rows() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let provider = ProviderKind::Claude;
+        let channel_id = 42_592_300;
+        let seed = runtime_seed(provider.clone(), channel_id, None);
+        let expected = InflightTurnIdentity::from_state(&seed);
+        let mut stamp = seed.clone();
+        stamp.runtime_kind = Some(RuntimeHandoffKind::ClaudeTui);
+        stamp.tmux_session_name = Some("AgentDesk-claude-r2".to_string());
+
+        assert_eq!(
+            stamp_runtime_handoff_if_matches_identity_in_root(
+                root.path(),
+                &stamp,
+                &expected,
+                "test::missing_row",
+            ),
+            GuardedSaveOutcome::Missing,
+        );
+
+        let mut newer = seed.clone();
+        newer.user_msg_id = 99_999;
+        newer.output_path = Some("/runtime/newer-turn.jsonl".to_string());
+        save_inflight_state_in_root(root.path(), &newer).expect("seed re-owned row");
+        assert_eq!(
+            stamp_runtime_handoff_if_matches_identity_in_root(
+                root.path(),
+                &stamp,
+                &expected,
+                "test::concurrent_reowner",
+            ),
+            GuardedSaveOutcome::IdentityMismatch,
+        );
+        let preserved = load(root.path(), &provider, channel_id);
+        assert_eq!(preserved.user_msg_id, 99_999);
+        assert_eq!(
+            preserved.output_path.as_deref(),
+            Some("/runtime/newer-turn.jsonl")
+        );
+    }
+
+    #[test]
+    fn runtime_stamp_fails_closed_for_ambiguous_or_reserved_authority() {
+        let provider = ProviderKind::Codex;
+        for (index, mutate) in ["id0", "restart", "rebind"].into_iter().enumerate() {
+            let root = tempfile::tempdir().expect("runtime root");
+            let channel_id = 42_592_400 + index as u64;
+            let mut seed = runtime_seed(provider.clone(), channel_id, None);
+            match mutate {
+                "id0" => {
+                    seed.user_msg_id = 0;
+                    seed.turn_start_offset = None;
+                }
+                "restart" => seed.set_restart_mode(InflightRestartMode::DrainRestart),
+                "rebind" => seed.rebind_origin = true,
+                _ => unreachable!(),
+            }
+            save_inflight_state_in_root(root.path(), &seed).expect("seed reserved row");
+            let expected = InflightTurnIdentity::from_state(&seed);
+            let mut stamp = seed.clone();
+            stamp.runtime_kind = Some(RuntimeHandoffKind::CodexTui);
+            stamp.tmux_session_name = Some("AgentDesk-codex-r2".to_string());
+
+            assert_eq!(
+                stamp_runtime_handoff_if_matches_identity_in_root(
+                    root.path(),
+                    &stamp,
+                    &expected,
+                    "test::reserved_authority",
+                ),
+                GuardedSaveOutcome::IdentityMismatch,
+                "{mutate} authority must fail closed",
+            );
+            let preserved = load(root.path(), &provider, channel_id);
+            assert_eq!(preserved.runtime_kind, seed.runtime_kind);
+            assert_eq!(preserved.tmux_session_name, seed.tmux_session_name);
+        }
+    }
+
+    #[test]
+    fn runtime_stamp_commits_only_final_standby_or_watcher_owner_decision() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let provider = ProviderKind::Claude;
+        let channel_id = 42_592_500;
+        let seed = runtime_seed(provider.clone(), channel_id, None);
+        save_inflight_state_in_root(root.path(), &seed).expect("seed owner row");
+        let expected = InflightTurnIdentity::from_state(&seed);
+
+        let mut standby = seed.clone();
+        standby.runtime_kind = Some(RuntimeHandoffKind::ClaudeTui);
+        standby.tmux_session_name = Some("AgentDesk-claude-owner-r2".to_string());
+        standby.set_relay_owner_kind(RelayOwnerKind::StandbyRelay);
+        assert_eq!(
+            stamp_runtime_handoff_if_matches_identity_in_root(
+                root.path(),
+                &standby,
+                &expected,
+                "test::standby_owner",
+            ),
+            GuardedSaveOutcome::Saved,
+        );
+        let persisted_standby = load(root.path(), &provider, channel_id);
+        assert_eq!(
+            persisted_standby.effective_relay_owner_kind(),
+            RelayOwnerKind::StandbyRelay
+        );
+
+        let standby_expected = InflightTurnIdentity::from_state(&persisted_standby);
+        let mut watcher = persisted_standby.clone();
+        watcher.set_relay_owner_kind(RelayOwnerKind::Watcher);
+        assert_eq!(
+            stamp_runtime_handoff_if_matches_identity_in_root(
+                root.path(),
+                &watcher,
+                &standby_expected,
+                "test::watcher_owner",
+            ),
+            GuardedSaveOutcome::Saved,
+        );
+        let persisted_watcher = load(root.path(), &provider, channel_id);
+        assert_eq!(
+            persisted_watcher.effective_relay_owner_kind(),
+            RelayOwnerKind::Watcher
+        );
+    }
+}

--- a/src/services/discord/recovery_engine/restore_inflight.rs
+++ b/src/services/discord/recovery_engine/restore_inflight.rs
@@ -2144,6 +2144,18 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
         )
         .await;
 
+        // The generic reader feeds RuntimeReady into turn_bridge, just like the
+        // immediate watcher-reattach branches below. Consume the outgoing
+        // process's planned-restart authority through the same identity-guarded
+        // readoption helper before the reader can publish that handoff. A failed
+        // adoption stays fail-closed: runtime_stamp will continue refusing the
+        // reserved durable row rather than writing through restart authority.
+        if super::runtime::readopt_marker_eligible_real_user(&state) {
+            let _ = super::runtime::mark_readopted_from_inflight(
+                shared, provider, channel_id, &state, true,
+            );
+        }
+
         let adk_session_key = build_adk_session_key(shared, channel_id, provider, None).await;
         let adk_session_name = channel_name.clone();
         let adk_session_info = derive_adk_session_info(
@@ -2328,10 +2340,126 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
 
 #[cfg(test)]
 mod tests {
+    use crate::services::agent_protocol::{RuntimeHandoffKind, StreamMessage};
+    use crate::services::discord::InflightRestartMode;
     use crate::services::discord::inflight::{
         self, GuardedSaveOutcome, InflightTurnIdentity, InflightTurnState, RelayOwnerKind,
     };
     use crate::services::provider::ProviderKind;
+
+    fn generic_recovery_runtime_ready(
+        shared: &std::sync::Arc<super::SharedData>,
+        provider: &ProviderKind,
+        state: &InflightTurnState,
+        runtime_state: &InflightTurnState,
+        tx: &std::sync::mpsc::Sender<StreamMessage>,
+    ) -> GuardedSaveOutcome {
+        assert!(super::super::runtime::readopt_marker_eligible_real_user(
+            state
+        ));
+        let outcome = super::super::runtime::mark_readopted_from_inflight(
+            shared,
+            provider,
+            serenity::model::id::ChannelId::new(state.channel_id),
+            state,
+            true,
+        );
+        tx.send(StreamMessage::RuntimeReady {
+            handoff: super::super::runtime_handoff_for_recovery(
+                runtime_state.runtime_kind.expect("runtime kind"),
+                runtime_state.output_path.clone().expect("output path"),
+                runtime_state.input_fifo_path.clone(),
+                runtime_state
+                    .tmux_session_name
+                    .clone()
+                    .expect("tmux session"),
+                runtime_state.session_id.clone(),
+                runtime_state.last_offset,
+            ),
+        })
+        .expect("publish RuntimeReady after readoption");
+        assert!(
+            inflight::load_inflight_state(provider, state.channel_id)
+                .expect("readopted durable row")
+                .restart_mode
+                .is_none(),
+            "the generic recovery handoff must observe consumed restart authority"
+        );
+        outcome
+    }
+
+    #[test]
+    fn generic_recovery_consumes_restart_before_runtime_ready_and_persists_runtime_stamp() {
+        let _guard = crate::config::test_env_lock::acquire_shared_test_env_lock();
+        let root = tempfile::tempdir().expect("runtime root");
+        let _env = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            root.path(),
+        );
+        let shared = super::super::make_shared_data_for_tests_with_storage(None);
+        let provider = ProviderKind::Claude;
+        let channel_id = 4_259_703;
+        let mut state = InflightTurnState::new(
+            provider.clone(),
+            channel_id,
+            Some("adk-4259-generic-recovery".to_string()),
+            343_742_347_365_974_026,
+            4_259_713,
+            4_259_714,
+            "generic recovery runtime handoff".to_string(),
+            Some("provider-session-before-recovery".to_string()),
+            Some("AgentDesk-claude-old-runtime".to_string()),
+            Some("/runtime/old-transcript.jsonl".to_string()),
+            None,
+            128,
+        );
+        state.set_restart_mode(InflightRestartMode::DrainRestart);
+        inflight::save_inflight_state(&state).expect("seed planned-restart row");
+        let expected = InflightTurnIdentity::from_state(&state);
+
+        let mut runtime_state = state.clone();
+        runtime_state.runtime_kind = Some(RuntimeHandoffKind::ClaudeTui);
+        runtime_state.output_path = Some("/runtime/recovered-transcript.jsonl".to_string());
+        runtime_state.last_offset = 4_096;
+        runtime_state.watcher_owner_channel_id = Some(channel_id);
+        runtime_state.set_relay_owner_kind(RelayOwnerKind::Watcher);
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        assert_eq!(
+            generic_recovery_runtime_ready(&shared, &provider, &state, &runtime_state, &tx,),
+            GuardedSaveOutcome::Saved,
+        );
+        assert!(matches!(
+            rx.recv().expect("RuntimeReady published"),
+            StreamMessage::RuntimeReady { .. }
+        ));
+        assert_eq!(
+            inflight::stamp_runtime_handoff_if_matches_identity(
+                &runtime_state,
+                &expected,
+                "test::generic_recovery_runtime_ready",
+            ),
+            GuardedSaveOutcome::Saved,
+            "runtime stamp must succeed only after generic recovery consumes restart authority"
+        );
+
+        let persisted = inflight::load_inflight_state(&provider, channel_id)
+            .expect("runtime-stamped recovery row");
+        assert!(persisted.readopted_from_inflight);
+        assert_eq!(persisted.restart_mode, None);
+        assert_eq!(persisted.restart_generation, None);
+        assert_eq!(persisted.runtime_kind, Some(RuntimeHandoffKind::ClaudeTui));
+        assert_eq!(
+            persisted.output_path.as_deref(),
+            Some("/runtime/recovered-transcript.jsonl")
+        );
+        assert_eq!(persisted.last_offset, 4_096);
+        assert_eq!(persisted.watcher_owner_channel_id, Some(channel_id));
+        assert_eq!(
+            persisted.effective_relay_owner_kind(),
+            RelayOwnerKind::Watcher
+        );
+    }
 
     #[test]
     fn restore_rollout_output_path_patch_preserves_concurrent_relay_fields() {

--- a/src/services/discord/recovery_engine/restore_inflight.rs
+++ b/src/services/discord/recovery_engine/restore_inflight.rs
@@ -2144,18 +2144,13 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
         )
         .await;
 
-        // The generic reader feeds RuntimeReady into turn_bridge, just like the
-        // immediate watcher-reattach branches below. Consume the outgoing
-        // process's planned-restart authority through the same identity-guarded
-        // readoption helper before the reader can publish that handoff. A failed
-        // adoption stays fail-closed: runtime_stamp will continue refusing the
-        // reserved durable row rather than writing through restart authority.
+        // Consume outgoing planned-restart authority (identity-guarded readoption)
+        // before the reader publishes RuntimeReady; failed adoption stays fail-closed.
         if super::runtime::readopt_marker_eligible_real_user(&state) {
             let _ = super::runtime::mark_readopted_from_inflight(
                 shared, provider, channel_id, &state, true,
             );
         }
-
         let adk_session_key = build_adk_session_key(shared, channel_id, provider, None).await;
         let adk_session_name = channel_name.clone();
         let adk_session_info = derive_adk_session_info(

--- a/src/services/discord/recovery_engine/runtime.rs
+++ b/src/services/discord/recovery_engine/runtime.rs
@@ -99,24 +99,23 @@ pub(in crate::services::discord) fn readopt_marker_eligible_real_user(
 ///     live successor turn owns a DIFFERENT id and can never match, so the entry
 ///     is inert once its turn ends (see `ReadoptedMailboxOwner`).
 ///   * The on-disk `readopted_from_inflight` marker — the companion signal for a
-///     PRESENT row, written through the identity-guarded single-field patch
+///     PRESENT row, written through the identity-guarded narrow patch
 ///     `mark_readopted_from_inflight_if_identity_unchanged` (NOT a blind whole-row
 ///     save): a concurrently-cleared row is NOT resurrected (`Missing`), and a row
-///     a newer turn re-owns is NOT clobbered (`IdentityMismatch`). It preserves
-///     `restart_mode`, so it also lands on DrainRestart-preserved rows — where the
-///     broad identity-refresh save would refuse to write, which is why the ABSENT
-///     path relies on the ledger rather than this marker.
+///     a newer turn re-owns is NOT clobbered (`IdentityMismatch`). Under the same
+///     canonical lock it also consumes any planned-restart marker, transferring
+///     durable authority to the replacement process before runtime handoff.
 ///
 /// This does NOT touch the completion lifecycle: the re-adopted turn's own
 /// `✅`/footer + analytics still fire (see the `readopted_from_inflight` field doc
 /// for why it is DISTINCT from `relay_ownership_only`).
-fn mark_readopted_from_inflight(
+pub(super) fn mark_readopted_from_inflight(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: ChannelId,
     state: &inflight::InflightTurnState,
     persist_durable_marker: bool,
-) {
+) -> inflight::GuardedSaveOutcome {
     // The re-adopted mailbox slot carries the turn's effective finalizer id as its
     // `active_user_message_id` (`mailbox_try_start_turn(..., finalizer_msg_id)` /
     // the existing-active-turn rebind below), so the ledger keys the row-ABSENT
@@ -137,17 +136,16 @@ fn mark_readopted_from_inflight(
             active_user_message_id,
             state,
         );
+        return inflight::GuardedSaveOutcome::Saved;
     }
 
-    if !persist_durable_marker {
-        return;
-    }
     let expected = inflight::InflightTurnIdentity::from_state(state);
-    match inflight::mark_readopted_from_inflight_if_identity_unchanged(
+    let outcome = inflight::mark_readopted_from_inflight_if_identity_unchanged(
         provider,
         channel_id.get(),
         &expected,
-    ) {
+    );
+    match outcome {
         inflight::GuardedSaveOutcome::Saved => {}
         inflight::GuardedSaveOutcome::Missing => {
             tracing::debug!(
@@ -171,6 +169,7 @@ fn mark_readopted_from_inflight(
             );
         }
     }
+    outcome
 }
 
 async fn reregister_active_turn_from_inflight_inner(
@@ -242,7 +241,7 @@ async fn reregister_active_turn_from_inflight_inner(
             reseed_watcher_owned_finalizer_ledger(shared, channel_id, finalizer_turn_id, &provider);
             // #4370: a real-user turn re-bound to the mailbox across a restart.
             if readopted_ledger_record_allowed(state) {
-                mark_readopted_from_inflight(
+                let _ = mark_readopted_from_inflight(
                     shared,
                     &provider,
                     channel_id,

--- a/src/services/discord/turn_bridge/runtime_handoff_loop.rs
+++ b/src/services/discord/turn_bridge/runtime_handoff_loop.rs
@@ -80,11 +80,13 @@ struct WatcherRuntimeHandoffState<'a> {
     terminal_control_drain_until: &'a mut Option<std::time::Instant>,
 }
 
-// #4259 PR-2a: the `TmuxReady` identity-guarded save + its outcome-conditional
-// dirty policy live in a child module so this parent stays below the giant
-// (>= 1000 prod LoC) threshold (codex r1).
 mod guarded_save;
-use guarded_save::{guarded_runtime_handoff_save, tmux_ready_state_dirty_after_guarded_save};
+#[cfg(test)]
+mod tests;
+use guarded_save::{
+    guarded_runtime_atomic_stamp, guarded_runtime_handoff_save,
+    tmux_ready_state_dirty_after_guarded_save,
+};
 
 pub(super) async fn handle_runtime_handoff_loop_message(
     message: RuntimeHandoffLoopMessage,
@@ -468,7 +470,7 @@ pub(super) async fn handle_runtime_handoff_loop_message(
                     tmux_session_name,
                     last_offset,
                 } => {
-                    handle_watcher_runtime_handoff(
+                    guarded_save_outcome = Some(handle_watcher_runtime_handoff(
                         WatcherRuntimeHandoffContext {
                             shared_owned: &shared_owned,
                             provider: &provider,
@@ -492,14 +494,14 @@ pub(super) async fn handle_runtime_handoff_loop_message(
                             state_dirty: &mut state_dirty,
                             terminal_control_drain_until: &mut terminal_control_drain_until,
                         },
-                    );
+                    ));
                 }
                 RuntimeHandoff::ClaudeTui {
                     transcript_path,
                     tmux_session_name,
                     last_offset,
                 } => {
-                    handle_watcher_runtime_handoff(
+                    guarded_save_outcome = Some(handle_watcher_runtime_handoff(
                         WatcherRuntimeHandoffContext {
                             shared_owned: &shared_owned,
                             provider: &provider,
@@ -523,7 +525,7 @@ pub(super) async fn handle_runtime_handoff_loop_message(
                             state_dirty: &mut state_dirty,
                             terminal_control_drain_until: &mut terminal_control_drain_until,
                         },
-                    );
+                    ));
                 }
                 RuntimeHandoff::CodexTui {
                     rollout_path,
@@ -534,7 +536,7 @@ pub(super) async fn handle_runtime_handoff_loop_message(
                     if let Some(thread_id) = thread_id {
                         inflight_state.session_id = Some(thread_id);
                     }
-                    handle_watcher_runtime_handoff(
+                    guarded_save_outcome = Some(handle_watcher_runtime_handoff(
                         WatcherRuntimeHandoffContext {
                             shared_owned: &shared_owned,
                             provider: &provider,
@@ -558,29 +560,32 @@ pub(super) async fn handle_runtime_handoff_loop_message(
                             state_dirty: &mut state_dirty,
                             terminal_control_drain_until: &mut terminal_control_drain_until,
                         },
-                    );
+                    ));
                 }
                 RuntimeHandoff::ProcessBackend {
                     output_path,
                     session_name,
                     last_offset,
                 } => {
+                    let expected_identity =
+                        crate::services::discord::inflight::InflightTurnIdentity::from_state(
+                            inflight_state,
+                        );
                     tmux_last_offset = Some(last_offset);
                     inflight_state.runtime_kind = Some(RuntimeHandoffKind::ProcessBackend);
                     inflight_state.tmux_session_name = Some(session_name);
                     inflight_state.output_path = Some(output_path);
                     inflight_state.input_fifo_path = None;
                     inflight_state.last_offset = last_offset;
-                    state_dirty = true;
-                    // #2235: see CodexTui arm — durable stamp of
-                    // runtime_kind across a bridge-crash window.
-                    // #4259 PR-2a: kept BLIND (held-back ratchet row) — this
-                    // stamp rewrites identity-pinned `tmux_session_name` (plus
-                    // the ProcessBackend `output_path`); even the
-                    // `_allow_output_restamp` variant (codex r1) pins the
-                    // 4-field identity, so convert only after verifying the
-                    // session name is stable across the stamp.
-                    let _ = save_inflight_state(&inflight_state);
+                    let outcome = guarded_runtime_atomic_stamp(
+                        inflight_state,
+                        &expected_identity,
+                        channel_id,
+                        "turn_bridge::runtime_handoff_loop::runtime_ready_process_backend",
+                    );
+                    state_dirty =
+                        tmux_ready_state_dirty_after_guarded_save(state_dirty, Some(outcome));
+                    guarded_save_outcome = Some(outcome);
                     if done {
                         terminal_control_drain_until = None;
                     }
@@ -632,22 +637,24 @@ pub(super) async fn handle_runtime_handoff_loop_message(
             // Do NOT set tmux_handed_off: ProcessBackend has no watcher,
             // so the handoff cleanup path would delete the placeholder
             // with no one to send the final response.
+            let expected_identity =
+                crate::services::discord::inflight::InflightTurnIdentity::from_state(
+                    inflight_state,
+                );
             tmux_last_offset = Some(last_offset);
             inflight_state.runtime_kind = Some(RuntimeHandoffKind::ProcessBackend);
             inflight_state.tmux_session_name = Some(session_name);
             inflight_state.output_path = Some(output_path);
             inflight_state.input_fifo_path = None;
             inflight_state.last_offset = last_offset;
-            state_dirty = true;
-            // #2235: persist runtime_kind stamp immediately —
-            // ProcessBackend has no watcher so we want the
-            // on-disk row to reflect the new backend before
-            // any potential bridge crash.
-            // #4259 PR-2a: kept BLIND (held-back ratchet row) — rewrites
-            // identity-pinned `tmux_session_name` (plus `output_path`); even
-            // the `_allow_output_restamp` variant (codex r1) pins the 4-field
-            // identity, so convert only after verifying session-name stability.
-            let _ = save_inflight_state(&inflight_state);
+            let outcome = guarded_runtime_atomic_stamp(
+                inflight_state,
+                &expected_identity,
+                channel_id,
+                "turn_bridge::runtime_handoff_loop::process_ready",
+            );
+            state_dirty = tmux_ready_state_dirty_after_guarded_save(state_dirty, Some(outcome));
+            guarded_save_outcome = Some(outcome);
             if done {
                 terminal_control_drain_until = None;
             }
@@ -684,7 +691,7 @@ pub(super) async fn handle_runtime_handoff_loop_message(
 fn handle_watcher_runtime_handoff(
     ctx: WatcherRuntimeHandoffContext<'_>,
     state: WatcherRuntimeHandoffState<'_>,
-) {
+) -> crate::services::discord::inflight::GuardedSaveOutcome {
     let shared_owned = ctx.shared_owned;
     let provider = ctx.provider;
     let channel_id = ctx.channel_id;
@@ -704,6 +711,8 @@ fn handle_watcher_runtime_handoff(
     let watcher_owns_assistant_relay = state.watcher_owns_assistant_relay;
     let state_dirty = state.state_dirty;
     let terminal_control_drain_until = state.terminal_control_drain_until;
+    let expected_identity =
+        crate::services::discord::inflight::InflightTurnIdentity::from_state(inflight_state);
 
     *tmux_last_offset = Some(last_offset);
     inflight_state.runtime_kind = Some(runtime_kind);
@@ -723,33 +732,9 @@ fn handle_watcher_runtime_handoff(
     inflight_state.input_fifo_path = fifo_path;
     inflight_state.last_offset = last_offset;
     *state_dirty |= inflight_state.set_watcher_owner_channel_id(watcher_owner_channel_id.get());
-    // #2235 NOTE: we deliberately do NOT durably save the row here.
-    // `watcher_owns_live_relay` is still `false` at this point and only flips
-    // to `true` after the watcher is successfully claimed and spawned (the
-    // leader-branch path below). A save before that flag is set would leak a
-    // v8 row with the new handoff shape alongside `watcher_owns_live_relay =
-    // false`, which on restart would make the restored watcher yield to a
-    // phantom bridge owner (codex adversarial review on #2235). The
-    // existing branch-specific saves at the post-flag flip points plus the
-    // centralized `state_dirty` flush already cover the durable-stamp
-    // guarantee for watcher-owned RuntimeReady paths.
-    //
-    // #4259 PR-2a: the three branch-specific `save_inflight_state` calls in
-    // this helper (standby, leader-watcher spawn, and the
-    // `watcher_ready_for_relay` handoff) stay BLIND (held-back ratchet rows).
-    // This helper rewrites identity-pinned `tmux_session_name` from the
-    // handoff and serves ClaudeTui (transcript_path) / CodexTui (rollout_path)
-    // / recovery+rebind LegacyTmuxWrapper flows; the `_allow_output_restamp`
-    // variant (codex r1) tolerates only `output_path` drift, so converting
-    // these needs per-flow verification that the session name is stable (or an
-    // adoption-aware variant, cf. `save_existing_inflight_rebind_adoption_*`)
-    // plus the TmuxReady-arm-style outcome-conditional `state_dirty` handling.
-    //
-    // #2263: the standby branch is INTENTIONALLY not covered by this
-    // invariant — see the in-branch comment near the
-    // `*standby_relay_owns_output = true` assignment for why the flag
-    // stays `false` on standby and the trade-off vs duplicate delivery.
-
+    // Do not stamp before relay ownership is final: a runtime-shaped row with
+    // no durable relay owner would make a restored watcher yield incorrectly.
+    // R2 performs one field-scoped stamp below after the standby/watcher choice.
     // #226: Atomic claim via try_claim_watcher
     let cancel = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let paused = Arc::new(std::sync::atomic::AtomicBool::new(true));
@@ -891,7 +876,6 @@ fn handle_watcher_runtime_handoff(
                     // by `standby_relay_owns_output = true` above; that
                     // local flag is what gates the bridge's terminal
                     // delivery suppression for the current turn.
-                    let _ = save_inflight_state(inflight_state);
                 } else {
                     let ts = chrono::Local::now().format("%H:%M:%S");
                     tracing::warn!(
@@ -936,7 +920,6 @@ fn handle_watcher_runtime_handoff(
                     ),
                 );
                 *watcher_relay_available_for_turn = true;
-                let _ = save_inflight_state(inflight_state);
                 watcher_ready_for_relay = true;
             } else {
                 let ts = chrono::Local::now().format("%H:%M:%S");
@@ -958,7 +941,14 @@ fn handle_watcher_runtime_handoff(
         *tmux_handed_off = true;
         inflight_state.set_relay_owner_kind(super::inflight::RelayOwnerKind::Watcher);
         *watcher_owns_assistant_relay = true;
-        let _ = save_inflight_state(inflight_state);
+    }
+    let outcome = guarded_runtime_atomic_stamp(
+        inflight_state,
+        &expected_identity,
+        channel_id,
+        "turn_bridge::runtime_handoff_loop::watcher_runtime_owner_handoff",
+    );
+    if watcher_ready_for_relay {
         if let Some(watcher) = shared_owned.tmux_watchers.get(watcher_owner_channel_id) {
             *watcher_relay_available_for_turn = true;
             if let Ok(mut guard) = watcher.resume_offset.lock() {
@@ -991,8 +981,9 @@ fn handle_watcher_runtime_handoff(
                 .store(false, std::sync::atomic::Ordering::Release);
         }
     }
-    *state_dirty = true;
+    *state_dirty = tmux_ready_state_dirty_after_guarded_save(*state_dirty, Some(outcome));
     if done {
         *terminal_control_drain_until = None;
     }
+    outcome
 }

--- a/src/services/discord/turn_bridge/runtime_handoff_loop/guarded_save.rs
+++ b/src/services/discord/turn_bridge/runtime_handoff_loop/guarded_save.rs
@@ -49,6 +49,35 @@ pub(super) fn guarded_runtime_handoff_save(
     outcome
 }
 
+/// Identity-guarded atomic stamp for runtime handoffs that may first-populate
+/// `tmux_session_name`. The store validates the pre-mutation durable identity
+/// and authority under the sidecar lock, then patches only runtime/session/
+/// output/owner evidence. `Missing` never creates a row: every bridge entry
+/// path seeds or adopts the durable row before a runtime handoff can arrive.
+pub(super) fn guarded_runtime_atomic_stamp(
+    inflight_state: &InflightTurnState,
+    expected: &crate::services::discord::inflight::InflightTurnIdentity,
+    channel_id: ChannelId,
+    caller: &'static str,
+) -> crate::services::discord::inflight::GuardedSaveOutcome {
+    use crate::services::discord::inflight::{
+        GuardedSaveOutcome, stamp_runtime_handoff_if_matches_identity,
+    };
+    let outcome = stamp_runtime_handoff_if_matches_identity(inflight_state, expected, caller);
+    if matches!(
+        outcome,
+        GuardedSaveOutcome::Missing | GuardedSaveOutcome::IdentityMismatch
+    ) {
+        tracing::warn!(
+            channel_id = channel_id.get(),
+            caller,
+            ?outcome,
+            "runtime-handoff atomic stamp skipped; durable row no longer owned by this turn"
+        );
+    }
+    outcome
+}
+
 /// #4259 PR-2a (codex r1): the `TmuxReady` arm's dirty marking, made
 /// conditional on the guarded-save outcome. The arm used to end with an
 /// unconditional `state_dirty = true`, which re-queued the arm's mutations for

--- a/src/services/discord/turn_bridge/runtime_handoff_loop/tests.rs
+++ b/src/services/discord/turn_bridge/runtime_handoff_loop/tests.rs
@@ -1,0 +1,160 @@
+use super::*;
+use crate::services::discord::inflight::{
+    GuardedSaveOutcome, load_inflight_state, save_inflight_state,
+};
+
+fn runtime_seed(provider: ProviderKind, channel_id: u64) -> InflightTurnState {
+    InflightTurnState::new(
+        provider,
+        channel_id,
+        Some("adk-4259-r2".to_string()),
+        343_742_347_365_974_026,
+        77_010,
+        18,
+        "runtime handoff".to_string(),
+        Some("provider-session-before-handoff".to_string()),
+        None,
+        Some("/seeded/runtime-output.jsonl".to_string()),
+        None,
+        512,
+    )
+}
+
+async fn dispatch_process_handoff(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    state: &mut InflightTurnState,
+    message: RuntimeHandoffLoopMessage,
+    state_dirty: &mut bool,
+) -> RuntimeHandoffLoopOutcome {
+    let channel_id = ChannelId::new(state.channel_id);
+    let mut terminal_control_ready_observed = false;
+    let mut tmux_last_offset = None;
+    let mut watcher_owner_channel_id = channel_id;
+    let mut standby_relay_owns_output = false;
+    let mut watcher_relay_available_for_turn = false;
+    let mut watcher_handoff_claim_outcome = WatcherHandoffClaimOutcome::None;
+    let mut tmux_handed_off = false;
+    let mut watcher_owns_assistant_relay = false;
+    let mut terminal_control_drain_until = None;
+    let mut last_activity_heartbeat_at = None;
+
+    handle_runtime_handoff_loop_message(
+        message,
+        RuntimeHandoffLoopContext {
+            shared_owned: shared,
+            provider,
+            channel_id,
+            done: false,
+            adk_session_name: &None,
+        },
+        RuntimeHandoffLoopState {
+            terminal_control_ready_observed: &mut terminal_control_ready_observed,
+            tmux_last_offset: &mut tmux_last_offset,
+            inflight_state: state,
+            watcher_owner_channel_id: &mut watcher_owner_channel_id,
+            standby_relay_owns_output: &mut standby_relay_owns_output,
+            watcher_relay_available_for_turn: &mut watcher_relay_available_for_turn,
+            watcher_handoff_claim_outcome: &mut watcher_handoff_claim_outcome,
+            tmux_handed_off: &mut tmux_handed_off,
+            watcher_owns_assistant_relay: &mut watcher_owns_assistant_relay,
+            state_dirty,
+            terminal_control_drain_until: &mut terminal_control_drain_until,
+            last_activity_heartbeat_at: &mut last_activity_heartbeat_at,
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn process_runtime_ready_first_population_is_saved() {
+    let _lock = crate::config::shared_test_env_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    let root = tempfile::tempdir().expect("runtime root");
+    let _env_reset = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+        "AGENTDESK_ROOT_DIR",
+        root.path(),
+    );
+    let provider = ProviderKind::Codex;
+    let mut state = runtime_seed(provider.clone(), 42_592_601);
+    save_inflight_state(&state).expect("seed owner row");
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    let mut state_dirty = false;
+
+    let outcome = dispatch_process_handoff(
+        &shared,
+        &provider,
+        &mut state,
+        RuntimeHandoffLoopMessage::RuntimeReady {
+            handoff: RuntimeHandoff::ProcessBackend {
+                output_path: "/runtime/process-ready.jsonl".to_string(),
+                session_name: "process-session-r2".to_string(),
+                last_offset: 4096,
+            },
+        },
+        &mut state_dirty,
+    )
+    .await;
+
+    assert_eq!(outcome, Some(GuardedSaveOutcome::Saved));
+    assert!(
+        state_dirty,
+        "the existing dirty flag from watcher-owner normalization remains queued"
+    );
+    let persisted = load_inflight_state(&provider, state.channel_id).expect("persisted row");
+    assert_eq!(
+        persisted.runtime_kind,
+        Some(RuntimeHandoffKind::ProcessBackend)
+    );
+    assert_eq!(
+        persisted.tmux_session_name.as_deref(),
+        Some("process-session-r2")
+    );
+    assert_eq!(persisted.last_offset, 4096);
+}
+
+#[tokio::test]
+async fn process_ready_skips_reowned_row_and_does_not_queue_stale_flush() {
+    let _lock = crate::config::shared_test_env_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    let root = tempfile::tempdir().expect("runtime root");
+    let _env_reset = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+        "AGENTDESK_ROOT_DIR",
+        root.path(),
+    );
+    let provider = ProviderKind::Claude;
+    let mut state = runtime_seed(provider.clone(), 42_592_602);
+    let mut newer = state.clone();
+    newer.user_msg_id = 99_999;
+    newer.output_path = Some("/runtime/newer-turn.jsonl".to_string());
+    save_inflight_state(&newer).expect("seed re-owned row");
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    let mut state_dirty = false;
+
+    let outcome = dispatch_process_handoff(
+        &shared,
+        &provider,
+        &mut state,
+        RuntimeHandoffLoopMessage::ProcessReady {
+            output_path: "/runtime/stale-process.jsonl".to_string(),
+            session_name: "stale-process-session".to_string(),
+            last_offset: 8192,
+        },
+        &mut state_dirty,
+    )
+    .await;
+
+    assert_eq!(outcome, Some(GuardedSaveOutcome::IdentityMismatch));
+    assert!(
+        !state_dirty,
+        "a stale handoff must not queue a later whole-row flush"
+    );
+    let persisted = load_inflight_state(&provider, state.channel_id).expect("preserved row");
+    assert_eq!(persisted.user_msg_id, 99_999);
+    assert_eq!(
+        persisted.output_path.as_deref(),
+        Some("/runtime/newer-turn.jsonl")
+    );
+}


### PR DESCRIPTION
## Summary
- add a locked, field-scoped runtime-handoff stamp that validates pre-mutation turn identity and restart/rebind authority before updating runtime/session/output/owner evidence
- convert all five R2 blind-save sites: `RuntimeReady::ProcessBackend`, `ProcessReady`, and the shared watcher-handoff standby, watcher-spawn, and watcher-handoff saves
- collapse the shared watcher helper to one final-owner transaction before watcher unpause and apply outcome-conditional dirty handling
- lower the blind-save ratchet from 8 to 3 without touching R3, R4, R5, `turn_bridge/mod.rs`, or the finalizer/abandon/recovery lanes

## Converted sites
1. `RuntimeHandoff::ProcessBackend` in `RuntimeReady`
2. `RuntimeHandoffLoopMessage::ProcessReady`
3. watcher helper standby relay durable stamp
4. watcher helper leader spawn durable stamp
5. watcher helper final watcher handoff durable stamp

`ClaudeTui` and `CodexTui` flow through the shared watcher helper; first population and same-session restamp are covered by the new field-scoped stamp tests. The already-guarded `ClaudeEAdapter` path remains unchanged.

## Identity and authority behavior
- capture `InflightTurnIdentity` before handoff mutations
- permit first population only when the durable row still matches the pre-mutation identity
- permit same-session restamps but reject changed established session names
- fail closed for offsetless id-0, restart-mode, rebind-origin, and concurrent re-owner rows
- patch only `runtime_kind`, session/output/FIFO fields, provider session id, offset, watcher-owner channel, and relay owner under the sidecar lock

## Missing semantics
The stamp returns `Missing` and never creates a row. Normal intake/headless paths create the inflight row before `spawn_turn_bridge`; recovery starts from an existing loaded row; TUI-direct synthetic paths claim with create-if-absent/guarded persistence before the bridge starts. Therefore runtime handoff is not a legitimate first-row creator, and `Missing` means lifecycle ownership was cleared rather than an initialization opportunity. Regression coverage verifies no row resurrection.

## Verification
All commands ran under the shared build token with `set -euo pipefail`; every reported rc is the command rc.

- `cargo fmt --all` — rc 0
- `cargo fmt --all -- --check` — rc 0
- `cargo check --lib` — rc 0
- `cargo test --lib turn_bridge` — rc 0, 321 passed
- `cargo test --lib inflight` — rc 0, 391 passed
- `python3 scripts/check_inflight_blind_save_ratchet.py` — rc 0, 3 sites / baseline 3
- `python3 tests/test_inflight_blind_save_ratchet.py` — rc 0, 13 passed
- `python3 scripts/generate_inventory_docs.py` — rc 0
- `python3 scripts/check_agent_maintenance_docs.py` — rc 0

## Rollback
Revert this PR and restore the ratchet baseline from 3 to 8. No state format or schema migration is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)