### PR TITLE
test(discord): fix main-red placeholder suppression footer expectation

### DIFF
--- a/src/services/discord/tmux_placeholder_suppression/mod.rs
+++ b/src/services/discord/tmux_placeholder_suppression/mod.rs
@@ -358,7 +358,7 @@ mod placeholder_suppression_tests {
             "🟢 진행 중\n턴 트리거: https://discord.com/channels/1/2/3\n턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)\n마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)\n\nTools\n└ cargo test --lib tmux\nSubagents\n└ review inspect\n{long_tail}"
         );
         let status_block = discord::single_message_panel::compose_footer_status_block("⠋", &panel);
-        assert!(status_block.starts_with("⠋ 진행 중"));
+        assert!(status_block.starts_with("-# ⠋ 진행 중"));
         assert!(status_block.contains("마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)"));
         assert!(status_block.contains("Tools"));
         assert!(status_block.contains("Subagents"));


### PR DESCRIPTION
main push CI red 즉시 대응 (#4835 이후 규율).

**원인**: #4826이 completion footer 헤더에 `-# ` (Discord small-text) 접두를 의도적으로 추가하며 `single_message_panel` 자체 테스트는 갱신했으나 `tmux_placeholder_suppression`의 `footer_status_block()` 헬퍼 기대값(`starts_with("⠋ 진행 중")`)을 누락 → main full 스위트에서 `task_notification_*_exposed_body_preserves` 4건 실패 (CI Main run 30035812712). PR targeted lane에는 이 테스트가 없어 사전 검출 불가(의도된 #4835 트레이드오프).

**수정**: 테스트 헬퍼 기대값 1줄을 `-# ⠋ 진행 중`으로 정렬. 프로덕션 무변경. 인근 negative assertion(`!contains("진행 중 — Claude")`)은 접두와 무관하게 유효 확인.

**검증**: `cargo fmt --check` 클린, `cargo test --lib placeholder_suppression` 42 passed.

test-only 선례에 따라 Anthropic 단독 판정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)