### PR TITLE
ci(#4747): opt2 long-pole PR test split

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -149,6 +149,16 @@ jobs:
           shared-key: cargo-dependencies-v2
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      # #4466: keep the real Win32 named-mutex ownership and cross-process
+      # blocking proof off the PR critical path while retaining daily coverage.
+      - name: Discord thread-create cross-process lock
+        shell: bash
+        env:
+          BASH_ENV: /dev/null
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
+        run: cargo test --lib discord_thread_create -- --test-threads=1
+
       - name: cargo test (non-PG)
         run: cargo test --all-targets -- --skip _pg_ --skip postgres_
         env:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -366,13 +366,14 @@ jobs:
         shell: bash
         run: sccache --show-stats || true
 
-  # Cross-OS Rust compile lanes: macOS + Windows. Gated on the narrower
-  # rust_compile filter so docs-only, dashboard-only, JS-policy-only,
-  # script-only, workflow-metadata-only, and Node-package-only PRs skip the
-  # ~25 min macOS lane and the ~30 min Windows lane entirely. Nightly still
-  # exercises the full matrix daily, so cross-OS Rust drift cannot land
+  # Cross-OS Rust compile lane. Gated on the narrower rust_compile filter so
+  # docs-only, dashboard-only, JS-policy-only, script-only, workflow-metadata-
+  # only, and Node-package-only PRs skip Windows compilation. Nightly retains
+  # the full macOS/Windows test matrix, so cross-OS Rust drift cannot land
   # silently.
   check_fast_cross_os:
+    # Keep this advisory job name stable: the infrastructure-failure classifier
+    # identifies its non-blocking diagnostics by this exact context string.
     name: Fast check + non-PG tests (${{ matrix.os }})
     needs: changes
     # Advisory (non-required) cross-OS lane. Run only when a Rust-compile
@@ -439,10 +440,11 @@ jobs:
           shared-key: cargo-dependencies-v2
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      # Stage 1 keeps Windows inline and default-feature-only instead of
-      # `just check`: this lane's job is cross-OS compile and targeted test
-      # signal, while fmt/staged clippy and full workspace checks are
-      # authoritative in the Ubuntu jobs above.
+      # Keep Windows inline and default-feature-only instead of `just check`.
+      # This PR lane provides cross-OS compile signal only; main-push and
+      # nightly retain the Windows runtime and non-PG test coverage outside the
+      # PR critical path (#4747 option 2). Ubuntu fmt/staged clippy and full
+      # workspace checks remain authoritative in the jobs above.
       - name: cargo check
         shell: bash
         env:
@@ -450,40 +452,6 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: "0"
           CARGO_PROFILE_TEST_DEBUG: "0"
         run: cargo check --workspace --all-targets
-
-      # #4466: compile-only coverage cannot prove Win32 named-mutex ownership
-      # or cross-process blocking. This non-advisory step runs the real child
-      # process proof on the Windows runner.
-      - name: Discord thread-create cross-process lock
-        shell: bash
-        env:
-          BASH_ENV: /dev/null
-          CARGO_PROFILE_DEV_DEBUG: "0"
-          CARGO_PROFILE_TEST_DEBUG: "0"
-        run: cargo test --lib discord_thread_create -- --test-threads=1
-
-      - name: cargo test (non-PG, targeted subset)
-        # Windows is an advisory anti-rot lane for this Unix-only project; its
-        # known test/runner flakes must not paint the PR red. See #4202/#4423.
-        continue-on-error: true
-        shell: bash
-        env:
-          BASH_ENV: /dev/null
-          CARGO_PROFILE_DEV_DEBUG: "0"
-          CARGO_PROFILE_TEST_DEBUG: "0"
-        run: |
-          set -euo pipefail
-          cargo test --all-targets transition -- --skip _pg --skip pg_ --skip postgres --test-threads=1
-          cargo test --all-targets auto_queue -- --skip _pg --skip pg_ --skip postgres
-          cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
-          cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
-          cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
-          # Health must precede relay_recovery: fail-fast recipes otherwise hide
-          # health regressions whenever the earlier recovery filter also fails.
-          python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
-          env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres
-          cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres
-          cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
 
       - name: sccache stats
         if: always() && runner.os != 'macOS'

--- a/justfile
+++ b/justfile
@@ -51,6 +51,7 @@ test-non-pg:
     cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
     cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
     cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+    cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres
     # Run health first so a fail-fast relay_recovery failure cannot hide it.
     python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
     env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -67,36 +67,13 @@ targets = {
     "needs" => "changes",
     "if" => "needs.changes.outputs.rust_compile == 'true' && needs.changes.outputs.cross_os_rust == 'true'",
     "runs_on" => '${{ matrix.os }}',
-    # #4466 formally admits the non-advisory Windows named-mutex runtime proof.
-    # #4747 (opt.3) re-pins after making PR cache access restore-only.
-    "job_sha256" => "7040d0cb8412f30c878bc1357c28c7dd9ad6483d315d83cacddfb1382cc66011",
+    # #4747 (opt.2) re-pins the compile-only PR lane after moving long-pole
+    # Windows runtime tests to nightly. Option 3 keeps PR cache access restore-only.
+    "job_sha256" => "d27244ced15d0bb13f89e680de42978cb74452af4b02457ab034d462f4fa103a",
     "cargo_steps" => {
       "cargo check" => {
         "commands" => ["cargo check --workspace --all-targets"],
         "continue_on_error" => nil,
-        "timeout_minutes" => nil,
-      },
-      "Discord thread-create cross-process lock" => {
-        "commands" => ["cargo test --lib discord_thread_create -- --test-threads=1"],
-        "continue_on_error" => nil,
-        "timeout_minutes" => nil,
-      },
-      "cargo test (non-PG, targeted subset)" => {
-        "commands" => [
-          "set -euo pipefail",
-          "cargo test --all-targets transition -- --skip _pg --skip pg_ --skip postgres --test-threads=1",
-          "cargo test --all-targets auto_queue -- --skip _pg --skip pg_ --skip postgres",
-          "cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres",
-          "cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres",
-          "cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres",
-          "# Health must precede relay_recovery: fail-fast recipes otherwise hide",
-          "# health regressions whenever the earlier recovery filter also fails.",
-          "python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres",
-          "env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres",
-          "cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres",
-          "cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres",
-        ],
-        "continue_on_error" => true,
         "timeout_minutes" => nil,
       },
     },

--- a/scripts/check_test_lane_coverage.py
+++ b/scripts/check_test_lane_coverage.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Reject new Rust library test modules that no curated CI lane fully selects.
 
-AgentDesk's ``test-non-pg`` recipe and PR test jobs intentionally use libtest
-name filters instead of running every library test. This source-only guard finds
+AgentDesk's main-push ``test-non-pg`` recipe intentionally uses libtest name
+filters instead of running every library test. This source-only guard finds
 ``#[cfg(test)] mod ...`` declarations, derives their logical Rust module paths
 (including ``#[path = "..."]`` aliases), and compares them with each curated
 ``cargo test`` command's positive and ``--skip`` filters.
@@ -476,26 +476,36 @@ def cargo_test_filter(command: str) -> LaneFilter | None:
 
 
 def discover_lane_filters(repo_root: Path) -> tuple[LaneFilter, ...]:
-    """Parse selection contracts from test-non-pg and PR targeted commands."""
+    """Parse selection contracts from positive main-push and PR test lanes."""
     just_text = (repo_root / "justfile").read_text(encoding="utf-8")
-    workflow = (repo_root / ".github/workflows/ci-pr.yml").read_text(encoding="utf-8")
+    workflows = (
+        (repo_root / ".github/workflows/ci-main.yml").read_text(encoding="utf-8"),
+        (repo_root / ".github/workflows/ci-pr.yml").read_text(encoding="utf-8"),
+    )
 
     commands = list(just_recipe_commands(just_text, "test-non-pg"))
-    for line in workflow.splitlines():
-        if "cargo test" not in line:
-            continue
-        command = line.strip()
-        if command.startswith("run:"):
-            command = command.removeprefix("run:").strip()
-            if len(command) >= 2 and command[0] == command[-1] and command[0] in "\"'":
-                command = command[1:-1]
-        commands.append(command)
+    for workflow in workflows:
+        for line in workflow.splitlines():
+            command = line.strip()
+            if "cargo test" not in command or command.startswith("#"):
+                continue
+            if command.startswith("run:"):
+                command = command.removeprefix("run:").strip()
+                if (
+                    len(command) >= 2
+                    and command[0] == command[-1]
+                    and command[0] in "\"'"
+                ):
+                    command = command[1:-1]
+            commands.append(command)
 
-    for recipe in sorted(set(re.findall(r"\bjust\s+([A-Za-z0-9_-]+)", workflow))):
-        try:
-            commands.extend(just_recipe_commands(just_text, recipe))
-        except ValueError:
-            continue
+        for recipe in sorted(
+            set(re.findall(r"\bjust\s+([A-Za-z0-9_-]+)", workflow))
+        ):
+            try:
+                commands.extend(just_recipe_commands(just_text, recipe))
+            except ValueError:
+                continue
 
     lanes: list[LaneFilter] = []
     for command in commands:

--- a/tests/test_discord_thread_create_ci_wiring.py
+++ b/tests/test_discord_thread_create_ci_wiring.py
@@ -12,8 +12,14 @@ class DiscordThreadCreateCiWiringTests(unittest.TestCase):
         self.assertEqual(justfile.count(FOCUSED_COMMAND), 1)
         self.assertNotIn("cargo test --lib cli::discord_thread_create", justfile)
 
-    def test_windows_job_has_non_advisory_runtime_step(self) -> None:
+    def test_pr_windows_job_is_compile_only(self) -> None:
         workflow = (ROOT / ".github/workflows/ci-pr.yml").read_text(encoding="utf-8")
+        self.assertNotIn("Discord thread-create cross-process lock", workflow)
+
+    def test_nightly_windows_job_has_non_advisory_runtime_step(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci-nightly.yml").read_text(
+            encoding="utf-8"
+        )
         marker = "      - name: Discord thread-create cross-process lock\n"
         start = workflow.index(marker)
         end = workflow.index("\n      - name:", start + len(marker))
@@ -25,10 +31,10 @@ class DiscordThreadCreateCiWiringTests(unittest.TestCase):
         self.assertIn('CARGO_PROFILE_DEV_DEBUG: "0"', step)
         self.assertIn('CARGO_PROFILE_TEST_DEBUG: "0"', step)
 
-    def test_whole_job_guard_registers_the_runtime_step(self) -> None:
+    def test_whole_job_guard_tracks_compile_only_pr_lane(self) -> None:
         guard = (ROOT / "scripts/check-ci-runner-hardening.sh").read_text(encoding="utf-8")
-        self.assertIn('"Discord thread-create cross-process lock" => {', guard)
-        self.assertIn(f'"commands" => ["{FOCUSED_COMMAND}"]', guard)
+        self.assertNotIn('"Discord thread-create cross-process lock" => {', guard)
+        self.assertNotIn('"cargo test (non-PG, targeted subset)" => {', guard)
 
 
 if __name__ == "__main__":

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -38,6 +38,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres",
     "python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres",
     "env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres",
     "cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres",
@@ -134,6 +135,16 @@ class FastCheckCiWiringTests(unittest.TestCase):
             r"(?m)^    if: needs\.changes\.outputs\.pg_db == 'true'$",
         )
 
+    def test_pr_cross_os_lane_is_compile_only(self) -> None:
+        job = job_block(PR_WORKFLOW.read_text(encoding="utf-8"), "check_fast_cross_os")
+
+        self.assertIn("name: Fast check + non-PG tests (${{ matrix.os }})", job)
+        self.assertIn("os: [windows-latest]", job)
+        self.assertIn("- name: cargo check", job)
+        self.assertNotRegex(job, r"(?m)^\s*cargo test\b")
+        self.assertNotIn("- name: cargo test", job)
+        self.assertNotIn("Discord thread-create cross-process lock", job)
+
     def test_main_and_nightly_retain_non_pg_test_coverage(self) -> None:
         justfile = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
         self.assertIn("check: fmt-check lint cargo-check test", justfile)
@@ -154,6 +165,10 @@ class FastCheckCiWiringTests(unittest.TestCase):
                 self.assertIn(
                     "cargo test --all-targets -- --skip _pg_ --skip postgres_", job
                 )
+        self.assertIn(
+            "cargo test --lib discord_thread_create -- --test-threads=1",
+            job_block(nightly, "full_windows"),
+        )
 
     def test_ci_script_checks_runs_this_contract(self) -> None:
         script = (REPO_ROOT / "scripts/ci-script-checks.sh").read_text(

--- a/tests/test_relay_recovery_ci_wiring.py
+++ b/tests/test_relay_recovery_ci_wiring.py
@@ -28,7 +28,7 @@ class RelayRecoveryCiWiringTest(unittest.TestCase):
     def test_relay_recovery_filter_wired_into_every_targeted_non_pg_lane(self) -> None:
         expected_counts = {
             "justfile": 1,
-            ".github/workflows/ci-pr.yml": 1,
+            ".github/workflows/ci-pr.yml": 0,
             ".github/workflows/ci-macos-trusted.yml": 2,
         }
         for relative_path, expected_count in expected_counts.items():
@@ -37,8 +37,8 @@ class RelayRecoveryCiWiringTest(unittest.TestCase):
                 self.assertEqual(
                     count_executable_relay_recovery_commands(text),
                     expected_count,
-                    f"{relative_path} must run the relay_recovery non-PG filter "
-                    f"in all {expected_count} targeted lane(s)",
+                    f"{relative_path} must retain exactly {expected_count} "
+                    "relay_recovery non-PG lane(s)",
                 )
 
     def test_commented_or_echoed_commands_do_not_count_as_executable_wiring(self) -> None:

--- a/tests/test_test_lane_coverage.py
+++ b/tests/test_test_lane_coverage.py
@@ -148,6 +148,26 @@ class LaneFilterTests(unittest.TestCase):
         lanes = (coverage.LaneFilter(("service::tests::one_case",), ()),)
         self.assertEqual(coverage.uncovered_modules(modules, lanes), modules)
 
+    def test_discovers_main_push_recipe_after_pr_test_moves(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / ".github/workflows").mkdir(parents=True)
+            (root / "justfile").write_text(
+                "test-non-pg:\n    cargo test --lib retained_tests\n",
+                encoding="utf-8",
+            )
+            (root / ".github/workflows/ci-main.yml").write_text(
+                "run: just test-non-pg\n", encoding="utf-8"
+            )
+            (root / ".github/workflows/ci-pr.yml").write_text(
+                "run: cargo check --workspace\n", encoding="utf-8"
+            )
+
+            self.assertEqual(
+                coverage.discover_lane_filters(root),
+                (coverage.LaneFilter(("retained_tests",), ()),),
+            )
+
     def test_module_filter_covers_nested_module(self) -> None:
         modules = {"service::tests", "other::tests"}
         lanes = (coverage.LaneFilter(("service",), ()),)
@@ -202,6 +222,9 @@ class RatchetTests(unittest.TestCase):
         )
         (root / "justfile").write_text(
             "test-non-pg:\n    cargo test --lib covered_tests\n", encoding="utf-8"
+        )
+        (root / ".github/workflows/ci-main.yml").write_text(
+            "run: just test-non-pg\n", encoding="utf-8"
         )
         (root / ".github/workflows/ci-pr.yml").write_text(
             "run: cargo test --lib targeted_tests\n", encoding="utf-8"


### PR DESCRIPTION
## Summary

- move the Windows PR long-pole runtime tests off the PR critical path while preserving the existing advisory job/context name
- retain the Win32 cross-process proof in the nightly Windows lane and retain the full curated non-PG set on main push
- make the test-lane coverage ratchet treat `ci-main.yml` as a positive lane alongside PR-targeted lanes, with no baseline growth
- synchronize the hardening hash and CI wiring manifests

Closes #4747 (option 2).

## Measured evidence

Collected with `gh run view <run-id> --json jobs` from the 12 most recent successful CI PR runs that executed the Windows cross-OS lane:

| Invocation | n | Median | Range |
| --- | ---: | ---: | ---: |
| `Fast check + non-PG tests (windows-latest)` job | 12 | 1323.5s (22m03.5s) | 1134–1435s |
| `Discord thread-create cross-process lock` | 12 | 530.5s | 427–580s |
| `cargo test (non-PG, targeted subset)` | 12 | 338.5s | 271–364s |

Run IDs: 30056430779, 30055806437, 30054090442, 30053890041, 30053889857, 30053497203, 30051379284, 30050121356, 30049962691, 30049237742, 30048444455, 30044601964.

## Expected PR wall-clock change

For PRs that trigger the advisory Windows lane:

- before: median 1323.5s (22m03.5s)
- after: estimated median 454s (7m34s), computed per run as job duration minus the two removed runtime-test steps
- expected reduction: 869.5s (14m29.5s), 65.7%

The estimate is deliberately based on observed step durations and leaves all checkout/toolchain/cache/cargo-check overhead intact.

## Coverage change

- Pre-merge: Windows runtime execution and the Windows targeted non-PG subset move out of PR CI under the owner-approved option-2 tradeoff. The conditional PostgreSQL/high-risk required lanes and Ubuntu compile/policy/lint/script lanes are unchanged.
- Post-merge: main push still runs `just check` / `test-non-pg`; nightly Windows still runs the full non-PG suite and now explicitly owns the focused Win32 cross-process proof.
- Ratchet: `check_test_lane_coverage.py` now parses main-push and PR positive lanes. The curated set is 26 invocations, and the locked baseline remains exactly 701 entries; no baseline growth.
- Required/mirror contexts: unchanged. The advisory Windows job name is also intentionally unchanged because the infrastructure-failure classifier keys on it.

## Verification

- `./scripts/ci-script-checks.sh` — PASS
- `python3 -m unittest tests.test_fast_check_ci_wiring tests.test_test_lane_coverage` — 25 tests PASS
- focused wiring suite including Discord thread-create and relay recovery — 32 tests PASS
- `actionlint` — PASS
- `python3 scripts/generate_inventory_docs.py` — all generated outputs unchanged
- `python3 scripts/check_agent_maintenance_docs.py` — PASS
- `cargo fmt --all --check` — PASS
- `cargo check --lib` — PASS (existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)