### PR TITLE
fix(#4259): R3 guard stream-loop blind saves

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -535,7 +535,8 @@ src/
 │   │   │   │   ├── identity_gate/
 │   │   │   │   │   ├── claude_e_stamp.rs
 │   │   │   │   │   ├── heartbeat.rs
-│   │   │   │   │   └── runtime_stamp.rs
+│   │   │   │   │   ├── runtime_stamp.rs
+│   │   │   │   │   └── stream_loop_patch.rs
 │   │   │   │   ├── delivery_rewind.rs
 │   │   │   │   ├── identity_gate.rs
 │   │   │   │   ├── post_loop_identity_guard_tests.rs

--- a/scripts/check_inflight_blind_save_ratchet.py
+++ b/scripts/check_inflight_blind_save_ratchet.py
@@ -54,20 +54,19 @@ from pathlib import Path
 #
 # #4259 PR-1 baseline = 29; PR-2a lowered to 26; #4596 lowered to 25;
 # post-loop-finalize lowered to 21; external writers lowered to 13; R1 stream
-# tick lowered to 8; R2 runtime-handoff atomic stamps lower to 3. Remaining:
+# tick lowered to 8; R2 runtime-handoff atomic stamps lower to 3; R3 stream-loop
+# terminal/cancel patches lower to 1. Remaining:
 #   turn_bridge/runtime_handoff_loop.rs .. 0  (R2 field-scoped locked stamp)
 #   turn_bridge/stream_tick.rs .......... 0  (R1)
-#   turn_bridge/stream_loop.rs .......... 2  (R3)
+#   turn_bridge/stream_loop.rs .......... 0  (R3 narrow locked patches)
 #   turn_bridge/post_loop_finalize.rs ... 0
 #   turn_bridge/mod.rs (hotfile, solo) .. 1  (R4)
 #   external (router/session/tui) ....... 0
 #
-# R2 converts RuntimeReady ProcessBackend, ProcessReady, and the shared watcher
-# handoff's standby/spawn/handoff saves. The store-side locked RMW accepts a
-# first `tmux_session_name` population only after the pre-mutation durable
-# identity and authority match, pins an established session against changes,
-# and patches only runtime/session/output/owner evidence.
-BASELINE = 3
+# R3 converts cancel restart-mode sync and Done placeholder clearing to narrow
+# identity/authority-checked locked patches, so neither path can overwrite or
+# recreate a row owned by a newer turn.
+BASELINE = 1
 
 SCAN_ROOT = Path("src") / "services" / "discord"
 

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -141,8 +141,9 @@ pub(super) use self::save_store::{
 };
 pub(in crate::services::discord) use self::save_store::{
     GuardedSaveOutcome, bind_recovery_anchor_if_matches_identity,
+    clear_long_running_placeholder_if_matches_identity,
     mark_readopted_from_inflight_if_identity_unchanged,
-    patch_restart_full_response_if_identity_unchanged,
+    patch_restart_full_response_if_identity_unchanged, patch_restart_mode_if_matches_identity,
     persist_leak_recovery_response_offset_if_matches_identity_locked,
     persist_recovery_output_path_if_matches_identity_locked,
     recovery_anchor_msg_id_if_matches_identity,

--- a/src/services/discord/inflight/save_store.rs
+++ b/src/services/discord/inflight/save_store.rs
@@ -23,8 +23,9 @@ mod rebind_adoption;
 pub(in crate::services::discord) use self::delivery_rewind::save_inflight_delivery_rewind_if_matches_identity;
 pub(in crate::services::discord) use self::identity_gate::{
     GuardedSaveOutcome, bind_recovery_anchor_if_matches_identity,
+    clear_long_running_placeholder_if_matches_identity,
     mark_readopted_from_inflight_if_identity_unchanged,
-    patch_restart_full_response_if_identity_unchanged,
+    patch_restart_full_response_if_identity_unchanged, patch_restart_mode_if_matches_identity,
     persist_leak_recovery_response_offset_if_matches_identity_locked,
     persist_recovery_output_path_if_matches_identity_locked,
     recovery_anchor_msg_id_if_matches_identity,

--- a/src/services/discord/inflight/save_store/identity_gate.rs
+++ b/src/services/discord/inflight/save_store/identity_gate.rs
@@ -5,9 +5,14 @@ mod claude_e_stamp;
 mod heartbeat;
 #[path = "identity_gate/runtime_stamp.rs"]
 mod runtime_stamp;
+#[path = "identity_gate/stream_loop_patch.rs"]
+mod stream_loop_patch;
 pub(in crate::services::discord) use claude_e_stamp::stamp_claude_e_process_if_matches_identity;
 pub(in crate::services::discord) use heartbeat::touch_inflight_state_if_matches_identity;
 pub(in crate::services::discord) use runtime_stamp::stamp_runtime_handoff_if_matches_identity;
+pub(in crate::services::discord) use stream_loop_patch::{
+    clear_long_running_placeholder_if_matches_identity, patch_restart_mode_if_matches_identity,
+};
 
 pub(in crate::services::discord) fn save_inflight_state_if_identity_unchanged(
     state: &InflightTurnState,

--- a/src/services/discord/inflight/save_store/identity_gate/stream_loop_patch.rs
+++ b/src/services/discord/inflight/save_store/identity_gate/stream_loop_patch.rs
@@ -1,0 +1,359 @@
+use super::*;
+
+pub(in crate::services::discord) fn patch_restart_mode_if_matches_identity(
+    state: &InflightTurnState,
+    expected: &InflightTurnIdentity,
+    previous_restart_mode: Option<InflightRestartMode>,
+    previous_restart_generation: Option<u64>,
+    caller: &'static str,
+) -> GuardedSaveOutcome {
+    let Some(root) = inflight_runtime_root() else {
+        return GuardedSaveOutcome::IoError;
+    };
+    patch_restart_mode_if_matches_identity_in_root(
+        &root,
+        state,
+        expected,
+        previous_restart_mode,
+        previous_restart_generation,
+        caller,
+    )
+}
+
+fn patch_restart_mode_if_matches_identity_in_root(
+    root: &Path,
+    state: &InflightTurnState,
+    expected: &InflightTurnIdentity,
+    previous_restart_mode: Option<InflightRestartMode>,
+    previous_restart_generation: Option<u64>,
+    caller: &'static str,
+) -> GuardedSaveOutcome {
+    let Some(provider) = state.provider_kind() else {
+        return GuardedSaveOutcome::IoError;
+    };
+    if state.restart_mode.is_some() != state.restart_generation.is_some()
+        || previous_restart_mode.is_some() != previous_restart_generation.is_some()
+    {
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+    let path = inflight_state_path(root, &provider, state.channel_id);
+    let Ok(_lock) = lock_inflight_state_path(&path) else {
+        return GuardedSaveOutcome::IoError;
+    };
+    let Some(mut on_disk) = load_inflight_state_unlocked(&path) else {
+        return GuardedSaveOutcome::Missing;
+    };
+    let durable = InflightTurnIdentity::from_state(&on_disk);
+    if expected.user_msg_id == 0 && expected.turn_start_offset.is_none() {
+        tracing::info!(
+            provider = %provider.as_str(),
+            channel_id = state.channel_id,
+            caller,
+            snapshot_identity = ?expected,
+            durable_identity = ?durable,
+            "stream-loop restart-mode patch skipped because offsetless id-0 snapshot cannot safely match a durable row"
+        );
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+    if on_disk.rebind_origin
+        || !expected.matches_state(&on_disk)
+        || on_disk.restart_mode != previous_restart_mode
+        || on_disk.restart_generation != previous_restart_generation
+    {
+        tracing::info!(
+            provider = %provider.as_str(),
+            channel_id = state.channel_id,
+            caller,
+            snapshot_identity = ?expected,
+            durable_identity = ?durable,
+            expected_restart_mode = ?previous_restart_mode,
+            durable_restart_mode = ?on_disk.restart_mode,
+            expected_restart_generation = ?previous_restart_generation,
+            durable_restart_generation = ?on_disk.restart_generation,
+            durable_rebind_origin = on_disk.rebind_origin,
+            "stream-loop restart-mode patch skipped because durable row identity or authority changed"
+        );
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+
+    on_disk.restart_mode = state.restart_mode;
+    on_disk.restart_generation = state.restart_generation;
+    match persist_under_lock(
+        root,
+        &path,
+        &on_disk,
+        "src/services/discord/inflight/save_store/identity_gate/stream_loop_patch.rs:patch_restart_mode_if_matches_identity_in_root",
+    ) {
+        Ok(()) => GuardedSaveOutcome::Saved,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel_id = state.channel_id,
+                caller,
+                error = %error,
+                "stream-loop restart-mode patch failed; leaving durable row untouched"
+            );
+            GuardedSaveOutcome::IoError
+        }
+    }
+}
+
+pub(in crate::services::discord) fn clear_long_running_placeholder_if_matches_identity(
+    provider: &ProviderKind,
+    channel_id: u64,
+    expected: &InflightTurnIdentity,
+    caller: &'static str,
+) -> GuardedSaveOutcome {
+    let Some(root) = inflight_runtime_root() else {
+        return GuardedSaveOutcome::IoError;
+    };
+    clear_long_running_placeholder_if_matches_identity_in_root(
+        &root, provider, channel_id, expected, caller,
+    )
+}
+
+fn clear_long_running_placeholder_if_matches_identity_in_root(
+    root: &Path,
+    provider: &ProviderKind,
+    channel_id: u64,
+    expected: &InflightTurnIdentity,
+    caller: &'static str,
+) -> GuardedSaveOutcome {
+    let path = inflight_state_path(root, provider, channel_id);
+    let Ok(_lock) = lock_inflight_state_path(&path) else {
+        return GuardedSaveOutcome::IoError;
+    };
+    let Some(mut on_disk) = load_inflight_state_unlocked(&path) else {
+        return GuardedSaveOutcome::Missing;
+    };
+    let durable = InflightTurnIdentity::from_state(&on_disk);
+    if expected.user_msg_id == 0 && expected.turn_start_offset.is_none() {
+        tracing::info!(
+            provider = %provider.as_str(),
+            channel_id,
+            caller,
+            snapshot_identity = ?expected,
+            durable_identity = ?durable,
+            "stream-loop placeholder patch skipped because offsetless id-0 snapshot cannot safely match a durable row"
+        );
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+    if on_disk.restart_mode.is_some() || on_disk.rebind_origin || !expected.matches_state(&on_disk)
+    {
+        tracing::info!(
+            provider = %provider.as_str(),
+            channel_id,
+            caller,
+            snapshot_identity = ?expected,
+            durable_identity = ?durable,
+            durable_restart_mode = ?on_disk.restart_mode,
+            durable_rebind_origin = on_disk.rebind_origin,
+            "stream-loop placeholder patch skipped because durable row identity or authority changed"
+        );
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+
+    on_disk.long_running_placeholder_active = false;
+    match persist_under_lock(
+        root,
+        &path,
+        &on_disk,
+        "src/services/discord/inflight/save_store/identity_gate/stream_loop_patch.rs:clear_long_running_placeholder_if_matches_identity_in_root",
+    ) {
+        Ok(()) => GuardedSaveOutcome::Saved,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel_id,
+                caller,
+                error = %error,
+                "stream-loop placeholder patch failed; leaving durable row untouched"
+            );
+            GuardedSaveOutcome::IoError
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn owner_state(channel_id: u64, user_msg_id: u64) -> InflightTurnState {
+        InflightTurnState::new(
+            ProviderKind::Codex,
+            channel_id,
+            Some("adk-4259-r3".to_string()),
+            343_742_347_365_974_026,
+            user_msg_id,
+            18,
+            "stream loop patch".to_string(),
+            Some("provider-session".to_string()),
+            Some("AgentDesk-codex-4259-r3".to_string()),
+            Some("/runtime/4259-r3.jsonl".to_string()),
+            Some("/runtime/4259-r3.input".to_string()),
+            512,
+        )
+    }
+
+    fn load(root: &Path, provider: &ProviderKind, channel_id: u64) -> InflightTurnState {
+        let path = inflight_state_path(root, provider, channel_id);
+        serde_json::from_str(&std::fs::read_to_string(path).expect("read inflight row"))
+            .expect("parse inflight row")
+    }
+
+    #[test]
+    fn cancel_restart_patch_first_populates_same_owner_without_rewriting_other_fields() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let channel_id = 42_593_100;
+        let owner = owner_state(channel_id, 77_010);
+        save_inflight_state_in_root(root.path(), &owner).expect("seed owner row");
+        let expected = InflightTurnIdentity::from_state(&owner);
+
+        let mut cancelled = owner.clone();
+        cancelled.full_response = "stale in-memory response".to_string();
+        cancelled.set_restart_mode(InflightRestartMode::DrainRestart);
+        assert_eq!(
+            patch_restart_mode_if_matches_identity_in_root(
+                root.path(),
+                &cancelled,
+                &expected,
+                None,
+                None,
+                "test::cancel_restart_first_populate",
+            ),
+            GuardedSaveOutcome::Saved,
+        );
+
+        let persisted = load(root.path(), &ProviderKind::Codex, channel_id);
+        assert_eq!(
+            persisted.restart_mode,
+            Some(InflightRestartMode::DrainRestart)
+        );
+        assert_eq!(persisted.restart_generation, cancelled.restart_generation);
+        assert!(persisted.full_response.is_empty());
+    }
+
+    #[test]
+    fn cancel_restart_patch_rejects_reowner_and_changed_restart_authority() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let channel_id = 42_593_101;
+        let owner = owner_state(channel_id, 77_010);
+        let expected = InflightTurnIdentity::from_state(&owner);
+        let mut cancelled = owner.clone();
+        cancelled.set_restart_mode(InflightRestartMode::DrainRestart);
+
+        let mut successor = owner_state(channel_id, 99_999);
+        successor.full_response = "new owner".to_string();
+        save_inflight_state_in_root(root.path(), &successor).expect("seed successor row");
+        assert_eq!(
+            patch_restart_mode_if_matches_identity_in_root(
+                root.path(),
+                &cancelled,
+                &expected,
+                None,
+                None,
+                "test::cancel_restart_reowner",
+            ),
+            GuardedSaveOutcome::IdentityMismatch,
+        );
+        assert_eq!(
+            load(root.path(), &ProviderKind::Codex, channel_id).user_msg_id,
+            99_999
+        );
+
+        successor = owner.clone();
+        successor.set_restart_mode(InflightRestartMode::HotSwapHandoff);
+        save_inflight_state_in_root(root.path(), &successor).expect("seed changed authority");
+        assert_eq!(
+            patch_restart_mode_if_matches_identity_in_root(
+                root.path(),
+                &cancelled,
+                &expected,
+                None,
+                None,
+                "test::cancel_restart_authority",
+            ),
+            GuardedSaveOutcome::IdentityMismatch,
+        );
+        assert_eq!(
+            load(root.path(), &ProviderKind::Codex, channel_id).restart_mode,
+            Some(InflightRestartMode::HotSwapHandoff),
+        );
+    }
+
+    #[test]
+    fn stream_loop_patches_never_create_missing_rows() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let channel_id = 42_593_102;
+        let owner = owner_state(channel_id, 77_010);
+        let expected = InflightTurnIdentity::from_state(&owner);
+        let mut cancelled = owner.clone();
+        cancelled.set_restart_mode(InflightRestartMode::DrainRestart);
+
+        assert_eq!(
+            patch_restart_mode_if_matches_identity_in_root(
+                root.path(),
+                &cancelled,
+                &expected,
+                None,
+                None,
+                "test::cancel_restart_missing",
+            ),
+            GuardedSaveOutcome::Missing,
+        );
+        assert_eq!(
+            clear_long_running_placeholder_if_matches_identity_in_root(
+                root.path(),
+                &ProviderKind::Codex,
+                channel_id,
+                &expected,
+                "test::placeholder_missing",
+            ),
+            GuardedSaveOutcome::Missing,
+        );
+        assert!(!inflight_state_path(root.path(), &ProviderKind::Codex, channel_id).exists());
+    }
+
+    #[test]
+    fn done_placeholder_patch_clears_same_owner_but_preserves_reowner() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let channel_id = 42_593_103;
+        let mut owner = owner_state(channel_id, 77_010);
+        owner.long_running_placeholder_active = true;
+        save_inflight_state_in_root(root.path(), &owner).expect("seed owner row");
+        let expected = InflightTurnIdentity::from_state(&owner);
+
+        assert_eq!(
+            clear_long_running_placeholder_if_matches_identity_in_root(
+                root.path(),
+                &ProviderKind::Codex,
+                channel_id,
+                &expected,
+                "test::placeholder_same_owner",
+            ),
+            GuardedSaveOutcome::Saved,
+        );
+        assert!(
+            !load(root.path(), &ProviderKind::Codex, channel_id).long_running_placeholder_active
+        );
+
+        let mut successor = owner_state(channel_id, 99_999);
+        successor.long_running_placeholder_active = true;
+        successor.full_response = "new owner".to_string();
+        save_inflight_state_in_root(root.path(), &successor).expect("seed successor row");
+        assert_eq!(
+            clear_long_running_placeholder_if_matches_identity_in_root(
+                root.path(),
+                &ProviderKind::Codex,
+                channel_id,
+                &expected,
+                "test::placeholder_reowner",
+            ),
+            GuardedSaveOutcome::IdentityMismatch,
+        );
+        let persisted = load(root.path(), &ProviderKind::Codex, channel_id);
+        assert_eq!(persisted.user_msg_id, 99_999);
+        assert!(persisted.long_running_placeholder_active);
+        assert_eq!(persisted.full_response, "new owner");
+    }
+}

--- a/src/services/discord/turn_bridge/stream_loop.rs
+++ b/src/services/discord/turn_bridge/stream_loop.rs
@@ -237,6 +237,8 @@ pub(super) async fn run_stream_loop(
     let mut last_status_panel_edit = *state.last_status_panel_edit;
     let mut bridge_spans = *state.bridge_spans;
     let mut status_panel_generation = *state.status_panel_generation;
+    let mut stream_tick_expected_identity =
+        crate::services::discord::inflight::InflightTurnIdentity::from_state(&inflight_state);
 
     // #2289 cancel finalization helper. Both the pre-`try_recv` guard
     // and the post-`try_recv` re-sample funnel through this so the
@@ -250,8 +252,22 @@ pub(super) async fn run_stream_loop(
     // boundary) so the loop exits to the cancel post-processing path.
     macro_rules! finalize_cancel_inner {
         () => {{
+            let previous_restart_mode = inflight_state.restart_mode;
+            let previous_restart_generation = inflight_state.restart_generation;
             if sync_inflight_restart_mode_from_cancel(cancel_token.as_ref(), &mut inflight_state) {
-                let _ = save_inflight_state(&inflight_state);
+                let outcome =
+                    crate::services::discord::inflight::patch_restart_mode_if_matches_identity(
+                        &inflight_state,
+                        &stream_tick_expected_identity,
+                        previous_restart_mode,
+                        previous_restart_generation,
+                        "turn_bridge::stream_loop::cancel_restart_mode",
+                    );
+                refresh_stream_tick_expected_identity_after_handoff(
+                    &mut stream_tick_expected_identity,
+                    &inflight_state,
+                    Some(outcome),
+                );
             }
             cancelled = true;
             close_all_tracked_background_children(
@@ -266,12 +282,6 @@ pub(super) async fn run_stream_loop(
 
     let mut pending_long_running_open_after_state_save = None;
     let mut pending_long_running_retarget_after_state_save = None;
-    // The periodic flush must remain bound to the owner that entered this
-    // stream loop. Runtime handoff may mutate identity-bearing cursor fields
-    // before a later tick, so deriving expected identity inside the tick would
-    // authorize a mutated stale snapshot rather than the original owner.
-    let mut stream_tick_expected_identity =
-        crate::services::discord::inflight::InflightTurnIdentity::from_state(&inflight_state);
 
     'outer: while !done
         || terminal_control_drain_until.is_some_and(|deadline| std::time::Instant::now() < deadline)
@@ -409,6 +419,7 @@ pub(super) async fn run_stream_loop(
                                     gateway: &gateway,
                                     channel_id,
                                     provider: &provider,
+                                    expected_identity: &stream_tick_expected_identity,
                                     voice_progress_playback_channel_id,
                                     watcher_owns_assistant_relay,
                                     watcher_relay_available_for_turn,

--- a/src/services/discord/turn_bridge/stream_loop.rs
+++ b/src/services/discord/turn_bridge/stream_loop.rs
@@ -240,16 +240,8 @@ pub(super) async fn run_stream_loop(
     let mut stream_tick_expected_identity =
         crate::services::discord::inflight::InflightTurnIdentity::from_state(&inflight_state);
 
-    // #2289 cancel finalization helper. Both the pre-`try_recv` guard
-    // and the post-`try_recv` re-sample funnel through this so the
-    // cancellation bookkeeping (inflight sync, `cancelled = true`,
-    // background-child abort) stays in lock step and cannot drift.
-    // Implemented as a macro so it can mutate locals owned by the
-    // surrounding `while` body without moving them into a closure that
-    // would conflict with `&mut` borrows held elsewhere. The macro
-    // performs the bookkeeping; callers must follow with `break 'outer`
-    // (or be in a position where falling through hits the outer loop
-    // boundary) so the loop exits to the cancel post-processing path.
+    // #2289: both cancel guards share this macro to keep inflight sync, cancellation, and child abort atomic without closure borrow conflicts.
+    // Callers must then exit `'outer` (explicitly or by fallthrough) into cancel post-processing.
     macro_rules! finalize_cancel_inner {
         () => {{
             let previous_restart_mode = inflight_state.restart_mode;

--- a/src/services/discord/turn_bridge/stream_loop/content_arms.rs
+++ b/src/services/discord/turn_bridge/stream_loop/content_arms.rs
@@ -303,10 +303,7 @@ pub(super) async fn handle_stream_content_message(
                                         "turn_bridge::stream_loop::done_pending_placeholder_clear",
                                     );
                             }
-                            // #1255: turn finished while a long-running placeholder
-                            // is still Active — close it now so the user does not
-                            // stare at a stale 🔄 card. Idempotent if a prior
-                            // ToolResult already fired Completed.
+                            // #1255: close an Active long-run card at turn finish; idempotent after ToolResult completion.
                             if let Some((key, snapshot, close_trigger, ack_consumed)) =
                                 long_running_placeholder_active.take()
                             {
@@ -331,12 +328,7 @@ pub(super) async fn handle_stream_content_message(
                                         .placeholder_controller
                                         .transition(gateway.as_ref(), key.clone(), target)
                                         .await;
-                                    // codex round-10/11 P2/P3: on `EditFailed`,
-                                    // re-stash the tuple so subsequent
-                                    // streaming/sweeper paths can retry the
-                                    // terminal edit. Only clear the persisted
-                                    // flag on a committed (or already-terminal)
-                                    // transition.
+                                    // Re-stash `EditFailed` for streaming/sweeper retry; clear the flag only after a committed/already-terminal transition.
                                     use super::super::super::placeholder_controller::PlaceholderControllerOutcome::*;
                                     if matches!(outcome, Edited | Coalesced | AlreadyTerminal) {
                                         inflight_state.long_running_placeholder_active = false;

--- a/src/services/discord/turn_bridge/stream_loop/content_arms.rs
+++ b/src/services/discord/turn_bridge/stream_loop/content_arms.rs
@@ -39,6 +39,7 @@ pub(super) async fn handle_stream_content_message(
     let gateway = Arc::clone(ctx.gateway);
     let channel_id = ctx.channel_id;
     let provider = ctx.provider.clone();
+    let expected_identity = ctx.expected_identity;
     let voice_progress_playback_channel_id = ctx.voice_progress_playback_channel_id;
     let watcher_owns_assistant_relay = ctx.watcher_owns_assistant_relay;
     let watcher_relay_available_for_turn = ctx.watcher_relay_available_for_turn;
@@ -294,7 +295,13 @@ pub(super) async fn handle_stream_content_message(
                             }
                             if pending_long_running_open_after_state_save.take().is_some() {
                                 inflight_state.long_running_placeholder_active = false;
-                                let _ = save_inflight_state(inflight_state);
+                                let _ = crate::services::discord::inflight::
+                                    clear_long_running_placeholder_if_matches_identity(
+                                        &provider,
+                                        channel_id.get(),
+                                        expected_identity,
+                                        "turn_bridge::stream_loop::done_pending_placeholder_clear",
+                                    );
                             }
                             // #1255: turn finished while a long-running placeholder
                             // is still Active — close it now so the user does not

--- a/src/services/discord/turn_bridge/stream_loop/content_arms/types.rs
+++ b/src/services/discord/turn_bridge/stream_loop/content_arms/types.rs
@@ -48,6 +48,8 @@ pub(in super::super) struct StreamContentArmContext<'a> {
     pub(in super::super) gateway: &'a Arc<dyn TurnGateway>,
     pub(in super::super) channel_id: ChannelId,
     pub(in super::super) provider: &'a ProviderKind,
+    pub(in super::super) expected_identity:
+        &'a crate::services::discord::inflight::InflightTurnIdentity,
     pub(in super::super) voice_progress_playback_channel_id: Option<ChannelId>,
     pub(in super::super) watcher_owns_assistant_relay: bool,
     pub(in super::super) watcher_relay_available_for_turn: bool,


### PR DESCRIPTION
## Summary

- complete #4259 R3 by replacing the stream-loop cancel and Done-path blind whole-row saves with locked identity-guarded field patches
- lower the production blind-save ratchet from 3 to 1; the sole remaining caller is the R4-owned `turn_bridge/mod.rs` site
- add same-owner, re-owner, authority-change, and missing-row regressions for both patches

## Site decisions

1. **Cancel restart-mode sync — field-scoped patch.** The cancel macro mutates only `restart_mode` and `restart_generation`. `patch_restart_mode_if_matches_identity` locks and reloads the row, checks the pre-mutation stream-loop identity plus the exact previous restart authority, rejects rebind/id-0 ambiguity, and writes only those two fields. A whole-row guarded save would grant the stale stream snapshot unnecessary authority over unrelated relay/output fields.
2. **Done pending-placeholder clear — field-scoped patch.** This site only consumes a pending-open marker and clears `long_running_placeholder_active`. `clear_long_running_placeholder_if_matches_identity` locks and reloads the existing row, requires the current stream-loop identity and ordinary non-restart/non-rebind authority, and writes only the placeholder bit. The site is not a row creator: the pending marker is produced only after the stream-tick guarded persistence path, so `Missing` is a terminal no-op and must not recreate the row.

The stream-loop expected identity already refreshed after successful runtime handoff stamps is reused for both sites. The cancel patch refreshes that same expected identity only on `Saved`, matching the R1 handoff pattern. `turn_bridge/mod.rs`, `stream_tick.rs`, and the other active campaign surfaces are untouched.

## Verification

All commands ran under the shared build token with `set -o pipefail`:

- `cargo fmt --all` — rc=0
- `cargo fmt --all --check` — rc=0
- `cargo check --lib` — rc=0
- `cargo test --lib turn_bridge` — rc=0, 321 passed
- `cargo test --lib inflight` — rc=0, 396 passed
- `python3 scripts/check_inflight_blind_save_ratchet.py` — rc=0, baseline/count 1
- `python3 scripts/generate_inventory_docs.py` — rc=0
- `python3 scripts/check_agent_maintenance_docs.py` — rc=0

Closes the R3 decomposition item of #4259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)