### PR TITLE
fix(#4770): adopt legacy idle relay queues

### DIFF
--- a/src/services/claude_tui/hook_relay/ordered_queue.rs
+++ b/src/services/claude_tui/hook_relay/ordered_queue.rs
@@ -1181,6 +1181,35 @@ mod tests {
     }
 
     #[test]
+    fn gc_adopts_legacy_idle_queue_before_later_retirement() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let queue_dir = temp_dir.path().join("legacy-idle");
+        std::fs::create_dir_all(queue_dir.join("ingress")).unwrap();
+        std::fs::write(queue_dir.join("worker.lock"), b"").unwrap();
+        std::fs::write(queue_dir.join("completed-high-water"), b"1").unwrap();
+        age_queue_tree(&queue_dir, LEDGER_RETENTION + Duration::from_secs(1));
+
+        gc_ordered_hook_relay_queue(&queue_dir);
+
+        assert!(
+            queue_dir.exists(),
+            "legacy adoption must preserve the queue"
+        );
+        assert!(
+            queue_dir.join("producer.lock").exists(),
+            "legacy adoption must materialize the producer lock"
+        );
+
+        age_queue_tree(&queue_dir, LEDGER_RETENTION + Duration::from_secs(1));
+        gc_ordered_hook_relay_queue(&queue_dir);
+
+        assert!(
+            !queue_dir.exists(),
+            "an adopted idle queue must retire after the shared retention age"
+        );
+    }
+
+    #[test]
     fn gc_preserves_recently_emptied_queue() {
         let temp_dir = tempfile::tempdir().unwrap();
         let queue_dir = temp_dir.path().join("recent");
@@ -1405,8 +1434,12 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let provider_root = temp_dir.path().join(relay_queue_subdir("claude"));
         std::fs::create_dir_all(&provider_root).unwrap();
-        for queue_index in 0..1_000 {
-            std::fs::create_dir(provider_root.join(format!("queue-{queue_index:04}"))).unwrap();
+        let queue_dirs = (0..1_000)
+            .map(|queue_index| provider_root.join(format!("queue-{queue_index:04}")))
+            .collect::<Vec<_>>();
+        for queue_dir in &queue_dirs {
+            std::fs::create_dir(queue_dir).unwrap();
+            std::fs::write(queue_dir.join("worker.lock"), b"").unwrap();
         }
 
         let started = Instant::now();
@@ -1423,6 +1456,30 @@ mod tests {
         assert!(
             elapsed < Duration::from_secs(5),
             "1,000 idle queue scan exceeded the bounded-time budget: {elapsed:?}"
+        );
+        assert!(queue_dirs.iter().all(|queue_dir| queue_dir.exists()));
+        assert!(
+            queue_dirs
+                .iter()
+                .all(|queue_dir| queue_dir.join("producer.lock").exists()),
+            "the first scan must safely adopt every legacy queue"
+        );
+
+        for queue_dir in &queue_dirs {
+            age_queue_tree(queue_dir, LEDGER_RETENTION + Duration::from_secs(1));
+        }
+        let later_stats = scan_ordered_hook_relay_queues_once(temp_dir.path()).unwrap();
+
+        assert_eq!(
+            later_stats,
+            OrderedHookRelayScanStats {
+                queue_count: 1_000,
+                active_queue_count: 0,
+            }
+        );
+        assert!(
+            queue_dirs.iter().all(|queue_dir| !queue_dir.exists()),
+            "a later aged scan must retire every adopted idle queue"
         );
     }
 

--- a/src/services/claude_tui/hook_relay/queue_retention.rs
+++ b/src/services/claude_tui/hook_relay/queue_retention.rs
@@ -15,8 +15,14 @@ impl IdleQueueRetentionGuard {
     pub(super) fn acquire(queue_dir: &Path) -> Option<Self> {
         let worker_lock_path = queue_dir.join("worker.lock");
         let producer_lock_path = queue_dir.join("producer.lock");
-        let lock_files_existed = worker_lock_path.exists() && producer_lock_path.exists();
+        let worker_lock_existed = worker_lock_path.exists();
+        let producer_lock_existed = producer_lock_path.exists();
+        let lock_files_existed = worker_lock_existed && producer_lock_existed;
         let worker_lock = lock_relay_queue_file(&worker_lock_path, true).ok()??;
+        if worker_lock_existed && !producer_lock_existed {
+            let _producer_lock =
+                lock_relay_queue_file_with_mode(&producer_lock_path, true, true).ok()??;
+        }
         Some(Self {
             queue_dir: queue_dir.to_path_buf(),
             lock_files_existed,


### PR DESCRIPTION
## Summary

- Correct the #4770 causal model: the sampled main-thread `pthread_cond_wait` is Tokio runtime parking, while `readdir` belongs to the dedicated `hook-relay-recovery` OS thread.
- Finish PR #4821 retention for pre-retention legacy queues that have `worker.lock` but no `producer.lock`.
- Adopt each legacy queue under the worker lock by materializing and exclusively probing `producer.lock`, while preserving it on the first observation.
- Retire the adopted queue only on a later pass after the shared two-hour retention age, empty-artifact revalidation, and both exclusive locks.

## Root cause

PR #4821 sampled `worker.lock && producer.lock` before lock acquisition. Legacy queues created before #4821 lack `producer.lock`; since dead sessions have no producer to create it, `lock_files_existed` stayed false forever and cleanup always returned early. The 100ms recovery thread therefore kept scanning the full historical queue set indefinitely.

PR #4831 fixed a different class: synchronous directory walks performed from Tokio async paths were moved to `spawn_blocking`. This queue scanner already runs on a named `std::thread`, so the remaining root fix is bounded retention rather than another Tokio wrapper.

## Safety

- First adoption never authorizes deletion.
- Active worker or producer lock contention fails closed.
- Unknown entries, symlinks, nested directories, metadata errors, and non-empty queues remain preserved.
- No session-death inference or count-based eviction is introduced.
- Hotfiles and the active #4852/#4848/#4851 lane surfaces are untouched.

## Verification

- `cargo fmt --all --check` — rc 0
- `cargo check --lib` — rc 0
- `env -u AGENTDESK_ROOT_DIR cargo test --lib services::claude_tui::hook_relay::ordered_queue::tests` — rc 0; `17 passed; 0 failed; 1 ignored`
- `bash scripts/ci-script-checks.sh` — rc 0; Rust test-lane coverage ratchet included
- `python3 scripts/generate_inventory_docs.py` — rc 0
- `python3 scripts/check_agent_maintenance_docs.py` — rc 0; `agent-maintenance freshness check passed`
- tracked generated diff check — rc 0
- Mutation proof: removing legacy adoption makes `gc_adopts_legacy_idle_queue_before_later_retirement` fail with rc 101; restoring it passes with rc 0.
- Independent Fable review of the pre-rebase identical patch: `VERDICT: CLEAN`.

Closes #4770

🤖 Generated with [Claude Code](https://claude.com/claude-code)
