### PR TITLE
fix(#4488): recover two-message panels after restart

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -644,7 +644,9 @@ src/
 │   │   │   ├── status_panel.rs
 │   │   │   ├── status_panel_completion_producer.rs
 │   │   │   ├── terminal_text_idempotency.rs
-│   │   │   └── terminal_watcher.rs
+│   │   │   ├── terminal_watcher.rs
+│   │   │   ├── tmux_probe.rs
+│   │   │   └── two_message_panel.rs
 │   │   ├── recovery_paths/
 │   │   │   ├── controller_cutover.rs
 │   │   │   ├── mod.rs

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -655,6 +655,18 @@
   fire-and-forget session banner (`session_banner.rs`) is untouched. Delete
   failures fall back to the existing durable status-panel orphan store (also
   worker-local). OFF path is byte-identical.
+- #4488 two-message restart recovery + E2E: the restart inflight scan delegates
+  panel repair to `recovery_engine/two_message_panel.rs` before watcher/bridge
+  reattachment. The helper treats Discord message existence and snowflake order
+  only as repair evidence, then authorizes the replacement exclusively through
+  the existing full `InflightTurnIdentity` CAS and in-lock generation bump. A
+  just-sent panel is pre-registered in the worker-local orphan store, a bind loser
+  deletes or queues only its own duplicate, and an old live panel is retired only
+  after the same episode durably owns the replacement. The #4830 process-local
+  cache invalidation epoch is intentionally not copied across restart or panel
+  identities; the new panel starts uncached, while terminal reconcile remains
+  keyed to the rebound panel generation. No PG lease, leader gate, schema field,
+  or cross-node authority is added. The default-OFF flag remains unchanged.
 - #3038 (b) early TUI completion gate extraction: `turn_bridge/mod.rs` moved the
   #2293/#2780 early TUI quiescence gate (the eligibility filter + bounded
   `run_tui_completion_gate` probe + timed-out warning that compute

--- a/scripts/e2e/run_tui_relay.py
+++ b/scripts/e2e/run_tui_relay.py
@@ -3754,15 +3754,15 @@ def run_assertion(
             window,
             body_marker=str(params["body_marker"]),
             panel_regex=str(
-                params.get("panel_regex", r"Processing\.\.\.|진행 중|^🟢|^📦")
+                params.get("panel_regex", r"Processing\.\.\.|진행 중|응답 완료|^🟢|^✅|^🔴|^📦")
             ),
         )
     elif "single_status_panel" in spec:
         params = spec["single_status_panel"]
         panel_regex = (
-            params.get("panel_regex", r"Processing\.\.\.|진행 중|^🟢|^📦")
+            params.get("panel_regex", r"Processing\.\.\.|진행 중|응답 완료|^🟢|^✅|^🔴|^📦")
             if isinstance(params, dict)
-            else r"Processing\.\.\.|진행 중|^🟢|^📦"
+            else r"Processing\.\.\.|진행 중|응답 완료|^🟢|^✅|^🔴|^📦"
         )
         assertions.single_status_panel(window, panel_regex=str(panel_regex))
     elif "completion_chrome_after_body" in spec:

--- a/scripts/e2e/run_tui_relay.py
+++ b/scripts/e2e/run_tui_relay.py
@@ -3744,6 +3744,27 @@ def run_assertion(
             ),
             include_our_send=bool(params.get("include_our_send", False)),
         )
+    elif "status_panel_after_body" in spec:
+        params = spec["status_panel_after_body"]
+        if not isinstance(params, dict) or "body_marker" not in params:
+            raise assertions.AssertionError(
+                f"status_panel_after_body requires body_marker: {spec!r}"
+            )
+        assertions.status_panel_after_body(
+            window,
+            body_marker=str(params["body_marker"]),
+            panel_regex=str(
+                params.get("panel_regex", r"Processing\.\.\.|진행 중|^🟢|^📦")
+            ),
+        )
+    elif "single_status_panel" in spec:
+        params = spec["single_status_panel"]
+        panel_regex = (
+            params.get("panel_regex", r"Processing\.\.\.|진행 중|^🟢|^📦")
+            if isinstance(params, dict)
+            else r"Processing\.\.\.|진행 중|^🟢|^📦"
+        )
+        assertions.single_status_panel(window, panel_regex=str(panel_regex))
     elif "completion_chrome_after_body" in spec:
         params = spec["completion_chrome_after_body"]
         body_marker = params.get("body_marker") if isinstance(params, dict) else params

--- a/scripts/e2e/run_tui_relay.py
+++ b/scripts/e2e/run_tui_relay.py
@@ -3279,8 +3279,18 @@ def run_one_cell(
     _update_record_window_snapshot(record, window)
 
     try:
+        enabled_features = frozenset(
+            feature.strip()
+            for feature in os.environ.get("AGENTDESK_E2E_FEATURES", "").split(",")
+            if feature.strip()
+        )
         for assertion_spec in scenario.get("assertions") or []:
-            run_assertion(assertion_spec, window=window, record=record)
+            run_assertion(
+                assertion_spec,
+                window=window,
+                record=record,
+                enabled_features=enabled_features,
+            )
             record["assertions"].append({"spec": assertion_spec, "passed": True})
 
         idle_check = assert_cell_idle(
@@ -3638,9 +3648,16 @@ def run_assertion(
     *,
     window: assertions.Window,
     record: dict[str, Any] | None = None,
+    enabled_features: frozenset[str] = frozenset(),
 ) -> None:
     if not isinstance(spec, dict):
         raise assertions.AssertionError(f"bad assertion spec: {spec!r}")
+    required_feature = spec.get("requires_feature")
+    if required_feature is not None:
+        required_feature = str(required_feature)
+        if required_feature not in enabled_features:
+            return
+        spec = {key: value for key, value in spec.items() if key != "requires_feature"}
     if "message_count_between_markers" in spec:
         params = spec["message_count_between_markers"]
         assertions.message_count_between_markers(

--- a/scripts/e2e/tui_relay/assertions.py
+++ b/scripts/e2e/tui_relay/assertions.py
@@ -448,7 +448,7 @@ def status_panel_after_body(
     window: Window,
     *,
     body_marker: str,
-    panel_regex: str = r"Processing\.\.\.|진행 중|^🟢|^📦",
+    panel_regex: str = r"Processing\.\.\.|진행 중|응답 완료|^🟢|^✅|^🔴|^📦",
 ) -> None:
     body_messages = [
         message
@@ -478,7 +478,7 @@ def status_panel_after_body(
 def single_status_panel(
     window: Window,
     *,
-    panel_regex: str = r"Processing\.\.\.|진행 중|^🟢|^📦",
+    panel_regex: str = r"Processing\.\.\.|진행 중|응답 완료|^🟢|^✅|^🔴|^📦",
 ) -> None:
     panels = [
         message

--- a/scripts/e2e/tui_relay/assertions.py
+++ b/scripts/e2e/tui_relay/assertions.py
@@ -444,6 +444,54 @@ def chrome_count(
         )
 
 
+def status_panel_after_body(
+    window: Window,
+    *,
+    body_marker: str,
+    panel_regex: str = r"Processing\.\.\.|진행 중|^🟢|^📦",
+) -> None:
+    body_messages = [
+        message
+        for message in _raw_assertion_messages(window)
+        if body_marker in (message.get("content") or "")
+    ]
+    if not body_messages:
+        raise AssertionError(f"body marker {body_marker!r} not found in raw window")
+    newest_body = max(body_messages, key=_message_order_key)
+    panel_messages = [
+        message
+        for message in _raw_assertion_messages(window)
+        if re.search(panel_regex, message.get("content") or "")
+    ]
+    if not panel_messages:
+        raise AssertionError(
+            f"status panel matching {panel_regex!r} not found after body {body_marker!r}"
+        )
+    newest_panel = max(panel_messages, key=_message_order_key)
+    if _message_order_key(newest_panel) <= _message_order_key(newest_body):
+        raise AssertionError(
+            "status panel was not anchored below the newest answer body: "
+            f"panel={newest_panel.get('id')} body={newest_body.get('id')}"
+        )
+
+
+def single_status_panel(
+    window: Window,
+    *,
+    panel_regex: str = r"Processing\.\.\.|진행 중|^🟢|^📦",
+) -> None:
+    panels = [
+        message
+        for message in _raw_assertion_messages(window)
+        if re.search(panel_regex, message.get("content") or "")
+    ]
+    if len(panels) != 1:
+        raise AssertionError(
+            f"expected exactly one status panel matching {panel_regex!r}, got "
+            f"{len(panels)}: {[(m.get('id'), (m.get('content') or '')[:80]) for m in panels]}"
+        )
+
+
 def completion_chrome_after_body(
     window: Window, *, body_marker: str, required: bool = False
 ) -> None:

--- a/scripts/e2e/tui_relay/test_assertions.py
+++ b/scripts/e2e/tui_relay/test_assertions.py
@@ -336,6 +336,20 @@ class RunAssertionDispatch(unittest.TestCase):
         with self.assertRaises(assertions.AssertionError):
             self.run_assertion({"ordered_text_present": ["b", "a"]}, window=window)
 
+    def test_feature_required_assertion_is_skipped_until_enabled(self):
+        spec = {
+            "requires_feature": "two_message_panel",
+            "status_panel_after_body": {"body_marker": "[BODY]"},
+        }
+        empty = _window(_relay_msg(1, "body [BODY]"))
+        self.run_assertion(spec, window=empty)
+        with self.assertRaises(assertions.AssertionError):
+            self.run_assertion(
+                spec,
+                window=empty,
+                enabled_features=frozenset({"two_message_panel"}),
+            )
+
     def test_no_duplicate_marker_dispatch(self):
         window = _window(_relay_msg(1, "x [M]"), _relay_msg(2, "y [M]"))
         with self.assertRaises(assertions.AssertionError):

--- a/scripts/e2e/tui_relay/test_assertions.py
+++ b/scripts/e2e/tui_relay/test_assertions.py
@@ -266,6 +266,35 @@ class RawChromeAndEditAssertions(unittest.TestCase):
         with self.assertRaises(assertions.AssertionError):
             assertions.chrome_count(window, text="응답 완료", exact=1)
 
+    def test_status_panel_after_body(self):
+        good = _window(
+            _relay_msg(10, "body [BODY]"),
+            _raw_bot_msg(20, "Processing..."),
+        )
+        assertions.status_panel_after_body(good, body_marker="[BODY]")
+
+        stranded = _window(
+            _raw_bot_msg(10, "Processing..."),
+            _relay_msg(20, "body [BODY]"),
+        )
+        with self.assertRaises(assertions.AssertionError):
+            assertions.status_panel_after_body(stranded, body_marker="[BODY]")
+
+        missing = _window(_relay_msg(10, "body [BODY]"))
+        with self.assertRaises(assertions.AssertionError):
+            assertions.status_panel_after_body(missing, body_marker="[BODY]")
+
+    def test_single_status_panel(self):
+        good = _window(_raw_bot_msg(10, "Processing..."))
+        assertions.single_status_panel(good)
+
+        duplicate = _window(
+            _raw_bot_msg(10, "Processing..."),
+            _raw_bot_msg(20, "🟢 진행 중"),
+        )
+        with self.assertRaises(assertions.AssertionError):
+            assertions.single_status_panel(duplicate)
+
     def test_completion_chrome_after_body(self):
         window = _window(
             _relay_msg(1, "body [BODY]"),
@@ -339,6 +368,19 @@ class RunAssertionDispatch(unittest.TestCase):
         self.run_assertion({"raw_text_absent": "[LATE]"}, window=window)
         self.run_assertion({"marker_absent": {"marker": "[LATE]"}}, window=window)
         self.run_assertion({"chrome_count": {"text": "응답 완료", "exact": 1}}, window=window)
+        self.run_assertion(
+            {
+                "status_panel_after_body": {
+                    "body_marker": "[BODY]",
+                    "panel_regex": r"^✅",
+                }
+            },
+            window=window,
+        )
+        self.run_assertion(
+            {"single_status_panel": {"panel_regex": r"^✅"}},
+            window=window,
+        )
         self.run_assertion(
             {"completion_chrome_after_body": {"body_marker": "[BODY]"}},
             window=window,

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -36,7 +36,7 @@ pub(in crate::services::discord) use episode_guard::{
 };
 pub(in crate::services::discord) use store::InflightDeliveryRewindReason;
 use store::inflight_provider_dir;
-pub(in crate::services::discord::inflight) use store::inflight_state_path;
+pub(in crate::services::discord) use store::inflight_state_path;
 pub(crate) use store::lock_inflight_state_path;
 
 // #3715 / #3835: the rebind-origin dead-watcher/orphan-lock helpers PLUS the

--- a/src/services/discord/inflight/store.rs
+++ b/src/services/discord/inflight/store.rs
@@ -27,7 +27,7 @@ pub(super) fn inflight_provider_dir(root: &Path, provider: &ProviderKind) -> Pat
     root.join(provider.as_str())
 }
 
-pub(in crate::services::discord::inflight) fn inflight_state_path(
+pub(in crate::services::discord) fn inflight_state_path(
     root: &Path,
     provider: &ProviderKind,
     channel_id: u64,

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -29,6 +29,8 @@ use std::process::Command;
 
 #[path = "recovery_engine/status_panel.rs"]
 mod recovery_status_panel;
+#[path = "recovery_engine/two_message_panel.rs"]
+mod recovery_two_message_panel;
 #[path = "recovery_engine/status_panel_completion_producer.rs"]
 mod status_panel_completion_producer;
 use self::status_panel_completion_producer::*;
@@ -44,6 +46,8 @@ mod phase_policy;
 // recovery start-offset helper cluster into a leaf module.
 #[path = "recovery_engine/terminal_watcher.rs"]
 mod terminal_watcher;
+#[path = "recovery_engine/tmux_probe.rs"]
+mod tmux_probe;
 // #3479 item-2: behavior-preserving extraction of the inflight-state derivation
 // helper cluster (handoff message, ready-for-input probes, worktree info /
 // spawn-cwd derivation) into a leaf module.
@@ -179,13 +183,13 @@ use self::completion_delivery::{
 // a by-name import of a cfg'd-out item is a hard E0432 on non-unix targets.
 #[cfg(unix)]
 use self::restore_inflight::detect_live_tmux_output_path;
-use self::restore_inflight::tmux_session_alive_with_retry;
 pub(in crate::services::discord) use self::restore_inflight::{
     finish_recovered_turn_mailbox, restore_inflight_turns,
 };
 use self::restore_persist_outcome::{RestorePersistOutcome, restore_codex_rollout_output_path};
 pub(super) use self::runtime::reregister_active_turn_from_inflight;
 pub(in crate::services::discord) use self::terminal_text_idempotency::RecoveryDeliveryContext;
+use self::tmux_probe::tmux_session_alive_with_retry;
 // #3479: re-import the analytics + transcript helpers so root call sites stay
 // byte-identical. `recovered_transcript_turn_id` is gated on cfg(test) — the root
 // reaches it only from its unit test (prod calls it inside analytics_transcript).

--- a/src/services/discord/recovery_engine/restore_inflight.rs
+++ b/src/services/discord/recovery_engine/restore_inflight.rs
@@ -10,47 +10,7 @@
 use super::terminal_watcher::restart_report_watcher_start;
 use super::*;
 
-/// Retry-aware tmux session check for recovery after dcserver restart.
-/// The first check can false-negative if tmux CLI hasn't fully initialized yet.
-pub(super) fn tmux_session_alive_with_retry(name: &str) -> bool {
-    if tmux_session_has_live_pane(name) {
-        return true;
-    }
-    // #2428 H5: retry up to 2 more times with exponential backoff + jitter
-    // (was a fixed 1s gap; see `recovery_retry_backoff`).
-    for attempt in 1..=2u32 {
-        std::thread::sleep(recovery_retry_backoff(attempt));
-        if tmux_session_has_live_pane(name) {
-            tracing::info!(
-                "  [recovery] tmux pane alive on retry {} for {}",
-                attempt,
-                name
-            );
-            return true;
-        }
-    }
-    false
-}
-
-/// Retry-aware tmux has_session check.
-fn tmux_has_session_with_retry(name: &str) -> bool {
-    if crate::services::platform::tmux::has_session(name) {
-        return true;
-    }
-    // #2428 H5: see `recovery_retry_backoff`.
-    for attempt in 1..=2u32 {
-        std::thread::sleep(recovery_retry_backoff(attempt));
-        if crate::services::platform::tmux::has_session(name) {
-            tracing::info!(
-                "  [recovery] tmux session found on retry {} for {}",
-                attempt,
-                name
-            );
-            return true;
-        }
-    }
-    false
-}
+use super::tmux_probe::{tmux_has_session_with_retry, tmux_session_alive_with_retry};
 
 #[cfg(not(unix))]
 fn build_tmux_death_diagnostic(_name: &str, _output_path: Option<&str>) -> Option<String> {
@@ -155,7 +115,7 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
 
     let settings_snapshot = shared.settings.read().await.clone();
 
-    for state in states {
+    for mut state in states {
         // #897 round-4 High: rebind_origin inflights are synthetic
         // placeholders owned by `/api/inflight/rebind` and do NOT carry
         // a real user message, dispatch context, or placeholder Discord
@@ -734,6 +694,10 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                     restore_recovered_session_worktree(session, &state);
                 }
 
+                super::recovery_two_message_panel::recover_two_message_panel(
+                    http, shared, provider, &mut state,
+                )
+                .await;
                 let finish_mailbox_on_completion =
                     reregister_active_turn_from_inflight(shared, &state).await;
 
@@ -1771,6 +1735,10 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
             recovery_phase_after_tmux_probe(true, Some(pane_alive)),
             RecoveryPhase::WatcherReattach
         ) {
+            super::recovery_two_message_panel::recover_two_message_panel(
+                http, shared, provider, &mut state,
+            )
+            .await;
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(
                 "  [{ts}] ↻ inflight recovery: pane alive for channel {}, spawning watcher immediately",
@@ -1894,6 +1862,10 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                 restore_recovered_session_worktree(session, &state);
             }
 
+            super::recovery_two_message_panel::recover_two_message_panel(
+                http, shared, provider, &mut state,
+            )
+            .await;
             let finish_mailbox_on_completion =
                 reregister_active_turn_from_inflight(shared, &state).await;
 

--- a/src/services/discord/recovery_engine/tmux_probe.rs
+++ b/src/services/discord/recovery_engine/tmux_probe.rs
@@ -1,0 +1,39 @@
+use super::*;
+
+/// Retry-aware tmux session check for recovery after dcserver restart.
+/// The first check can false-negative if tmux CLI has not fully initialized yet.
+pub(super) fn tmux_session_alive_with_retry(name: &str) -> bool {
+    if tmux_session_has_live_pane(name) {
+        return true;
+    }
+    for attempt in 1..=2u32 {
+        std::thread::sleep(recovery_retry_backoff(attempt));
+        if tmux_session_has_live_pane(name) {
+            tracing::info!(
+                "  [recovery] tmux pane alive on retry {} for {}",
+                attempt,
+                name
+            );
+            return true;
+        }
+    }
+    false
+}
+
+pub(super) fn tmux_has_session_with_retry(name: &str) -> bool {
+    if crate::services::platform::tmux::has_session(name) {
+        return true;
+    }
+    for attempt in 1..=2u32 {
+        std::thread::sleep(recovery_retry_backoff(attempt));
+        if crate::services::platform::tmux::has_session(name) {
+            tracing::info!(
+                "  [recovery] tmux session found on retry {} for {}",
+                attempt,
+                name
+            );
+            return true;
+        }
+    }
+    false
+}

--- a/src/services/discord/recovery_engine/two_message_panel.rs
+++ b/src/services/discord/recovery_engine/two_message_panel.rs
@@ -35,6 +35,10 @@ trait RecoveryPanelGateway {
         Box::pin(async {})
     }
 
+    fn after_ownership_reload<'a>(&'a self) -> RecoveryPanelFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
     fn send_panel<'a>(
         &'a self,
         channel_id: ChannelId,
@@ -179,7 +183,7 @@ async fn recover_two_message_panel_with_gateway<G: RecoveryPanelGateway + ?Sized
         channel_id.get(),
         new_panel_id.get(),
         &inflight::StatusPanelBindGuard {
-            require_identity: Some(identity),
+            require_identity: Some(identity.clone()),
             skip_if_panel_already_set: panel_message_id.is_none(),
             require_current_status_message_id: panel_message_id.map(MessageId::get),
             bump_status_panel_generation: true,
@@ -259,12 +263,17 @@ async fn recover_two_message_panel_with_gateway<G: RecoveryPanelGateway + ?Sized
         return false;
     }
 
-    status_panel_orphan_store::remove(
+    gateway.after_ownership_reload().await;
+    if status_panel_orphan_store::remove_pending_bind_if_owned(
         provider,
         &shared.token_hash,
         channel_id.get(),
         new_panel_id.get(),
-    );
+        &identity,
+    ) == status_panel_orphan_store::PendingBindOwnedRemovalOutcome::OwnershipMismatch
+    {
+        return false;
+    }
     *state = reloaded.expect("still_owned requires a loaded inflight row");
     true
 }
@@ -297,6 +306,7 @@ mod tests {
         deleted: Arc<Mutex<Vec<MessageId>>>,
         replacement_on_send: Option<inflight::InflightTurnState>,
         replacement_after_bind: Option<inflight::InflightTurnState>,
+        replacement_after_ownership_reload: Option<inflight::InflightTurnState>,
     }
 
     impl RecoveryPanelGateway for MockGateway {
@@ -312,6 +322,15 @@ mod tests {
             Box::pin(async move {
                 if let Some(replacement) = self.replacement_after_bind.as_ref() {
                     inflight::save_inflight_state(replacement).expect("persist post-bind owner");
+                }
+            })
+        }
+
+        fn after_ownership_reload<'a>(&'a self) -> RecoveryPanelFuture<'a, ()> {
+            Box::pin(async move {
+                if let Some(replacement) = self.replacement_after_ownership_reload.as_ref() {
+                    inflight::save_inflight_state(replacement)
+                        .expect("persist owner after ownership reload");
                 }
             })
         }
@@ -396,6 +415,7 @@ mod tests {
             deleted: Arc::new(Mutex::new(Vec::new())),
             replacement_on_send: None,
             replacement_after_bind: None,
+            replacement_after_ownership_reload: None,
         };
 
         assert!(
@@ -434,6 +454,7 @@ mod tests {
             deleted: Arc::new(Mutex::new(Vec::new())),
             replacement_on_send: None,
             replacement_after_bind: None,
+            replacement_after_ownership_reload: None,
         };
 
         assert!(
@@ -465,6 +486,7 @@ mod tests {
             deleted: Arc::new(Mutex::new(Vec::new())),
             replacement_on_send: Some(replacement.clone()),
             replacement_after_bind: None,
+            replacement_after_ownership_reload: None,
         };
 
         assert!(
@@ -501,6 +523,7 @@ mod tests {
             deleted: Arc::new(Mutex::new(Vec::new())),
             replacement_on_send: None,
             replacement_after_bind: Some(replacement.clone()),
+            replacement_after_ownership_reload: None,
         };
 
         assert!(
@@ -515,6 +538,46 @@ mod tests {
             vec![MessageId::new(200), MessageId::new(400)]
         );
         assert!(status_panel_orphan_store::load_pending(&provider, &shared.token_hash).is_empty());
+    }
+
+    #[tokio::test]
+    async fn replacement_owner_after_final_reload_keeps_recovery_panel_protected() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let (_root, _guard) = isolate_runtime_root();
+        let shared = shared_with_two_message_enabled();
+        let provider = ProviderKind::Claude;
+        let mut stale = live_state(44_884, 7_005);
+        inflight::save_inflight_state(&stale).expect("seed stale owner");
+        let mut replacement = live_state(44_884, 8_005);
+        replacement.started_at = "2099-01-01 00:00:02".to_string();
+        replacement.current_msg_id = 900;
+        replacement.status_message_id = Some(901);
+        replacement.status_panel_generation = 11;
+        let gateway = MockGateway {
+            probe: PersistedPanelState::Live,
+            next_id: MessageId::new(400),
+            sent: Arc::new(Mutex::new(Vec::new())),
+            deleted: Arc::new(Mutex::new(Vec::new())),
+            replacement_on_send: None,
+            replacement_after_bind: None,
+            replacement_after_ownership_reload: Some(replacement.clone()),
+        };
+
+        assert!(
+            !recover_two_message_panel_with_gateway(&gateway, &shared, &provider, &mut stale).await
+        );
+        let durable = inflight::load_inflight_state(&provider, replacement.channel_id)
+            .expect("replacement owner remains");
+        assert_eq!(durable.user_msg_id, replacement.user_msg_id);
+        assert_eq!(durable.status_message_id, Some(901));
+        assert_eq!(*gateway.deleted.lock().unwrap(), vec![MessageId::new(200)]);
+        assert_eq!(
+            status_panel_orphan_store::load_pending(&provider, &shared.token_hash),
+            vec![(replacement.channel_id, 400)],
+            "the failed exact-owner removal must leave the panel for the sweeper"
+        );
     }
 
     #[test]

--- a/src/services/discord/recovery_engine/two_message_panel.rs
+++ b/src/services/discord/recovery_engine/two_message_panel.rs
@@ -31,6 +31,10 @@ trait RecoveryPanelGateway {
         panel_id: MessageId,
     ) -> RecoveryPanelFuture<'a, PersistedPanelState>;
 
+    fn after_bind<'a>(&'a self) -> RecoveryPanelFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
     fn send_panel<'a>(
         &'a self,
         channel_id: ChannelId,
@@ -143,11 +147,8 @@ async fn recover_two_message_panel_with_gateway<G: RecoveryPanelGateway + ?Sized
         return false;
     }
 
-    let started_at_unix =
-        chrono::NaiveDateTime::parse_from_str(&state.started_at, "%Y-%m-%d %H:%M:%S")
-            .ok()
-            .map(|timestamp| timestamp.and_utc().timestamp())
-            .unwrap_or_else(|| chrono::Utc::now().timestamp());
+    let started_at_unix = inflight::parse_started_at_unix(&state.started_at)
+        .unwrap_or_else(|| chrono::Utc::now().timestamp());
     let panel_text = shared.ui.placeholder_live_events.render_status_panel(
         channel_id,
         provider,
@@ -214,12 +215,7 @@ async fn recover_two_message_panel_with_gateway<G: RecoveryPanelGateway + ?Sized
         return false;
     }
 
-    status_panel_orphan_store::remove(
-        provider,
-        &shared.token_hash,
-        channel_id.get(),
-        new_panel_id.get(),
-    );
+    gateway.after_bind().await;
     if let Some(old_panel_id) = panel_message_id
         && panel_state == PersistedPanelState::Live
         && gateway
@@ -235,15 +231,41 @@ async fn recover_two_message_panel_with_gateway<G: RecoveryPanelGateway + ?Sized
         );
     }
 
-    let Some(reloaded) = inflight::load_inflight_state(provider, channel_id.get()) else {
-        return false;
-    };
-    if !inflight::InflightTurnIdentity::from_state(state).matches_state(&reloaded)
-        || reloaded.status_message_id != Some(new_panel_id.get())
-    {
+    let reloaded = inflight::load_inflight_state(provider, channel_id.get());
+    let still_owned = reloaded.as_ref().is_some_and(|reloaded| {
+        inflight::InflightTurnIdentity::from_state(state).matches_state(reloaded)
+            && reloaded.status_message_id == Some(new_panel_id.get())
+    });
+    if !still_owned {
+        if gateway
+            .delete_panel(channel_id, new_panel_id)
+            .await
+            .is_err()
+        {
+            status_panel_orphan_store::enqueue(
+                provider,
+                &shared.token_hash,
+                channel_id.get(),
+                new_panel_id.get(),
+            );
+        } else {
+            status_panel_orphan_store::remove(
+                provider,
+                &shared.token_hash,
+                channel_id.get(),
+                new_panel_id.get(),
+            );
+        }
         return false;
     }
-    *state = reloaded;
+
+    status_panel_orphan_store::remove(
+        provider,
+        &shared.token_hash,
+        channel_id.get(),
+        new_panel_id.get(),
+    );
+    *state = reloaded.expect("still_owned requires a loaded inflight row");
     true
 }
 
@@ -274,6 +296,7 @@ mod tests {
         sent: Arc<Mutex<Vec<MessageId>>>,
         deleted: Arc<Mutex<Vec<MessageId>>>,
         replacement_on_send: Option<inflight::InflightTurnState>,
+        replacement_after_bind: Option<inflight::InflightTurnState>,
     }
 
     impl RecoveryPanelGateway for MockGateway {
@@ -283,6 +306,14 @@ mod tests {
             _panel_id: MessageId,
         ) -> RecoveryPanelFuture<'a, PersistedPanelState> {
             Box::pin(async move { self.probe })
+        }
+
+        fn after_bind<'a>(&'a self) -> RecoveryPanelFuture<'a, ()> {
+            Box::pin(async move {
+                if let Some(replacement) = self.replacement_after_bind.as_ref() {
+                    inflight::save_inflight_state(replacement).expect("persist post-bind owner");
+                }
+            })
         }
 
         fn send_panel<'a>(
@@ -364,6 +395,7 @@ mod tests {
             sent: Arc::new(Mutex::new(Vec::new())),
             deleted: Arc::new(Mutex::new(Vec::new())),
             replacement_on_send: None,
+            replacement_after_bind: None,
         };
 
         assert!(
@@ -401,6 +433,7 @@ mod tests {
             sent: Arc::new(Mutex::new(Vec::new())),
             deleted: Arc::new(Mutex::new(Vec::new())),
             replacement_on_send: None,
+            replacement_after_bind: None,
         };
 
         assert!(
@@ -431,6 +464,7 @@ mod tests {
             sent: Arc::new(Mutex::new(Vec::new())),
             deleted: Arc::new(Mutex::new(Vec::new())),
             replacement_on_send: Some(replacement.clone()),
+            replacement_after_bind: None,
         };
 
         assert!(
@@ -443,6 +477,44 @@ mod tests {
         assert_eq!(durable.status_message_id, Some(901));
         assert_eq!(durable.status_panel_generation, 11);
         assert_eq!(*gateway.deleted.lock().unwrap(), vec![MessageId::new(400)]);
+    }
+
+    #[tokio::test]
+    async fn replacement_owner_after_bind_cannot_leak_recovery_panel() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let (_root, _guard) = isolate_runtime_root();
+        let shared = shared_with_two_message_enabled();
+        let provider = ProviderKind::Claude;
+        let mut stale = live_state(44_883, 7_004);
+        inflight::save_inflight_state(&stale).expect("seed stale owner");
+        let mut replacement = live_state(44_883, 8_004);
+        replacement.started_at = "2099-01-01 00:00:01".to_string();
+        replacement.current_msg_id = 900;
+        replacement.status_message_id = Some(901);
+        replacement.status_panel_generation = 11;
+        let gateway = MockGateway {
+            probe: PersistedPanelState::Live,
+            next_id: MessageId::new(400),
+            sent: Arc::new(Mutex::new(Vec::new())),
+            deleted: Arc::new(Mutex::new(Vec::new())),
+            replacement_on_send: None,
+            replacement_after_bind: Some(replacement.clone()),
+        };
+
+        assert!(
+            !recover_two_message_panel_with_gateway(&gateway, &shared, &provider, &mut stale).await
+        );
+        let durable = inflight::load_inflight_state(&provider, replacement.channel_id)
+            .expect("replacement owner remains");
+        assert_eq!(durable.user_msg_id, replacement.user_msg_id);
+        assert_eq!(durable.status_message_id, Some(901));
+        assert_eq!(
+            *gateway.deleted.lock().unwrap(),
+            vec![MessageId::new(200), MessageId::new(400)]
+        );
+        assert!(status_panel_orphan_store::load_pending(&provider, &shared.token_hash).is_empty());
     }
 
     #[test]

--- a/src/services/discord/recovery_engine/two_message_panel.rs
+++ b/src/services/discord/recovery_engine/two_message_panel.rs
@@ -1,0 +1,471 @@
+//! Restart recovery for the rollout-gated two-message status panel (#4488).
+//!
+//! A persisted panel handle can point above the latest answer chunk after a crash
+//! between rollover and re-anchor, or at a panel that was deleted while dcserver
+//! was down. Recovery publishes a replacement below the persisted answer and
+//! atomically rebinds it to the same durable turn identity. Discord ordering and
+//! message shape are only evidence that repair is needed; they never authorize
+//! ownership mutation.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use poise::serenity_prelude as serenity;
+
+use super::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PersistedPanelState {
+    Missing,
+    Live,
+    ProbeFailed,
+}
+
+type RecoveryPanelFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+trait RecoveryPanelGateway {
+    fn probe_panel<'a>(
+        &'a self,
+        channel_id: ChannelId,
+        panel_id: MessageId,
+    ) -> RecoveryPanelFuture<'a, PersistedPanelState>;
+
+    fn send_panel<'a>(
+        &'a self,
+        channel_id: ChannelId,
+        content: &'a str,
+    ) -> RecoveryPanelFuture<'a, Result<MessageId, String>>;
+
+    fn delete_panel<'a>(
+        &'a self,
+        channel_id: ChannelId,
+        panel_id: MessageId,
+    ) -> RecoveryPanelFuture<'a, Result<(), String>>;
+}
+
+struct SerenityRecoveryPanelGateway<'a> {
+    http: &'a Arc<serenity::Http>,
+}
+
+fn probe_error_is_missing(error: &serenity::Error) -> bool {
+    matches!(error, serenity::Error::Http(http_error)
+        if http_error.status_code().is_some_and(|status| status.as_u16() == 404))
+}
+
+impl RecoveryPanelGateway for SerenityRecoveryPanelGateway<'_> {
+    fn probe_panel<'a>(
+        &'a self,
+        channel_id: ChannelId,
+        panel_id: MessageId,
+    ) -> RecoveryPanelFuture<'a, PersistedPanelState> {
+        Box::pin(async move {
+            match self.http.get_message(channel_id, panel_id).await {
+                Ok(_) => PersistedPanelState::Live,
+                Err(error) if probe_error_is_missing(&error) => PersistedPanelState::Missing,
+                Err(error) => {
+                    tracing::warn!(
+                        channel_id = channel_id.get(),
+                        panel_message_id = panel_id.get(),
+                        error = %error,
+                        "two-message restart recovery could not probe the persisted panel; preserving it"
+                    );
+                    PersistedPanelState::ProbeFailed
+                }
+            }
+        })
+    }
+
+    fn send_panel<'a>(
+        &'a self,
+        channel_id: ChannelId,
+        content: &'a str,
+    ) -> RecoveryPanelFuture<'a, Result<MessageId, String>> {
+        Box::pin(async move {
+            crate::services::discord::http::send_channel_message(self.http, channel_id, content)
+                .await
+                .map(|message| message.id)
+                .map_err(|error| error.to_string())
+        })
+    }
+
+    fn delete_panel<'a>(
+        &'a self,
+        channel_id: ChannelId,
+        panel_id: MessageId,
+    ) -> RecoveryPanelFuture<'a, Result<(), String>> {
+        Box::pin(async move {
+            crate::services::discord::http::delete_channel_message(self.http, channel_id, panel_id)
+                .await
+                .map_err(|error| error.to_string())
+        })
+    }
+}
+
+fn recovery_reanchor_needed(
+    answer_message_id: MessageId,
+    panel_message_id: Option<MessageId>,
+    panel_state: PersistedPanelState,
+) -> bool {
+    match (panel_message_id, panel_state) {
+        (_, PersistedPanelState::ProbeFailed) => false,
+        (None, _) | (Some(_), PersistedPanelState::Missing) => true,
+        (Some(panel), PersistedPanelState::Live) => panel.get() <= answer_message_id.get(),
+    }
+}
+
+async fn recover_two_message_panel_with_gateway<G: RecoveryPanelGateway + ?Sized>(
+    gateway: &G,
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    state: &mut inflight::InflightTurnState,
+) -> bool {
+    if !shared.ui.two_message_panel_enabled || !shared.ui.status_panel_v2_enabled {
+        return false;
+    }
+    let Some(channel_id) = inflight::opt_channel_id(state.channel_id) else {
+        return false;
+    };
+    let Some(answer_message_id) = inflight::opt_message_id(state.current_msg_id) else {
+        return false;
+    };
+    if crate::services::discord::is_synthetic_headless_message_id_raw(answer_message_id.get()) {
+        return false;
+    }
+
+    let identity = inflight::InflightTurnIdentity::from_state(state);
+    let panel_message_id = state.status_message_id.and_then(inflight::opt_message_id);
+    let panel_state = match panel_message_id {
+        Some(panel_id) => gateway.probe_panel(channel_id, panel_id).await,
+        None => PersistedPanelState::Missing,
+    };
+    if !recovery_reanchor_needed(answer_message_id, panel_message_id, panel_state) {
+        return false;
+    }
+
+    let started_at_unix =
+        chrono::NaiveDateTime::parse_from_str(&state.started_at, "%Y-%m-%d %H:%M:%S")
+            .ok()
+            .map(|timestamp| timestamp.and_utc().timestamp())
+            .unwrap_or_else(|| chrono::Utc::now().timestamp());
+    let panel_text = shared.ui.placeholder_live_events.render_status_panel(
+        channel_id,
+        provider,
+        started_at_unix,
+    );
+    let new_panel_id = match gateway.send_panel(channel_id, &panel_text).await {
+        Ok(message_id) => message_id,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel_id = channel_id.get(),
+                error = %error,
+                "two-message restart recovery failed to publish a replacement panel"
+            );
+            return false;
+        }
+    };
+
+    status_panel_orphan_store::enqueue_pending_bind(
+        provider,
+        &shared.token_hash,
+        channel_id.get(),
+        new_panel_id.get(),
+        Some(identity.clone()),
+    );
+    let bind_outcome = inflight::bind_status_panel(
+        provider,
+        channel_id.get(),
+        new_panel_id.get(),
+        &inflight::StatusPanelBindGuard {
+            require_identity: Some(identity),
+            skip_if_panel_already_set: panel_message_id.is_none(),
+            require_current_status_message_id: panel_message_id.map(MessageId::get),
+            bump_status_panel_generation: true,
+            ..Default::default()
+        },
+    );
+    if !bind_outcome.is_bound() {
+        if gateway
+            .delete_panel(channel_id, new_panel_id)
+            .await
+            .is_err()
+        {
+            status_panel_orphan_store::enqueue(
+                provider,
+                &shared.token_hash,
+                channel_id.get(),
+                new_panel_id.get(),
+            );
+        } else {
+            status_panel_orphan_store::remove(
+                provider,
+                &shared.token_hash,
+                channel_id.get(),
+                new_panel_id.get(),
+            );
+        }
+        tracing::warn!(
+            provider = %provider.as_str(),
+            channel_id = channel_id.get(),
+            outcome = ?bind_outcome,
+            "two-message restart recovery lost durable episode ownership; discarded replacement panel"
+        );
+        return false;
+    }
+
+    status_panel_orphan_store::remove(
+        provider,
+        &shared.token_hash,
+        channel_id.get(),
+        new_panel_id.get(),
+    );
+    if let Some(old_panel_id) = panel_message_id
+        && panel_state == PersistedPanelState::Live
+        && gateway
+            .delete_panel(channel_id, old_panel_id)
+            .await
+            .is_err()
+    {
+        status_panel_orphan_store::enqueue(
+            provider,
+            &shared.token_hash,
+            channel_id.get(),
+            old_panel_id.get(),
+        );
+    }
+
+    let Some(reloaded) = inflight::load_inflight_state(provider, channel_id.get()) else {
+        return false;
+    };
+    if !inflight::InflightTurnIdentity::from_state(state).matches_state(&reloaded)
+        || reloaded.status_message_id != Some(new_panel_id.get())
+    {
+        return false;
+    }
+    *state = reloaded;
+    true
+}
+
+pub(super) async fn recover_two_message_panel(
+    http: &Arc<serenity::Http>,
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    state: &mut inflight::InflightTurnState,
+) -> bool {
+    recover_two_message_panel_with_gateway(
+        &SerenityRecoveryPanelGateway { http },
+        shared,
+        provider,
+        state,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Clone)]
+    struct MockGateway {
+        probe: PersistedPanelState,
+        next_id: MessageId,
+        sent: Arc<Mutex<Vec<MessageId>>>,
+        deleted: Arc<Mutex<Vec<MessageId>>>,
+        replacement_on_send: Option<inflight::InflightTurnState>,
+    }
+
+    impl RecoveryPanelGateway for MockGateway {
+        fn probe_panel<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _panel_id: MessageId,
+        ) -> RecoveryPanelFuture<'a, PersistedPanelState> {
+            Box::pin(async move { self.probe })
+        }
+
+        fn send_panel<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _content: &'a str,
+        ) -> RecoveryPanelFuture<'a, Result<MessageId, String>> {
+            Box::pin(async move {
+                self.sent.lock().unwrap().push(self.next_id);
+                if let Some(replacement) = self.replacement_on_send.as_ref() {
+                    inflight::save_inflight_state(replacement).expect("persist replacement owner");
+                }
+                Ok(self.next_id)
+            })
+        }
+
+        fn delete_panel<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            panel_id: MessageId,
+        ) -> RecoveryPanelFuture<'a, Result<(), String>> {
+            Box::pin(async move {
+                self.deleted.lock().unwrap().push(panel_id);
+                Ok(())
+            })
+        }
+    }
+
+    fn shared_with_two_message_enabled() -> Arc<SharedData> {
+        let mut shared = crate::services::discord::make_shared_data_for_tests();
+        let shared_mut = Arc::get_mut(&mut shared).expect("fresh shared state");
+        shared_mut.ui.status_panel_v2_enabled = true;
+        shared_mut.ui.two_message_panel_enabled = true;
+        shared
+    }
+
+    fn live_state(channel_id: u64, user_msg_id: u64) -> inflight::InflightTurnState {
+        let mut state = inflight::InflightTurnState::new(
+            ProviderKind::Claude,
+            channel_id,
+            Some("adk-test".to_string()),
+            1,
+            user_msg_id,
+            300,
+            "restart recovery".to_string(),
+            None,
+            Some("AgentDesk-claude-adk-test".to_string()),
+            Some("/tmp/issue-4488.jsonl".to_string()),
+            None,
+            10,
+        );
+        state.status_message_id = Some(200);
+        state.status_panel_generation = 3;
+        state
+    }
+
+    fn isolate_runtime_root() -> (tempfile::TempDir, crate::config::TestEnvVarGuard) {
+        let root = tempfile::tempdir().expect("runtime root");
+        let guard = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            root.path(),
+        );
+        (root, guard)
+    }
+
+    #[tokio::test]
+    async fn restart_reanchors_stranded_panel_and_persists_new_epoch() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let (_root, _guard) = isolate_runtime_root();
+        let shared = shared_with_two_message_enabled();
+        let provider = ProviderKind::Claude;
+        let mut state = live_state(44_880, 7_001);
+        inflight::save_inflight_state(&state).expect("seed inflight");
+        let gateway = MockGateway {
+            probe: PersistedPanelState::Live,
+            next_id: MessageId::new(400),
+            sent: Arc::new(Mutex::new(Vec::new())),
+            deleted: Arc::new(Mutex::new(Vec::new())),
+            replacement_on_send: None,
+        };
+
+        assert!(
+            recover_two_message_panel_with_gateway(&gateway, &shared, &provider, &mut state).await
+        );
+        assert_eq!(state.current_msg_id, 300);
+        assert_eq!(state.status_message_id, Some(400));
+        assert_eq!(state.status_panel_generation, 4);
+        assert_eq!(*gateway.deleted.lock().unwrap(), vec![MessageId::new(200)]);
+        assert!(status_panel_orphan_store::load_pending(&provider, &shared.token_hash).is_empty());
+
+        assert!(
+            !recover_two_message_panel_with_gateway(&gateway, &shared, &provider, &mut state).await,
+            "a second recovery pass must reuse the already-correct panel"
+        );
+        assert_eq!(gateway.sent.lock().unwrap().len(), 1);
+        assert_eq!(gateway.deleted.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn restart_recreates_missing_panel_without_duplicate_old_delete() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let (_root, _guard) = isolate_runtime_root();
+        let shared = shared_with_two_message_enabled();
+        let provider = ProviderKind::Claude;
+        let mut state = live_state(44_881, 7_002);
+        state.status_message_id = Some(500);
+        state.current_msg_id = 300;
+        inflight::save_inflight_state(&state).expect("seed inflight");
+        let gateway = MockGateway {
+            probe: PersistedPanelState::Missing,
+            next_id: MessageId::new(600),
+            sent: Arc::new(Mutex::new(Vec::new())),
+            deleted: Arc::new(Mutex::new(Vec::new())),
+            replacement_on_send: None,
+        };
+
+        assert!(
+            recover_two_message_panel_with_gateway(&gateway, &shared, &provider, &mut state).await
+        );
+        assert_eq!(state.status_message_id, Some(600));
+        assert!(gateway.deleted.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn replacement_owner_survives_recovery_send_race() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let (_root, _guard) = isolate_runtime_root();
+        let shared = shared_with_two_message_enabled();
+        let provider = ProviderKind::Claude;
+        let mut stale = live_state(44_882, 7_003);
+        inflight::save_inflight_state(&stale).expect("seed stale owner");
+        let mut replacement = live_state(44_882, 8_003);
+        replacement.started_at = "2099-01-01 00:00:00".to_string();
+        replacement.current_msg_id = 900;
+        replacement.status_message_id = Some(901);
+        replacement.status_panel_generation = 11;
+        let gateway = MockGateway {
+            probe: PersistedPanelState::Live,
+            next_id: MessageId::new(400),
+            sent: Arc::new(Mutex::new(Vec::new())),
+            deleted: Arc::new(Mutex::new(Vec::new())),
+            replacement_on_send: Some(replacement.clone()),
+        };
+
+        assert!(
+            !recover_two_message_panel_with_gateway(&gateway, &shared, &provider, &mut stale).await
+        );
+        let durable = inflight::load_inflight_state(&provider, replacement.channel_id)
+            .expect("replacement owner remains");
+        assert_eq!(durable.user_msg_id, replacement.user_msg_id);
+        assert_eq!(durable.current_msg_id, 900);
+        assert_eq!(durable.status_message_id, Some(901));
+        assert_eq!(durable.status_panel_generation, 11);
+        assert_eq!(*gateway.deleted.lock().unwrap(), vec![MessageId::new(400)]);
+    }
+
+    #[test]
+    fn ordering_is_only_repair_evidence() {
+        assert!(recovery_reanchor_needed(
+            MessageId::new(300),
+            Some(MessageId::new(200)),
+            PersistedPanelState::Live,
+        ));
+        assert!(!recovery_reanchor_needed(
+            MessageId::new(300),
+            Some(MessageId::new(400)),
+            PersistedPanelState::Live,
+        ));
+        assert!(recovery_reanchor_needed(
+            MessageId::new(300),
+            Some(MessageId::new(400)),
+            PersistedPanelState::Missing,
+        ));
+        assert!(!recovery_reanchor_needed(
+            MessageId::new(300),
+            Some(MessageId::new(200)),
+            PersistedPanelState::ProbeFailed,
+        ));
+    }
+}

--- a/src/services/discord/status_panel_orphan_store.rs
+++ b/src/services/discord/status_panel_orphan_store.rs
@@ -267,6 +267,97 @@ fn remove_pending_bind_in_root(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) enum PendingBindOwnedRemovalOutcome {
+    OwnershipMismatch,
+    OwnedRecordRemoved,
+    OwnedRecordMissing,
+}
+
+fn ensure_pending_bind_protection_in_root(
+    root: &Path,
+    provider: &ProviderKind,
+    token_hash: &str,
+    channel_id: u64,
+    panel_msg_id: u64,
+    identity: &InflightTurnIdentity,
+) {
+    let _store_guard = STORE_WRITE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let mut entries = load_channel_in_root(root, provider, token_hash, channel_id);
+    if entries.iter().any(|entry| entry.id == panel_msg_id) {
+        return;
+    }
+    entries.push(StatusPanelOrphanEntry::pending_bind(
+        panel_msg_id,
+        Some(identity.clone()),
+    ));
+    save_channel_in_root(root, provider, token_hash, channel_id, &entries);
+}
+
+fn remove_pending_bind_if_owned_in_root(
+    root: &Path,
+    inflight_root: &Path,
+    provider: &ProviderKind,
+    token_hash: &str,
+    channel_id: u64,
+    panel_msg_id: u64,
+    identity: &InflightTurnIdentity,
+) -> PendingBindOwnedRemovalOutcome {
+    let inflight_path = crate::services::discord::inflight::inflight_state_path(
+        inflight_root,
+        provider,
+        channel_id,
+    );
+    let Ok(_inflight_guard) =
+        crate::services::discord::inflight::lock_inflight_state_path(&inflight_path)
+    else {
+        ensure_pending_bind_protection_in_root(
+            root,
+            provider,
+            token_hash,
+            channel_id,
+            panel_msg_id,
+            identity,
+        );
+        return PendingBindOwnedRemovalOutcome::OwnershipMismatch;
+    };
+    let Some(inflight) = fs::read_to_string(&inflight_path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<InflightTurnState>(&raw).ok())
+    else {
+        ensure_pending_bind_protection_in_root(
+            root,
+            provider,
+            token_hash,
+            channel_id,
+            panel_msg_id,
+            identity,
+        );
+        return PendingBindOwnedRemovalOutcome::OwnershipMismatch;
+    };
+    if !identity.matches_state(&inflight) || inflight.status_message_id != Some(panel_msg_id) {
+        ensure_pending_bind_protection_in_root(
+            root,
+            provider,
+            token_hash,
+            channel_id,
+            panel_msg_id,
+            identity,
+        );
+        return PendingBindOwnedRemovalOutcome::OwnershipMismatch;
+    }
+
+    let _store_guard = STORE_WRITE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let mut entries = load_channel_in_root(root, provider, token_hash, channel_id);
+    let before = entries.len();
+    entries.retain(|entry| !(entry.id == panel_msg_id && entry.is_pending_bind()));
+    if entries.len() == before {
+        return PendingBindOwnedRemovalOutcome::OwnedRecordMissing;
+    }
+    save_channel_in_root(root, provider, token_hash, channel_id, &entries);
+    PendingBindOwnedRemovalOutcome::OwnedRecordRemoved
+}
+
 fn is_queued_in_root(
     root: &Path,
     provider: &ProviderKind,
@@ -443,6 +534,33 @@ pub(in crate::services::discord) fn remove_pending_bind(
         return;
     };
     remove_pending_bind_in_root(&root, provider, token_hash, channel_id, panel_msg_id);
+}
+
+/// Drop a pending-bind record only while the same durable turn still owns the
+/// exact panel. The inflight flock stays held through the orphan-store removal,
+/// so a replacement owner cannot land between the ownership check and removal.
+pub(in crate::services::discord) fn remove_pending_bind_if_owned(
+    provider: &ProviderKind,
+    token_hash: &str,
+    channel_id: u64,
+    panel_msg_id: u64,
+    identity: &InflightTurnIdentity,
+) -> PendingBindOwnedRemovalOutcome {
+    let (Some(root), Some(inflight_root)) = (
+        runtime_store::discord_status_panel_orphans_root(),
+        runtime_store::discord_inflight_root(),
+    ) else {
+        return PendingBindOwnedRemovalOutcome::OwnershipMismatch;
+    };
+    remove_pending_bind_if_owned_in_root(
+        &root,
+        &inflight_root,
+        provider,
+        token_hash,
+        channel_id,
+        panel_msg_id,
+        identity,
+    )
 }
 
 /// Is this panel still queued for deletion? Used by [`drain`] to re-validate a

--- a/src/services/discord/status_panel_orphan_store_tests.rs
+++ b/src/services/discord/status_panel_orphan_store_tests.rs
@@ -125,6 +125,141 @@ fn pending_bind_drain_removes_record_when_bind_landed_without_delete() {
 }
 
 #[test]
+fn pending_bind_exact_owner_remove_keeps_record_after_reownership() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let orphan_root = root.path().join("orphans");
+    let inflight_root = root.path().join("inflight");
+    let provider = ProviderKind::Claude;
+    let token = "tok";
+    let channel_id = 100;
+    let panel_id = 5001;
+    let original = test_inflight(&provider, channel_id, 7001, Some(panel_id), 6001, Some(10));
+    let replacement = test_inflight(&provider, channel_id, 7002, Some(5002), 6002, Some(20));
+    enqueue_pending_bind_in_root(
+        &orphan_root,
+        &provider,
+        token,
+        channel_id,
+        panel_id,
+        Some(InflightTurnIdentity::from_state(&original)),
+    );
+    let inflight_path = crate::services::discord::inflight::inflight_state_path(
+        &inflight_root,
+        &provider,
+        channel_id,
+    );
+    fs::create_dir_all(inflight_path.parent().expect("inflight parent")).expect("mkdir inflight");
+    fs::write(
+        &inflight_path,
+        serde_json::to_string_pretty(&replacement).expect("replacement json"),
+    )
+    .expect("persist replacement");
+
+    assert_eq!(
+        remove_pending_bind_if_owned_in_root(
+            &orphan_root,
+            &inflight_root,
+            &provider,
+            token,
+            channel_id,
+            panel_id,
+            &InflightTurnIdentity::from_state(&original),
+        ),
+        PendingBindOwnedRemovalOutcome::OwnershipMismatch
+    );
+    assert_eq!(
+        load_pending_in_root(&orphan_root, &provider, token),
+        vec![(channel_id, panel_id)]
+    );
+}
+
+#[test]
+fn pending_bind_exact_owner_remove_clears_matching_record() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let orphan_root = root.path().join("orphans");
+    let inflight_root = root.path().join("inflight");
+    let provider = ProviderKind::Claude;
+    let token = "tok";
+    let channel_id = 100;
+    let panel_id = 5001;
+    let live = test_inflight(&provider, channel_id, 7001, Some(panel_id), 6001, Some(10));
+    enqueue_pending_bind_in_root(
+        &orphan_root,
+        &provider,
+        token,
+        channel_id,
+        panel_id,
+        Some(InflightTurnIdentity::from_state(&live)),
+    );
+    let inflight_path = crate::services::discord::inflight::inflight_state_path(
+        &inflight_root,
+        &provider,
+        channel_id,
+    );
+    fs::create_dir_all(inflight_path.parent().expect("inflight parent")).expect("mkdir inflight");
+    fs::write(
+        &inflight_path,
+        serde_json::to_string_pretty(&live).expect("live json"),
+    )
+    .expect("persist live owner");
+
+    assert_eq!(
+        remove_pending_bind_if_owned_in_root(
+            &orphan_root,
+            &inflight_root,
+            &provider,
+            token,
+            channel_id,
+            panel_id,
+            &InflightTurnIdentity::from_state(&live),
+        ),
+        PendingBindOwnedRemovalOutcome::OwnedRecordRemoved
+    );
+    assert!(load_pending_in_root(&orphan_root, &provider, token).is_empty());
+}
+
+#[test]
+fn pending_bind_exact_owner_remove_restores_missing_protection_after_reownership() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let orphan_root = root.path().join("orphans");
+    let inflight_root = root.path().join("inflight");
+    let provider = ProviderKind::Claude;
+    let token = "tok";
+    let channel_id = 100;
+    let panel_id = 5001;
+    let original = test_inflight(&provider, channel_id, 7001, Some(panel_id), 6001, Some(10));
+    let replacement = test_inflight(&provider, channel_id, 7002, Some(5002), 6002, Some(20));
+    let inflight_path = crate::services::discord::inflight::inflight_state_path(
+        &inflight_root,
+        &provider,
+        channel_id,
+    );
+    fs::create_dir_all(inflight_path.parent().expect("inflight parent")).expect("mkdir inflight");
+    fs::write(
+        &inflight_path,
+        serde_json::to_string_pretty(&replacement).expect("replacement json"),
+    )
+    .expect("persist replacement");
+
+    assert_eq!(
+        remove_pending_bind_if_owned_in_root(
+            &orphan_root,
+            &inflight_root,
+            &provider,
+            token,
+            channel_id,
+            panel_id,
+            &InflightTurnIdentity::from_state(&original),
+        ),
+        PendingBindOwnedRemovalOutcome::OwnershipMismatch
+    );
+    assert_eq!(
+        load_pending_in_root(&orphan_root, &provider, token),
+        vec![(channel_id, panel_id)]
+    );
+}
+
+#[test]
 fn pending_bind_drain_defers_same_turn_unbound_window() {
     let root = tempfile::tempdir().expect("tempdir");
     let root = root.path();

--- a/tests/e2e/tui_relay/scenarios/E-15-long-response-chunk-completeness.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-15-long-response-chunk-completeness.yaml
@@ -49,6 +49,11 @@ assertions:
   - no_duplicate_marker: "[E2E:E15:END]"
   # #4488 PR-F: the separate status panel must remain below the newest chunk
   # after the long-answer rollover.
-  - status_panel_after_body:
+  # These rollout assertions are opt-in. Set
+  # AGENTDESK_E2E_FEATURES=two_message_panel only when the boot-bound
+  # placeholder.two_message_panel_enabled flag is enabled for the target.
+  - requires_feature: two_message_panel
+    status_panel_after_body:
       body_marker: "[E2E:E15:END]"
-  - single_status_panel: true
+  - requires_feature: two_message_panel
+    single_status_panel: true

--- a/tests/e2e/tui_relay/scenarios/E-15-long-response-chunk-completeness.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-15-long-response-chunk-completeness.yaml
@@ -47,3 +47,8 @@ assertions:
   # the first chunk, or an ACK-timeout re-relay).
   - no_duplicate_marker: "[E2E:E15:BEGIN]"
   - no_duplicate_marker: "[E2E:E15:END]"
+  # #4488 PR-F: the separate status panel must remain below the newest chunk
+  # after the long-answer rollover.
+  - status_panel_after_body:
+      body_marker: "[E2E:E15:END]"
+  - single_status_panel: true

--- a/tests/e2e/tui_relay/scenarios/E-9-restart-mid-stream.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-9-restart-mid-stream.yaml
@@ -42,3 +42,9 @@ assertions:
   # (byte-identical only) does not catch. The sentinel must appear in exactly
   # one relay message across the whole window, pre- and post-restart.
   - no_duplicate_marker: "[E2E:E9:STREAM_OK]"
+  # #4488 PR-F: with the two-message rollout enabled, restart recovery must
+  # leave the live panel below the latest answer chunk instead of reusing a
+  # stranded pre-restart panel above it.
+  - status_panel_after_body:
+      body_marker: "[E2E:E9:END]"
+  - single_status_panel: true

--- a/tests/e2e/tui_relay/scenarios/E-9-restart-mid-stream.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-9-restart-mid-stream.yaml
@@ -45,6 +45,11 @@ assertions:
   # #4488 PR-F: with the two-message rollout enabled, restart recovery must
   # leave the live panel below the latest answer chunk instead of reusing a
   # stranded pre-restart panel above it.
-  - status_panel_after_body:
+  # These rollout assertions are opt-in. Set
+  # AGENTDESK_E2E_FEATURES=two_message_panel only when the boot-bound
+  # placeholder.two_message_panel_enabled flag is enabled for the target.
+  - requires_feature: two_message_panel
+    status_panel_after_body:
       body_marker: "[E2E:E9:END]"
-  - single_status_panel: true
+  - requires_feature: two_message_panel
+    single_status_panel: true


### PR DESCRIPTION
## Summary
- implement PR-E restart recovery for rollout-gated two-message status panels
- recreate missing panels and catch up panels stranded above the latest answer chunk
- bind replacements with full episode identity + expected-old-panel CAS and an atomic generation bump
- pre-register replacement panels in the durable orphan store and preserve replacement owners on races
- extend PR-F relay E2E assertions/scenarios for long-answer and restart-mid-stream bottom-panel ordering and duplicate-panel detection

## Safety / compatibility
- keeps `placeholder.two_message_panel_enabled` default OFF
- adds no blind `save_inflight_state` call; ratchet remains at baseline 1
- leaves #4830 panel cache invalidation process-local and lets the replacement start uncached; terminal reconcile observes the rebound generation
- does not touch the four prohibited hotfiles

## PR-E / PR-F scope
- PR-E: complete for restart catch-up, missing-panel recreation, orphan convergence, and competing-owner preservation
- PR-F: long-answer rollover and restart-mid-stream live scenarios are wired with order/single-panel assertions; harness unit coverage included
- Remaining PR-F: destructive live panel-deletion/failure injection is not included because the current E2E control API has no scoped Discord message-delete/failure-injection primitive

## Verification
- `cargo fmt --all --check`
- `cargo check --lib`
- `cargo test --lib recovery_engine` (154 passed)
- `cargo test --lib placeholder_live_events` (221 passed)
- `cargo test --lib tmux_watcher` (288 passed)
- `python3 -m unittest scripts.e2e.tui_relay.test_assertions scripts.e2e.tui_relay.test_driver_health` (103 passed)
- `python3 scripts/check_inflight_blind_save_ratchet.py` (baseline 1)
- `./scripts/ci-script-checks.sh`
- inventory generation + agent-maintenance docs gate

Known main-branch baseline: `cargo test --lib turn_bridge` has one pre-existing failure in `bridge_footer_streaming_edit_text_includes_panel_footer`; the touched recovery/E2E changes do not modify that footer path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
