### PR TITLE
fix(#4856): corroborate growing relay stalls with inflight progress

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -98,6 +98,7 @@ COVERAGE_CONFIRM_TICKS = 2
 # matches the watchdog's calibrated delivery grace while still letting a
 # genuinely stalled foreground turn resume normal two-tick escalation.
 COVERAGE_ACTIVITY_FRESH_SECS = 10 * 60
+COVERAGE_INFLIGHT_UPDATED_AT_KEY = "coverage_inflight_updated_at"
 
 # Independent selector-sync states (#4408 phase 2, I1).  Compares the dcserver's
 # asserted relay bind (B = watcher-state `bound_output_path`) against the
@@ -1246,6 +1247,16 @@ def parse_transcript_ts(ts: str) -> float | None:
         return None
 
 
+def parse_local_timestamp(ts: object) -> float | None:
+    """Parse dcserver's local-time ``YYYY-MM-DD HH:MM:SS`` timestamps."""
+    if not isinstance(ts, str):
+        return None
+    try:
+        return float(time.mktime(time.strptime(ts, "%Y-%m-%d %H:%M:%S")))
+    except (ValueError, OverflowError):
+        return None
+
+
 def is_harness_control_assistant_record(record: object) -> bool:
     """Whether an assistant JSONL row is synthetic harness control data.
 
@@ -1456,6 +1467,9 @@ class WatcherStateProbe:
     # Provider session identity is authoritative across runtime-mirror/provider-
     # project path representations. It is optional for legacy watcher-state.
     bound_session_id: str | None = None
+    # Local-time bridge heartbeat copied from the watcher-state snapshot. Missing
+    # or malformed values remain None so coverage corroboration fails closed.
+    inflight_updated_at: float | None = None
 
 
 def canonical_session_uuid(value: object) -> str | None:
@@ -1486,13 +1500,19 @@ def parse_watcher_state_probe(
     desynced = desynced_raw if isinstance(desynced_raw, bool) else None
     bound = bound_output_path if isinstance(bound_output_path, str) else None
     bound_session_id = canonical_session_uuid(bound_session_id_raw)
+    inflight_updated_at = parse_local_timestamp(payload.get("inflight_updated_at"))
 
     has_activity_schema = (
         "relay_stall_state" in payload or "relay_health" in payload
     )
     if not has_activity_schema:
         return WatcherStateProbe(
-            200, attached, desynced, bound, bound_session_id=bound_session_id
+            200,
+            attached,
+            desynced,
+            bound,
+            bound_session_id=bound_session_id,
+            inflight_updated_at=inflight_updated_at,
         )
 
     malformed = False
@@ -1517,6 +1537,7 @@ def parse_watcher_state_probe(
                 malformed=True,
             ),
             bound_session_id,
+            inflight_updated_at,
         )
 
     def string_field(key: str) -> tuple[str | None, bool]:
@@ -1600,6 +1621,7 @@ def parse_watcher_state_probe(
             malformed=malformed,
         ),
         bound_session_id,
+        inflight_updated_at,
     )
 
 
@@ -2672,6 +2694,22 @@ def tick_coverage(
         if expected_alive is True
         else WatcherStateProbe(None)
     )
+    previous_inflight_updated_at = chs.get(COVERAGE_INFLIGHT_UPDATED_AT_KEY)
+    current_inflight_updated_at = probe.inflight_updated_at
+    inflight_update_advanced = bool(
+        _is_finite_nonnegative_number(previous_inflight_updated_at)
+        and current_inflight_updated_at is not None
+        and current_inflight_updated_at > float(previous_inflight_updated_at)
+    )
+    inflight_update_recent = bool(
+        current_inflight_updated_at is not None
+        and 0
+        <= now - current_inflight_updated_at
+        < COVERAGE_ACTIVITY_FRESH_SECS
+    )
+    if current_inflight_updated_at is not None:
+        chs[COVERAGE_INFLIGHT_UPDATED_AT_KEY] = current_inflight_updated_at
+
     previous = chs.get("coverage_uncovered_ticks", 0)
     if not isinstance(previous, int) or isinstance(previous, bool):
         previous = 0
@@ -2755,13 +2793,30 @@ def tick_coverage(
         transcript_loss_active = bool(
             transcript_probe is not None and transcript_probe.lost > 0
         )
-        growing_relay_stall = bool(growing_without_loss and not recent_relay)
+        inflight_progress_alive = bool(
+            inflight_update_advanced or inflight_update_recent
+        )
+        growing_relay_stall = bool(
+            growing_without_loss and not recent_relay and not inflight_progress_alive
+        )
         delivery_gap_active = bool(
             chs.get("gap_since")
             or chs.get("alerting")
             or transcript_loss_active
             or growing_relay_stall
         )
+        if (
+            not delivery_gap_active
+            and growing_without_loss
+            and not recent_relay
+            and inflight_progress_alive
+        ):
+            evidence = "advanced" if inflight_update_advanced else "recent"
+            rt.log(
+                f"[{cid}] coverage desync growth has live inflight update "
+                f"evidence={evidence} — not alarming"
+            )
+            return
         if not delivery_gap_active and zero_loss_observed and recent_relay:
             rt.log(
                 f"[{cid}] coverage desync has zero loss and recent relay "

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -1272,6 +1272,25 @@ class WatcherStateParserTests(unittest.TestCase):
             ),
         )
 
+    def test_parses_local_inflight_updated_at(self):
+        payload = self.payload()
+        payload["inflight_updated_at"] = "2026-07-24 10:43:58"
+
+        probe = parse_watcher_state_probe(200, payload)
+
+        self.assertEqual(
+            probe.inflight_updated_at,
+            time.mktime(time.strptime("2026-07-24 10:43:58", "%Y-%m-%d %H:%M:%S")),
+        )
+
+    def test_malformed_inflight_updated_at_fails_closed(self):
+        payload = self.payload()
+        payload["inflight_updated_at"] = "2026-07-24T10:43:58Z"
+
+        probe = parse_watcher_state_probe(200, payload)
+
+        self.assertIsNone(probe.inflight_updated_at)
+
     def test_nullable_activity_timestamps_are_valid_schema(self):
         probe = parse_watcher_state_probe(
             200,
@@ -2416,6 +2435,7 @@ class TickChannelTests(unittest.TestCase):
         rt.watcher_probe = probe
 
     def active_foreground_probe(self, **overrides) -> WatcherStateProbe:
+        inflight_updated_at = overrides.pop("inflight_updated_at", None)
         fields = {
             "relay_stall_state": "active_foreground_stream",
             "active_turn": "foreground",
@@ -2434,6 +2454,7 @@ class TickChannelTests(unittest.TestCase):
             attached=True,
             desynced=True,
             relay_activity=CoverageActivityProbe(**fields),
+            inflight_updated_at=inflight_updated_at,
         )
 
     def test_metadata_only_growth_cannot_steal_live_selection(self):
@@ -2911,7 +2932,76 @@ class TickChannelTests(unittest.TestCase):
         self.assertEqual(len(rt.alerts), 1)
         self.assertIn("attached_but_desynced", rt.alerts[0][0])
 
-    def test_growth_with_stale_relay_timestamp_still_alerts(self):
+    def test_growth_with_stale_relay_and_advanced_inflight_update_is_suppressed(self):
+        rt = self.make_rt()
+        tick_at = self.now + 600
+        stale_relay_ms = (
+            int(tick_at * 1000) - COVERAGE_ACTIVITY_FRESH_SECS * 1000
+        )
+        probe = self.active_foreground_probe(
+            queue_depth=1,
+            last_outbound_activity_ms=None,
+            last_relay_ts_ms=stale_relay_ms,
+            inflight_updated_at=tick_at - COVERAGE_ACTIVITY_FRESH_SECS - 1,
+        )
+        self.arm_coverage(rt, probe)
+        state = {
+            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+            "coverage_desync_since": self.now,
+            relay_watchdog.COVERAGE_INFLIGHT_UPDATED_AT_KEY: (
+                tick_at - COVERAGE_ACTIVITY_FRESH_SECS - 2
+            ),
+        }
+
+        tick_coverage(
+            rt,
+            TICK_CHANNEL,
+            state,
+            tick_at,
+            CoverageTranscriptProbe(growing=True, blocks=723, lost=0),
+        )
+
+        self.assertEqual(rt.alerts, [])
+        self.assertNotIn("last_coverage_alert", state)
+        self.assertTrue(
+            any(
+                "live inflight update evidence=advanced" in line
+                for line in rt.log_lines
+            )
+        )
+
+    def test_growth_with_stale_relay_and_stalled_inflight_update_still_alerts(self):
+        rt = self.make_rt()
+        tick_at = self.now + 600
+        stale_relay_ms = (
+            int(tick_at * 1000) - COVERAGE_ACTIVITY_FRESH_SECS * 1000
+        )
+        stalled_inflight = tick_at - COVERAGE_ACTIVITY_FRESH_SECS - 1
+        probe = self.active_foreground_probe(
+            queue_depth=1,
+            last_outbound_activity_ms=None,
+            last_relay_ts_ms=stale_relay_ms,
+            inflight_updated_at=stalled_inflight,
+        )
+        self.arm_coverage(rt, probe)
+        state = {
+            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+            "coverage_desync_since": self.now,
+            relay_watchdog.COVERAGE_INFLIGHT_UPDATED_AT_KEY: stalled_inflight,
+        }
+
+        tick_coverage(
+            rt,
+            TICK_CHANNEL,
+            state,
+            tick_at,
+            CoverageTranscriptProbe(growing=True, blocks=723, lost=0),
+        )
+
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("attached_but_desynced", rt.alerts[0][0])
+
+    def test_growth_with_stale_relay_and_absent_inflight_update_still_alerts(self):
         rt = self.make_rt()
         tick_at = self.now + 600
         stale_relay_ms = (


### PR DESCRIPTION
## Summary
- parse watcher-state `inflight_updated_at` as the dcserver's local-time timestamp
- suppress zero-loss `growing_relay_stall` only when that timestamp advances between ticks or is still fresh
- preserve existing alarms when the field is stale, absent, or malformed

## Safety
- watchdog remains read-only; no repair behavior added
- Rust runtime code is untouched
- existing delivery-gap and transcript-loss evidence still overrides suppression

## Tests
- `python3 -m unittest tests.test_relay_watchdog` (243 tests, OK)
- `./scripts/ci-script-checks.sh` (rc=0)
- mutation proof: disabling the new inflight-progress gate makes the FP-class-2 regression test fail

Closes #4856