### PR TITLE
fix(#4536): advance idle cursor only after confirmed commit

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1999,6 +1999,9 @@ these contextual numbers to match ordinary LoC churn.
   from #3864 moving SIGTERM queue-restore merge inside the mailbox actor; +10
   from #4018 round-2 adding the distinct `MonitorAutoTurn` active-turn marker
   while keeping monitor turns background for queue-yield/cancel semantics).
+- `src/services/cluster/stream_relay.rs` (tracked giant surface; #4536 carries the
+  ordered idle JSONL range plus wrapper-generation coordinate through the existing
+  producer queue/consumer protocol; keep per `scripts/giant_file_registry.toml`).
 - `src/services/discord/session_relay_sink.rs` (frozen giant surface; +1 from #4046
   S1r-1 conservatively rejecting the dormant fresh-send-only outcome at this
   replace-only caller; -59 from #3998 S1-f2 retiring the A2b rollout getter/cache
@@ -2008,7 +2011,8 @@ these contextual numbers to match ordinary LoC churn.
   `session_relay_sink/task_notification_context.rs`; -135 prod from #4365 moving
   the turn parser into `session_relay_sink/turn_parser.rs`, where terminal parse
   atomically hands off completed response/context and clears turn-local state
-  before asynchronous Discord delivery).
+  before asynchronous Discord delivery; #4536 keeps idle grace ranges pending
+  until a generation-scoped confirmed delivery commits the durable frontier).
 
 Decomposed below the giant-file threshold (no longer frozen; bugfix-scoped but
 normal test growth is allowed): `src/services/analytics.rs`,

--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -1,5 +1,7 @@
 # Discord Outbound Migration — Coverage Map (#1006 v3 / #1280 / #1436 / #1457)
 
+> Last refreshed: 2026-07-24 (#4536 — confirmed idle/catch-up ranged POSTs now persist a generation-scoped ordered JSONL frontier before advancing the in-memory watermark. This adds an internal delivery-record commit writer but no Discord transport verb or v3 producer callsite; the coverage map below is unchanged).
+>
 > Last refreshed: 2026-07-23 (#4797 round 4 — test gateway implementations thread the queued-dispatch capability required by the `TurnGateway` trait; outbound controller delivery verbs, production callsite coverage, and delivery semantics are unchanged).
 >
 > Last refreshed: 2026-07-21 (against #4706 lint-debt annotations only; outbound callsite coverage and delivery semantics are unchanged).

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -446,6 +446,11 @@
   before merging.
 
 ### Audited touches
+
+- 2026-07-24 — #4536 idle JSONL cursor/commit boundary: temporary active/grace
+  suppression now holds uncommitted ordered ranges, and only generation/EOF-checked
+  confirmed delivery advances the durable and in-memory frontiers. No inflight
+  blind save was added; #4843 reanchor and #4847 shared lease contracts remain intact.
 - #4756 blocking filesystem isolation: routine script reload scans remain inside the existing worker-local routine runtime and per-request validation paths, while startup dashboard provisioning and session-resume discovery retain their existing node-local paths. Moving those synchronous directory walks to Tokio's blocking pool changes no leader election, PG lease, worker placement, durable ownership, or cross-node routing authority.
 - #4340 r3 finalizer-panel ownership fencing remains worker-local: watchdog clear now returns the row removed under the existing per-channel inflight flock, and durable terminal-card records bind message IDs to turn episode plus panel/save revisions. No PostgreSQL schema, lease, leader election, cross-node routing, or owner placement authority changes.
 - #4777 PR-1 channel owner-authority rollout scope: `owner_authority_channel_ids`

--- a/docs/relay-state-contract.md
+++ b/docs/relay-state-contract.md
@@ -328,6 +328,32 @@ plan.
 - Invariant key: `session_terminal_post_lease_required` (enforced structurally by
   the mandatory acquire and production-entry regression tests).
 
+## I10. idle JSONL cursors consume only classified drops or confirmed commits (#4536)
+
+- Definition: the idle backstop range decision
+  (`sym:session_relay_sink::idle_jsonl::idle_jsonl_suppressed_range_action`)
+  separates intentional classification drops from temporary inflight/grace
+  deferral.
+- Producer: confirmed ranged transport commits through
+  `SessionBoundDiscordRelaySink::advance_idle_range_after_confirmed_post`
+  (`sym:session_relay_sink::SessionBoundDiscordRelaySink::advance_idle_range_after_confirmed_post`),
+  which first persists the generation-scoped frontier via
+  `commit_ordered_jsonl_range`
+  (`sym:outbound::delivery_record::commit_ordered_jsonl_range`) and then advances
+  the in-memory watermark.
+- Consumer: the idle loop advances its local cursor only when the range is an
+  intentional drop or current-generation committed coverage reaches its end;
+  enqueue acceptance alone leaves the pending range retryable.
+- Invariant: active-turn, post-inflight-grace, and new-session-grace suppression
+  never consumes an uncommitted byte. A confirmed ranged POST must match the
+  queued wrapper generation and remain EOF-bounded before either authority is
+  advanced.
+- Violation surface: enqueue followed by transport/commit failure permanently
+  skips a wake/background answer, or a delayed range commits against a replaced
+  transcript and suppresses unrelated output.
+- Invariant key: `idle_cursor_confirmed_commit_only` (enforced structurally and by
+  cursor/commit/generation regression tests).
+
 ## How to add a new invariant
 
 1. Document it here with the same structure (definition, producer,

--- a/scripts/giant_file_registry.toml
+++ b/scripts/giant_file_registry.toml
@@ -712,6 +712,14 @@ deadline = "2026-10-31"
 decompose_issue = "#4712"
 
 [[entry]]
+# Crossed the threshold in #4536 when ordered idle ranges gained generation
+# coordinates alongside the existing sequence/terminal-fence queue protocol.
+file = "src/services/cluster/stream_relay.rs"
+decision = "keep"
+owner = "discord-relay"
+keep_reason = "The queue, exact-sequence outcome ring, and producer/consumer frame protocol form one ordered delivery boundary; keep them cohesive while #4766 relay lanes establish the ranged commit contract."
+
+[[entry]]
 # Crossed the 1000-prod-LoC threshold when #3017 re-landed the single
 # output-offset relay-dedup authority: the idle-JSONL relay loop now consults
 # `committed_relay_offset` (read-only) with generation-aware watermark resets to

--- a/src/services/cluster/registry_adapter_sink.rs
+++ b/src/services/cluster/registry_adapter_sink.rs
@@ -147,6 +147,7 @@ mod tests {
             turn_started_at: String::new(),
             turn_start_offset: None,
             relay_range: None,
+            relay_generation_mtime_ns: None,
         };
         sink.deliver(&frame).await.expect("infallible");
         sink.deliver(&frame).await.expect("infallible");

--- a/src/services/cluster/stream_relay.rs
+++ b/src/services/cluster/stream_relay.rs
@@ -155,8 +155,12 @@ pub struct StreamFrame {
     /// identity for backpressure attribution, but only frames with
     /// `terminal_consumed_end` can advance the sink commit fence.
     pub turn_start_offset: Option<u64>,
-    /// Idle/catch-up lease range; never a commit fence.
+    /// Idle/catch-up ordered JSONL range. The range is a commit candidate only
+    /// when `relay_generation_mtime_ns` still matches the live wrapper.
     pub relay_range: Option<(u64, u64)>,
+    /// Wrapper generation captured with `relay_range`. A queued range from a
+    /// replaced wrapper must never commit against the replacement transcript.
+    pub relay_generation_mtime_ns: Option<i64>,
 }
 
 /// Per-session counters. Exposed via the supervisor for diagnostics.
@@ -477,9 +481,21 @@ impl RelayProducer {
         self.try_send_frame_with_sequence_and_identity(payload, None)
     }
 
-    pub fn try_send_frame_for_range(&self, payload: String, start: u64, end: u64) -> bool {
-        self.enqueue(payload, None, None, Some((start, end)))
-            .is_alive()
+    pub fn try_send_frame_for_range(
+        &self,
+        payload: String,
+        start: u64,
+        end: u64,
+        generation_mtime_ns: i64,
+    ) -> bool {
+        self.enqueue(
+            payload,
+            None,
+            None,
+            Some((start, end)),
+            Some(generation_mtime_ns),
+        )
+        .is_alive()
     }
 
     fn enqueue(
@@ -488,6 +504,7 @@ impl RelayProducer {
         terminal: Option<TerminalCommitFence>,
         identity: Option<RelayTurnIdentity>,
         range: Option<(u64, u64)>,
+        relay_generation_mtime_ns: Option<i64>,
     ) -> RelaySendOutcome {
         try_send_frame_inner(
             &self.matched,
@@ -499,6 +516,7 @@ impl RelayProducer {
             terminal,
             identity,
             range,
+            relay_generation_mtime_ns,
         )
     }
 
@@ -511,7 +529,7 @@ impl RelayProducer {
         payload: String,
         frame_identity: Option<RelayTurnIdentity>,
     ) -> RelaySendOutcome {
-        self.enqueue(payload, None, frame_identity, None)
+        self.enqueue(payload, None, frame_identity, None, None)
     }
 
     /// #3041 P1-3 (Part a, B1): forward the RESULT-bearing chunk as a terminal
@@ -524,7 +542,7 @@ impl RelayProducer {
         payload: String,
         terminal: TerminalCommitFence,
     ) -> RelaySendOutcome {
-        self.enqueue(payload, Some(terminal), None, None)
+        self.enqueue(payload, Some(terminal), None, None, None)
     }
 }
 
@@ -663,6 +681,7 @@ fn try_send_frame_inner(
     terminal: Option<TerminalCommitFence>,
     frame_identity: Option<RelayTurnIdentity>,
     relay_range: Option<(u64, u64)>,
+    relay_generation_mtime_ns: Option<i64>,
 ) -> RelaySendOutcome {
     if shutdown.load(Ordering::Acquire) {
         return RelaySendOutcome::closed();
@@ -689,6 +708,7 @@ fn try_send_frame_inner(
         turn_started_at: frame_identity.turn_started_at,
         turn_start_offset: frame_identity.turn_start_offset,
         relay_range,
+        relay_generation_mtime_ns,
     };
     metrics.frames_received.fetch_add(1, Ordering::AcqRel);
     match queue.push_drop_oldest(frame) {
@@ -748,6 +768,7 @@ impl StreamRelayHandle {
             &self.metrics,
             &self.sequence,
             payload,
+            None,
             None,
             None,
             None,
@@ -1118,12 +1139,13 @@ mod tests {
         let handle = spawn_stream_relay(matched_for("c-range"), sink.clone());
         let producer = handle.producer();
 
-        assert!(producer.try_send_frame_for_range("idle-result".into(), 640, 1_024));
+        assert!(producer.try_send_frame_for_range("idle-result".into(), 640, 1_024, 77));
         flush_pending().await;
 
         let delivered = sink.delivered();
         assert_eq!(delivered.len(), 1);
         assert_eq!(delivered[0].relay_range, Some((640, 1_024)));
+        assert_eq!(delivered[0].relay_generation_mtime_ns, Some(77));
         assert_eq!(delivered[0].terminal_consumed_end, None);
         assert_eq!(delivered[0].turn_start_offset, None);
         handle.shutdown().await;

--- a/src/services/discord/inflight/orphan_relay_reclaim.rs
+++ b/src/services/discord/inflight/orphan_relay_reclaim.rs
@@ -30,8 +30,8 @@
 //! So a delivered-but-unmirrored row STAYS orphan-shaped under the flock and the
 //! downgrade PROCEEDS — that is expected and correct. Single delivery is then
 //! guaranteed because EVERY re-delivery path re-reads `effective_committed_offset`
-//! FRESH and `idle_relay_range_action` returns `SkipAlreadyRelayed` (whole body
-//! already past the watermark) or `SendSuffixFrom(committed)` (only the
+//! FRESH and `idle_relay_range_action` returns `AdvanceCommitted` (whole body
+//! already past the watermark) or `SendPendingSuffixFrom(committed)` (only the
 //! uncommitted tail). The caller's unlocked `committed <= turn_floor` gate is a
 //! first-line filter for the already-advanced case; the send-point re-gate is
 //! the authority.

--- a/src/services/discord/outbound/delivery_record.rs
+++ b/src/services/discord/outbound/delivery_record.rs
@@ -365,6 +365,63 @@ pub(in crate::services::discord) fn write_delivered_frontier(
     write_delivered_frontier_at(&record_path_or_err(provider, channel_id)?, frontier)
 }
 
+fn commit_ordered_jsonl_range_at(
+    path: &Path,
+    range: (u64, u64),
+    generation_mtime_ns: i64,
+) -> Result<bool, String> {
+    if generation_mtime_ns == 0 || range.1 <= range.0 {
+        return Ok(false);
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    let _lock = lock_record_path(path)?;
+    let mut record = read_record_at(path).unwrap_or_default();
+    if let Some(frontier) = record.delivered_frontier.as_ref()
+        && frontier.generation_mtime_ns == generation_mtime_ns
+        && frontier.range.1 >= range.1
+    {
+        return Ok(true);
+    }
+    let previous_attempts = record
+        .delivered_frontier
+        .as_ref()
+        .filter(|frontier| frontier.generation_mtime_ns == generation_mtime_ns)
+        .map(|frontier| frontier.attempts)
+        .unwrap_or(0);
+    let committed_range = record
+        .delivered_frontier
+        .as_ref()
+        .filter(|frontier| frontier.generation_mtime_ns == generation_mtime_ns)
+        .map(|frontier| (frontier.range.0.min(range.0), frontier.range.1.max(range.1)))
+        .unwrap_or(range);
+    record.delivered_frontier = Some(DeliveredCommit {
+        range: committed_range,
+        generation_mtime_ns,
+        attempts: previous_attempts.saturating_add(1),
+        panel_msg_id: None,
+        panel_channel_id: None,
+    });
+    write_record_at(path, &record)?;
+    Ok(true)
+}
+
+/// Durably commit a confirmed idle/catch-up JSONL range. Unlike the rollout
+/// shadow writer, this is delivery authority and is therefore flag-independent.
+pub(in crate::services::discord) fn commit_ordered_jsonl_range(
+    provider: &ProviderKind,
+    channel: ChannelId,
+    range: (u64, u64),
+    generation_mtime_ns: i64,
+) -> Result<bool, String> {
+    commit_ordered_jsonl_range_at(
+        &record_path_or_err(provider, channel.get())?,
+        range,
+        generation_mtime_ns,
+    )
+}
+
 fn write_watcher_owner_context_at(
     path: &Path,
     watcher_owner_channel_id: u64,
@@ -1542,6 +1599,38 @@ mod tests {
             panel_msg_id: Some(999),
             panel_channel_id: Some(1234),
         }
+    }
+
+    #[test]
+    fn ordered_jsonl_commit_is_generation_scoped_and_monotonic() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("record.json");
+
+        assert!(commit_ordered_jsonl_range_at(&path, (100, 200), 7).unwrap());
+        assert!(commit_ordered_jsonl_range_at(&path, (150, 180), 7).unwrap());
+        assert_eq!(
+            read_record_at(&path).unwrap().delivered_frontier.unwrap(),
+            DeliveredCommit {
+                range: (100, 200),
+                generation_mtime_ns: 7,
+                attempts: 1,
+                panel_msg_id: None,
+                panel_channel_id: None,
+            }
+        );
+
+        assert!(commit_ordered_jsonl_range_at(&path, (0, 50), 8).unwrap());
+        assert_eq!(
+            read_record_at(&path)
+                .unwrap()
+                .delivered_frontier
+                .unwrap()
+                .range,
+            (0, 50),
+            "a replacement wrapper starts a new coordinate space"
+        );
+        assert!(!commit_ordered_jsonl_range_at(&path, (50, 50), 8).unwrap());
+        assert!(!commit_ordered_jsonl_range_at(&path, (50, 60), 0).unwrap());
     }
 
     #[test]

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -2847,6 +2847,8 @@ mod tests {
 
     #[tokio::test]
     async fn watcher_preemption_blocks_task_context_route_promotion_before_card_post_4277() {
+        let temp = tempfile::tempdir().expect("temp runtime root");
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
         let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -38,12 +38,13 @@ mod relay_format;
 mod task_notification_context;
 mod turn_parser;
 use self::idle_jsonl::{
-    IdleJsonlSessionInitRearm, IdleRelayRangeAction, idle_jsonl_apply_active_inflight_gate,
+    IdleJsonlSessionInitRearm, IdleJsonlSuppression, IdleRelayRangeAction,
+    idle_jsonl_apply_active_inflight_gate,
     idle_jsonl_clear_session_init_on_generation_signature_change, idle_jsonl_consume_offset,
-    idle_jsonl_payload_contains_init_event, idle_jsonl_payload_contains_schedule_wakeup_setup,
-    idle_jsonl_payload_contains_user_event, idle_jsonl_prepare_dedup_shared,
-    idle_jsonl_relay_source_for_matched, idle_jsonl_session_has_init,
-    idle_jsonl_should_retry_without_dedup_shared, idle_relay_range_action,
+    idle_jsonl_current_eof, idle_jsonl_payload_contains_init_event,
+    idle_jsonl_payload_contains_schedule_wakeup_setup, idle_jsonl_payload_contains_user_event,
+    idle_jsonl_prepare_dedup_shared, idle_jsonl_relay_source_for_matched,
+    idle_jsonl_session_has_init, idle_jsonl_suppressed_range_action, idle_relay_range_action,
     prune_idle_jsonl_session_state, read_jsonl_range,
 };
 use self::task_notification_context::ensure_card_and_route;
@@ -535,11 +536,97 @@ impl SessionBoundDiscordRelaySink {
             .ingest_frame(frame)
     }
 
-    /// #3041 P1-3 (Part a, B1 — FRAME-CARRIED commit fence): the post-POST wrapper around
-    /// the identity-gated advance. Re-loads inflight FRESH AFTER the POST (codex P1-3 issue
-    /// 3 — a pre-POST snapshot could authorize a wrong-turn advance if the turn was
-    /// cleared/replaced during the POST), runs the pure gate
-    /// (`advance_offset_for_confirmed_delegated_terminal`), and commits the #3151 marker.
+    /// Commit a confirmed idle/catch-up delivery in the frame's ordered JSONL
+    /// coordinate space. The wrapper generation and current EOF are rechecked
+    /// after transport before either durable or in-memory authority advances.
+    pub(in crate::services::discord) fn advance_idle_range_after_confirmed_post(
+        &self,
+        shared: &super::SharedData,
+        provider: &ProviderKind,
+        channel_id: u64,
+        session_name: &str,
+        delivery: &SessionRelayDelivery,
+    ) -> bool {
+        let Some((start, end)) = delivery.relay_range.filter(|(start, end)| end > start) else {
+            return false;
+        };
+        let Some(frame_generation) = delivery
+            .relay_generation_mtime_ns
+            .filter(|generation| *generation != 0)
+        else {
+            return false;
+        };
+        let current_generation = dr::current_generation_mtime_ns(session_name);
+        let current_eof = idle_jsonl_current_eof(provider, session_name);
+        if current_generation == 0
+            || current_generation != frame_generation
+            || current_eof.is_none_or(|eof| end > eof)
+        {
+            return false;
+        }
+        if !matches!(
+            dr::commit_ordered_jsonl_range(
+                provider,
+                ChannelId::new(channel_id),
+                (start, end),
+                frame_generation,
+            ),
+            Ok(true)
+        ) {
+            return false;
+        }
+        super::tmux::advance_watcher_confirmed_end(
+            shared,
+            provider,
+            ChannelId::new(channel_id),
+            session_name,
+            end,
+            "src/services/discord/session_relay_sink.rs:idle_range_confirmed_advance",
+        );
+        dr::record_delivered_content_fingerprint(
+            provider,
+            ChannelId::new(channel_id),
+            session_name,
+            &delivery.response_text,
+        );
+        true
+    }
+
+    pub(in crate::services::discord) fn idle_range_already_committed_before_transport(
+        &self,
+        shared: &super::SharedData,
+        provider: &ProviderKind,
+        channel_id: u64,
+        session_name: &str,
+        delivery: &SessionRelayDelivery,
+    ) -> bool {
+        let Some((_, end)) = delivery.relay_range else {
+            return false;
+        };
+        let Some(frame_generation) = delivery.relay_generation_mtime_ns else {
+            return false;
+        };
+        let current_generation = dr::current_generation_mtime_ns(session_name);
+        let current_eof = idle_jsonl_current_eof(provider, session_name);
+        if frame_generation == 0 || current_generation != frame_generation || current_eof.is_none()
+        {
+            return false;
+        }
+        dr::effective_committed_offset(
+            shared,
+            provider,
+            ChannelId::new(channel_id),
+            session_name,
+            current_eof,
+        )
+        .max(dr::delivered_frontier_end_current_generation(
+            provider,
+            ChannelId::new(channel_id),
+            session_name,
+            current_eof,
+        )) >= end
+    }
+
     fn advance_after_confirmed_post(
         &self,
         shared: &super::SharedData,
@@ -549,15 +636,25 @@ impl SessionBoundDiscordRelaySink {
         delivery: &SessionRelayDelivery,
         sink_lease_guard: Option<&SinkDeliveryLeaseGuard>,
     ) {
-        let fresh_inflight = super::inflight::load_inflight_state(provider, channel_id);
-        let advanced = self.advance_offset_for_confirmed_delegated_terminal(
-            shared,
-            provider,
-            channel_id,
-            session_name,
-            delivery,
-            fresh_inflight.as_ref(),
-        );
+        let advanced = if delivery.relay_range.is_some() {
+            self.advance_idle_range_after_confirmed_post(
+                shared,
+                provider,
+                channel_id,
+                session_name,
+                delivery,
+            )
+        } else {
+            let fresh_inflight = super::inflight::load_inflight_state(provider, channel_id);
+            self.advance_offset_for_confirmed_delegated_terminal(
+                shared,
+                provider,
+                channel_id,
+                session_name,
+                delivery,
+                fresh_inflight.as_ref(),
+            )
+        };
         // #3151 CLEAR: advance committed FIRST, THEN commit the marker. #3159 BUG 1: the
         // commit outcome MUST reflect whether the advance fired — see
         // `SinkDeliveryLeaseGuard::commit` (a refused-advance `Delivered` is a black-hole).
@@ -928,6 +1025,30 @@ impl SessionBoundDiscordRelaySink {
             Some(guard)
         };
 
+        if delivery.relay_range.is_some() {
+            if self.idle_range_already_committed_before_transport(
+                &shared,
+                &provider,
+                channel_id,
+                &delivery.session_name,
+                &delivery,
+            ) {
+                if let Some(guard) = sink_lease_guard.as_ref() {
+                    guard.commit(super::LeaseOutcome::Delivered);
+                }
+                return Ok(SessionRelayDeliveryOutcome::Delivered);
+            }
+            let frame_generation = delivery.relay_generation_mtime_ns.unwrap_or(0);
+            let current_generation = dr::current_generation_mtime_ns(&delivery.session_name);
+            let current_eof = idle_jsonl_current_eof(&provider, &delivery.session_name);
+            if frame_generation == 0
+                || current_generation != frame_generation
+                || current_eof.is_none_or(|eof| lease_range.1 > eof)
+            {
+                return Ok(SessionRelayDeliveryOutcome::NotDelivered);
+            }
+        }
+
         let http = shared.serenity_http_or_token_fallback().ok_or_else(|| {
             RelaySinkError::Transient(format!(
                 "discord http unavailable for provider {}",
@@ -1285,6 +1406,7 @@ async fn run_idle_jsonl_relay_loop(
     let producers =
         crate::services::cluster::relay_producer_registry::global_relay_producer_registry();
     let mut offsets: HashMap<String, u64> = HashMap::new();
+    let mut pending_ends: HashMap<String, u64> = HashMap::new();
     let mut first_seen_at: HashMap<String, Instant> = HashMap::new();
     let mut last_inflight_seen_at: HashMap<String, Instant> = HashMap::new();
     let mut session_init_seen: HashSet<String> = HashSet::new();
@@ -1310,16 +1432,46 @@ async fn run_idle_jsonl_relay_loop(
             let offset = offsets.entry(session_name.clone()).or_insert(len);
             if len < *offset {
                 *offset = 0;
+                pending_ends.remove(&session_name);
                 session_init_seen.remove(&session_name);
             }
             let current_generation_signature =
                 super::tmux::read_generation_file_mtime_ns(&session_name);
-            idle_jsonl_clear_session_init_on_generation_signature_change(
+            if idle_jsonl_clear_session_init_on_generation_signature_change(
                 &mut session_init_seen,
                 &mut session_generation_signatures,
                 &session_name,
                 current_generation_signature,
-            );
+            ) {
+                pending_ends.remove(&session_name);
+            }
+            let channel = ChannelId::new(channel_id);
+            let shared_for_dedup = idle_jsonl_prepare_dedup_shared(
+                &health_registry,
+                &matched,
+                channel,
+                &session_name,
+                len,
+                &mut session_init_seen,
+            )
+            .await;
+            let Some(shared) = shared_for_dedup else {
+                continue;
+            };
+            let committed = dr::effective_committed_offset(
+                &shared,
+                &matched.provider,
+                channel,
+                &session_name,
+                Some(len),
+            )
+            .max(dr::delivered_frontier_end_current_generation(
+                &matched.provider,
+                channel,
+                &session_name,
+                Some(len),
+            ));
+
             macro_rules! consume_idle_offset {
                 ($to:expr, $rearm:expr) => {
                     idle_jsonl_consume_offset(
@@ -1335,9 +1487,6 @@ async fn run_idle_jsonl_relay_loop(
             if let Some(mut inflight) =
                 super::inflight::load_inflight_state(&matched.provider, channel_id)
             {
-                // #3960: if a SessionBoundRelay claim lost its producer before
-                // commit, downgrade it to the ownerless backstop after fresh
-                // liveness/offset checks; the send point still re-gates delivery.
                 if orphan_reclaim::reclaim_orphaned_session_bound_relay_if_dead(
                     &health_registry,
                     &producers,
@@ -1351,39 +1500,68 @@ async fn run_idle_jsonl_relay_loop(
                     inflight.set_relay_owner_kind(super::inflight::RelayOwnerKind::None);
                 }
                 if !super::inflight::ownerless_external_input_inflight_is_stale(&inflight) {
-                    let _decision = idle_jsonl_apply_active_inflight_gate(
+                    let decision = idle_jsonl_apply_active_inflight_gate(
                         &mut last_inflight_seen_at,
                         &matched,
                         channel_id,
                         &inflight,
-                        len,
-                        offset,
                     );
+                    if matches!(
+                        decision,
+                        idle_jsonl::IdleJsonlInflightGateDecision::DeferUntilCommitted
+                    ) {
+                        let pending_end = pending_ends.entry(session_name.clone()).or_insert(len);
+                        *pending_end = (*pending_end).max(len);
+                        if matches!(
+                            idle_jsonl_suppressed_range_action(
+                                committed,
+                                *offset,
+                                *pending_end,
+                                IdleJsonlSuppression::DeferUntilCommitted,
+                            ),
+                            IdleRelayRangeAction::AdvanceCommitted
+                        ) {
+                            consume_idle_offset!(*pending_end, IdleJsonlSessionInitRearm::Keep);
+                            pending_ends.remove(&session_name);
+                        }
+                    }
                     continue;
                 }
                 last_inflight_seen_at.remove(&session_name);
-                tracing::debug!(
-                    provider = matched.provider.as_str(),
-                    channel_id,
-                    tmux_session = %session_name,
-                    user_msg_id = inflight.user_msg_id,
-                    updated_at = %inflight.updated_at,
-                    "idle JSONL relay ignored stale ownerless TUI-direct inflight blocker"
-                );
             }
-            if last_inflight_seen_at
+
+            let in_recent_inflight_grace = last_inflight_seen_at
                 .get(&session_name)
-                .is_some_and(|seen_at| seen_at.elapsed() < IDLE_JSONL_RELAY_RECENT_INFLIGHT_GRACE)
-            {
-                consume_idle_offset!(len, IdleJsonlSessionInitRearm::Keep);
+                .is_some_and(|seen_at| seen_at.elapsed() < IDLE_JSONL_RELAY_RECENT_INFLIGHT_GRACE);
+            let in_new_session_grace =
+                first_seen.elapsed() < IDLE_JSONL_RELAY_RECENT_INFLIGHT_GRACE;
+            if in_recent_inflight_grace || in_new_session_grace {
+                let pending_end = pending_ends.entry(session_name.clone()).or_insert(len);
+                *pending_end = (*pending_end).max(len);
+                match idle_jsonl_suppressed_range_action(
+                    committed,
+                    *offset,
+                    *pending_end,
+                    IdleJsonlSuppression::DeferUntilCommitted,
+                ) {
+                    IdleRelayRangeAction::AdvanceCommitted => {
+                        consume_idle_offset!(*pending_end, IdleJsonlSessionInitRearm::Keep);
+                        pending_ends.remove(&session_name);
+                    }
+                    IdleRelayRangeAction::HoldPending => {}
+                    _ => unreachable!("deferred suppression returns only hold/advance"),
+                }
                 continue;
             }
             if len <= *offset {
+                pending_ends.remove(&session_name);
                 continue;
             }
 
             let start = *offset;
-            let end = len.min(start.saturating_add(IDLE_JSONL_RELAY_MAX_BYTES_PER_TICK));
+            let was_deferred = pending_ends.contains_key(&session_name);
+            let pending_end = pending_ends.remove(&session_name).unwrap_or(len).max(len);
+            let end = pending_end.min(start.saturating_add(IDLE_JSONL_RELAY_MAX_BYTES_PER_TICK));
             let Ok(payload) = read_jsonl_range(&relay_source.path, start, end) else {
                 continue;
             };
@@ -1391,173 +1569,59 @@ async fn run_idle_jsonl_relay_loop(
                 consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
                 continue;
             }
-            // Classify the WHOLE payload first so the dedup/trim run on an
-            // already-classified turn (mirrors `idle_relay_range_action`'s ordering;
-            // the per-reason debug logs below stay for observability).
-            let in_new_session_grace =
-                first_seen.elapsed() < IDLE_JSONL_RELAY_RECENT_INFLIGHT_GRACE;
-            if in_new_session_grace {
-                consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
-                tracing::debug!(
-                    provider = matched.provider.as_str(),
-                    channel_id,
-                    tmux_session = %session_name,
-                    bytes = payload.len(),
-                    "idle JSONL relay skipped new-session grace payload"
-                );
-                continue;
-            }
-            if idle_jsonl_payload_contains_user_event(&payload) {
-                consume_idle_offset!(end, IdleJsonlSessionInitRearm::Clear);
-                tracing::debug!(
-                    provider = matched.provider.as_str(),
-                    channel_id,
-                    tmux_session = %session_name,
-                    bytes = payload.len(),
-                    "idle JSONL relay skipped active-turn payload with user/tool-result event"
-                );
-                continue;
-            }
             if idle_jsonl_payload_contains_schedule_wakeup_setup(&payload) {
                 consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
-                tracing::debug!(
-                    provider = matched.provider.as_str(),
-                    channel_id,
-                    tmux_session = %session_name,
-                    bytes = payload.len(),
-                    "idle JSONL relay skipped ScheduleWakeup setup payload"
-                );
                 continue;
             }
-            let channel = ChannelId::new(channel_id);
-            let shared_for_dedup = idle_jsonl_prepare_dedup_shared(
-                &health_registry,
-                &matched,
-                channel,
-                &session_name,
-                len,
-                &mut session_init_seen,
-            )
-            .await;
+            if !was_deferred && idle_jsonl_payload_contains_user_event(&payload) {
+                consume_idle_offset!(end, IdleJsonlSessionInitRearm::Clear);
+                continue;
+            }
             let session_has_init =
                 idle_jsonl_session_has_init(&mut session_init_seen, &session_name, &payload);
-            if !relay_source.allow_continued_session_without_init && !session_has_init {
-                consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
-                tracing::debug!(
-                    provider = matched.provider.as_str(),
-                    channel_id,
-                    tmux_session = %session_name,
-                    bytes = payload.len(),
-                    "idle JSONL relay skipped non-init active-session payload"
-                );
-                continue;
-            }
-            let Some(producer) = producers.get_producer(&session_name) else {
-                tracing::debug!(
-                    tmux_session = %session_name,
-                    "idle JSONL relay found new bytes but no session-bound producer"
-                );
-                continue;
-            };
-            if idle_jsonl_should_retry_without_dedup_shared(shared_for_dedup.as_ref()) {
-                tracing::debug!(
-                    provider = matched.provider.as_str(),
-                    channel_id,
-                    tmux_session = %session_name,
-                    range_start = start,
-                    range_end = end,
-                    "idle JSONL relay skipped range because dedup shared data is unavailable; will retry without consuming"
-                );
-                continue;
-            }
-            // #3017 single output-offset authority: this idle path and the watcher both read
-            // the SAME JSONL (E-13: an inflight-less wake relayed twice). The watcher is PRIMARY
-            // and advances `confirmed_end_offset`; this backstop only CONSULTS it read-only
-            // (committed >= range end → skip), no advance (codex P1: `try_send_frame` only QUEUES).
-            if let Some(shared) = shared_for_dedup {
-                // #3089 B2b: durable-frontier dedup authority (flag OFF → in-memory).
-                let committed = dr::effective_committed_offset(
-                    &shared,
-                    &matched.provider,
-                    channel,
-                    &session_name,
-                    Some(len),
-                );
-                // Classification passed above → consults ONLY the offset-authority dedup branch.
-                match idle_relay_range_action(
-                    &payload,
-                    start,
-                    end,
-                    committed,
-                    false,
-                    relay_source.allow_continued_session_without_init,
-                    session_has_init,
-                ) {
-                    IdleRelayRangeAction::SkipAlreadyRelayed => {
-                        // Whole range already delivered by the watcher → skip.
-                        consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
-                        tracing::debug!(
-                            provider = matched.provider.as_str(),
-                            channel_id,
-                            tmux_session = %session_name,
-                            committed_relay_offset = committed,
-                            end,
-                            "idle JSONL relay skipped range already relayed by watcher (offset authority dedup)"
-                        );
-                        continue;
-                    }
-                    IdleRelayRangeAction::SendSuffixFrom(from) => {
-                        // Codex r5 P2 + codex r6 P1 (black-hole): PARTIAL overlap — the watcher
-                        // delivered the `[start, committed)` prefix; deliver ONLY the uncommitted
-                        // suffix THIS pass (a next-tick bounce would re-read a suffix that lost the
-                        // `system/init` event → re-classified and DROPPED). See `SendSuffixFrom`.
-                        let suffix = match read_jsonl_range(&relay_source.path, from, end) {
-                            Ok(suffix) => suffix,
-                            Err(_) => continue,
-                        };
-                        if suffix.is_empty() {
-                            consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
-                            continue;
-                        }
-                        if producer.try_send_frame_for_range(
-                            String::from_utf8_lossy(&suffix).into_owned(),
-                            from,
-                            end,
-                        ) {
-                            consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
-                            tracing::debug!(
-                                provider = matched.provider.as_str(),
-                                channel_id,
-                                tmux_session = %session_name,
-                                committed_relay_offset = committed,
-                                start,
-                                end,
-                                bytes = suffix.len(),
-                                "idle JSONL relay sent un-committed suffix after trimming already-relayed prefix (offset authority dedup, no black-hole)"
-                            );
-                        }
-                        continue;
-                    }
-                    // `committed <= start` → nothing covered → fall through to the full-range send.
-                    IdleRelayRangeAction::SendFull => {}
-                    // Unreachable here: `in_new_session_grace = false` and the payload already
-                    // passed the init gate (classification happened above).
-                    IdleRelayRangeAction::SkipClassified => {}
-                }
-            }
-            if producer.try_send_frame_for_range(
-                String::from_utf8_lossy(&payload).into_owned(),
+            let action = idle_relay_range_action(
+                &payload,
                 start,
                 end,
-            ) {
-                consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
-                tracing::debug!(
-                    provider = matched.provider.as_str(),
-                    channel_id,
-                    tmux_session = %session_name,
-                    bytes = payload.len(),
-                    "idle JSONL relay forwarded background session output"
-                );
+                committed,
+                relay_source.allow_continued_session_without_init,
+                session_has_init,
+                was_deferred,
+            );
+            match action {
+                IdleRelayRangeAction::DropAndConsume => {
+                    consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
+                }
+                IdleRelayRangeAction::AdvanceCommitted => {
+                    consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
+                }
+                IdleRelayRangeAction::SendPendingSuffixFrom(from) => {
+                    let Some(producer) = producers.get_producer(&session_name) else {
+                        continue;
+                    };
+                    let suffix = if from == start {
+                        payload.clone()
+                    } else {
+                        match read_jsonl_range(&relay_source.path, from, end) {
+                            Ok(suffix) => suffix,
+                            Err(_) => continue,
+                        }
+                    };
+                    if suffix.is_empty() {
+                        continue;
+                    }
+                    if producer.try_send_frame_for_range(
+                        String::from_utf8_lossy(&suffix).into_owned(),
+                        from,
+                        end,
+                        current_generation_signature,
+                    ) {
+                        pending_ends.insert(session_name.clone(), end);
+                    }
+                }
+                IdleRelayRangeAction::HoldPending => {
+                    pending_ends.insert(session_name.clone(), end);
+                }
             }
         }
 
@@ -1568,6 +1632,7 @@ async fn run_idle_jsonl_relay_loop(
             &mut last_inflight_seen_at,
             &mut session_init_seen,
             &mut session_generation_signatures,
+            &mut pending_ends,
         );
         tokio::time::sleep(IDLE_JSONL_RELAY_POLL_INTERVAL).await;
     }
@@ -1579,6 +1644,9 @@ mod relay_state_contract_refs {
     fn relay_state_contract_symbol_references_compile() {
         let _ = super::turn_parser::SessionRelayParser::ingest_frame;
         let _ = super::SessionBoundDiscordRelaySink::deliver_response;
+        let _ = super::SessionBoundDiscordRelaySink::advance_idle_range_after_confirmed_post;
+        let _ = super::idle_jsonl::idle_jsonl_suppressed_range_action;
+        let _ = crate::services::discord::outbound::delivery_record::commit_ordered_jsonl_range;
     }
 }
 
@@ -1639,6 +1707,7 @@ mod tests {
             turn_started_at: String::new(),
             turn_start_offset: None,
             relay_range: None,
+            relay_generation_mtime_ns: None,
         }
     }
 
@@ -1651,6 +1720,9 @@ mod tests {
     ) -> StreamFrame {
         let mut frame = frame(binding, payload, sequence);
         frame.relay_range = Some((range_start, range_end));
+        frame.relay_generation_mtime_ns = Some(dr::current_generation_mtime_ns(
+            &binding.expected_session_name,
+        ));
         frame
     }
 
@@ -1693,6 +1765,7 @@ mod tests {
             turn_started_at: turn_started_at.to_string(),
             turn_start_offset,
             relay_range: None,
+            relay_generation_mtime_ns: None,
         }
     }
 
@@ -2264,7 +2337,7 @@ mod tests {
             idle_relay_range_action(full_bytes, start, end, committed, false, false, false);
         assert_eq!(
             action,
-            super::IdleRelayRangeAction::SendSuffixFrom(committed),
+            super::IdleRelayRangeAction::SendPendingSuffixFrom(committed),
             "the loop must deliver the uncommitted suffix in the same pass (no black-hole)"
         );
 
@@ -2287,29 +2360,34 @@ mod tests {
             idle_relay_range_action(suffix, 0, suffix.len() as u64, 0, false, false, false);
         assert_eq!(
             suffix_only_action,
-            super::IdleRelayRangeAction::SkipClassified,
+            super::IdleRelayRangeAction::DropAndConsume,
             "re-gating the init-less suffix as a fresh payload WOULD black-hole it (the old bug)"
         );
         assert_eq!(
-            idle_relay_range_action(suffix, 0, suffix.len() as u64, 0, false, true, false,),
-            super::IdleRelayRangeAction::SendFull,
+            idle_relay_range_action(suffix, 0, suffix.len() as u64, 0, true, false, false),
+            super::IdleRelayRangeAction::SendPendingSuffixFrom(0),
             "a known continued Codex TUI runtime binding may relay assistant-only suffixes without init"
         );
 
         // Whole range uncommitted → relay the full payload (control case).
         assert_eq!(
             idle_relay_range_action(full_bytes, start, end, 0, false, false, false),
-            super::IdleRelayRangeAction::SendFull
+            super::IdleRelayRangeAction::SendPendingSuffixFrom(start)
         );
         // Whole range already committed → skip (control case).
         assert_eq!(
             idle_relay_range_action(full_bytes, start, end, end, false, false, false),
-            super::IdleRelayRangeAction::SkipAlreadyRelayed
+            super::IdleRelayRangeAction::AdvanceCommitted
         );
-        // New-session grace still wins over everything (ordering preserved).
         assert_eq!(
-            idle_relay_range_action(full_bytes, start, end, committed, true, true, false),
-            super::IdleRelayRangeAction::SkipClassified
+            idle_jsonl_suppressed_range_action(
+                committed,
+                start,
+                end,
+                IdleJsonlSuppression::DeferUntilCommitted,
+            ),
+            super::IdleRelayRangeAction::HoldPending,
+            "new-session grace holds uncommitted bytes instead of consuming them"
         );
     }
 
@@ -2325,7 +2403,7 @@ mod tests {
 
         assert_eq!(
             idle_relay_range_action(continued_chunk, start, end, 0, false, false, false),
-            super::IdleRelayRangeAction::SkipClassified,
+            super::IdleRelayRangeAction::DropAndConsume,
             "without session-level init state, a later init-less chunk would be dropped"
         );
         assert!(idle_jsonl_session_has_init(
@@ -2351,10 +2429,10 @@ mod tests {
                 end,
                 0,
                 false,
-                false,
-                session_init_seen.contains(session_name)
+                session_init_seen.contains(session_name),
+                false
             ),
-            super::IdleRelayRangeAction::SendFull,
+            super::IdleRelayRangeAction::SendPendingSuffixFrom(start),
             "once the session has accepted an init chunk, later chunks are not re-gated by init"
         );
         idle_jsonl_consume_offset(
@@ -2402,10 +2480,10 @@ mod tests {
                 continued_chunk.len() as u64,
                 0,
                 false,
-                false,
-                session_init_seen.contains(session_name)
+                session_init_seen.contains(session_name),
+                false
             ),
-            super::IdleRelayRangeAction::SkipClassified,
+            super::IdleRelayRangeAction::DropAndConsume,
             "after generation reset, assistant-only bytes cannot inherit the prior wrapper's init marker"
         );
     }
@@ -2499,10 +2577,10 @@ mod tests {
                 tick_a_end,
                 0,
                 false,
-                false,
                 tick_a_session_has_init,
+                false,
             ),
-            super::IdleRelayRangeAction::SendFull,
+            super::IdleRelayRangeAction::SendPendingSuffixFrom(0),
             "tick A relays the init-only payload"
         );
         idle_jsonl_consume_offset(
@@ -2532,10 +2610,10 @@ mod tests {
                 tick_b_end,
                 0,
                 false,
-                false,
                 tick_b_session_has_init,
+                false,
             ),
-            super::IdleRelayRangeAction::SendFull,
+            super::IdleRelayRangeAction::SendPendingSuffixFrom(tick_b_start),
             "tick B relays the assistant-only continuation without a fresh init/user event/inflight"
         );
         idle_jsonl_consume_offset(
@@ -2582,8 +2660,6 @@ mod tests {
             &background,
             42,
             &inflight,
-            end,
-            &mut offset,
         );
         assert_eq!(
             decision,
@@ -2596,8 +2672,8 @@ mod tests {
         );
 
         assert_eq!(
-            idle_relay_range_action(wake_payload.as_bytes(), offset, end, 0, false, false, false,),
-            super::IdleRelayRangeAction::SendFull,
+            idle_relay_range_action(wake_payload.as_bytes(), offset, end, 0, false, false, false),
+            super::IdleRelayRangeAction::SendPendingSuffixFrom(offset),
             "the preserved Y bytes relay on the next no-inflight tick"
         );
         offset = end;
@@ -2648,8 +2724,6 @@ mod tests {
             &matched,
             42,
             &inflight,
-            end,
-            &mut offset,
         );
         assert_eq!(
             decision,
@@ -2764,9 +2838,10 @@ mod tests {
 
         probe.release.notify_waiters();
         let result = sink_task.await.expect("sink task joined");
-        assert!(
-            matches!(result, Err(RelaySinkError::Transient(_))),
-            "the fake token makes transport unavailable only after lease acquisition"
+        assert_eq!(
+            result.expect("stale or unprovable ranged frame is declined after acquire"),
+            RelaySinkOutcome::TerminalNotDelivered,
+            "a range without a provable live generation must not reach transport"
         );
     }
 
@@ -3037,7 +3112,92 @@ mod tests {
             frame_turn_started_at: turn_started_at.to_string(),
             frame_turn_start_offset: turn_start_offset,
             relay_range: None,
+            relay_generation_mtime_ns: None,
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn idle_range_commit_requires_current_generation_and_persists_frontier() {
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        struct EnvReset(Option<std::ffi::OsString>);
+        impl Drop for EnvReset {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+                }
+            }
+        }
+        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let temp = tempfile::tempdir().expect("tempdir");
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
+        let channel = ChannelId::new(45_360);
+        let session = ProviderKind::Claude.build_tmux_session_name(&channel.get().to_string());
+        let output_path =
+            crate::services::cluster::session_matcher::expected_rollout_path_for(&session);
+        let generation_path =
+            crate::services::tmux_common::session_temp_path(&session, "generation");
+        std::fs::create_dir_all(std::path::Path::new(&output_path).parent().unwrap())
+            .expect("output dir");
+        std::fs::write(&output_path, vec![b'x'; 256]).expect("output file");
+        std::fs::write(&generation_path, b"1").expect("generation marker");
+        let generation = dr::current_generation_mtime_ns(&session);
+        assert_ne!(generation, 0);
+
+        let shared = super::super::make_shared_data_for_tests();
+        let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
+        let mut delivery = delivery_with_fence_offset(&session, None, 0, "", None);
+        delivery.channel_id = channel.get();
+        delivery.relay_range = Some((128, 256));
+        delivery.relay_generation_mtime_ns = Some(generation);
+
+        assert!(!sink.idle_range_already_committed_before_transport(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            &session,
+            &delivery,
+        ));
+        assert!(sink.advance_idle_range_after_confirmed_post(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            &session,
+            &delivery,
+        ));
+        assert_eq!(shared.committed_relay_offset(channel), 256);
+        assert!(sink.idle_range_already_committed_before_transport(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            &session,
+            &delivery,
+        ));
+        assert_eq!(
+            dr::delivered_frontier_end_current_generation(
+                &ProviderKind::Claude,
+                channel,
+                &session,
+                Some(256),
+            ),
+            256,
+            "confirmed ranged delivery is durable even when rollout shadow mode is off"
+        );
+
+        delivery.relay_range = Some((256, 300));
+        delivery.relay_generation_mtime_ns = Some(generation.saturating_add(1));
+        assert!(!sink.advance_idle_range_after_confirmed_post(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            &session,
+            &delivery,
+        ));
+        assert_eq!(shared.committed_relay_offset(channel), 256);
     }
 
     #[test]
@@ -4545,6 +4705,7 @@ mod tests {
             frame_turn_started_at: "2026-06-04T00:00:00Z".to_string(),
             frame_turn_start_offset: None,
             relay_range: None,
+            relay_generation_mtime_ns: None,
         }
     }
 

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -3119,22 +3119,8 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn idle_range_commit_requires_current_generation_and_persists_frontier() {
-        let _env_lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        struct EnvReset(Option<std::ffi::OsString>);
-        impl Drop for EnvReset {
-            fn drop(&mut self) {
-                match self.0.take() {
-                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-                }
-            }
-        }
-        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
         let temp = tempfile::tempdir().expect("tempdir");
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
-
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
         let channel = ChannelId::new(45_360);
         let session = ProviderKind::Claude.build_tmux_session_name(&channel.get().to_string());
         let output_path =
@@ -3202,21 +3188,8 @@ mod tests {
 
     #[test]
     fn same_id0_turn_frame_and_inflight_derive_equal_delivery_lease_key() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        struct EnvReset(Option<std::ffi::OsString>);
-        impl Drop for EnvReset {
-            fn drop(&mut self) {
-                match self.0.take() {
-                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-                }
-            }
-        }
-        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
         let temp = tempfile::TempDir::new().expect("temp runtime root");
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
 
         let channel = ChannelId::new(8_041);
         let generation = 17;
@@ -3494,21 +3467,8 @@ mod tests {
     //      `Delivered`/advance and fail.
     #[test]
     fn cutover_short_replace_production_path_advance_is_fresh_identity_gated() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        struct EnvReset(Option<std::ffi::OsString>);
-        impl Drop for EnvReset {
-            fn drop(&mut self) {
-                match self.0.take() {
-                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-                }
-            }
-        }
-        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
         let temp = tempfile::TempDir::new().unwrap();
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
 
         // The sink's `SinkPostHeartbeat` spawns a `DeliveryLeaseHeartbeat` task,
         // which needs a Tokio reactor. Drive the production helper on a local
@@ -3645,21 +3605,8 @@ mod tests {
     // duplicate check miss.
     #[test]
     fn session_sink_short_replace_raw_body_fingerprint_refuses_watcher_rerelay_4081() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        struct EnvReset(Option<std::ffi::OsString>);
-        impl Drop for EnvReset {
-            fn drop(&mut self) {
-                match self.0.take() {
-                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-                }
-            }
-        }
-        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
         let temp = tempfile::TempDir::new().expect("temp runtime root");
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
 
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -4256,21 +4203,8 @@ mod tests {
     // even though a snapshot taken before the POST would have matched.
     #[test]
     fn sink_post_post_recheck_blocks_advance_when_inflight_replaced_during_post() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        struct EnvReset(Option<std::ffi::OsString>);
-        impl Drop for EnvReset {
-            fn drop(&mut self) {
-                match self.0.take() {
-                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-                }
-            }
-        }
-        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
         let temp = tempfile::TempDir::new().unwrap();
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
 
         let shared = super::super::make_shared_data_for_tests();
         let channel = ChannelId::new(8_041);
@@ -4733,34 +4667,18 @@ mod tests {
     // RAII guard's Drop STILL released the lease, so the NEXT terminal delivery
     // is NOT blocked for up to ~10 minutes.
     //
-    // SAFETY (await_holding_lock): `shared_test_env_lock()` and the dedupe
-    // `TEST_LOCK` are std test-serialization Mutexes (NOT production locks). They
-    // are held across `deliver_response().await` only to keep this test's
-    // `AGENTDESK_ROOT_DIR` + shared dedupe state isolated from other tests; the
-    // awaited future itself never tries to re-acquire either lock, so there is no
-    // deadlock — this is the established pattern (see `src/reconcile.rs`).
+    // The canonical root guard serializes the process-wide env mutation. The
+    // dedupe lock is also held across the await because the future does not
+    // reacquire it and the lease assertion needs one uninterrupted state window.
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn deliver_response_err_path_releases_external_input_lease_via_guard() {
-        let _env_lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        struct EnvReset(Option<std::ffi::OsString>);
-        impl Drop for EnvReset {
-            fn drop(&mut self) {
-                match self.0.take() {
-                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-                }
-            }
-        }
-        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
         let temp = tempfile::TempDir::new().unwrap();
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
 
         let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
             .lock()
-            .unwrap();
+            .unwrap_or_else(|poison| poison.into_inner());
         crate::services::tui_prompt_dedupe::reset_state_for_tests();
 
         let channel_id = 8_041_u64;

--- a/src/services/discord/session_relay_sink/idle_jsonl.rs
+++ b/src/services/discord/session_relay_sink/idle_jsonl.rs
@@ -17,31 +17,26 @@ use crate::services::provider::ProviderKind;
 const MISMATCHED_INFLIGHT_LOG_THROTTLE: Duration = Duration::from_secs(60);
 static MISMATCHED_INFLIGHT_LOGGED_AT: OnceLock<Mutex<HashMap<String, Instant>>> = OnceLock::new();
 
-/// REAL loop ordering: classification gates run on the WHOLE payload FIRST (an
-/// `init` event anywhere keeps the range relayable), the offset-authority dedup
-/// SECOND. Extracting it makes the "init in committed prefix, suffix uncommitted"
-/// black-hole regression testable without spinning the live poll loop.
+/// The idle cursor may advance only for intentional classification drops or a
+/// committed frontier. Temporary ownership/grace suppression holds the range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum IdleJsonlSuppression {
+    DropAndConsume,
+    DeferUntilCommitted,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum IdleRelayRangeAction {
-    /// Classification dropped the range (grace window, user/tool-result event,
-    /// ScheduleWakeup setup, or non-init active-session payload). Advance the
-    /// offset past `end` without relaying.
-    SkipClassified,
-    /// The offset authority already covers `[start, end)` (`committed >= end`).
-    /// Advance past `end` without relaying (dedup, whole range).
-    SkipAlreadyRelayed,
-    /// PARTIAL overlap (`start < committed < end`): the prefix was already relayed;
-    /// relay ONLY the uncommitted `[committed, end)` suffix of THIS classified turn (not
-    /// re-gated as a fresh non-init payload → no black-hole, codex r6 P1).
-    SendSuffixFrom(u64),
-    /// Nothing covered (`committed <= start`): relay the whole `[start, end)`.
-    SendFull,
+    DropAndConsume,
+    HoldPending,
+    AdvanceCommitted,
+    SendPendingSuffixFrom(u64),
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum IdleJsonlInflightGateDecision {
     SuppressWithoutConsuming,
-    ConsumeToEnd,
+    DeferUntilCommitted,
 }
 
 pub(super) fn idle_jsonl_should_retry_without_dedup_shared<T>(
@@ -65,10 +60,21 @@ pub(super) struct IdleJsonlRelaySource {
 pub(super) fn idle_jsonl_relay_source_for_matched(
     matched: &MatchedChannel,
 ) -> IdleJsonlRelaySource {
-    if matched.provider == ProviderKind::Codex
-        && let Some(binding) = crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(
-            &matched.expected_session_name,
-        )
+    idle_jsonl_relay_source(
+        &matched.provider,
+        &matched.expected_session_name,
+        &matched.expected_rollout_path,
+    )
+}
+
+fn idle_jsonl_relay_source(
+    provider: &ProviderKind,
+    session_name: &str,
+    fallback_path: &str,
+) -> IdleJsonlRelaySource {
+    if *provider == ProviderKind::Codex
+        && let Some(binding) =
+            crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(session_name)
         && binding.runtime_kind == RuntimeHandoffKind::CodexTui
         && !binding.output_path.trim().is_empty()
         && std::path::Path::new(&binding.output_path).exists()
@@ -80,9 +86,18 @@ pub(super) fn idle_jsonl_relay_source_for_matched(
     }
 
     IdleJsonlRelaySource {
-        path: matched.expected_rollout_path.clone(),
+        path: fallback_path.to_string(),
         allow_continued_session_without_init: false,
     }
+}
+
+pub(super) fn idle_jsonl_current_eof(provider: &ProviderKind, session_name: &str) -> Option<u64> {
+    let fallback =
+        crate::services::cluster::session_matcher::expected_rollout_path_for(session_name);
+    let source = idle_jsonl_relay_source(provider, session_name, &fallback);
+    std::fs::metadata(source.path)
+        .ok()
+        .map(|metadata| metadata.len())
 }
 
 pub(super) fn idle_jsonl_inflight_mismatches_session(
@@ -117,8 +132,6 @@ pub(super) fn idle_jsonl_apply_active_inflight_gate(
     matched: &MatchedChannel,
     channel_id: u64,
     inflight: &InflightTurnState,
-    len: u64,
-    offset: &mut u64,
 ) -> IdleJsonlInflightGateDecision {
     if idle_jsonl_should_skip_mismatched_inflight(
         last_inflight_seen_at,
@@ -129,8 +142,7 @@ pub(super) fn idle_jsonl_apply_active_inflight_gate(
         return IdleJsonlInflightGateDecision::SuppressWithoutConsuming;
     }
     last_inflight_seen_at.insert(matched.expected_session_name.clone(), Instant::now());
-    *offset = len;
-    IdleJsonlInflightGateDecision::ConsumeToEnd
+    IdleJsonlInflightGateDecision::DeferUntilCommitted
 }
 
 pub(super) fn idle_jsonl_session_has_init(
@@ -227,12 +239,14 @@ pub(super) fn prune_idle_jsonl_session_state(
     last_inflight_seen_at: &mut HashMap<String, Instant>,
     session_init_seen: &mut HashSet<String>,
     session_generation_signatures: &mut HashMap<String, i64>,
+    pending_ends: &mut HashMap<String, u64>,
 ) {
     offsets.retain(|session, _| seen_sessions.contains(session));
     first_seen_at.retain(|session, _| seen_sessions.contains(session));
     last_inflight_seen_at.retain(|session, _| seen_sessions.contains(session));
     session_init_seen.retain(|session| seen_sessions.contains(session));
     session_generation_signatures.retain(|session, _| seen_sessions.contains(session));
+    pending_ends.retain(|session, _| seen_sessions.contains(session));
     prune_mismatched_inflight_log_sessions(seen_sessions);
 }
 
@@ -274,39 +288,47 @@ fn log_mismatched_inflight_skip(
     );
 }
 
-/// Pure decision for the idle relay's classification + offset-authority dedup,
-/// in the loop's real order. `payload` is the full `[start, end)` bytes.
-/// `in_new_session_grace` mirrors the runtime `first_seen.elapsed() < grace`
-/// gate. `committed` is the offset authority's `committed_relay_offset`.
-/// `session_init_seen` means this session already passed an init-bearing range,
-/// so later chunks from the same file are not dropped solely for lacking init.
+pub(super) fn idle_jsonl_suppressed_range_action(
+    committed: u64,
+    _start: u64,
+    end: u64,
+    suppression: IdleJsonlSuppression,
+) -> IdleRelayRangeAction {
+    if suppression == IdleJsonlSuppression::DropAndConsume {
+        return IdleRelayRangeAction::DropAndConsume;
+    }
+    if committed >= end {
+        IdleRelayRangeAction::AdvanceCommitted
+    } else {
+        IdleRelayRangeAction::HoldPending
+    }
+}
+
+/// Pure decision for the idle relay's intentional classification drops and
+/// current-generation committed-frontier dedup. Temporary grace suppression is
+/// handled separately by [`idle_jsonl_suppressed_range_action`].
 pub(super) fn idle_relay_range_action(
     payload: &[u8],
     start: u64,
     end: u64,
     committed: u64,
-    in_new_session_grace: bool,
     allow_continued_session_without_init: bool,
     session_init_seen: bool,
+    was_deferred: bool,
 ) -> IdleRelayRangeAction {
-    // Classification first, on the WHOLE payload (matches the loop's gate
-    // ordering at the top of `run_idle_jsonl_relay_loop`).
-    if in_new_session_grace
-        || idle_jsonl_payload_contains_user_event(payload)
-        || idle_jsonl_payload_contains_schedule_wakeup_setup(payload)
-        || (!allow_continued_session_without_init
+    if idle_jsonl_payload_contains_schedule_wakeup_setup(payload)
+        || (!was_deferred && idle_jsonl_payload_contains_user_event(payload))
+        || (!was_deferred
+            && !allow_continued_session_without_init
             && !session_init_seen
             && !idle_jsonl_payload_contains_init_event(payload))
     {
-        return IdleRelayRangeAction::SkipClassified;
+        return IdleRelayRangeAction::DropAndConsume;
     }
-    // Offset-authority dedup second, on the already-classified range.
     if committed >= end {
-        IdleRelayRangeAction::SkipAlreadyRelayed
-    } else if committed > start {
-        IdleRelayRangeAction::SendSuffixFrom(committed)
+        IdleRelayRangeAction::AdvanceCommitted
     } else {
-        IdleRelayRangeAction::SendFull
+        IdleRelayRangeAction::SendPendingSuffixFrom(committed.max(start))
     }
 }
 
@@ -433,8 +455,8 @@ mod tests {
             idle_jsonl_session_has_init(&mut session_init_seen, session_name, payload);
         assert!(session_has_init);
         assert_eq!(
-            idle_relay_range_action(payload, start, end, 0, false, false, session_has_init),
-            IdleRelayRangeAction::SendFull,
+            idle_relay_range_action(payload, start, end, 0, false, session_has_init, false),
+            IdleRelayRangeAction::SendPendingSuffixFrom(start),
             "without the missing-shared gate this eligible range would fall through to send"
         );
 
@@ -442,8 +464,8 @@ mod tests {
             idle_jsonl_should_retry_without_dedup_shared(shared_for_dedup);
         assert!(retry_without_consuming);
         if !retry_without_consuming
-            && idle_relay_range_action(payload, start, end, 0, false, false, session_has_init)
-                == IdleRelayRangeAction::SendFull
+            && idle_relay_range_action(payload, start, end, 0, false, session_has_init, false)
+                == IdleRelayRangeAction::SendPendingSuffixFrom(start)
         {
             send_attempts += 1;
             idle_jsonl_consume_offset(
@@ -505,21 +527,19 @@ mod tests {
             end,
             committed,
             false,
-            false,
             session_has_init,
+            false,
         ) {
-            IdleRelayRangeAction::SendFull => {
+            IdleRelayRangeAction::SendPendingSuffixFrom(from) => {
+                assert_eq!(from, start);
                 send_attempts += 1;
-                idle_jsonl_consume_offset(
-                    &mut session_init_seen,
-                    session_name,
-                    &mut offset,
-                    end,
-                    IdleJsonlSessionInitRearm::Keep,
-                );
             }
             other => panic!("first shared pass must send, got {other:?}"),
         }
+        assert_eq!(
+            offset, start,
+            "enqueue acceptance is not a confirmed commit and must not consume the cursor"
+        );
 
         shared
             .tmux_relay_coord(channel)
@@ -540,10 +560,10 @@ mod tests {
             end,
             committed,
             false,
-            false,
             session_init_seen.contains(session_name),
+            false,
         ) {
-            IdleRelayRangeAction::SkipAlreadyRelayed => {
+            IdleRelayRangeAction::AdvanceCommitted => {
                 idle_jsonl_consume_offset(
                     &mut session_init_seen,
                     session_name,
@@ -559,7 +579,56 @@ mod tests {
             send_attempts, 1,
             "shared dedup sends the range exactly once"
         );
-        assert_eq!(offset, end);
+        assert_eq!(offset, start);
         assert_eq!(duplicate_actor_offset, end);
+    }
+
+    #[test]
+    fn deferred_active_range_ignores_user_prefix_and_relays_uncommitted_tail() {
+        let payload = concat!(
+            "{\"type\":\"user\",\"message\":{\"content\":\"wake\"}}\n",
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"wake answer\"}]}}\n",
+            "{\"type\":\"result\",\"result\":\"wake answer\"}\n"
+        )
+        .as_bytes();
+        assert_eq!(
+            idle_relay_range_action(payload, 100, 300, 180, false, false, true),
+            IdleRelayRangeAction::SendPendingSuffixFrom(180),
+            "the user event explains why the range was deferred; it must not discard the assistant tail after grace"
+        );
+        assert_eq!(
+            idle_relay_range_action(payload, 100, 300, 180, false, false, false),
+            IdleRelayRangeAction::DropAndConsume,
+            "a fresh active-turn classification still intentionally drops the range"
+        );
+    }
+
+    #[test]
+    fn temporary_suppression_holds_until_confirmed_commit() {
+        let start = 128;
+        let end = 256;
+
+        assert_eq!(
+            idle_jsonl_suppressed_range_action(
+                127,
+                start,
+                end,
+                IdleJsonlSuppression::DeferUntilCommitted,
+            ),
+            IdleRelayRangeAction::HoldPending
+        );
+        assert_eq!(
+            idle_jsonl_suppressed_range_action(
+                end,
+                start,
+                end,
+                IdleJsonlSuppression::DeferUntilCommitted,
+            ),
+            IdleRelayRangeAction::AdvanceCommitted
+        );
+        assert_eq!(
+            idle_jsonl_suppressed_range_action(0, start, end, IdleJsonlSuppression::DropAndConsume,),
+            IdleRelayRangeAction::DropAndConsume
+        );
     }
 }

--- a/src/services/discord/session_relay_sink/orphan_reclaim.rs
+++ b/src/services/discord/session_relay_sink/orphan_reclaim.rs
@@ -231,21 +231,8 @@ mod tests {
 
     #[tokio::test]
     async fn cross_session_reclaim_uses_row_owner_and_unblocks_iterating_session() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        struct EnvReset(Option<std::ffi::OsString>);
-        impl Drop for EnvReset {
-            fn drop(&mut self) {
-                match self.0.take() {
-                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-                }
-            }
-        }
-        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
         let temp = tempfile::TempDir::new().expect("temp runtime root");
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
 
         let provider = ProviderKind::Claude;
         let channel_id = 4_136_116;
@@ -295,21 +282,8 @@ mod tests {
         use crate::services::cluster::stream_relay::{DiscardSink, RelaySink, spawn_stream_relay};
         use std::sync::Arc;
 
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        struct EnvReset(Option<std::ffi::OsString>);
-        impl Drop for EnvReset {
-            fn drop(&mut self) {
-                match self.0.take() {
-                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-                }
-            }
-        }
-        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
         let temp = tempfile::TempDir::new().expect("temp runtime root");
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
 
         let provider = ProviderKind::Claude;
         let channel_id = 4_140_117;

--- a/src/services/discord/session_relay_sink/orphan_reclaim.rs
+++ b/src/services/discord/session_relay_sink/orphan_reclaim.rs
@@ -21,8 +21,8 @@
 //! delivery that lands AFTER this read still leaves the row orphan-shaped, so the
 //! downgrade proceeds. Single delivery is then guaranteed at the SEND POINT —
 //! every re-delivery path re-reads `effective_committed_offset` FRESH and
-//! `idle_relay_range_action` returns `SkipAlreadyRelayed` (body already past the
-//! watermark) or `SendSuffixFrom(committed)` (only the uncommitted tail). See the
+//! `idle_relay_range_action` returns `AdvanceCommitted` (body already past the
+//! watermark) or `SendPendingSuffixFrom(committed)` (only the uncommitted tail). See the
 //! `send_point_re_gate_*` tests below.
 
 use crate::services::cluster::relay_producer_registry::RelayProducerRegistry;
@@ -393,7 +393,7 @@ mod tests {
                 false,
                 false
             ),
-            IdleRelayRangeAction::SkipAlreadyRelayed,
+            IdleRelayRangeAction::AdvanceCommitted,
             "the send-point re-gate skips a body already past the watermark — no double-relay"
         );
     }
@@ -424,7 +424,7 @@ mod tests {
                 false,
                 false
             ),
-            IdleRelayRangeAction::SendSuffixFrom(committed_advanced),
+            IdleRelayRangeAction::SendPendingSuffixFrom(committed_advanced),
             "the send-point re-gate delivers only the uncommitted tail — no duplicate of the \
              delivered prefix"
         );

--- a/src/services/discord/session_relay_sink/task_notification_context.rs
+++ b/src/services/discord/session_relay_sink/task_notification_context.rs
@@ -688,6 +688,7 @@ mod tests {
             frame_turn_started_at: "2026-07-11T01:37:00Z".to_string(),
             frame_turn_start_offset: Some(4055),
             relay_range: None,
+            relay_generation_mtime_ns: None,
         };
         let transport = OrderedTransport {
             fail: AtomicBool::new(false),

--- a/src/services/discord/session_relay_sink/turn_parser.rs
+++ b/src/services/discord/session_relay_sink/turn_parser.rs
@@ -113,6 +113,7 @@ impl SessionRelayParser {
                     frame_turn_started_at: frame.turn_started_at.clone(),
                     frame_turn_start_offset: frame.turn_start_offset,
                     relay_range: frame.relay_range,
+                    relay_generation_mtime_ns: frame.relay_generation_mtime_ns,
                 });
                 break;
             } else {
@@ -150,4 +151,5 @@ pub(in crate::services::discord) struct SessionRelayDelivery {
     pub(super) frame_turn_started_at: String,
     pub(super) frame_turn_start_offset: Option<u64>,
     pub(super) relay_range: Option<(u64, u64)>,
+    pub(super) relay_generation_mtime_ns: Option<i64>,
 }

--- a/src/services/discord/tui_prompt_relay/bridge_completion.rs
+++ b/src/services/discord/tui_prompt_relay/bridge_completion.rs
@@ -84,26 +84,10 @@ pub(super) fn ensure_tui_direct_bridge_delivery_committed(
 mod tests {
     use super::*;
 
-    const AGENTDESK_ROOT_DIR_ENV: &str = "AGENTDESK_ROOT_DIR";
-
-    struct EnvGuard(Option<String>);
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match self.0.take() {
-                Some(value) => unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, value) },
-                None => unsafe { std::env::remove_var(AGENTDESK_ROOT_DIR_ENV) },
-            }
-        }
-    }
-
     #[test]
     fn tui_direct_bridge_completion_rejects_uncommitted_matching_inflight() {
-        let _lock = crate::services::turn_orchestrator::test_support::lock_test_env();
-        let previous = std::env::var(AGENTDESK_ROOT_DIR_ENV).ok();
-        let _guard = EnvGuard(previous);
         let temp = tempfile::tempdir().expect("temp runtime root");
-        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, temp.path()) };
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
 
         let provider = ProviderKind::Codex;
         let channel_id = ChannelId::new(88_001);

--- a/src/services/discord/tui_prompt_relay/synthetic_orphan_reclaim.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_orphan_reclaim.rs
@@ -137,29 +137,10 @@ mod tests {
     };
     use crate::services::provider::ProviderKind;
 
-    struct EnvReset(Option<std::ffi::OsString>);
-
-    impl Drop for EnvReset {
-        fn drop(&mut self) {
-            match self.0.take() {
-                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-            }
-        }
-    }
-
-    fn isolated_runtime_root() -> (
-        std::sync::MutexGuard<'static, ()>,
-        tempfile::TempDir,
-        EnvReset,
-    ) {
-        let env_lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+    fn isolated_runtime_root() -> (tempfile::TempDir, crate::config::TestEnvVarGuard) {
         let root = tempfile::TempDir::new().expect("runtime root");
-        let env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", root.path()) };
-        (env_lock, root, env)
+        let env = crate::config::set_agentdesk_root_for_test(root.path());
+        (root, env)
     }
 
     fn write_inflight_fixture(
@@ -245,7 +226,7 @@ mod tests {
     /// `tui_direct_pending_start::tests::backstop_orphan_reclaim_*`.
     #[test]
     fn orphan_row_is_reclaimable_matches_stale_session_bound_orphan_on_caller_session() {
-        let (_env_lock, _root, _env) = isolated_runtime_root();
+        let (_root, _env) = isolated_runtime_root();
         let tmux = "AgentDesk-claude-adk-cc";
         let orphan = session_bound_row(4242, tmux, true);
         // Sanity: this is a genuine producer-dead SessionBoundRelay orphan.
@@ -264,7 +245,7 @@ mod tests {
     /// reclaimable. Guards over-reclaim of a slow-but-live turn.
     #[test]
     fn orphan_row_is_reclaimable_skips_fresh_row() {
-        let (_env_lock, _root, _env) = isolated_runtime_root();
+        let (_root, _env) = isolated_runtime_root();
         let tmux = "AgentDesk-claude-adk-cc";
         let fresh = session_bound_row(4343, tmux, false);
         assert!(
@@ -283,7 +264,7 @@ mod tests {
     /// otherwise orphan-shaped.
     #[test]
     fn orphan_row_is_reclaimable_skips_foreign_session() {
-        let (_env_lock, _root, _env) = isolated_runtime_root();
+        let (_root, _env) = isolated_runtime_root();
         let orphan = session_bound_row(4444, "AgentDesk-claude-adk-cc", true);
         assert!(
             session_bound_relay_external_input_orphan_shape(&orphan),
@@ -297,7 +278,7 @@ mod tests {
 
     #[test]
     fn pending_start_reclaim_orphan_fn_uses_real_ordering_for_session_bound_orphan() {
-        let (_env_lock, root, _env) = isolated_runtime_root();
+        let (root, _env) = isolated_runtime_root();
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()

--- a/src/services/discord/tui_prompt_relay/synthetic_start.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start.rs
@@ -425,27 +425,6 @@ mod tests {
     use crate::services::turn_orchestrator::ActiveTurnKind;
     use ::serenity::model::id::{MessageId, UserId};
 
-    struct EnvGuard {
-        previous: Option<std::ffi::OsString>,
-    }
-
-    impl EnvGuard {
-        fn set_root(path: &std::path::Path) -> Self {
-            let previous = std::env::var_os("AGENTDESK_ROOT_DIR");
-            unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", path) };
-            Self { previous }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match self.previous.as_ref() {
-                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-            }
-        }
-    }
-
     fn synthetic_owner() -> UserId {
         UserId::new(TUI_DIRECT_SYNTHETIC_OWNER_USER_ID)
     }
@@ -513,11 +492,8 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn young_rowless_synthetic_owner_is_not_reclaimed() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_018_200);
@@ -556,11 +532,8 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn aged_rowless_synthetic_owner_reclaims_and_finalizes_ledger() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_018_201);
@@ -624,11 +597,8 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn monitor_auto_turn_slot_is_not_reclaimed_even_when_aged() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_018_202);
@@ -671,11 +641,8 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn stale_synthetic_owner_finalized_row_reclaims_for_new_turn() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_018_203);
@@ -719,11 +686,8 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn stale_synthetic_owner_replaced_requires_same_tmux_session() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_018_204);
@@ -757,11 +721,8 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn stale_synthetic_owner_live_inflight_still_skips_reclaim() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_018_260);
@@ -805,11 +766,8 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn claim_adopting_existing_mailbox_does_not_increment_global_active() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_019_230);
@@ -848,11 +806,8 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test(flavor = "current_thread")]
     async fn synthetic_finish_session_key_mismatch_preserves_newer_turn() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_019_231);
@@ -886,11 +841,8 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test(flavor = "current_thread")]
     async fn synthetic_finish_routes_release_through_finalizer() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_019_232);
@@ -998,11 +950,8 @@ mod tests {
     // starved injection / task-notification turn win relay ownership.
     #[tokio::test(flavor = "current_thread")]
     async fn readopted_from_inflight_real_owner_committed_row_reclaims_for_starved_synthetic() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_370_050);
@@ -1059,11 +1008,8 @@ mod tests {
     // fix regressing into a live-turn thief.
     #[tokio::test(flavor = "current_thread")]
     async fn readopted_from_inflight_real_owner_live_turn_is_never_stolen() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_370_060);
@@ -1119,11 +1065,8 @@ mod tests {
     // enforces at the recovery site.
     #[tokio::test(flavor = "current_thread")]
     async fn readopted_from_inflight_id0_row_is_never_reclaimed() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_370_070);
@@ -1166,11 +1109,8 @@ mod tests {
     // freshly-started real-user turn stays untouched.
     #[tokio::test(flavor = "current_thread")]
     async fn real_owner_without_readopted_marker_is_never_reclaimed() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_370_070);
@@ -1214,11 +1154,8 @@ mod tests {
     // real-user turn — and `active_request_owner` would never transition.
     #[tokio::test(flavor = "current_thread")]
     async fn readopted_from_inflight_turn_yields_mailbox_to_injection_and_task_notification() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
 
@@ -1350,11 +1287,8 @@ mod tests {
     /// reclaim — the exact regression a direct-seed test would miss.
     #[tokio::test(flavor = "current_thread")]
     async fn path_b_absent_row_in_ledger_aged_reclaims_and_evicts() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_370_080);
@@ -1437,11 +1371,8 @@ mod tests {
     /// steal what might be a genuinely live turn.
     #[tokio::test(flavor = "current_thread")]
     async fn path_b_absent_row_not_in_ledger_is_never_reclaimed() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_370_081);
@@ -1478,11 +1409,8 @@ mod tests {
     /// gate for the re-adopted class, exactly as for the #4018 synthetic class.
     #[tokio::test(flavor = "current_thread")]
     async fn path_b_absent_row_in_ledger_young_is_not_reclaimed() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_370_082);
@@ -1539,11 +1467,8 @@ mod tests {
     /// ledger entry can NEVER authorize stealing the live successor.
     #[tokio::test(flavor = "current_thread")]
     async fn path_b_absent_row_ledger_different_user_msg_id_is_never_stolen() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_370_083);
@@ -1600,11 +1525,8 @@ mod tests {
     /// have been stolen — this is the test that pins the enforced invariant.
     #[tokio::test(flavor = "current_thread")]
     async fn path_b_absent_row_ledger_live_not_finished_is_never_stolen() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_370_084);
@@ -1700,11 +1622,8 @@ mod tests {
             "the reclaim finalize context must not be a backstop-cleanup shape — that is the only shape that strips ⏳ / withholds ✅ on a Cancel (#4370 F3b)"
         );
 
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .expect("shared env lock poisoned");
         let root = tempfile::tempdir().expect("runtime root");
-        let _env = EnvGuard::set_root(root.path());
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let provider = ProviderKind::Claude;
         let shared = crate::services::discord::make_shared_data_for_tests();
         let channel_id = ChannelId::new(4_370_090);
@@ -1723,9 +1642,9 @@ mod tests {
 
         // Observe the ACTUAL finalizer-scheduled reactions. In test builds
         // `schedule_reaction_cleanup` records synchronously into a global the
-        // recorder captures; this and the finalizer's own reaction tests all
-        // serialize on `shared_test_env_lock` (held above), so the recorder cannot
-        // race. An empty record set proves the reclaim scheduled NO reaction change
+        // recorder captures; this test's canonical root guard also holds the
+        // crate-wide shared test-environment lock, so the recorder cannot race.
+        // An empty record set proves the reclaim scheduled NO reaction change
         // and therefore cannot suppress the already-pending completion footer / ✅.
         crate::services::discord::turn_finalizer::cleanup::begin_reaction_cleanup_recording();
 

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -7,36 +7,6 @@ fn compact_command_name_first_stub() -> &'static str {
     "<command-name>/compact</command-name>\n            <command-message>compact</command-message>\n            <command-args></command-args>"
 }
 
-/// Scoped env-var override for inflight persistence tests. `AGENTDESK_ROOT_DIR`
-/// is process-global, so serialize it with the shared test env lock.
-struct EnvRootGuard {
-    previous: Option<std::ffi::OsString>,
-    _lock: std::sync::MutexGuard<'static, ()>,
-}
-
-impl EnvRootGuard {
-    fn set(path: &std::path::Path) -> Self {
-        let lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        let previous = std::env::var_os("AGENTDESK_ROOT_DIR");
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", path) };
-        Self {
-            previous,
-            _lock: lock,
-        }
-    }
-}
-
-impl Drop for EnvRootGuard {
-    fn drop(&mut self) {
-        match self.previous.take() {
-            Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-            None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-        }
-    }
-}
-
 // ====================================================================
 // #3154 P2-2 (c) — the KEY residual risk: prove there is NO relay GAP
 // (not merely no duplicate) on the deferred synthetic-start path.
@@ -2574,7 +2544,7 @@ fn claude_bridge_lease_clears_when_tail_dedup_skips_spawn() {
 #[tokio::test]
 async fn claude_bridge_lease_guard_cleans_no_binding_precondition_skip() {
     let temp = tempfile::tempdir().expect("temp runtime root");
-    let _env = EnvRootGuard::set(temp.path());
+    let _env = crate::config::set_agentdesk_root_for_test(temp.path());
     let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
         .lock()
         .unwrap();
@@ -3178,7 +3148,7 @@ fn codex_external_input_relay_output_path_uses_rollout_not_wrapper() {
 #[test]
 fn codex_external_input_binding_refreshes_from_live_rollout_marker() {
     let temp = tempfile::tempdir().expect("temp runtime root");
-    let _env = EnvRootGuard::set(temp.path());
+    let _env = crate::config::set_agentdesk_root_for_test(temp.path());
     let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
         .lock()
         .unwrap();
@@ -3229,7 +3199,7 @@ fn codex_external_input_binding_refreshes_from_live_rollout_marker() {
 #[test]
 fn codex_ownerless_external_input_undelivered_turn_needs_rollout_repair() {
     let dir = tempfile::tempdir().expect("temp dir");
-    let _env = EnvRootGuard::set(dir.path());
+    let _env = crate::config::set_agentdesk_root_for_test(dir.path());
     let rollout_path = dir.path().join("rollout.jsonl");
     std::fs::write(
         &rollout_path,
@@ -3360,7 +3330,7 @@ fn idle_bridge_stands_down_for_every_resolved_non_bridge_synthetic_claim() {
     use super::synthetic_start::tui_direct_synthetic_non_bridge_owner_matches;
 
     let root = tempfile::tempdir().expect("runtime root");
-    let _env = EnvRootGuard::set(root.path());
+    let _env = crate::config::set_agentdesk_root_for_test(root.path());
     let tmux = "AgentDesk-codex-adk-cdx-4455";
     let channel = ChannelId::new(1_479_671_301_387_059_200);
     let lease = ExternalInputRelayLease::unassigned(Some(channel.get()));
@@ -3597,7 +3567,7 @@ fn failed_synthetic_placeholder_delete_is_terminal_cleanup_guarded() {
 #[tokio::test]
 async fn compact_continuation_injection_skips_synthetic_and_leaves_mailbox_free() {
     let temp = tempfile::tempdir().expect("temp runtime root");
-    let _env = EnvRootGuard::set(temp.path());
+    let _env = crate::config::set_agentdesk_root_for_test(temp.path());
     let shared = super::super::make_shared_data_for_tests();
     let provider = ProviderKind::Claude;
     let channel_id = ChannelId::new(940_000_000_004_082);
@@ -3671,7 +3641,7 @@ async fn compact_continuation_injection_skips_synthetic_and_leaves_mailbox_free(
 #[tokio::test]
 async fn genuine_tui_direct_typed_prompt_still_creates_synthetic_inflight() {
     let temp = tempfile::tempdir().expect("temp runtime root");
-    let _env = EnvRootGuard::set(temp.path());
+    let _env = crate::config::set_agentdesk_root_for_test(temp.path());
     let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
         .lock()
         .unwrap();
@@ -3825,7 +3795,7 @@ fn save_ownerless_tui_direct_inflight_for_mailbox_release_test(
 #[tokio::test]
 async fn stale_ownerless_tui_direct_mailbox_release_allows_new_synthetic_claim() {
     let temp = tempfile::tempdir().expect("temp runtime root");
-    let _env = EnvRootGuard::set(temp.path());
+    let _env = crate::config::set_agentdesk_root_for_test(temp.path());
     let shared = super::super::make_shared_data_for_tests();
     let provider = ProviderKind::Codex;
     let channel_id = ChannelId::new(940_000_000_000_009);
@@ -3890,7 +3860,7 @@ async fn stale_ownerless_tui_direct_mailbox_release_allows_new_synthetic_claim()
 #[tokio::test]
 async fn stale_ownerless_tui_direct_mailbox_release_preserves_fresh_owner() {
     let temp = tempfile::tempdir().expect("temp runtime root");
-    let _env = EnvRootGuard::set(temp.path());
+    let _env = crate::config::set_agentdesk_root_for_test(temp.path());
     let shared = super::super::make_shared_data_for_tests();
     let provider = ProviderKind::Codex;
     let channel_id = ChannelId::new(940_000_000_000_010);


### PR DESCRIPTION
## Summary
- keep matching-inflight, post-inflight-grace, and new-session-grace JSONL ranges pending instead of consuming them at enqueue time
- carry the ordered range plus wrapper-generation coordinate through the #4847 shared delivery-lease path
- recheck current generation, EOF, and committed coverage after lease acquisition; skip duplicate queued frames before transport
- persist confirmed ranged delivery in the durable frontier before advancing the in-memory watermark/local cursor

## Design alignment
Implements the read-only design from issue comment 5064160911. Relative to that design, this uses the landed #4847 three-class lease key and ordered `relay_range`, while keeping strict inflight terminal fences separate from idle ranged commits. The new generation coordinate and EOF-bound post-transport gate preserve #4843 same-path compact/reanchor safety.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --lib`
- `cargo test --lib session_relay` (93 passed)
- `cargo test --lib delivery_record` (66 passed)
- `cargo test --lib tui_prompt_relay` (196 passed)
- `cargo test --lib stream_relay` (19 passed)
- `cargo test --lib orphan_reclaim` (15 passed)
- `python3 scripts/check_inflight_blind_save_ratchet.py` (baseline 1)
- `python3 scripts/check_contract_symbol_refs.py` (35 anchors)
- `./scripts/ci-script-checks.sh`
- inventory and agent-maintenance docs gates

Closes #4536

🤖 Generated with [Claude Code](https://claude.com/claude-code)
