### PR TITLE
fix(#4277): disambiguate inflightless relay leases

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -237,7 +237,9 @@
     `TmuxDeathLifecycleDecision` plumbing; +25 from #4455 adding the explicit
     force-replace claim action used only when Codex rebind proves that a live
     same-output watcher still belongs to an earlier provider turn).
-  - `src/services/discord/tmux.rs` (frozen giant surface; -9 from the #4804
+  - `src/services/discord/tmux.rs` (frozen giant surface; test-only #4277 re-exports
+    the watcher delivery-lease key helper so session-sink production-entry tests
+    prove bidirectional contention on the same idle JSONL range; -9 from the #4804
     Windows-compile hotfix moving `footer_background_marker_session_key` into
     the cross-platform `task_notification_delivery::terminal_identity` (tmux.rs
     keeps a `use` of the shared helper; key format unchanged); test-only #4104 pins

--- a/docs/relay-state-contract.md
+++ b/docs/relay-state-contract.md
@@ -303,6 +303,31 @@ plan.
 - Invariant key: `mailbox_episode_identity_exact` (enforced by the actor predicate
   and mutation-proven regression tests rather than an observe-only hook).
 
+## I9. every session-bound terminal POST holds the shared delivery lease (#4277)
+
+- Definition: terminal deliveries parsed by
+  `SessionRelayParser::ingest_frame`
+  (`sym:session_relay_sink::turn_parser::SessionRelayParser::ingest_frame`) carry
+  either their strict turn fence, an idle/catch-up ordered JSONL range, or the
+  legacy no-range shape.
+- Producer: `SessionBoundDiscordRelaySink::deliver_response`
+  (`sym:session_relay_sink::SessionBoundDiscordRelaySink::deliver_response`)
+  derives one lease coordinate before any Discord transport. Strict fenced
+  frames use `[turn_start_offset, terminal_consumed_end)`, ordered idle/catch-up
+  frames use their carried range, and unresolvable legacy frames still contend
+  on the degenerate key and zero-width coordinate.
+- Consumer: the sink and watcher share the channel's `DeliveryLeaseCell`; a lost
+  acquire is a deterministic not-delivered result and must never fall through to
+  a markerless POST.
+- Invariant: there is no session-bound terminal POST/edit path without first
+  winning the shared delivery lease. The controller short-replace path owns its
+  own acquire; all other terminal paths use `SinkDeliveryLeaseGuard`.
+- Violation surface: an inflight-less idle-tail frame POSTs without a lease while
+  the watcher independently wins the fallback-keyed lease for the same bytes,
+  producing a duplicate Discord response.
+- Invariant key: `session_terminal_post_lease_required` (enforced structurally by
+  the mandatory acquire and production-entry regression tests).
+
 ## How to add a new invariant
 
 1. Document it here with the same structure (definition, producer,

--- a/src/services/cluster/registry_adapter_sink.rs
+++ b/src/services/cluster/registry_adapter_sink.rs
@@ -146,6 +146,7 @@ mod tests {
             turn_user_msg_id: 0,
             turn_started_at: String::new(),
             turn_start_offset: None,
+            relay_range: None,
         };
         sink.deliver(&frame).await.expect("infallible");
         sink.deliver(&frame).await.expect("infallible");

--- a/src/services/cluster/stream_relay.rs
+++ b/src/services/cluster/stream_relay.rs
@@ -155,6 +155,8 @@ pub struct StreamFrame {
     /// identity for backpressure attribution, but only frames with
     /// `terminal_consumed_end` can advance the sink commit fence.
     pub turn_start_offset: Option<u64>,
+    /// Idle/catch-up lease range; never a commit fence.
+    pub relay_range: Option<(u64, u64)>,
 }
 
 /// Per-session counters. Exposed via the supervisor for diagnostics.
@@ -475,6 +477,31 @@ impl RelayProducer {
         self.try_send_frame_with_sequence_and_identity(payload, None)
     }
 
+    pub fn try_send_frame_for_range(&self, payload: String, start: u64, end: u64) -> bool {
+        self.enqueue(payload, None, None, Some((start, end)))
+            .is_alive()
+    }
+
+    fn enqueue(
+        &self,
+        payload: String,
+        terminal: Option<TerminalCommitFence>,
+        identity: Option<RelayTurnIdentity>,
+        range: Option<(u64, u64)>,
+    ) -> RelaySendOutcome {
+        try_send_frame_inner(
+            &self.matched,
+            &self.queue,
+            &self.shutdown,
+            &self.metrics,
+            &self.sequence,
+            payload,
+            terminal,
+            identity,
+            range,
+        )
+    }
+
     /// Non-blocking enqueue for a non-terminal frame with optional turn identity.
     /// The identity is inert for sink commits (`terminal_consumed_end` stays None)
     /// but lets a later backpressure eviction degrade the affected turn's mirror
@@ -484,16 +511,7 @@ impl RelayProducer {
         payload: String,
         frame_identity: Option<RelayTurnIdentity>,
     ) -> RelaySendOutcome {
-        try_send_frame_inner(
-            &self.matched,
-            &self.queue,
-            &self.shutdown,
-            &self.metrics,
-            &self.sequence,
-            payload,
-            None,
-            frame_identity,
-        )
+        self.enqueue(payload, None, frame_identity, None)
     }
 
     /// #3041 P1-3 (Part a, B1): forward the RESULT-bearing chunk as a terminal
@@ -506,16 +524,7 @@ impl RelayProducer {
         payload: String,
         terminal: TerminalCommitFence,
     ) -> RelaySendOutcome {
-        try_send_frame_inner(
-            &self.matched,
-            &self.queue,
-            &self.shutdown,
-            &self.metrics,
-            &self.sequence,
-            payload,
-            Some(terminal),
-            None,
-        )
+        self.enqueue(payload, Some(terminal), None, None)
     }
 }
 
@@ -653,6 +662,7 @@ fn try_send_frame_inner(
     payload: String,
     terminal: Option<TerminalCommitFence>,
     frame_identity: Option<RelayTurnIdentity>,
+    relay_range: Option<(u64, u64)>,
 ) -> RelaySendOutcome {
     if shutdown.load(Ordering::Acquire) {
         return RelaySendOutcome::closed();
@@ -678,6 +688,7 @@ fn try_send_frame_inner(
         turn_user_msg_id: frame_identity.turn_user_msg_id,
         turn_started_at: frame_identity.turn_started_at,
         turn_start_offset: frame_identity.turn_start_offset,
+        relay_range,
     };
     metrics.frames_received.fetch_add(1, Ordering::AcqRel);
     match queue.push_drop_oldest(frame) {
@@ -737,6 +748,7 @@ impl StreamRelayHandle {
             &self.metrics,
             &self.sequence,
             payload,
+            None,
             None,
             None,
         )
@@ -1097,6 +1109,23 @@ mod tests {
         }
         assert_eq!(handle.metrics().snapshot().frames_delivered, 5);
         assert_eq!(handle.metrics().snapshot().dropped_frames, 0);
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn session_relay_ordered_range_frame_carries_idle_delivery_coordinate() {
+        let sink = Arc::new(CapturingSink::default());
+        let handle = spawn_stream_relay(matched_for("c-range"), sink.clone());
+        let producer = handle.producer();
+
+        assert!(producer.try_send_frame_for_range("idle-result".into(), 640, 1_024));
+        flush_pending().await;
+
+        let delivered = sink.delivered();
+        assert_eq!(delivered.len(), 1);
+        assert_eq!(delivered[0].relay_range, Some((640, 1_024)));
+        assert_eq!(delivered[0].terminal_consumed_end, None);
+        assert_eq!(delivered[0].turn_start_offset, None);
         handle.shutdown().await;
     }
 

--- a/src/services/discord/delivery_lease_key.rs
+++ b/src/services/discord/delivery_lease_key.rs
@@ -59,11 +59,12 @@ impl DeliveryLeaseKey {
         )
     }
 
-    /// Build a lease key while allowing an observed JSONL range start to stand
-    /// in for a missing persisted turn boundary. TUI-direct turns can lose their
-    /// inflight row before terminal delivery; the immutable range start still
-    /// distinguishes the turn and prevents two relay owners from sharing the
-    /// degenerate channel-only key.
+    /// Build a lease key while allowing the canonical relay-range start to stand
+    /// in for a missing persisted turn boundary. The fallback is authoritative
+    /// only when `started_at` is also absent; partially identified legacy callers
+    /// keep the historical all-degenerate collapse so their actor backstop keys do
+    /// not silently change. Watcher and sink owners pass the same `[start, end)`
+    /// delivery range start, so an inflight-less TUI-direct turn still converges.
     #[track_caller]
     pub(in crate::services::discord) fn new_for_site_with_fallback_offset(
         channel_id: ChannelId,
@@ -78,13 +79,24 @@ impl DeliveryLeaseKey {
             let started_at = turn_started_at
                 .map(str::trim)
                 .filter(|value| !value.is_empty());
-            let effective_start_offset = turn_start_offset.or(fallback_turn_start_offset);
-            if let Some(start_offset) = effective_start_offset {
+            if let (Some(started_at), Some(start_offset)) = (started_at, turn_start_offset) {
                 return Self {
                     channel_id,
                     generation,
                     user_msg_id,
-                    turn_started_at: started_at.map(str::to_string),
+                    turn_started_at: Some(started_at.to_string()),
+                    turn_start_offset: Some(start_offset),
+                };
+            }
+            if started_at.is_none()
+                && turn_start_offset.is_none()
+                && let Some(start_offset) = fallback_turn_start_offset
+            {
+                return Self {
+                    channel_id,
+                    generation,
+                    user_msg_id,
+                    turn_started_at: None,
                     turn_start_offset: Some(start_offset),
                 };
             }
@@ -101,24 +113,24 @@ impl DeliveryLeaseKey {
             // Residual legacy fallback: all sites derive id-0 disambiguators from
             // the same origin (inflight state / frame fence stamped from it), so a
             // same-turn miss degrades everywhere together and dedup still holds.
-            Self {
+            return Self {
                 channel_id,
                 generation,
                 user_msg_id,
                 turn_started_at: None,
                 turn_start_offset: None,
-            }
-        } else {
-            // Preserve the old non-zero TurnKey behavior: the Discord snowflake is
-            // already the turn discriminator, so auxiliary timestamps must not
-            // participate in equality for non-zero ids.
-            Self {
-                channel_id,
-                generation,
-                user_msg_id,
-                turn_started_at: None,
-                turn_start_offset: None,
-            }
+            };
+        }
+
+        // Preserve the old non-zero TurnKey behavior: the Discord snowflake is
+        // already the turn discriminator, so auxiliary timestamps must not
+        // participate in equality for non-zero ids.
+        Self {
+            channel_id,
+            generation,
+            user_msg_id,
+            turn_started_at: None,
+            turn_start_offset: None,
         }
     }
 

--- a/src/services/discord/delivery_lease_key.rs
+++ b/src/services/discord/delivery_lease_key.rs
@@ -48,16 +48,43 @@ impl DeliveryLeaseKey {
         turn_start_offset: Option<u64>,
         site: &'static str,
     ) -> Self {
+        Self::new_for_site_with_fallback_offset(
+            channel_id,
+            generation,
+            user_msg_id,
+            turn_started_at,
+            turn_start_offset,
+            None,
+            site,
+        )
+    }
+
+    /// Build a lease key while allowing an observed JSONL range start to stand
+    /// in for a missing persisted turn boundary. TUI-direct turns can lose their
+    /// inflight row before terminal delivery; the immutable range start still
+    /// distinguishes the turn and prevents two relay owners from sharing the
+    /// degenerate channel-only key.
+    #[track_caller]
+    pub(in crate::services::discord) fn new_for_site_with_fallback_offset(
+        channel_id: ChannelId,
+        generation: u64,
+        user_msg_id: u64,
+        turn_started_at: Option<&str>,
+        turn_start_offset: Option<u64>,
+        fallback_turn_start_offset: Option<u64>,
+        site: &'static str,
+    ) -> Self {
         if user_msg_id == 0 {
             let started_at = turn_started_at
                 .map(str::trim)
                 .filter(|value| !value.is_empty());
-            if let (Some(started_at), Some(start_offset)) = (started_at, turn_start_offset) {
+            let effective_start_offset = turn_start_offset.or(fallback_turn_start_offset);
+            if let Some(start_offset) = effective_start_offset {
                 return Self {
                     channel_id,
                     generation,
                     user_msg_id,
-                    turn_started_at: Some(started_at.to_string()),
+                    turn_started_at: started_at.map(str::to_string),
                     turn_start_offset: Some(start_offset),
                 };
             }
@@ -152,5 +179,63 @@ impl DeliveryLeaseKey {
 
     pub(in crate::services::discord) fn is_degenerate_legacy(&self) -> bool {
         self.user_msg_id == 0 && self.turn_started_at.is_none() && self.turn_start_offset.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fallback_key(channel: ChannelId, offset: u64, site: &'static str) -> DeliveryLeaseKey {
+        DeliveryLeaseKey::new_for_site_with_fallback_offset(
+            channel,
+            33,
+            0,
+            None,
+            None,
+            Some(offset),
+            site,
+        )
+    }
+
+    #[test]
+    fn id_zero_without_inflight_uses_observed_range_start_4277() {
+        let channel = ChannelId::new(4_277);
+        let first = fallback_key(channel, 2_484_989, "watcher");
+        let same = fallback_key(channel, 2_484_989, "idle_tail");
+        let next = fallback_key(channel, 2_486_000, "watcher");
+
+        assert!(!first.is_degenerate_legacy());
+        assert_eq!(
+            first, same,
+            "both relay owners must contend on one turn key"
+        );
+        assert_ne!(first, next, "a later TUI-direct turn needs a distinct key");
+    }
+
+    #[test]
+    fn watcher_and_idle_tail_cannot_acquire_same_fallback_turn_concurrently_4277() {
+        let channel = ChannelId::new(4_278);
+        let cell = super::super::DeliveryLeaseCell::new(channel);
+        let watcher_key = fallback_key(channel, 900, "watcher");
+        let idle_key = fallback_key(channel, 900, "idle_tail");
+
+        assert!(cell.try_acquire(
+            watcher_key,
+            super::super::LeaseHolder::Watcher { instance_id: 1 },
+            900,
+            1_200,
+            super::super::lease_now_ms().saturating_add(1_000),
+        ));
+        assert!(
+            !cell.try_acquire(
+                idle_key,
+                super::super::LeaseHolder::Sink,
+                900,
+                1_200,
+                super::super::lease_now_ms().saturating_add(1_000),
+            ),
+            "the second relay owner must lose the one-turn delivery lease"
+        );
     }
 }

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -639,8 +639,12 @@ impl SessionBoundDiscordRelaySink {
             delivery.frame_turn_user_msg_id,
             shared.restart.current_generation,
         );
-        let sink_lease_key =
-            delivery_lease_key_for_frame(channel, shared.restart.current_generation, delivery);
+        let sink_lease_key = delivery_lease_key_for_frame(
+            channel,
+            shared.restart.current_generation,
+            delivery,
+            start,
+        );
         let cell = shared.delivery_lease(channel);
         // Self-heal (`SinkDeliveryLeaseGuard::acquire`): reclaim an EXPIRED prior holder before acquire (a stale dead lease must not force a markerless POST).
         cell.reclaim_if_expired(super::lease_now_ms());
@@ -909,6 +913,7 @@ impl SessionBoundDiscordRelaySink {
                     channel,
                     shared.restart.current_generation,
                     &delivery,
+                    start,
                 );
                 let cell = shared.delivery_lease(channel);
                 SinkDeliveryLeaseGuard::acquire(&cell, sink_lease_key, start, end)
@@ -1527,13 +1532,15 @@ fn delivery_lease_key_for_frame(
     channel: ChannelId,
     generation: u64,
     delivery: &SessionRelayDelivery,
+    relay_range_start: u64,
 ) -> super::DeliveryLeaseKey {
-    super::DeliveryLeaseKey::new_for_site(
+    super::DeliveryLeaseKey::new_for_site_with_fallback_offset(
         channel,
         generation,
         delivery.frame_turn_user_msg_id,
         Some(&delivery.frame_turn_started_at),
         delivery.frame_turn_start_offset,
+        Some(relay_range_start),
         "sink",
     )
 }
@@ -2702,6 +2709,38 @@ mod tests {
     }
 
     #[test]
+    fn inflightless_sink_and_watcher_converge_on_canonical_range_start_4277() {
+        let channel = ChannelId::new(4_277_002);
+        let generation = 23;
+        let canonical_range_start = 640;
+        let watcher_observed_current_offset = 1_024;
+        let delivery = delivery_with_fence_offset(
+            "AgentDesk-claude-4277-convergence",
+            Some(1_024),
+            0,
+            "",
+            None,
+        );
+
+        let sink_key =
+            delivery_lease_key_for_frame(channel, generation, &delivery, canonical_range_start);
+        let watcher_key = crate::services::discord::tmux::pinned_delivery_lease_key_for_test(
+            channel,
+            generation,
+            None,
+            &delivery.session_name,
+            watcher_observed_current_offset,
+            canonical_range_start,
+        );
+
+        assert_eq!(
+            sink_key, watcher_key,
+            "the sink frame may lack identity and the watcher current offset may differ, but both owners must key the same turn from the shared delivery-range start"
+        );
+        assert!(!sink_key.is_degenerate_legacy());
+    }
+
+    #[test]
     fn same_id0_turn_frame_and_inflight_derive_equal_delivery_lease_key() {
         let _lock = crate::config::shared_test_env_lock()
             .lock()
@@ -2738,7 +2777,7 @@ mod tests {
             Some(start_offset),
         );
 
-        let frame_key = delivery_lease_key_for_frame(channel, generation, &delivery);
+        let frame_key = delivery_lease_key_for_frame(channel, generation, &delivery, start_offset);
         let inflight_key =
             super::super::DeliveryLeaseKey::from_inflight_state(channel, generation, &inflight);
 

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -884,7 +884,12 @@ impl SessionBoundDiscordRelaySink {
             (Some(start), Some(end)) if end > start => Some((start, end)),
             _ => None,
         };
-        let cutover_short_replace = cutover_range.is_some()
+        // Task-context delivery may confirm a card and then promote the response
+        // route from PlaceholderEdit to NewMessage. Keep that entire operation on
+        // the outer lease so both the card transport and the final answer remain
+        // guarded even though the route mutates inside `ensure_card_and_route`.
+        let cutover_short_replace = delivery.task_notification_context.is_none()
+            && cutover_range.is_some()
             && !relay_text.is_empty()
             && matches!(route, SessionBoundTerminalDeliveryRoute::PlaceholderEdit(_))
             && !session_bound_should_send_new_chunks_for_placeholder(&relay_text);
@@ -2763,6 +2768,92 @@ mod tests {
             matches!(result, Err(RelaySinkError::Transient(_))),
             "the fake token makes transport unavailable only after lease acquisition"
         );
+    }
+
+    #[tokio::test]
+    async fn watcher_preemption_blocks_task_context_route_promotion_before_card_post_4277() {
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        crate::services::tui_prompt_dedupe::reset_state_for_tests();
+
+        let channel_id = 4_277_006;
+        let channel = ChannelId::new(channel_id);
+        let binding = matched(&channel_id.to_string());
+        let registry = Arc::new(HealthRegistry::new());
+        let shared = super::super::make_shared_data_for_tests();
+        shared
+            .http
+            .cached_bot_token
+            .set("test-token".to_string())
+            .expect("test token set once");
+        registry
+            .register(ProviderKind::Claude.as_str().to_string(), shared.clone())
+            .await;
+
+        let mut rebind = inflight_for(
+            &binding.expected_session_name,
+            RelayOwnerKind::Watcher,
+            true,
+        );
+        rebind.channel_id = channel_id;
+        rebind.user_msg_id = 0;
+        rebind.current_msg_id = 9_001;
+        rebind.started_at = "2026-07-24T01:00:00Z".to_string();
+        rebind.turn_start_offset = Some(640);
+        super::super::inflight::save_inflight_state(&rebind).expect("persist rebind inflight");
+
+        let range_start = 640;
+        let range_end = 1_024;
+        let watcher_key = crate::services::discord::tmux::pinned_delivery_lease_key_for_test(
+            channel,
+            shared.restart.current_generation,
+            Some(&rebind),
+            &binding.expected_session_name,
+            range_end,
+            range_start,
+        );
+        assert!(shared.delivery_lease(channel).try_acquire(
+            watcher_key,
+            super::super::LeaseHolder::Watcher { instance_id: 91 },
+            range_start,
+            range_end,
+            super::super::lease_now_ms().saturating_add(10_000),
+        ));
+        let sink = SessionBoundDiscordRelaySink::new(registry);
+        let payload = concat!(
+            "{\"type\":\"system\",\"subtype\":\"task_notification\",\"task_id\":\"bg-route-mutation-4277\",\"tool_use_id\":\"toolu-bg-route-mutation-4277\",\"status\":\"completed\",\"summary\":\"background work\",\"task_notification_kind\":\"background\"}\n",
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"task answer\"}]}}\n",
+            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"task answer\"}\n"
+        );
+        let terminal = terminal_frame_offset(
+            &binding,
+            payload,
+            1,
+            range_end,
+            0,
+            &rebind.started_at,
+            Some(range_start),
+        );
+
+        let outcome = sink
+            .deliver(&terminal)
+            .await
+            .expect("lost lease is a known not-delivered outcome");
+
+        assert_eq!(outcome, RelaySinkOutcome::TerminalNotDelivered);
+        assert_eq!(sink.delivered_total.load(Ordering::Acquire), 0);
+        assert!(
+            crate::services::tui_prompt_dedupe::prompt_anchor_for_response(
+                ProviderKind::Claude.as_str(),
+                &binding.expected_session_name,
+                channel_id,
+            )
+            .is_none(),
+            "task-card ensure must not run after the outer lease loses"
+        );
+        super::super::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
+        crate::services::tui_prompt_dedupe::reset_state_for_tests();
     }
 
     #[tokio::test]

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -296,9 +296,9 @@ struct SinkDeliveryLeaseGuard {
 
 impl SinkDeliveryLeaseGuard {
     /// Self-heal a dead PRIOR holder, then CAS-acquire as `LeaseHolder::Sink` for
-    /// `(turn, [start,end))`. `Some` (spawning the heartbeat) only when the acquire wins; a
-    /// FAILED acquire (another holder owns the range) → `None` → markerless heartbeat-less
-    /// POST that never blocks delivery (single-winner CAS — no dup, no self-black-hole).
+    /// `(turn, [start,end))`. `Some` (spawning the heartbeat) only when the acquire wins;
+    /// `None` means another holder owns the range and the caller must return NotDelivered
+    /// without reaching transport.
     fn acquire(
         cell: &Arc<super::DeliveryLeaseCell>,
         key: super::DeliveryLeaseKey,
@@ -392,15 +392,28 @@ fn session_bound_should_send_new_chunks_for_placeholder(response_text: &str) -> 
     response_text.len() > super::DISCORD_MSG_LIMIT
 }
 
-/// #3089 A2b (review-fix Medium-1): pure `SinkDeliveryLeaseGuard` acquire decision — legacy
-/// branches acquire ONE `Leased{Sink}` marker over `cutover_range`; the cut-over short-replace
-/// branch is EXCLUDED (controller owns the single lease). Extracted so the no-double-acquire
-/// invariant is testable: dropping `!cutover` fails `cutover_skips_sink_guard_acquire`.
-fn sink_guard_lease_range(
-    cutover_range: Option<(u64, u64)>,
-    cutover_short_replace: bool,
-) -> Option<(u64, u64)> {
-    cutover_range.filter(|_| !cutover_short_replace)
+/// Pick the one ordered coordinate used by every terminal sink path. Strict
+/// commit-fenced frames take precedence; inflight-less idle/catch-up frames use
+/// their carried range; legacy no-range frames still return a degenerate
+/// zero-width coordinate so no terminal POST can bypass the shared lease.
+fn sink_delivery_lease_coordinate(delivery: &SessionRelayDelivery) -> ((u64, u64), Option<u64>) {
+    if let (Some(start), Some(end)) = (
+        delivery.frame_turn_start_offset,
+        delivery.terminal_consumed_end,
+    ) && end > start
+    {
+        return ((start, end), Some(start));
+    }
+    if let Some((start, end)) = delivery.relay_range
+        && end > start
+    {
+        return ((start, end), Some(start));
+    }
+
+    // A terminal delivery without an ordered byte range must still serialize on
+    // the channel cell. The zero-width coordinate and absent fallback retain the
+    // legacy degenerate id-0 key instead of allowing a lease-free POST.
+    ((0, 0), None)
 }
 
 #[derive(Clone, Debug, Default)]
@@ -474,11 +487,19 @@ fn inflight_turn_id(state: &InflightTurnState) -> Option<String> {
     (state.user_msg_id != 0).then(|| format!("discord:{}:{}", state.channel_id, state.user_msg_id))
 }
 
+#[cfg(test)]
+struct SinkLeaseTestProbe {
+    acquired: tokio::sync::Notify,
+    release: tokio::sync::Notify,
+}
+
 pub(in crate::services::discord) struct SessionBoundDiscordRelaySink {
     health_registry: Arc<HealthRegistry>,
     frames_total: AtomicU64,
     delivered_total: AtomicU64,
     by_session: Mutex<HashMap<String, SessionRelayParser>>,
+    #[cfg(test)]
+    lease_test_probe: Option<Arc<SinkLeaseTestProbe>>,
 }
 
 impl SessionBoundDiscordRelaySink {
@@ -488,7 +509,19 @@ impl SessionBoundDiscordRelaySink {
             frames_total: AtomicU64::new(0),
             delivered_total: AtomicU64::new(0),
             by_session: Mutex::new(HashMap::new()),
+            #[cfg(test)]
+            lease_test_probe: None,
         }
+    }
+
+    #[cfg(test)]
+    fn with_lease_test_probe(
+        health_registry: Arc<HealthRegistry>,
+        lease_test_probe: Arc<SinkLeaseTestProbe>,
+    ) -> Self {
+        let mut sink = Self::new(health_registry);
+        sink.lease_test_probe = Some(lease_test_probe);
+        sink
     }
 
     fn ingest_frame(&self, frame: &StreamFrame) -> Vec<SessionRelayDelivery> {
@@ -643,7 +676,7 @@ impl SessionBoundDiscordRelaySink {
             channel,
             shared.restart.current_generation,
             delivery,
-            start,
+            Some(start),
         );
         let cell = shared.delivery_lease(channel);
         // Self-heal (`SinkDeliveryLeaseGuard::acquire`): reclaim an EXPIRED prior holder before acquire (a stale dead lease must not force a markerless POST).
@@ -688,7 +721,7 @@ impl SessionBoundDiscordRelaySink {
                 },
                 edit_fail_policy: toc::EditFailPlaceholderPolicy::PreserveAlways,
                 fallback_commit_policy: toc::FallbackCommitPolicy::CommitOnFallback,
-                acquire_failure_mode: toc::AcquireFailureMode::ProceedMarkerless,
+                acquire_failure_mode: toc::AcquireFailureMode::Transient,
                 advance: Some(&advance),
                 heartbeat: Some(&heartbeat),
             },
@@ -840,16 +873,62 @@ impl SessionBoundDiscordRelaySink {
                     provider.as_str()
                 ))
             })?;
+        let (raw_response_text, relay_text) =
+            relay_format::session_bound_relay_bodies(&shared, &provider, &delivery);
+        let channel = ChannelId::new(channel_id);
+
+        let cutover_range = match (
+            delivery.frame_turn_start_offset,
+            delivery.terminal_consumed_end,
+        ) {
+            (Some(start), Some(end)) if end > start => Some((start, end)),
+            _ => None,
+        };
+        let cutover_short_replace = cutover_range.is_some()
+            && !relay_text.is_empty()
+            && matches!(route, SessionBoundTerminalDeliveryRoute::PlaceholderEdit(_))
+            && !session_bound_should_send_new_chunks_for_placeholder(&relay_text);
+        let (lease_range, lease_fallback_start) = sink_delivery_lease_coordinate(&delivery);
+        let sink_lease_guard = if cutover_short_replace {
+            None
+        } else {
+            let sink_lease_key = delivery_lease_key_for_frame(
+                channel,
+                shared.restart.current_generation,
+                &delivery,
+                lease_fallback_start,
+            );
+            let cell = shared.delivery_lease(channel);
+            let Some(guard) = SinkDeliveryLeaseGuard::acquire(
+                &cell,
+                sink_lease_key,
+                lease_range.0,
+                lease_range.1,
+            ) else {
+                tracing::debug!(
+                    provider = provider.as_str(),
+                    channel_id,
+                    tmux_session = %delivery.session_name,
+                    lease_start = lease_range.0,
+                    lease_end = lease_range.1,
+                    "session-bound relay sink deferred terminal delivery because another owner holds the lease"
+                );
+                return Ok(SessionRelayDeliveryOutcome::NotDelivered);
+            };
+            #[cfg(test)]
+            if let Some(probe) = &self.lease_test_probe {
+                probe.acquired.notify_one();
+                probe.release.notified().await;
+            }
+            Some(guard)
+        };
+
         let http = shared.serenity_http_or_token_fallback().ok_or_else(|| {
             RelaySinkError::Transient(format!(
                 "discord http unavailable for provider {}",
                 provider.as_str()
             ))
         })?;
-
-        let (raw_response_text, relay_text) =
-            relay_format::session_bound_relay_bodies(&shared, &provider, &delivery);
-        let channel = ChannelId::new(channel_id);
         let (route, task_card_message_id, task_response_claim_outcome) =
             ensure_card_and_route(&self.health_registry, &shared, &delivery, route).await?;
         let (task_response_claim, task_response_already_delivered): (
@@ -879,45 +958,6 @@ impl SessionBoundDiscordRelaySink {
             }
             None => (None, false),
         };
-
-        // #3089 A2b/#3998 S1-f2: structurally eligible short-replace
-        // (PlaceholderEdit + single-message body) routes to the controller
-        // unconditionally. The controller owns the single lease, so the sink skips
-        // `SinkDeliveryLeaseGuard` (no double-acquire). ONLY a real ordered
-        // `[start,end)` is eligible; degenerate stays legacy. EMPTY `relay_text`
-        // ALSO stays legacy (review-fix M2): legacy
-        // `replace_long_message_raw_with_outcome` treats zero chunks as
-        // `EditedOriginal` (delivered/advance, `formatting.rs:2063`) but the
-        // controller returns `Skipped` (no-advance) for `body.is_empty()` —
-        // diverting would flip → Transient.
-        let cutover_range = match (
-            delivery.frame_turn_start_offset,
-            delivery.terminal_consumed_end,
-        ) {
-            (Some(start), Some(end)) if end > start => Some((start, end)),
-            _ => None,
-        };
-        let cutover_short_replace = cutover_range.is_some()
-            && !relay_text.is_empty()
-            && matches!(route, SessionBoundTerminalDeliveryRoute::PlaceholderEdit(_))
-            && !session_bound_should_send_new_chunks_for_placeholder(&relay_text);
-
-        // #3151: acquire the in-flight `Leased{Sink}` marker BEFORE the POST (see
-        // `SinkDeliveryLeaseGuard`). The legacy long-chunk + new-message branches acquire
-        // ONE marker over the real ordered `cutover_range`; the cut-over short-replace branch
-        // is EXCLUDED (the CONTROLLER owns its lease — no double-acquire). The pure
-        // `sink_guard_lease_range` encodes that (review-fix Medium-1).
-        let sink_lease_guard = sink_guard_lease_range(cutover_range, cutover_short_replace)
-            .and_then(|(start, end)| {
-                let sink_lease_key = delivery_lease_key_for_frame(
-                    channel,
-                    shared.restart.current_generation,
-                    &delivery,
-                    start,
-                );
-                let cell = shared.delivery_lease(channel);
-                SinkDeliveryLeaseGuard::acquire(&cell, sink_lease_key, start, end)
-            });
 
         if task_response_already_delivered {
             self.advance_after_confirmed_post(
@@ -1474,7 +1514,11 @@ async fn run_idle_jsonl_relay_loop(
                             consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
                             continue;
                         }
-                        if producer.try_send_frame(String::from_utf8_lossy(&suffix).into_owned()) {
+                        if producer.try_send_frame_for_range(
+                            String::from_utf8_lossy(&suffix).into_owned(),
+                            from,
+                            end,
+                        ) {
                             consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
                             tracing::debug!(
                                 provider = matched.provider.as_str(),
@@ -1496,7 +1540,11 @@ async fn run_idle_jsonl_relay_loop(
                     IdleRelayRangeAction::SkipClassified => {}
                 }
             }
-            if producer.try_send_frame(String::from_utf8_lossy(&payload).into_owned()) {
+            if producer.try_send_frame_for_range(
+                String::from_utf8_lossy(&payload).into_owned(),
+                start,
+                end,
+            ) {
                 consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
                 tracing::debug!(
                     provider = matched.provider.as_str(),
@@ -1525,6 +1573,7 @@ mod relay_state_contract_refs {
     #[test]
     fn relay_state_contract_symbol_references_compile() {
         let _ = super::turn_parser::SessionRelayParser::ingest_frame;
+        let _ = super::SessionBoundDiscordRelaySink::deliver_response;
     }
 }
 
@@ -1532,7 +1581,7 @@ fn delivery_lease_key_for_frame(
     channel: ChannelId,
     generation: u64,
     delivery: &SessionRelayDelivery,
-    relay_range_start: u64,
+    relay_range_start: Option<u64>,
 ) -> super::DeliveryLeaseKey {
     super::DeliveryLeaseKey::new_for_site_with_fallback_offset(
         channel,
@@ -1540,7 +1589,7 @@ fn delivery_lease_key_for_frame(
         delivery.frame_turn_user_msg_id,
         Some(&delivery.frame_turn_started_at),
         delivery.frame_turn_start_offset,
-        Some(relay_range_start),
+        relay_range_start,
         "sink",
     )
 }
@@ -1584,7 +1633,20 @@ mod tests {
             turn_user_msg_id: 0,
             turn_started_at: String::new(),
             turn_start_offset: None,
+            relay_range: None,
         }
+    }
+
+    fn ranged_frame(
+        binding: &MatchedChannel,
+        payload: &str,
+        sequence: u64,
+        range_start: u64,
+        range_end: u64,
+    ) -> StreamFrame {
+        let mut frame = frame(binding, payload, sequence);
+        frame.relay_range = Some((range_start, range_end));
+        frame
     }
 
     fn terminal_frame(
@@ -1625,6 +1687,7 @@ mod tests {
             turn_user_msg_id,
             turn_started_at: turn_started_at.to_string(),
             turn_start_offset,
+            relay_range: None,
         }
     }
 
@@ -2633,6 +2696,183 @@ mod tests {
         assert_eq!(outcome, RelaySinkOutcome::FrameAccepted);
     }
 
+    #[tokio::test]
+    async fn inflightless_ranged_frame_acquires_sink_lease_before_terminal_delivery_4277() {
+        let channel_id = 4_277_003;
+        let binding = matched(&channel_id.to_string());
+        let registry = Arc::new(HealthRegistry::new());
+        let shared = super::super::make_shared_data_for_tests();
+        shared
+            .http
+            .cached_bot_token
+            .set("test-token".to_string())
+            .expect("test token set once");
+        registry
+            .register(ProviderKind::Claude.as_str().to_string(), shared.clone())
+            .await;
+        let probe = Arc::new(SinkLeaseTestProbe {
+            acquired: tokio::sync::Notify::new(),
+            release: tokio::sync::Notify::new(),
+        });
+        let sink = Arc::new(SessionBoundDiscordRelaySink::with_lease_test_probe(
+            registry,
+            probe.clone(),
+        ));
+        let payload = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"idle result\"}]}}\n",
+            "{\"type\":\"result\",\"result\":\"idle result\"}\n"
+        );
+        let range_start = 640;
+        let range_end = 1_024;
+        let sink_task = {
+            let sink = sink.clone();
+            let frame = ranged_frame(&binding, payload, 1, range_start, range_end);
+            tokio::spawn(async move { sink.deliver(&frame).await })
+        };
+
+        tokio::time::timeout(Duration::from_secs(1), probe.acquired.notified())
+            .await
+            .expect("production RelaySink::deliver acquired the sink lease");
+        match shared.delivery_lease(ChannelId::new(channel_id)).read() {
+            super::super::LeaseSnapshot::Leased {
+                holder,
+                key,
+                start,
+                end,
+                ..
+            } => {
+                assert_eq!(holder, super::super::LeaseHolder::Sink);
+                assert_eq!((start, end), (range_start, range_end));
+                let watcher_key =
+                    crate::services::discord::tmux::pinned_delivery_lease_key_for_test(
+                        ChannelId::new(channel_id),
+                        shared.restart.current_generation,
+                        None,
+                        &binding.expected_session_name,
+                        range_end,
+                        range_start,
+                    );
+                assert_eq!(key, watcher_key);
+            }
+            other => panic!("expected production sink lease before transport, got {other:?}"),
+        }
+
+        probe.release.notify_waiters();
+        let result = sink_task.await.expect("sink task joined");
+        assert!(
+            matches!(result, Err(RelaySinkError::Transient(_))),
+            "the fake token makes transport unavailable only after lease acquisition"
+        );
+    }
+
+    #[tokio::test]
+    async fn watcher_preemption_blocks_inflightless_sink_post_4277() {
+        let channel_id = 4_277_004;
+        let channel = ChannelId::new(channel_id);
+        let binding = matched(&channel_id.to_string());
+        let registry = Arc::new(HealthRegistry::new());
+        let shared = super::super::make_shared_data_for_tests();
+        shared
+            .http
+            .cached_bot_token
+            .set("test-token".to_string())
+            .expect("test token set once");
+        registry
+            .register(ProviderKind::Claude.as_str().to_string(), shared.clone())
+            .await;
+        let sink = SessionBoundDiscordRelaySink::new(registry);
+        let range_start = 700;
+        let range_end = 900;
+        let watcher_key = crate::services::discord::tmux::pinned_delivery_lease_key_for_test(
+            channel,
+            shared.restart.current_generation,
+            None,
+            &binding.expected_session_name,
+            range_end,
+            range_start,
+        );
+        assert!(shared.delivery_lease(channel).try_acquire(
+            watcher_key,
+            super::super::LeaseHolder::Watcher { instance_id: 77 },
+            range_start,
+            range_end,
+            super::super::lease_now_ms().saturating_add(10_000),
+        ));
+        let payload = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"idle result\"}]}}\n",
+            "{\"type\":\"result\",\"result\":\"idle result\"}\n"
+        );
+
+        let outcome = sink
+            .deliver(&ranged_frame(&binding, payload, 1, range_start, range_end))
+            .await
+            .expect("lease contention is a known not-delivered outcome");
+
+        assert_eq!(outcome, RelaySinkOutcome::TerminalNotDelivered);
+        assert_eq!(sink.delivered_total.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn sink_preemption_blocks_watcher_acquire_for_same_inflightless_range_4277() {
+        let channel_id = 4_277_005;
+        let channel = ChannelId::new(channel_id);
+        let binding = matched(&channel_id.to_string());
+        let registry = Arc::new(HealthRegistry::new());
+        let shared = super::super::make_shared_data_for_tests();
+        shared
+            .http
+            .cached_bot_token
+            .set("test-token".to_string())
+            .expect("test token set once");
+        registry
+            .register(ProviderKind::Claude.as_str().to_string(), shared.clone())
+            .await;
+        let probe = Arc::new(SinkLeaseTestProbe {
+            acquired: tokio::sync::Notify::new(),
+            release: tokio::sync::Notify::new(),
+        });
+        let sink = Arc::new(SessionBoundDiscordRelaySink::with_lease_test_probe(
+            registry,
+            probe.clone(),
+        ));
+        let range_start = 800;
+        let range_end = 1_100;
+        let payload = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"idle result\"}]}}\n",
+            "{\"type\":\"result\",\"result\":\"idle result\"}\n"
+        );
+        let sink_task = {
+            let sink = sink.clone();
+            let frame = ranged_frame(&binding, payload, 1, range_start, range_end);
+            tokio::spawn(async move { sink.deliver(&frame).await })
+        };
+        tokio::time::timeout(Duration::from_secs(1), probe.acquired.notified())
+            .await
+            .expect("sink acquired before watcher contention");
+
+        let watcher_key = crate::services::discord::tmux::pinned_delivery_lease_key_for_test(
+            channel,
+            shared.restart.current_generation,
+            None,
+            &binding.expected_session_name,
+            range_end,
+            range_start,
+        );
+        assert!(
+            !shared.delivery_lease(channel).try_acquire(
+                watcher_key,
+                super::super::LeaseHolder::Watcher { instance_id: 88 },
+                range_start,
+                range_end,
+                super::super::lease_now_ms().saturating_add(10_000),
+            ),
+            "watcher must lose after the production sink acquired the canonical range"
+        );
+
+        probe.release.notify_waiters();
+        let _ = sink_task.await.expect("sink task joined");
+    }
+
     // #3041 P1-3 R5 (codex P1-3 — fence gates the ADVANCE, not the ACK): a
     // FENCE-LESS frame that carries a COMPLETE result (e.g. turn B's result riding
     // turn A's trailing tail) produces a delivery whose `terminal_consumed_end` is
@@ -2705,39 +2945,8 @@ mod tests {
             frame_turn_user_msg_id: turn_user_msg_id,
             frame_turn_started_at: turn_started_at.to_string(),
             frame_turn_start_offset: turn_start_offset,
+            relay_range: None,
         }
-    }
-
-    #[test]
-    fn inflightless_sink_and_watcher_converge_on_canonical_range_start_4277() {
-        let channel = ChannelId::new(4_277_002);
-        let generation = 23;
-        let canonical_range_start = 640;
-        let watcher_observed_current_offset = 1_024;
-        let delivery = delivery_with_fence_offset(
-            "AgentDesk-claude-4277-convergence",
-            Some(1_024),
-            0,
-            "",
-            None,
-        );
-
-        let sink_key =
-            delivery_lease_key_for_frame(channel, generation, &delivery, canonical_range_start);
-        let watcher_key = crate::services::discord::tmux::pinned_delivery_lease_key_for_test(
-            channel,
-            generation,
-            None,
-            &delivery.session_name,
-            watcher_observed_current_offset,
-            canonical_range_start,
-        );
-
-        assert_eq!(
-            sink_key, watcher_key,
-            "the sink frame may lack identity and the watcher current offset may differ, but both owners must key the same turn from the shared delivery-range start"
-        );
-        assert!(!sink_key.is_degenerate_legacy());
     }
 
     #[test]
@@ -2777,7 +2986,8 @@ mod tests {
             Some(start_offset),
         );
 
-        let frame_key = delivery_lease_key_for_frame(channel, generation, &delivery, start_offset);
+        let frame_key =
+            delivery_lease_key_for_frame(channel, generation, &delivery, Some(start_offset));
         let inflight_key =
             super::super::DeliveryLeaseKey::from_inflight_state(channel, generation, &inflight);
 
@@ -2885,7 +3095,7 @@ mod tests {
     }
 
     // #3089 A2b: drive the SAME ctx `deliver_short_replace_via_controller` builds
-    // (holder=Sink, ProceedMarkerless, Replace{Active}, PreserveAlways,
+    // (holder=Sink, Transient-on-contention, Replace{Active}, PreserveAlways,
     // CommitOnFallback, identity-gated `advance`) on a FRESH per-channel cell, and
     // assert (1) the cell is acquired EXACTLY ONCE — the no-double-acquire invariant
     // (the sink never also runs `SinkDeliveryLeaseGuard::acquire` on this branch) —
@@ -2933,7 +3143,7 @@ mod tests {
                 },
                 edit_fail_policy: toc::EditFailPlaceholderPolicy::PreserveAlways,
                 fallback_commit_policy: toc::FallbackCommitPolicy::CommitOnFallback,
-                acquire_failure_mode: toc::AcquireFailureMode::ProceedMarkerless,
+                acquire_failure_mode: toc::AcquireFailureMode::Transient,
                 advance: Some(&advance),
                 heartbeat: Some(&hb),
             },
@@ -3031,8 +3241,6 @@ mod tests {
     //  (a) advance = unconditional `true` (instead of the fresh identity gate):
     //      the MISMATCH case below would flip `NotDelivered`/no-advance into
     //      `Delivered`/advance and fail.
-    //  (b) guard-skip removed (`&& !cutover_short_replace` dropped from
-    //      `sink_guard_lease_range`): `cutover_skips_sink_guard_acquire` fails.
     #[test]
     fn cutover_short_replace_production_path_advance_is_fresh_identity_gated() {
         let _lock = crate::config::shared_test_env_lock()
@@ -3175,7 +3383,7 @@ mod tests {
                 .replace_calls
                 .load(std::sync::atomic::Ordering::SeqCst),
             1,
-            "the mismatched run still POSTs once (markerless-equivalent), only the advance differs"
+            "the mismatched run still POSTs once under its held lease; only the advance differs"
         );
     }
 
@@ -3291,31 +3499,23 @@ mod tests {
         );
     }
 
-    // #3089 A2b (review-fix Medium-1): the no-double-acquire invariant — a
-    // cut-over short-replace turn must SKIP the legacy `SinkDeliveryLeaseGuard`
-    // acquire so the controller owns the SINGLE lease. The pure
-    // `sink_guard_lease_range` returns `None` for any cut-over turn; dropping the
-    // `&& !cutover_short_replace` exclusion (the guard-skip mutation) makes it
-    // return `Some(..)` and fails here, while the legacy (non-cutover) branches
-    // still acquire over a real ordered range.
     #[test]
-    fn cutover_skips_sink_guard_acquire() {
-        // Cut-over ON + a real ordered range → guard MUST be skipped (no double-acquire).
+    fn terminal_lease_coordinate_prefers_fence_then_idle_range_then_degenerate() {
+        let fenced = delivery_with_fence_offset("fenced", Some(256), 0, "", Some(64));
         assert_eq!(
-            sink_guard_lease_range(Some((0, 256)), true),
-            None,
-            "a cut-over short-replace turn must NOT acquire the legacy sink guard \
-             (no double-acquire — the controller owns the single lease)"
+            sink_delivery_lease_coordinate(&fenced),
+            ((64, 256), Some(64))
         );
-        // Cut-over OFF (legacy long-chunk / new-message) → guard acquires the range.
+
+        let mut ranged = delivery_with_fence_offset("ranged", None, 0, "", None);
+        ranged.relay_range = Some((300, 512));
         assert_eq!(
-            sink_guard_lease_range(Some((0, 256)), false),
-            Some((0, 256)),
-            "the legacy branches still acquire ONE sink guard over the ordered range"
+            sink_delivery_lease_coordinate(&ranged),
+            ((300, 512), Some(300))
         );
-        // Absent range (degenerate / no fence) → no guard either way.
-        assert_eq!(sink_guard_lease_range(None, false), None);
-        assert_eq!(sink_guard_lease_range(None, true), None);
+
+        let degenerate = delivery_with_fence_offset("degenerate", None, 0, "", None);
+        assert_eq!(sink_delivery_lease_coordinate(&degenerate), ((0, 0), None));
     }
 
     // #3089 A2b (review-fix M2): an EMPTY body diverges between the controller and
@@ -3366,7 +3566,7 @@ mod tests {
                 },
                 edit_fail_policy: toc::EditFailPlaceholderPolicy::PreserveAlways,
                 fallback_commit_policy: toc::FallbackCommitPolicy::CommitOnFallback,
-                acquire_failure_mode: toc::AcquireFailureMode::ProceedMarkerless,
+                acquire_failure_mode: toc::AcquireFailureMode::Transient,
                 advance: Some(&advance),
                 heartbeat: Some(&hb),
             },
@@ -4253,6 +4453,7 @@ mod tests {
             frame_turn_user_msg_id: 0,
             frame_turn_started_at: "2026-06-04T00:00:00Z".to_string(),
             frame_turn_start_offset: None,
+            relay_range: None,
         }
     }
 
@@ -4666,8 +4867,8 @@ mod tests {
         }
 
         /// ACQUIRE FAILS when the watcher/bridge already holds the range: the guard is
-        /// `None` → the sink POSTs markerless (no double-commit, no self-black-hole),
-        /// and the existing holder's lease is untouched.
+        /// `None`, so the production caller returns NotDelivered before transport and
+        /// the existing holder's lease is untouched.
         #[test]
         fn acquire_fails_when_another_holder_owns_range() {
             let ch = ChannelId::new(7304);
@@ -4683,7 +4884,7 @@ mod tests {
                 END,
                 now.saturating_add(10_000),
             ));
-            // The sink's acquire loses → None (markerless POST; no duplicate).
+            // The sink's acquire loses → None; the caller must not POST.
             assert!(
                 SinkDeliveryLeaseGuard::acquire(&cell, turn, START, END).is_none(),
                 "the sink acquire must lose to the watcher's existing lease"
@@ -4697,7 +4898,7 @@ mod tests {
 
         /// A STALE-EXPIRED prior holder is self-healed by `acquire`'s
         /// `reclaim_if_expired` (mirrors the watcher) so the sink's acquire still
-        /// wins — otherwise the sink would POST markerless and reintroduce the dup.
+        /// wins instead of deferring forever behind a dead holder.
         #[tokio::test]
         async fn acquire_self_heals_an_expired_prior_holder() {
             let ch = ChannelId::new(7305);

--- a/src/services/discord/session_relay_sink/task_notification_context.rs
+++ b/src/services/discord/session_relay_sink/task_notification_context.rs
@@ -687,6 +687,7 @@ mod tests {
             frame_turn_user_msg_id: 0,
             frame_turn_started_at: "2026-07-11T01:37:00Z".to_string(),
             frame_turn_start_offset: Some(4055),
+            relay_range: None,
         };
         let transport = OrderedTransport {
             fail: AtomicBool::new(false),

--- a/src/services/discord/session_relay_sink/turn_parser.rs
+++ b/src/services/discord/session_relay_sink/turn_parser.rs
@@ -112,6 +112,7 @@ impl SessionRelayParser {
                     frame_turn_user_msg_id: frame.turn_user_msg_id,
                     frame_turn_started_at: frame.turn_started_at.clone(),
                     frame_turn_start_offset: frame.turn_start_offset,
+                    relay_range: frame.relay_range,
                 });
                 break;
             } else {
@@ -148,4 +149,5 @@ pub(in crate::services::discord) struct SessionRelayDelivery {
     pub(super) frame_turn_user_msg_id: u64,
     pub(super) frame_turn_started_at: String,
     pub(super) frame_turn_start_offset: Option<u64>,
+    pub(super) relay_range: Option<(u64, u64)>,
 }

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -2307,6 +2307,8 @@ async fn release_restored_watcher_active_turn_before_panel_edit(
 #[path = "tmux_watcher.rs"]
 #[allow(clippy::too_many_arguments)]
 mod tmux_watcher;
+#[cfg(test)]
+pub(in crate::services::discord) use self::tmux_watcher::pinned_delivery_lease_key_for_test;
 pub(super) use self::tmux_watcher::{
     TuiCompletionGateOutcome, emit_explicit_inflight_cleanup_signal, run_tui_completion_gate,
     tmux_output_watcher, tmux_output_watcher_with_restore,

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -174,6 +174,8 @@ use self::supervisor_relay::*;
 use self::terminal_abort_exits::*;
 use self::terminal_commit_epilogue::*;
 use self::terminal_readiness::*;
+#[cfg(test)]
+pub(in crate::services::discord) use self::turn_identity::pinned_delivery_lease_key as pinned_delivery_lease_key_for_test;
 use self::turn_stream_collector::*;
 use self::utf8_chunk_decoder::*;
 
@@ -1857,6 +1859,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         // below). Acquire is the atomic fast-path (B4); commit/advance/release run INLINE
         // (preserving the pre-P1-1 advance timing, avoiding an actor-deferral duplicate).
         // The actor CommitDelivery/ReleaseDelivery messages remain dormant.
+        let watcher_lease_start = data_start_offset;
+        let watcher_lease_end = terminal_event_consumed_offset(current_offset, &all_data);
         let (watcher_lease_turn, watcher_lease_key, watcher_lease_holder) =
             pinned_watcher_delivery_lease_identity(
                 channel_id,
@@ -1865,9 +1869,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 inflight_before_relay.as_ref(),
                 &tmux_session_name,
                 current_offset,
+                watcher_lease_start,
             );
-        let watcher_lease_start = data_start_offset;
-        let watcher_lease_end = terminal_event_consumed_offset(current_offset, &all_data);
         // #3610 PR-1d: capture the legacy long-chunk anchor here; record it only
         // after the post-advance M4 commit below.
         let mut watcher_long_chunk_anchor_msg_id: Option<MessageId> = None;

--- a/src/services/discord/tmux_watcher/turn_identity.rs
+++ b/src/services/discord/tmux_watcher/turn_identity.rs
@@ -234,12 +234,13 @@ pub(super) fn pinned_finalizer_turn_id(
         .unwrap_or(0)
 }
 
-pub(super) fn pinned_delivery_lease_key(
+pub(in crate::services::discord) fn pinned_delivery_lease_key(
     channel_id: poise::serenity_prelude::ChannelId,
     generation: u64,
     inflight_before_relay: Option<&crate::services::discord::inflight::InflightTurnState>,
     tmux_session_name: &str,
     current_offset: u64,
+    relay_range_start: u64,
 ) -> crate::services::discord::DeliveryLeaseKey {
     if let Some(state) = inflight_before_relay.filter(|state| {
         state.tmux_session_name.as_deref().map(str::trim) == Some(tmux_session_name.trim())
@@ -255,7 +256,7 @@ pub(super) fn pinned_delivery_lease_key(
             0,
             None,
             None,
-            Some(current_offset),
+            Some(relay_range_start),
             "watcher",
         )
     }
@@ -391,6 +392,7 @@ pub(super) fn pinned_watcher_delivery_lease_identity(
     inflight_before_relay: Option<&crate::services::discord::inflight::InflightTurnState>,
     tmux_session_name: &str,
     current_offset: u64,
+    relay_range_start: u64,
 ) -> (
     crate::services::discord::turn_finalizer::TurnKey,
     crate::services::discord::DeliveryLeaseKey,
@@ -408,6 +410,7 @@ pub(super) fn pinned_watcher_delivery_lease_identity(
             inflight_before_relay,
             tmux_session_name,
             current_offset,
+            relay_range_start,
         ),
         crate::services::discord::LeaseHolder::Watcher {
             instance_id: watcher_instance_id,

--- a/src/services/discord/tmux_watcher/turn_identity.rs
+++ b/src/services/discord/tmux_watcher/turn_identity.rs
@@ -249,8 +249,14 @@ pub(super) fn pinned_delivery_lease_key(
             channel_id, generation, state, "watcher",
         )
     } else {
-        crate::services::discord::DeliveryLeaseKey::new_for_site(
-            channel_id, generation, 0, None, None, "watcher",
+        crate::services::discord::DeliveryLeaseKey::new_for_site_with_fallback_offset(
+            channel_id,
+            generation,
+            0,
+            None,
+            None,
+            Some(current_offset),
+            "watcher",
         )
     }
 }
@@ -328,24 +334,17 @@ pub(super) fn degenerate_duplicate_refuses_delivery(
 pub(super) fn watcher_direct_terminal_response_decision(
     provider: &ProviderKind,
     channel_id: ChannelId,
-    generation: u64,
+    _generation: u64,
     tmux_session_name: &str,
     inflight_before_relay: Option<&crate::services::discord::inflight::InflightTurnState>,
-    current_offset: u64,
+    _current_offset: u64,
     fresh_assistant_text_in_observed_range: bool,
     response: &str,
 ) -> WatcherDirectTerminalResponseDecision {
     if response.trim().is_empty() {
         return WatcherDirectTerminalResponseDecision::Empty;
     }
-    let key = pinned_delivery_lease_key(
-        channel_id,
-        generation,
-        inflight_before_relay,
-        tmux_session_name,
-        current_offset,
-    );
-    let duplicate = key.is_degenerate_legacy()
+    let duplicate = inflight_before_relay.is_none()
         && crate::services::discord::outbound::delivery_record::recent_delivered_content_matches(
             provider,
             channel_id,
@@ -378,7 +377,7 @@ pub(super) fn watcher_direct_terminal_response_decision(
             response_len = response.len(),
             fresh_assistant_text_in_observed_range,
             pending_user_boundary,
-            "watcher: suppressed degenerate-key duplicate terminal response by content fingerprint"
+            "watcher: suppressed inflight-less duplicate terminal response by content fingerprint"
         );
         return WatcherDirectTerminalResponseDecision::RefusedDegenerateDuplicate;
     }

--- a/src/services/discord/tmux_watcher/turn_identity_tests.rs
+++ b/src/services/discord/tmux_watcher/turn_identity_tests.rs
@@ -259,6 +259,36 @@ fn pinned_delivery_lease_key_id0_without_offset_acquires_and_commits_delivery() 
 }
 
 #[test]
+fn no_inflight_offset_key_still_refuses_append_edit_tail_duplicate_4277() {
+    let temp = tempfile::TempDir::new().expect("temp runtime root");
+    let _root_guard = crate::config::set_agentdesk_root_for_test(temp.path());
+
+    let provider = ProviderKind::Claude;
+    let session = "AgentDesk-claude-adk-cc-4277";
+    let channel_id = poise::serenity_prelude::ChannelId::new(7_4277);
+    let body = "already edited prose tail";
+    let gen_path = crate::services::tmux_common::session_temp_path(session, "generation");
+    std::fs::create_dir_all(std::path::Path::new(&gen_path).parent().unwrap()).unwrap();
+    std::fs::write(&gen_path, b"1").unwrap();
+    crate::services::discord::outbound::delivery_record::record_delivered_content_fingerprint(
+        &provider, channel_id, session, body,
+    );
+
+    let key = pinned_delivery_lease_key(channel_id, 33, None, session, 2_484_989);
+    assert!(
+        !key.is_degenerate_legacy(),
+        "the observed range must promote the lease out of the channel-only legacy class"
+    );
+    assert_eq!(
+        watcher_direct_terminal_response_decision(
+            &provider, channel_id, 33, session, None, 2_484_989, false, body,
+        ),
+        WatcherDirectTerminalResponseDecision::RefusedDegenerateDuplicate,
+        "promoting the lease identity must not disable the content guard that blocks an append-edit tail reattachment"
+    );
+}
+
+#[test]
 fn degenerate_key_content_guard_requires_no_fresh_output_4081() {
     let temp = tempfile::TempDir::new().expect("temp runtime root");
     let _root_guard = crate::config::set_agentdesk_root_for_test(temp.path());

--- a/src/services/discord/tmux_watcher/turn_identity_tests.rs
+++ b/src/services/discord/tmux_watcher/turn_identity_tests.rs
@@ -222,7 +222,7 @@ fn pinned_delivery_lease_key_id0_without_offset_acquires_and_commits_delivery() 
     let mut state = state_with_offsets(0, session, None, 0);
     state.started_at = "2026-07-03T06:00:00Z".to_string();
 
-    let key = pinned_delivery_lease_key(channel_id, 33, Some(&state), session, 50);
+    let key = pinned_delivery_lease_key(channel_id, 33, Some(&state), session, 50, 0);
     let cell = crate::services::discord::DeliveryLeaseCell::new(channel_id);
     let holder = crate::services::discord::LeaseHolder::Watcher { instance_id: 77 };
     let acquired = cell.try_acquire(
@@ -274,7 +274,7 @@ fn no_inflight_offset_key_still_refuses_append_edit_tail_duplicate_4277() {
         &provider, channel_id, session, body,
     );
 
-    let key = pinned_delivery_lease_key(channel_id, 33, None, session, 2_484_989);
+    let key = pinned_delivery_lease_key(channel_id, 33, None, session, 2_484_989, 2_484_000);
     assert!(
         !key.is_degenerate_legacy(),
         "the observed range must promote the lease out of the channel-only legacy class"
@@ -610,8 +610,14 @@ async fn live_long_chunk_delivery_fingerprint_uses_raw_body_4081() {
 
     let generation = 33;
     let cell = shared.delivery_lease(channel_id);
-    let lease_key =
-        pinned_delivery_lease_key(channel_id, generation, None, session, raw_body.len() as u64);
+    let lease_key = pinned_delivery_lease_key(
+        channel_id,
+        generation,
+        None,
+        session,
+        raw_body.len() as u64,
+        0,
+    );
     let turn = crate::services::discord::turn_finalizer::TurnKey::new(channel_id, 0, generation);
     let outcome = super::super::terminal_long_chunks::deliver_long_chunks_via_controller(
         &LongChunkGateway,

--- a/src/services/discord/turn_finalizer/delivery_lease.rs
+++ b/src/services/discord/turn_finalizer/delivery_lease.rs
@@ -149,12 +149,6 @@ mod tests {
         let disambiguated =
             DeliveryLeaseKey::new_for_site(ch, 0, 0, Some("2026-07-03 06:00:00"), Some(10), "test");
 
-        // The dormant finalizer handlers receive keys pre-built by their relay
-        // owner; they never reconstruct an observed range. Preserve the legacy
-        // mixed-partial collapse here so a stale actor commit/release cannot change
-        // identity merely because one old caller happened to retain only one field.
-        // #4277's live watcher/sink fallback applies only when both persisted
-        // disambiguators are absent and both owners share the canonical range start.
         assert_eq!(
             missing_offset, missing_started_at,
             "all residual id-0 keys without full disambiguators collapse to the legacy degenerate identity"

--- a/src/services/discord/turn_finalizer/delivery_lease.rs
+++ b/src/services/discord/turn_finalizer/delivery_lease.rs
@@ -149,6 +149,12 @@ mod tests {
         let disambiguated =
             DeliveryLeaseKey::new_for_site(ch, 0, 0, Some("2026-07-03 06:00:00"), Some(10), "test");
 
+        // The dormant finalizer handlers receive keys pre-built by their relay
+        // owner; they never reconstruct an observed range. Preserve the legacy
+        // mixed-partial collapse here so a stale actor commit/release cannot change
+        // identity merely because one old caller happened to retain only one field.
+        // #4277's live watcher/sink fallback applies only when both persisted
+        // disambiguators are absent and both owners share the canonical range start.
         assert_eq!(
             missing_offset, missing_started_at,
             "all residual id-0 keys without full disambiguators collapse to the legacy degenerate identity"


### PR DESCRIPTION
## Root cause

The remaining #4277 dual-poster case was an inflight-less TUI-direct terminal turn. Once its inflight row disappeared, the watcher built the residual `(channel, generation, user_msg_id=0)` delivery-lease key without either turn discriminator. A watcher replacement / idle-tail competitor could therefore treat the same terminal range as an unscoped legacy turn and independently fresh-post the same prose.

The append-edit reattachment guard was coupled to that `is_degenerate_legacy()` classification. Promoting the lease key without separating the content guard would have reopened the older already-edited-tail replay, so the two concerns are now independent.

## Change

- Add an observed-range fallback to `DeliveryLeaseKey` so inflight-less id-0 turns use the watcher JSONL coordinate as a non-degenerate turn discriminator.
- Use the authoritative observed range in the watcher lease identity when no matching inflight row remains.
- Keep recent-content duplicate suppression active for every inflight-less terminal response, even after its lease identity is promoted.
- Add regressions for watcher/idle-tail lease contention, distinct subsequent TUI turns, append-edit tail replay suppression, and the normal fully identified path.

## Round 2 owner-convergence proof

The round-1 offset fallback used watcher `current_offset`, which is the read/batch end and can differ from the sink frame turn start. Round 2 instead keys both live owners from the canonical delivery range start:

- watcher: `data_start_offset` becomes `watcher_lease_start` and is passed into `pinned_watcher_delivery_lease_identity`;
- session-bound sink: the exact controller/guard `start` from `cutover_range = (frame_turn_start_offset, terminal_consumed_end)` is passed into `delivery_lease_key_for_frame`;
- idle-tail: it streams through the bridge/watcher pipeline from its resolved `start_offset`; the watcher range begins at that same coordinate.

The new cross-owner regression intentionally gives the watcher a different `current_offset` while the sink frame lacks `started_at` and `turn_start_offset`; both nevertheless derive the same key from the shared range start.

The dormant finalizer actor handlers do not reconstruct offsets; they consume the already-built key. Therefore the legacy mixed-partial `(Some(started_at), None)` / `(None, Some(offset))` collapse remains load-bearing for stale actor commit/release compatibility. The range fallback is restricted to the live-owner shape where both persisted disambiguators are absent, so `cargo test --lib delivery_lease` retains that contract.

## Distinction from adjacent issues

- #4365 / #4842 fixed stale `SessionRelayParser` ownership across async delivery and turn boundaries. This PR does not retain or reset parser prose.
- #4277 here fixes the separate inflight-less watcher/idle-tail delivery identity and append-edit replay guard.
- #4508 concerns restart/edit-target delivery records and is not broadened here.

## Verification

- `cargo fmt --all --check`
- `cargo check --lib`
- `cargo test --lib session_relay`
- `cargo test --lib tmux_watcher`
- `cargo test --lib 4277`
- `python3 scripts/check_inflight_blind_save_ratchet.py`
- `python3 scripts/check_contract_symbol_refs.py`
- `./scripts/ci-script-checks.sh`
- `python3 scripts/generate_inventory_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py`

Closes #4277

🤖 Generated with [Claude Code](https://claude.com/claude-code)
