### PR TITLE
test(discord): fix bridge footer expectation drift (-# header, drift #2)

### DIFF
--- a/src/services/discord/turn_bridge/single_message_footer.rs
+++ b/src/services/discord/turn_bridge/single_message_footer.rs
@@ -581,7 +581,7 @@ mod tests {
             &ProviderKind::Claude,
         );
 
-        assert!(rendered.starts_with("Bridge body\n\n⠸ 진행 중 — Claude"));
+        assert!(rendered.starts_with("Bridge body\n\n-# ⠸ 진행 중 — Claude"));
         assert!(!rendered.contains("계속 처리 중"));
         assert!(!rendered.contains('🟢'));
         assert!(rendered.contains("Subagents\n└ review inspect"));


### PR DESCRIPTION
#4826 푸터 `-# ` 접두 드리프트 2호 (1호: #4840).

`bridge_footer_streaming_edit_text_includes_panel_footer`가 구 헤더 포맷을 기대 — clean main(e0e7b992)에서 로컬 재현 확인. 이 모듈은 PR targeted lane에도 `just test-non-pg` 큐레이션 목록에도 없어 **어떤 CI lane에서도 실행되지 않음** — #4844 dual review의 로컬 광역 스위트가 발견.

수정: 기대값 1줄 정렬(test-only, 프로덕션 무변경). `cargo test --lib single_message_footer` 23 passed.

후속: CI 사각지대(큐레이션 누락 모듈) + 푸터 포맷 분산 assert 구조는 별도 이슈로 등록 예정.

test-only 선례에 따라 Anthropic 단독 판정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)