### PR TITLE
fix(token-daily-report): render None pct buckets as n/a

### DIFF
--- a/scripts/launchd-migrated/token-daily-report.py
+++ b/scripts/launchd-migrated/token-daily-report.py
@@ -600,6 +600,13 @@ def collect(yday):
 
 
 # --------------------------------------------------------------------------- #
+def _bucket_str(pct, countdown):
+    # usageStatus=unavailable accounts report pct=None
+    if pct is None:
+        return "n/a"
+    return f"**{pct:.0f}%**({countdown})"
+
+
 def render(data):
     L = [f"**[Token Manager] 일일 리포트 — {data['report_date']}**", ""]
     L.append("**Claude 계정 (cswap 3개)**")
@@ -608,7 +615,8 @@ def render(data):
         sc = ""
         if a.get("scoped"):
             sc = " / " + " ".join(f"{s['name']} {s['pct']:.0f}%" for s in a["scoped"] if s.get("pct") is not None)
-        L.append(f"- {star} #{a['n']} {a['email']}: 5h **{a['h5']:.0f}%**({a['h5_countdown']}) · 7d **{a['d7']:.0f}%**({a['d7_countdown']}){sc}")
+        stat = f" ⚠️{a['status']}" if a.get("status") not in (None, "ok") else ""
+        L.append(f"- {star} #{a['n']} {a['email']}: 5h {_bucket_str(a['h5'], a['h5_countdown'])} · 7d {_bucket_str(a['d7'], a['d7_countdown'])}{sc}{stat}")
     cx = data.get("codex_rate")
     if cx:
         parts = [f"{bn} **{bd['used']:.0f}%**" + (f"({bd['countdown']})" if bd.get("countdown") else "")


### PR DESCRIPTION
정본 워크스페이스 main에 직접 커밋돼 있던 고아 커밋(2580d425e)을 브랜치로 구출해 PR화. usageStatus=unavailable 계정의 pct=None이 render()의 :.0f 포맷에서 TypeError를 내던 문제 수정.

주의: 이 커밋은 canonical-edit-path 위반(작성 주체 미상 — token-manager 계열 추정)으로 main 워크스페이스에 남아 있었음. 배포 전 정리 과정에서 발견·보존함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)