### PR TITLE
fix(#4788): gate attachment state on routed admission

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -659,6 +659,7 @@ src/
 │   │   │       └── circuit_breaker_apply.rs
 │   │   ├── router/
 │   │   │   ├── intake_dispatch/
+│   │   │   │   ├── attachment.rs
 │   │   │   │   ├── notice.rs
 │   │   │   │   ├── queued.rs
 │   │   │   │   ├── skill.rs

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ test-non-pg:
     cargo test --lib pending_reaction_failure_adapter_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib intake_dispatch_invariant_queued_entrypoints_promote_markers -- --skip _pg --skip pg_ --skip postgres
     # #4788: raw attachment preparation must remain behind local admission.
-    cargo test --lib intake_dispatch::attachment::tests -- --skip _pg --skip pg_ --skip postgres
+    cargo test --lib intake_dispatch::attachment::tests attachment_materialization_requires_post_admission_opaque_permit -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib mailbox_reaction_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres

--- a/justfile
+++ b/justfile
@@ -39,6 +39,8 @@ test-non-pg:
     cargo test --lib intake_queue_transaction::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib pending_reaction_failure_adapter_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib intake_dispatch_invariant_queued_entrypoints_promote_markers -- --skip _pg --skip pg_ --skip postgres
+    # #4788: raw attachment preparation must remain behind local admission.
+    cargo test --lib intake_dispatch::attachment::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib mailbox_reaction_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ test-non-pg:
     cargo test --lib pending_reaction_failure_adapter_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib intake_dispatch_invariant_queued_entrypoints_promote_markers -- --skip _pg --skip pg_ --skip postgres
     # #4788: raw attachment preparation must remain behind local admission.
-    cargo test --lib intake_dispatch::attachment::tests attachment_materialization_requires_post_admission_opaque_permit -- --skip _pg --skip pg_ --skip postgres
+    cargo test --lib attachment -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib mailbox_reaction_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres

--- a/scripts/check_test_lane_coverage.py
+++ b/scripts/check_test_lane_coverage.py
@@ -25,7 +25,7 @@ from typing import Iterable
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BASELINE_REL = Path("scripts/test_lane_coverage_baseline.txt")
-BASELINE_ENTRY_COUNT = 701
+BASELINE_ENTRY_COUNT = 700
 
 # Attributes do not contain a closing square bracket in the forms used by this
 # repository. Strings and comments are blanked without changing offsets, so the

--- a/scripts/test_lane_coverage_baseline.txt
+++ b/scripts/test_lane_coverage_baseline.txt
@@ -357,7 +357,6 @@ services::discord::router::intake_gate::queue_effects::merged_placeholder_reuse_
 services::discord::router::intake_gate::queue_effects::schedule_post_enqueue_idle_drain_tests
 services::discord::router::intake_gate::reply_context_tests
 services::discord::router::intake_gate::stale_turn::thread_guard_stale_pure_tests
-services::discord::router::message_handler::attachments::attachment_tests
 services::discord::router::message_handler::goal_lifecycle::codex_goal_lifecycle_unit_tests
 services::discord::router::message_handler::headless_turn::fresh_routine_tests
 services::discord::router::message_handler::headless_turn::headless_hard_ceiling_tests

--- a/src/services/cluster/intake_router_hook.rs
+++ b/src/services/cluster/intake_router_hook.rs
@@ -319,16 +319,6 @@ pub(crate) async fn try_route_intake(
                 IntakeRouterDecision::SkippedDuplicate { resolved_owner },
             );
         }
-        Ok(Some((target_instance_id, _))) if ctx.has_nonportable_uploads => {
-            return apply_observe_mode(
-                ctx.mode,
-                IntakeRouterDecision::Blocked {
-                    reason: IntakeBlockedReason::NonPortableAttachmentRoutedTarget {
-                        target_instance_id,
-                    },
-                },
-            );
-        }
         Ok(Some((target_instance_id, _))) => {
             return apply_observe_mode(
                 ctx.mode,
@@ -2538,28 +2528,6 @@ mod pg_tests {
                 .await
                 .expect("count");
         assert_eq!(count, 0, "non-consuming /node target must not insert");
-
-        pool.close().await;
-        pg_db.drop().await;
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn raw_attachment_with_distinct_open_route_is_blocked_instead_of_deferred_pg() {
-        let pg_db = TestPostgresDb::create().await;
-        let pool = pg_db.connect_and_migrate().await;
-        seed_open_route(&pool, "ch-attachment-open-route", "worker-open-route").await;
-
-        let mut ctx = ctx_for_channel(IntakeRoutingMode::Enforce, "ch-attachment-open-route");
-        ctx.has_nonportable_uploads = true;
-        let decision = try_route_intake(&pool, &ctx).await;
-        assert_eq!(
-            decision,
-            IntakeRouterDecision::Blocked {
-                reason: IntakeBlockedReason::NonPortableAttachmentRoutedTarget {
-                    target_instance_id: "worker-open-route".to_string(),
-                },
-            }
-        );
 
         pool.close().await;
         pg_db.drop().await;

--- a/src/services/cluster/intake_router_hook.rs
+++ b/src/services/cluster/intake_router_hook.rs
@@ -319,6 +319,16 @@ pub(crate) async fn try_route_intake(
                 IntakeRouterDecision::SkippedDuplicate { resolved_owner },
             );
         }
+        Ok(Some((target_instance_id, _))) if ctx.has_nonportable_uploads => {
+            return apply_observe_mode(
+                ctx.mode,
+                IntakeRouterDecision::Blocked {
+                    reason: IntakeBlockedReason::NonPortableAttachmentRoutedTarget {
+                        target_instance_id,
+                    },
+                },
+            );
+        }
         Ok(Some((target_instance_id, _))) => {
             return apply_observe_mode(
                 ctx.mode,
@@ -2528,6 +2538,28 @@ mod pg_tests {
                 .await
                 .expect("count");
         assert_eq!(count, 0, "non-consuming /node target must not insert");
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn raw_attachment_with_distinct_open_route_is_blocked_instead_of_deferred_pg() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        seed_open_route(&pool, "ch-attachment-open-route", "worker-open-route").await;
+
+        let mut ctx = ctx_for_channel(IntakeRoutingMode::Enforce, "ch-attachment-open-route");
+        ctx.has_nonportable_uploads = true;
+        let decision = try_route_intake(&pool, &ctx).await;
+        assert_eq!(
+            decision,
+            IntakeRouterDecision::Blocked {
+                reason: IntakeBlockedReason::NonPortableAttachmentRoutedTarget {
+                    target_instance_id: "worker-open-route".to_string(),
+                },
+            }
+        );
 
         pool.close().await;
         pg_db.drop().await;

--- a/src/services/discord/commands/skill.rs
+++ b/src/services/discord/commands/skill.rs
@@ -285,6 +285,7 @@ async fn run_skill_slash_command(
             full_text,
             IntakeOrigin::SlashSkill,
             Vec::new(),
+            None,
         )
         .await?;
         return Ok(());
@@ -350,6 +351,7 @@ async fn run_skill_slash_command(
         skill_prompt,
         IntakeOrigin::SlashSkill,
         Vec::new(),
+        None,
     )
     .await?;
 

--- a/src/services/discord/commands/text_commands.rs
+++ b/src/services/discord/commands/text_commands.rs
@@ -2,7 +2,10 @@ use poise::serenity_prelude as serenity;
 use poise::serenity_prelude::{CreateAttachment, CreateMessage};
 use std::sync::Arc;
 
-use super::super::router::{IntakeDeps, IntakeOrigin, dispatch_skill_intake};
+use super::super::router::{
+    IntakeDeps, IntakeOrigin, LocalAdmissionPermit, dispatch_skill_intake,
+    finish_admitted_skill_intake,
+};
 use super::super::*;
 use super::build_provider_skill_prompt;
 use crate::services::provider::CancelToken;
@@ -130,7 +133,7 @@ pub(in crate::services::discord) async fn handle_text_command(
     channel_id: serenity::ChannelId,
     text: &str,
 ) -> Result<bool, Error> {
-    handle_text_command_with_uploads(ctx, msg, data, channel_id, text, &[]).await
+    handle_text_command_with_uploads(ctx, msg, data, channel_id, text, &[], &mut None).await
 }
 
 pub(in crate::services::discord) async fn handle_text_command_with_uploads(
@@ -140,6 +143,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
     channel_id: serenity::ChannelId,
     text: &str,
     preloaded_uploads: &[String],
+    admitted_attachment_permit: &mut Option<LocalAdmissionPermit>,
 ) -> Result<bool, Error> {
     let parts: Vec<&str> = text.splitn(3, char::is_whitespace).collect();
     let cmd = parts[0];
@@ -1460,18 +1464,33 @@ Any other message is sent to {p}.
                 shared: &data.shared,
                 token: &data.token,
             };
-            dispatch_skill_intake(
-                &deps,
-                data.provider.clone(),
-                channel_id,
-                confirm.id,
-                msg.author.id,
-                msg.author.name.clone(),
-                skill_prompt,
-                IntakeOrigin::TextSkill,
-                preloaded_uploads.to_vec(),
-            )
-            .await?;
+            if let Some(permit) = admitted_attachment_permit.take() {
+                finish_admitted_skill_intake(
+                    &deps,
+                    permit,
+                    data.provider.clone(),
+                    channel_id,
+                    confirm.id,
+                    msg.author.id,
+                    msg.author.name.clone(),
+                    skill_prompt,
+                    preloaded_uploads.to_vec(),
+                )
+                .await?;
+            } else {
+                dispatch_skill_intake(
+                    &deps,
+                    data.provider.clone(),
+                    channel_id,
+                    confirm.id,
+                    msg.author.id,
+                    msg.author.name.clone(),
+                    skill_prompt,
+                    IntakeOrigin::TextSkill,
+                    preloaded_uploads.to_vec(),
+                )
+                .await?;
+            }
             return Ok(true);
         }
 

--- a/src/services/discord/commands/text_commands.rs
+++ b/src/services/discord/commands/text_commands.rs
@@ -2,10 +2,7 @@ use poise::serenity_prelude as serenity;
 use poise::serenity_prelude::{CreateAttachment, CreateMessage};
 use std::sync::Arc;
 
-use super::super::router::{
-    IntakeDeps, IntakeOrigin, LocalAdmissionPermit, dispatch_skill_intake,
-    finish_admitted_skill_intake,
-};
+use super::super::router::{IntakeDeps, IntakeOrigin, LocalAdmissionPermit, dispatch_skill_intake};
 use super::super::*;
 use super::build_provider_skill_prompt;
 use crate::services::provider::CancelToken;
@@ -1464,33 +1461,19 @@ Any other message is sent to {p}.
                 shared: &data.shared,
                 token: &data.token,
             };
-            if let Some(permit) = admitted_attachment_permit.take() {
-                finish_admitted_skill_intake(
-                    &deps,
-                    permit,
-                    data.provider.clone(),
-                    channel_id,
-                    confirm.id,
-                    msg.author.id,
-                    msg.author.name.clone(),
-                    skill_prompt,
-                    preloaded_uploads.to_vec(),
-                )
-                .await?;
-            } else {
-                dispatch_skill_intake(
-                    &deps,
-                    data.provider.clone(),
-                    channel_id,
-                    confirm.id,
-                    msg.author.id,
-                    msg.author.name.clone(),
-                    skill_prompt,
-                    IntakeOrigin::TextSkill,
-                    preloaded_uploads.to_vec(),
-                )
-                .await?;
-            }
+            dispatch_skill_intake(
+                &deps,
+                data.provider.clone(),
+                channel_id,
+                confirm.id,
+                msg.author.id,
+                msg.author.name.clone(),
+                skill_prompt,
+                IntakeOrigin::TextSkill,
+                preloaded_uploads.to_vec(),
+                admitted_attachment_permit.take(),
+            )
+            .await?;
             return Ok(true);
         }
 

--- a/src/services/discord/router/intake_dispatch.rs
+++ b/src/services/discord/router/intake_dispatch.rs
@@ -3,6 +3,7 @@ use crate::services::cluster::intake_router_hook::{
     IntakeBlockedReason, IntakeRouterContext, IntakeRouterDecision, try_route_intake,
 };
 use crate::services::provider::ProviderKind;
+use poise::serenity_prelude as serenity;
 
 mod attachment;
 mod notice;
@@ -49,7 +50,24 @@ pub(crate) struct IntakeSubmission {
 }
 
 #[derive(Debug)]
-pub(crate) struct LocalAdmissionPermit(());
+pub(crate) struct LocalAdmissionPermit {
+    channel_id: serenity::ChannelId,
+    request_owner: serenity::UserId,
+}
+
+impl LocalAdmissionPermit {
+    fn for_submission(submission: &IntakeSubmission) -> Self {
+        Self {
+            channel_id: submission.request.channel_id,
+            request_owner: submission.request.request_owner,
+        }
+    }
+
+    fn permits_submission(&self, submission: &IntakeSubmission) -> bool {
+        self.channel_id == submission.request.channel_id
+            && self.request_owner == submission.request.request_owner
+    }
+}
 
 #[derive(Debug)]
 pub(crate) enum IntakeAdmission {
@@ -111,7 +129,7 @@ pub(crate) async fn admit_text_intake(
         return match decision {
             IntakeRouterDecision::Blocked { reason } => IntakeAdmission::Blocked { reason },
             IntakeRouterDecision::RanLocal { .. } => {
-                IntakeAdmission::Local(LocalAdmissionPermit(()))
+                IntakeAdmission::Local(LocalAdmissionPermit::for_submission(submission))
             }
             _ => unreachable!("dependency-free admission creates only blocked or local decisions"),
         };
@@ -161,7 +179,7 @@ pub(crate) async fn admit_text_intake(
     );
     let admission = match decision {
         IntakeRouterDecision::RanLocal { .. } | IntakeRouterDecision::Observed { .. } => {
-            IntakeAdmission::Local(LocalAdmissionPermit(()))
+            IntakeAdmission::Local(LocalAdmissionPermit::for_submission(submission))
         }
         IntakeRouterDecision::Forwarded {
             target_instance_id,
@@ -226,9 +244,19 @@ pub(crate) async fn finish_admitted_text_intake(
 
 pub(crate) async fn finish_admitted_local(
     deps: &IntakeDeps<'_>,
-    _permit: LocalAdmissionPermit,
+    permit: LocalAdmissionPermit,
     submission: IntakeSubmission,
 ) -> Result<(), super::super::Error> {
+    if !permit.permits_submission(&submission) {
+        tracing::error!(
+            admitted_channel_id = permit.channel_id.get(),
+            submitted_channel_id = submission.request.channel_id.get(),
+            admitted_request_owner = permit.request_owner.get(),
+            submitted_request_owner = submission.request.request_owner.get(),
+            "local admission permit does not match intake submission"
+        );
+        return Ok(());
+    }
     let preserve_on_cancel = submission.preserve_on_cancel;
     let queued_drain = matches!(submission.origin, IntakeOrigin::QueuedDrain);
     message_handler::finish_admitted_local(

--- a/src/services/discord/router/intake_dispatch.rs
+++ b/src/services/discord/router/intake_dispatch.rs
@@ -54,7 +54,6 @@ pub(crate) struct IntakeSubmission {
 pub(crate) struct LocalAdmissionPermit {
     channel_id: serenity::ChannelId,
     request_owner: serenity::UserId,
-    has_nonportable_uploads: bool,
 }
 
 impl LocalAdmissionPermit {
@@ -62,19 +61,12 @@ impl LocalAdmissionPermit {
         Self {
             channel_id: submission.request.channel_id,
             request_owner: submission.request.request_owner,
-            has_nonportable_uploads: submission.has_nonportable_uploads
-                || !submission.attachments.is_empty()
-                || !submission.preloaded_uploads.is_empty(),
         }
     }
 
     fn permits_submission(&self, submission: &IntakeSubmission) -> bool {
         self.channel_id == submission.request.channel_id
             && self.request_owner == submission.request.request_owner
-            && self.has_nonportable_uploads
-                == (submission.has_nonportable_uploads
-                    || !submission.attachments.is_empty()
-                    || !submission.preloaded_uploads.is_empty())
     }
 }
 

--- a/src/services/discord/router/intake_dispatch.rs
+++ b/src/services/discord/router/intake_dispatch.rs
@@ -25,6 +25,7 @@ pub(crate) enum IntakeOrigin {
     QueuedDrain,
     SlashSkill,
     TextSkill,
+    RawAttachment,
 }
 
 impl IntakeOrigin {
@@ -226,6 +227,14 @@ pub(crate) async fn finish_text_intake_admission(
     match admission {
         IntakeAdmission::Local(permit) => {
             finish_admitted_local(deps, permit, submission).await?;
+        }
+        IntakeAdmission::DeferredOpenRoute {
+            ref target_instance_id,
+        } if matches!(submission.origin, IntakeOrigin::RawAttachment) => {
+            let reason = IntakeBlockedReason::NonPortableAttachmentRoutedTarget {
+                target_instance_id: target_instance_id.clone(),
+            };
+            notify_blocked_intake(deps, &submission, &reason).await;
         }
         IntakeAdmission::DeferredOpenRoute { .. } => {
             defer_live_submission(deps, submission).await;

--- a/src/services/discord/router/intake_dispatch.rs
+++ b/src/services/discord/router/intake_dispatch.rs
@@ -52,10 +52,7 @@ pub(crate) struct IntakeSubmission {
 #[derive(Debug)]
 pub(crate) struct LocalAdmissionPermit {
     channel_id: serenity::ChannelId,
-    user_msg_id: serenity::MessageId,
     request_owner: serenity::UserId,
-    origin: IntakeOrigin,
-    preserve_on_cancel: bool,
     has_nonportable_uploads: bool,
 }
 
@@ -63,10 +60,7 @@ impl LocalAdmissionPermit {
     fn for_submission(submission: &IntakeSubmission) -> Self {
         Self {
             channel_id: submission.request.channel_id,
-            user_msg_id: submission.request.user_msg_id,
             request_owner: submission.request.request_owner,
-            origin: submission.origin,
-            preserve_on_cancel: submission.preserve_on_cancel,
             has_nonportable_uploads: submission.has_nonportable_uploads
                 || !submission.attachments.is_empty()
                 || !submission.preloaded_uploads.is_empty(),
@@ -75,10 +69,7 @@ impl LocalAdmissionPermit {
 
     fn permits_submission(&self, submission: &IntakeSubmission) -> bool {
         self.channel_id == submission.request.channel_id
-            && self.user_msg_id == submission.request.user_msg_id
             && self.request_owner == submission.request.request_owner
-            && self.origin == submission.origin
-            && self.preserve_on_cancel == submission.preserve_on_cancel
             && self.has_nonportable_uploads
                 == (submission.has_nonportable_uploads
                     || !submission.attachments.is_empty()
@@ -268,8 +259,6 @@ pub(crate) async fn finish_admitted_local(
         tracing::error!(
             admitted_channel_id = permit.channel_id.get(),
             submitted_channel_id = submission.request.channel_id.get(),
-            admitted_user_msg_id = permit.user_msg_id.get(),
-            submitted_user_msg_id = submission.request.user_msg_id.get(),
             admitted_request_owner = permit.request_owner.get(),
             submitted_request_owner = submission.request.request_owner.get(),
             "local admission permit does not match intake submission"

--- a/src/services/discord/router/intake_dispatch.rs
+++ b/src/services/discord/router/intake_dispatch.rs
@@ -4,17 +4,20 @@ use crate::services::cluster::intake_router_hook::{
 };
 use crate::services::provider::ProviderKind;
 
+mod attachment;
 mod notice;
 mod queued;
 mod skill;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use attachment::{prepare_admitted_live_attachments, resolve_attachment_admission};
 use notice::notify_blocked_intake;
 pub(crate) use queued::{
     QueuedAdmissionDisposition, admit_queued_intake, finish_admitted_queued_intake,
 };
 pub(crate) use skill::dispatch_skill_intake;
+pub(crate) use skill::finish_admitted_skill_intake;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum IntakeOrigin {
@@ -41,6 +44,7 @@ pub(crate) struct IntakeSubmission {
     pub(crate) origin: IntakeOrigin,
     pub(crate) preserve_on_cancel: bool,
     pub(crate) has_nonportable_uploads: bool,
+    pub(crate) attachments: Vec<message_handler::AttachmentDescriptor>,
     pub(crate) preloaded_uploads: Vec<String>,
     pub(crate) voice_announcement: Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
 }
@@ -144,6 +148,7 @@ pub(crate) async fn admit_text_intake(
         preserve_on_cancel: submission.preserve_on_cancel,
         node_override_instance_id: node_override.as_deref(),
         has_nonportable_uploads: submission.has_nonportable_uploads
+            || !submission.attachments.is_empty()
             || !submission.preloaded_uploads.is_empty(),
     };
 
@@ -185,6 +190,14 @@ pub(crate) async fn dispatch_text_intake(
     submission: IntakeSubmission,
 ) -> Result<(), super::super::Error> {
     let admission = admit_text_intake(deps, &submission).await;
+    finish_text_intake_admission(deps, admission, submission).await
+}
+
+pub(crate) async fn finish_text_intake_admission(
+    deps: &IntakeDeps<'_>,
+    admission: IntakeAdmission,
+    submission: IntakeSubmission,
+) -> Result<(), super::super::Error> {
     match admission {
         IntakeAdmission::Local(permit) => {
             finish_admitted_local(deps, permit, submission).await?;
@@ -202,6 +215,14 @@ pub(crate) async fn dispatch_text_intake(
         | IntakeAdmission::Blocked { .. } => {}
     }
     Ok(())
+}
+
+pub(crate) async fn finish_admitted_text_intake(
+    deps: &IntakeDeps<'_>,
+    permit: LocalAdmissionPermit,
+    submission: IntakeSubmission,
+) -> Result<(), super::super::Error> {
+    finish_admitted_local(deps, permit, submission).await
 }
 
 pub(crate) async fn finish_admitted_local(

--- a/src/services/discord/router/intake_dispatch.rs
+++ b/src/services/discord/router/intake_dispatch.rs
@@ -17,7 +17,6 @@ pub(crate) use queued::{
     QueuedAdmissionDisposition, admit_queued_intake, finish_admitted_queued_intake,
 };
 pub(crate) use skill::dispatch_skill_intake;
-pub(crate) use skill::finish_admitted_skill_intake;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum IntakeOrigin {

--- a/src/services/discord/router/intake_dispatch.rs
+++ b/src/services/discord/router/intake_dispatch.rs
@@ -52,20 +52,37 @@ pub(crate) struct IntakeSubmission {
 #[derive(Debug)]
 pub(crate) struct LocalAdmissionPermit {
     channel_id: serenity::ChannelId,
+    user_msg_id: serenity::MessageId,
     request_owner: serenity::UserId,
+    origin: IntakeOrigin,
+    preserve_on_cancel: bool,
+    has_nonportable_uploads: bool,
 }
 
 impl LocalAdmissionPermit {
     fn for_submission(submission: &IntakeSubmission) -> Self {
         Self {
             channel_id: submission.request.channel_id,
+            user_msg_id: submission.request.user_msg_id,
             request_owner: submission.request.request_owner,
+            origin: submission.origin,
+            preserve_on_cancel: submission.preserve_on_cancel,
+            has_nonportable_uploads: submission.has_nonportable_uploads
+                || !submission.attachments.is_empty()
+                || !submission.preloaded_uploads.is_empty(),
         }
     }
 
     fn permits_submission(&self, submission: &IntakeSubmission) -> bool {
         self.channel_id == submission.request.channel_id
+            && self.user_msg_id == submission.request.user_msg_id
             && self.request_owner == submission.request.request_owner
+            && self.origin == submission.origin
+            && self.preserve_on_cancel == submission.preserve_on_cancel
+            && self.has_nonportable_uploads
+                == (submission.has_nonportable_uploads
+                    || !submission.attachments.is_empty()
+                    || !submission.preloaded_uploads.is_empty())
     }
 }
 
@@ -251,6 +268,8 @@ pub(crate) async fn finish_admitted_local(
         tracing::error!(
             admitted_channel_id = permit.channel_id.get(),
             submitted_channel_id = submission.request.channel_id.get(),
+            admitted_user_msg_id = permit.user_msg_id.get(),
+            submitted_user_msg_id = submission.request.user_msg_id.get(),
             admitted_request_owner = permit.request_owner.get(),
             submitted_request_owner = submission.request.request_owner.get(),
             "local admission permit does not match intake submission"

--- a/src/services/discord/router/intake_dispatch/attachment.rs
+++ b/src/services/discord/router/intake_dispatch/attachment.rs
@@ -140,7 +140,10 @@ mod tests {
         let mut local_sessions = Vec::new();
 
         let outcome = resolve_attachment_admission_with(
-            IntakeAdmission::Local(LocalAdmissionPermit(())),
+            IntakeAdmission::Local(LocalAdmissionPermit {
+                channel_id: serenity::ChannelId::new(1),
+                request_owner: serenity::UserId::new(2),
+            }),
             |permit| {
                 local_sessions.push("session");
                 std::fs::write(&marker, b"upload").expect("write materialization marker");

--- a/src/services/discord/router/intake_dispatch/attachment.rs
+++ b/src/services/discord/router/intake_dispatch/attachment.rs
@@ -142,10 +142,7 @@ mod tests {
         let outcome = resolve_attachment_admission_with(
             IntakeAdmission::Local(LocalAdmissionPermit {
                 channel_id: serenity::ChannelId::new(1),
-                user_msg_id: serenity::MessageId::new(2),
-                request_owner: serenity::UserId::new(3),
-                origin: super::super::IntakeOrigin::LiveMessage,
-                preserve_on_cancel: true,
+                request_owner: serenity::UserId::new(2),
                 has_nonportable_uploads: true,
             }),
             |permit| {

--- a/src/services/discord/router/intake_dispatch/attachment.rs
+++ b/src/services/discord/router/intake_dispatch/attachment.rs
@@ -142,7 +142,11 @@ mod tests {
         let outcome = resolve_attachment_admission_with(
             IntakeAdmission::Local(LocalAdmissionPermit {
                 channel_id: serenity::ChannelId::new(1),
-                request_owner: serenity::UserId::new(2),
+                user_msg_id: serenity::MessageId::new(2),
+                request_owner: serenity::UserId::new(3),
+                origin: super::super::IntakeOrigin::LiveMessage,
+                preserve_on_cancel: true,
+                has_nonportable_uploads: true,
             }),
             |permit| {
                 local_sessions.push("session");

--- a/src/services/discord/router/intake_dispatch/attachment.rs
+++ b/src/services/discord/router/intake_dispatch/attachment.rs
@@ -143,7 +143,6 @@ mod tests {
             IntakeAdmission::Local(LocalAdmissionPermit {
                 channel_id: serenity::ChannelId::new(1),
                 request_owner: serenity::UserId::new(2),
-                has_nonportable_uploads: true,
             }),
             |permit| {
                 local_sessions.push("session");

--- a/src/services/discord/router/intake_dispatch/attachment.rs
+++ b/src/services/discord/router/intake_dispatch/attachment.rs
@@ -1,0 +1,155 @@
+use poise::serenity_prelude as serenity;
+
+use super::{IntakeAdmission, LocalAdmissionPermit};
+use crate::services::discord::{
+    HistoryItem, HistoryType, auto_restore_session, auto_restore_session_with_dm_hint,
+    bootstrap_thread_session,
+};
+
+pub(crate) type AttachmentAdmissionGate = Result<LocalAdmissionPermit, IntakeAdmission>;
+
+fn resolve_attachment_admission_with<T>(
+    admission: IntakeAdmission,
+    on_local: impl FnOnce(LocalAdmissionPermit) -> T,
+) -> Result<T, IntakeAdmission> {
+    match admission {
+        IntakeAdmission::Local(permit) => Ok(on_local(permit)),
+        nonlocal => Err(nonlocal),
+    }
+}
+
+pub(crate) fn resolve_attachment_admission(admission: IntakeAdmission) -> AttachmentAdmissionGate {
+    resolve_attachment_admission_with(admission, std::convert::identity)
+}
+
+async fn record_upload_history(
+    shared: &std::sync::Arc<crate::services::discord::SharedData>,
+    channel_id: serenity::ChannelId,
+    upload_records: &[String],
+) {
+    if upload_records.is_empty() {
+        return;
+    }
+    let mut data = shared.core.lock().await;
+    if let Some(session) = data.sessions.get_mut(&channel_id) {
+        session
+            .history
+            .extend(upload_records.iter().cloned().map(|content| HistoryItem {
+                item_type: HistoryType::User,
+                content,
+            }));
+    }
+}
+
+pub(crate) async fn prepare_admitted_live_attachments(
+    deps: &super::super::message_handler::IntakeDeps<'_>,
+    _local_permit: &LocalAdmissionPermit,
+    channel_id: serenity::ChannelId,
+    effective_channel_id: serenity::ChannelId,
+    is_dm: bool,
+    attachments: &[super::super::message_handler::AttachmentDescriptor],
+) -> Result<Vec<String>, super::super::super::Error> {
+    if attachments.is_empty() {
+        return Ok(Vec::new());
+    }
+    let ctx = deps.ctx_for_chained_dispatch.ok_or_else(|| {
+        std::io::Error::other("live attachment preparation requires a gateway context")
+    })?;
+
+    auto_restore_session_with_dm_hint(deps.shared, channel_id, ctx, Some(is_dm)).await;
+    if effective_channel_id != channel_id {
+        let needs_parent = {
+            let data = deps.shared.core.lock().await;
+            !data.sessions.contains_key(&channel_id)
+        };
+        if needs_parent {
+            auto_restore_session(deps.shared, effective_channel_id, ctx).await;
+            let parent_path = {
+                let data = deps.shared.core.lock().await;
+                data.sessions
+                    .get(&effective_channel_id)
+                    .and_then(|session| session.current_path.clone())
+            };
+            if let Some(path) = parent_path {
+                bootstrap_thread_session(deps.shared, channel_id, &path, deps.http, deps.cache)
+                    .await;
+            }
+        }
+    }
+
+    let attachment_permit =
+        super::super::message_handler::LocalAttachmentPreparationPermit::after_local_admission();
+    let upload_records = super::super::message_handler::prepare_admitted_local_attachment(
+        deps.http,
+        channel_id,
+        attachments,
+        deps.shared,
+        &attachment_permit,
+    )
+    .await?;
+    record_upload_history(deps.shared, channel_id, &upload_records).await;
+    Ok(upload_records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::cluster::intake_router_hook::IntakeBlockedReason;
+
+    fn nonlocal_admissions() -> Vec<IntakeAdmission> {
+        vec![
+            IntakeAdmission::Forwarded {
+                target_instance_id: "foreign".to_string(),
+                outbox_id: 7,
+            },
+            IntakeAdmission::SkippedDuplicate,
+            IntakeAdmission::DeferredOpenRoute {
+                target_instance_id: "foreign".to_string(),
+            },
+            IntakeAdmission::Blocked {
+                reason: IntakeBlockedReason::RoutingDependencyFailed {
+                    detail: "unavailable".to_string(),
+                },
+            },
+        ]
+    }
+
+    #[test]
+    fn nonlocal_attachment_admission_never_runs_local_materialization() {
+        for admission in nonlocal_admissions() {
+            let root = tempfile::tempdir().expect("temporary attachment root");
+            let marker = root.path().join("materialized");
+            let mut local_sessions = Vec::new();
+
+            let outcome = resolve_attachment_admission_with(admission, |permit| {
+                local_sessions.push("session");
+                std::fs::write(&marker, b"upload").expect("write materialization marker");
+                permit
+            });
+
+            assert!(outcome.is_err());
+            assert!(local_sessions.is_empty());
+            assert!(!marker.exists());
+        }
+    }
+
+    #[test]
+    fn local_attachment_admission_runs_materialization_once() {
+        let root = tempfile::tempdir().expect("temporary attachment root");
+        let marker = root.path().join("materialized");
+        let mut local_sessions = Vec::new();
+
+        let outcome = resolve_attachment_admission_with(
+            IntakeAdmission::Local(LocalAdmissionPermit(())),
+            |permit| {
+                local_sessions.push("session");
+                std::fs::write(&marker, b"upload").expect("write materialization marker");
+                permit
+            },
+        );
+
+        assert!(outcome.is_ok());
+        assert_eq!(local_sessions, vec!["session"]);
+        assert_eq!(std::fs::read(marker).expect("read marker"), b"upload");
+    }
+}

--- a/src/services/discord/router/intake_dispatch/queued.rs
+++ b/src/services/discord/router/intake_dispatch/queued.rs
@@ -54,6 +54,7 @@ pub(crate) async fn admit_queued_intake(
         origin: IntakeOrigin::QueuedDrain,
         preserve_on_cancel: intervention.preserve_on_cancel(),
         has_nonportable_uploads: !intervention.pending_uploads.is_empty(),
+        attachments: Vec::new(),
         preloaded_uploads: intervention.pending_uploads.clone(),
         voice_announcement: None,
     };

--- a/src/services/discord/router/intake_dispatch/skill.rs
+++ b/src/services/discord/router/intake_dispatch/skill.rs
@@ -1,6 +1,9 @@
 use poise::serenity_prelude as serenity;
 
-use super::{IntakeOrigin, IntakeSubmission, dispatch_text_intake};
+use super::{
+    IntakeOrigin, IntakeSubmission, LocalAdmissionPermit, dispatch_text_intake,
+    finish_admitted_local,
+};
 use crate::services::provider::ProviderKind;
 
 #[allow(clippy::too_many_arguments)]
@@ -38,6 +41,51 @@ pub(crate) async fn dispatch_skill_intake(
             origin,
             preserve_on_cancel: false,
             has_nonportable_uploads: !preloaded_uploads.is_empty(),
+            attachments: Vec::new(),
+            preloaded_uploads,
+            voice_announcement: None,
+        },
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn finish_admitted_skill_intake(
+    deps: &super::super::message_handler::IntakeDeps<'_>,
+    permit: LocalAdmissionPermit,
+    provider: ProviderKind,
+    channel_id: serenity::ChannelId,
+    user_msg_id: serenity::MessageId,
+    request_owner: serenity::UserId,
+    request_owner_name: String,
+    prompt: String,
+    preloaded_uploads: Vec<String>,
+) -> Result<(), super::super::super::Error> {
+    finish_admitted_local(
+        deps,
+        permit,
+        IntakeSubmission {
+            provider,
+            request: super::super::message_handler::IntakeRequest {
+                channel_id,
+                user_msg_id,
+                request_owner,
+                request_owner_name,
+                user_text: prompt,
+                reply_to_user_message: false,
+                defer_watcher_resume: false,
+                wait_for_completion: false,
+                merge_consecutive: false,
+                reply_context: None,
+                has_reply_boundary: false,
+                dm_hint: None,
+                turn_kind: super::super::TurnKind::Foreground,
+                preserve_on_cancel: false,
+            },
+            origin: IntakeOrigin::TextSkill,
+            preserve_on_cancel: false,
+            has_nonportable_uploads: !preloaded_uploads.is_empty(),
+            attachments: Vec::new(),
             preloaded_uploads,
             voice_announcement: None,
         },

--- a/src/services/discord/router/intake_dispatch/skill.rs
+++ b/src/services/discord/router/intake_dispatch/skill.rs
@@ -17,78 +17,36 @@ pub(crate) async fn dispatch_skill_intake(
     prompt: String,
     origin: IntakeOrigin,
     preloaded_uploads: Vec<String>,
+    admitted_local: Option<LocalAdmissionPermit>,
 ) -> Result<(), super::super::super::Error> {
-    dispatch_text_intake(
-        deps,
-        IntakeSubmission {
-            provider,
-            request: super::super::message_handler::IntakeRequest {
-                channel_id,
-                user_msg_id,
-                request_owner,
-                request_owner_name,
-                user_text: prompt,
-                reply_to_user_message: false,
-                defer_watcher_resume: false,
-                wait_for_completion: false,
-                merge_consecutive: false,
-                reply_context: None,
-                has_reply_boundary: false,
-                dm_hint: None,
-                turn_kind: super::super::TurnKind::Foreground,
-                preserve_on_cancel: false,
-            },
-            origin,
+    let submission = IntakeSubmission {
+        provider,
+        request: super::super::message_handler::IntakeRequest {
+            channel_id,
+            user_msg_id,
+            request_owner,
+            request_owner_name,
+            user_text: prompt,
+            reply_to_user_message: false,
+            defer_watcher_resume: false,
+            wait_for_completion: false,
+            merge_consecutive: false,
+            reply_context: None,
+            has_reply_boundary: false,
+            dm_hint: None,
+            turn_kind: super::super::TurnKind::Foreground,
             preserve_on_cancel: false,
-            has_nonportable_uploads: !preloaded_uploads.is_empty(),
-            attachments: Vec::new(),
-            preloaded_uploads,
-            voice_announcement: None,
         },
-    )
-    .await
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(crate) async fn finish_admitted_skill_intake(
-    deps: &super::super::message_handler::IntakeDeps<'_>,
-    permit: LocalAdmissionPermit,
-    provider: ProviderKind,
-    channel_id: serenity::ChannelId,
-    user_msg_id: serenity::MessageId,
-    request_owner: serenity::UserId,
-    request_owner_name: String,
-    prompt: String,
-    preloaded_uploads: Vec<String>,
-) -> Result<(), super::super::super::Error> {
-    finish_admitted_local(
-        deps,
-        permit,
-        IntakeSubmission {
-            provider,
-            request: super::super::message_handler::IntakeRequest {
-                channel_id,
-                user_msg_id,
-                request_owner,
-                request_owner_name,
-                user_text: prompt,
-                reply_to_user_message: false,
-                defer_watcher_resume: false,
-                wait_for_completion: false,
-                merge_consecutive: false,
-                reply_context: None,
-                has_reply_boundary: false,
-                dm_hint: None,
-                turn_kind: super::super::TurnKind::Foreground,
-                preserve_on_cancel: false,
-            },
-            origin: IntakeOrigin::TextSkill,
-            preserve_on_cancel: false,
-            has_nonportable_uploads: !preloaded_uploads.is_empty(),
-            attachments: Vec::new(),
-            preloaded_uploads,
-            voice_announcement: None,
-        },
-    )
-    .await
+        origin,
+        preserve_on_cancel: false,
+        has_nonportable_uploads: !preloaded_uploads.is_empty(),
+        attachments: Vec::new(),
+        preloaded_uploads,
+        voice_announcement: None,
+    };
+    if let Some(permit) = admitted_local {
+        finish_admitted_local(deps, permit, submission).await
+    } else {
+        dispatch_text_intake(deps, submission).await
+    }
 }

--- a/src/services/discord/router/intake_dispatch/tests.rs
+++ b/src/services/discord/router/intake_dispatch/tests.rs
@@ -310,6 +310,7 @@ async fn intake_dispatch_invariant_enforce_without_postgres_blocks_owner_unknown
         origin: IntakeOrigin::LiveMessage,
         preserve_on_cancel: false,
         has_nonportable_uploads: false,
+        attachments: Vec::new(),
         preloaded_uploads: Vec::new(),
         voice_announcement: None,
     };
@@ -344,6 +345,7 @@ async fn live_and_skill_producers_forward_to_foreign_owner_pg() {
             origin: IntakeOrigin::LiveMessage,
             preserve_on_cancel: true,
             has_nonportable_uploads: false,
+            attachments: Vec::new(),
             preloaded_uploads: Vec::new(),
             voice_announcement: None,
         },
@@ -400,6 +402,57 @@ async fn live_and_skill_producers_forward_to_foreign_owner_pg() {
     assert!(
         shared.core.lock().await.sessions.is_empty(),
         "foreign admission must not create a local session"
+    );
+
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn raw_attachment_foreign_owner_blocks_before_outbox_or_local_state_pg() {
+    let _env = ScopedIntakeTestEnv::enforce();
+    let pg_db = TestPostgresDb::create().await;
+    let pool = pg_db.connect_and_migrate().await;
+    let channel_id = ChannelId::new(4_350_151);
+    seed_foreign_owner(&pool, channel_id, "worker-owner-4350-raw-attachment").await;
+
+    let shared =
+        crate::services::discord::make_shared_data_for_tests_with_storage(Some(pool.clone()));
+    let http = Arc::new(serenity::Http::new("Bot intake-dispatch-test"));
+    let deps = deps(&http, &shared);
+    let submission = IntakeSubmission {
+        provider: ProviderKind::Claude,
+        request: request(channel_id, 4_350_161, "inspect the attachment"),
+        origin: IntakeOrigin::LiveMessage,
+        preserve_on_cancel: false,
+        has_nonportable_uploads: false,
+        attachments: vec![super::super::message_handler::AttachmentDescriptor {
+            filename: "report.txt".to_string(),
+            url: "https://cdn.discordapp.com/attachments/1/2/report.txt".to_string(),
+        }],
+        preloaded_uploads: Vec::new(),
+        voice_announcement: None,
+    };
+
+    assert!(matches!(
+        super::admit_text_intake(&deps, &submission).await,
+        super::IntakeAdmission::Blocked {
+            reason: crate::services::cluster::intake_router_hook::IntakeBlockedReason::NonPortableAttachmentForeignOwner { .. }
+        }
+    ));
+    let outbox_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM intake_outbox WHERE channel_id = $1")
+            .bind(channel_id.get().to_string())
+            .fetch_one(&pool)
+            .await
+            .expect("count raw attachment routes");
+    assert_eq!(
+        outbox_count, 0,
+        "raw attachments never enter a foreign outbox"
+    );
+    assert!(
+        shared.core.lock().await.sessions.is_empty(),
+        "blocked raw attachment admission must not create local session state"
     );
 
     pool.close().await;
@@ -551,6 +604,7 @@ async fn distinct_open_route_requeues_queued_successor_pg() {
             origin: IntakeOrigin::LiveMessage,
             preserve_on_cancel: false,
             has_nonportable_uploads: false,
+            attachments: Vec::new(),
             preloaded_uploads: Vec::new(),
             voice_announcement: None,
         },

--- a/src/services/discord/router/intake_dispatch/tests.rs
+++ b/src/services/discord/router/intake_dispatch/tests.rs
@@ -364,6 +364,7 @@ async fn live_and_skill_producers_forward_to_foreign_owner_pg() {
         "/unknown-skill".to_string(),
         IntakeOrigin::SlashSkill,
         Vec::new(),
+        None,
     )
     .await
     .expect("slash skill forwards");
@@ -379,6 +380,7 @@ async fn live_and_skill_producers_forward_to_foreign_owner_pg() {
         "Execute /registered-skill".to_string(),
         IntakeOrigin::TextSkill,
         Vec::new(),
+        None,
     )
     .await
     .expect("text skill forwards");

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -1723,23 +1723,39 @@ mod live_intake_preserve_wiring_tests {
             .find("stale_dispatch_turn_for_text(")
             .map(|offset| guard_pos + offset)
             .expect("stale dispatch lookup remains present for automation");
-        let submission_pos = module_src[stale_lookup_pos..]
-            .find("origin: super::IntakeOrigin::LiveMessage,")
+        let raw_submission_pos = module_src[stale_lookup_pos..]
+            .find("origin: super::IntakeOrigin::RawAttachment,")
             .map(|offset| stale_lookup_pos + offset)
+            .expect("raw-attachment IntakeSubmission construction exists");
+        let live_submission_pos = module_src[raw_submission_pos..]
+            .find("origin: super::IntakeOrigin::LiveMessage,")
+            .map(|offset| raw_submission_pos + offset)
             .expect("live-message IntakeSubmission construction exists");
-        let request_window = &module_src[stale_lookup_pos..submission_pos];
-        let submission_window = &module_src[submission_pos..];
+        let raw_request_window = &module_src[stale_lookup_pos..raw_submission_pos];
+        let raw_submission_window = &module_src[raw_submission_pos..live_submission_pos];
+        let live_request_window = &module_src[raw_submission_pos..live_submission_pos];
+        let live_submission_window = &module_src[live_submission_pos..];
 
         assert!(computation_pos < guard_pos && guard_pos < stale_lookup_pos);
         assert!(
-            request_window.contains("turn_kind,\n                    preserve_on_cancel,"),
-            "IntakeRequest must reuse the precomputed preservation value"
+            raw_request_window.contains("turn_kind,\n                        preserve_on_cancel,"),
+            "raw attachment IntakeRequest must reuse the precomputed preservation value"
         );
         assert!(
-            submission_window.contains(
-                "origin: super::IntakeOrigin::LiveMessage,\n                preserve_on_cancel,"
+            raw_submission_window.contains(
+                "origin: super::IntakeOrigin::RawAttachment,\n                    preserve_on_cancel,"
             ),
-            "IntakeSubmission must reuse the precomputed preservation value"
+            "raw attachment IntakeSubmission must reuse the precomputed preservation value"
+        );
+        assert!(
+            live_request_window.contains("turn_kind,\n                        preserve_on_cancel,"),
+            "live IntakeRequest must reuse the precomputed preservation value"
+        );
+        assert!(
+            live_submission_window.contains(
+                "origin: super::IntakeOrigin::LiveMessage,\n                    preserve_on_cancel,"
+            ),
+            "live IntakeSubmission must reuse the precomputed preservation value"
         );
     }
 }

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -29,25 +29,6 @@ use stale_turn::{
     thread_guard_should_force_clean_stale_thread,
 };
 
-async fn record_upload_history(
-    shared: &std::sync::Arc<SharedData>,
-    channel_id: serenity::ChannelId,
-    upload_records: &[String],
-) {
-    if upload_records.is_empty() {
-        return;
-    }
-    let mut data = shared.core.lock().await;
-    if let Some(session) = data.sessions.get_mut(&channel_id) {
-        session
-            .history
-            .extend(upload_records.iter().cloned().map(|content| HistoryItem {
-                item_type: HistoryType::User,
-                content,
-            }));
-    }
-}
-
 async fn append_pending_uploads(
     shared: &std::sync::Arc<SharedData>,
     channel_id: serenity::ChannelId,
@@ -672,12 +653,15 @@ pub(in crate::services::discord) async fn handle_event(
             {
                 return Ok(());
             }
+            let mut deferred_attachment_unbound_check = false;
             if !is_dm && !is_voice_transcript_announcement {
                 match resolve_runtime_channel_binding_status(&ctx.http, effective_channel_id).await
                 {
                     RuntimeChannelBindingStatus::Owned => {}
                     RuntimeChannelBindingStatus::Unowned => {
-                        if can_route_unbound_direct_session(
+                        if !new_message.attachments.is_empty() {
+                            deferred_attachment_unbound_check = true;
+                        } else if can_route_unbound_direct_session(
                             data,
                             ctx,
                             channel_id,
@@ -812,56 +796,114 @@ pub(in crate::services::discord) async fn handle_event(
                 }
             }
 
-            // Handle file attachments — download regardless of session state.
-            // For thread messages, bootstrap the thread session before saving so
-            // upload context attaches to the eventual turn instead of being
-            // dropped while only the parent session exists.
-            let upload_records = if !new_message.attachments.is_empty() {
+            let attachments = super::message_handler::describe_attachments(new_message);
+            let mut attachment_local_permit = None;
+            let mut admitted_attachment_submission = None;
+            if !attachments.is_empty() {
+                let has_reply_boundary = new_message.message_reference.is_some();
+                let reply_context = if has_reply_boundary {
+                    build_reply_context(ctx, channel_id, &new_message).await
+                } else {
+                    None
+                };
+                let turn_kind = super::message_handler::classify_turn_kind_from_author(
+                    user_id.get(),
+                    notify_resolution.user_id(),
+                );
+                let deps = super::message_handler::IntakeDeps {
+                    http: &ctx.http,
+                    cache: Some(&ctx.cache),
+                    ctx_for_chained_dispatch: Some(ctx),
+                    shared: &data.shared,
+                    token: &data.token,
+                };
+                let submission = super::IntakeSubmission {
+                    provider: data.provider.clone(),
+                    request: super::IntakeRequest {
+                        channel_id,
+                        user_msg_id: new_message.id,
+                        request_owner: user_id,
+                        request_owner_name: user_name.to_string(),
+                        user_text: text.to_string(),
+                        reply_to_user_message: false,
+                        defer_watcher_resume: false,
+                        wait_for_completion: false,
+                        merge_consecutive: false,
+                        reply_context: reply_context.clone(),
+                        has_reply_boundary,
+                        dm_hint: Some(is_dm),
+                        turn_kind,
+                        preserve_on_cancel,
+                    },
+                    origin: super::IntakeOrigin::LiveMessage,
+                    preserve_on_cancel,
+                    has_nonportable_uploads: true,
+                    attachments: attachments.clone(),
+                    preloaded_uploads: Vec::new(),
+                    voice_announcement: resolved_voice_announcement.clone(),
+                };
+                let admission = super::admit_text_intake(&deps, &submission).await;
+                match super::resolve_attachment_admission(admission) {
+                    Ok(permit) => {
+                        attachment_local_permit = Some(permit);
+                        admitted_attachment_submission = Some(submission);
+                    }
+                    Err(nonlocal) => {
+                        super::finish_text_intake_admission(&deps, nonlocal, submission).await?;
+                        return Ok(());
+                    }
+                }
+
+                if deferred_attachment_unbound_check
+                    && !can_route_unbound_direct_session(
+                        data,
+                        ctx,
+                        channel_id,
+                        effective_channel_id,
+                        is_dm,
+                    )
+                    .await
+                {
+                    let ts = chrono::Local::now().format("%H:%M:%S");
+                    tracing::info!(
+                        "  [{ts}] ⏭ BINDING-GUARD: skipping message {} in unbound channel {} (effective {})",
+                        new_message.id,
+                        channel_id,
+                        effective_channel_id
+                    );
+                    return Ok(());
+                }
+            }
+
+            // A local permit is the only path that may bootstrap session state,
+            // download bytes, or write upload history.
+            let upload_records = if let Some(permit) = attachment_local_permit.as_ref() {
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::info!(
                     "  [{ts}] ◀ [{user_name}] Upload: {} file(s)",
                     new_message.attachments.len()
                 );
-                auto_restore_session_with_dm_hint(&data.shared, channel_id, ctx, Some(is_dm)).await;
-                if effective_channel_id != channel_id {
-                    let needs_parent = {
-                        let d = data.shared.core.lock().await;
-                        !d.sessions.contains_key(&channel_id)
-                    };
-                    if needs_parent {
-                        auto_restore_session(&data.shared, effective_channel_id, ctx).await;
-                        let parent_path = {
-                            let d = data.shared.core.lock().await;
-                            d.sessions
-                                .get(&effective_channel_id)
-                                .and_then(|s| s.current_path.clone())
-                        };
-                        if let Some(path) = parent_path {
-                            bootstrap_thread_session(
-                                &data.shared,
-                                channel_id,
-                                &path,
-                                &ctx.http,
-                                Some(&ctx.cache),
-                            )
-                            .await;
-                        }
-                    }
-                }
-                let attachments = super::message_handler::describe_attachments(new_message);
-                let permit = super::message_handler::LocalAttachmentPreparationPermit::preserving_existing_intake_order();
-                super::message_handler::prepare_admitted_local_attachment(
-                    ctx,
+                super::prepare_admitted_live_attachments(
+                    &super::message_handler::IntakeDeps {
+                        http: &ctx.http,
+                        cache: Some(&ctx.cache),
+                        ctx_for_chained_dispatch: Some(ctx),
+                        shared: &data.shared,
+                        token: &data.token,
+                    },
+                    permit,
                     channel_id,
-                    &attachments,
-                    &data.shared,
-                    &permit,
+                    effective_channel_id,
+                    is_dm,
+                    &admitted_attachment_submission
+                        .as_ref()
+                        .expect("local attachment admission keeps its submission")
+                        .attachments,
                 )
                 .await?
             } else {
                 Vec::new()
             };
-            record_upload_history(&data.shared, channel_id, &upload_records).await;
             let mut upload_records_appended_to_session = false;
 
             let attachment_only_turn =
@@ -912,6 +954,7 @@ pub(in crate::services::discord) async fn handle_event(
                     channel_id,
                     &cmd_text,
                     &upload_records,
+                    &mut attachment_local_permit,
                 )
                 .await?;
                 if handled {
@@ -1011,12 +1054,21 @@ pub(in crate::services::discord) async fn handle_event(
                 }
             }
 
-            let has_reply_boundary = new_message.message_reference.is_some();
-            let reply_context = if has_reply_boundary {
-                build_reply_context(ctx, channel_id, &new_message).await
-            } else {
-                None
-            };
+            let (has_reply_boundary, reply_context) =
+                if let Some(admitted) = admitted_attachment_submission.as_ref() {
+                    (
+                        admitted.request.has_reply_boundary,
+                        admitted.request.reply_context.clone(),
+                    )
+                } else {
+                    let has_reply_boundary = new_message.message_reference.is_some();
+                    let reply_context = if has_reply_boundary {
+                        build_reply_context(ctx, channel_id, &new_message).await
+                    } else {
+                        None
+                    };
+                    (has_reply_boundary, reply_context)
+                };
             let merge_consecutive = upload_records.is_empty()
                 && should_merge_consecutive_messages(text, is_allowed_bot);
 
@@ -1535,11 +1587,15 @@ pub(in crate::services::discord) async fn handle_event(
             // placeholder content is the only visible record of the event;
             // foreground (human) messages keep the legacy delete-on-loss
             // behavior.
-            let notify_bot_id = notify_resolution.user_id();
-            let turn_kind = super::message_handler::classify_turn_kind_from_author(
-                user_id.get(),
-                notify_bot_id,
-            );
+            let turn_kind = admitted_attachment_submission
+                .as_ref()
+                .map(|submission| submission.request.turn_kind)
+                .unwrap_or_else(|| {
+                    super::message_handler::classify_turn_kind_from_author(
+                        user_id.get(),
+                        notify_resolution.user_id(),
+                    )
+                });
 
             let deps = super::message_handler::IntakeDeps {
                 http: &ctx.http,
@@ -1553,33 +1609,50 @@ pub(in crate::services::discord) async fn handle_event(
             } else {
                 upload_records.clone()
             };
-            let submission = super::IntakeSubmission {
-                provider: data.provider.clone(),
-                request: super::IntakeRequest {
-                    channel_id,
-                    user_msg_id: new_message.id,
-                    request_owner: user_id,
-                    request_owner_name: user_name.to_string(),
-                    user_text: text.to_string(),
-                    reply_to_user_message: false,
-                    defer_watcher_resume: false,
-                    wait_for_completion: false,
-                    merge_consecutive,
-                    reply_context,
-                    has_reply_boundary,
-                    dm_hint: Some(is_dm),
-                    turn_kind,
+            let submission = if let Some(mut admitted) = admitted_attachment_submission {
+                admitted.request.user_text = text.to_string();
+                admitted.request.merge_consecutive = merge_consecutive;
+                admitted.request.reply_context = reply_context;
+                admitted.request.has_reply_boundary = has_reply_boundary;
+                admitted.request.turn_kind = turn_kind;
+                admitted.attachments.clear();
+                admitted.preloaded_uploads = preloaded_uploads;
+                admitted.voice_announcement = resolved_voice_announcement;
+                admitted
+            } else {
+                super::IntakeSubmission {
+                    provider: data.provider.clone(),
+                    request: super::IntakeRequest {
+                        channel_id,
+                        user_msg_id: new_message.id,
+                        request_owner: user_id,
+                        request_owner_name: user_name.to_string(),
+                        user_text: text.to_string(),
+                        reply_to_user_message: false,
+                        defer_watcher_resume: false,
+                        wait_for_completion: false,
+                        merge_consecutive,
+                        reply_context,
+                        has_reply_boundary,
+                        dm_hint: Some(is_dm),
+                        turn_kind,
+                        preserve_on_cancel,
+                    },
+                    origin: super::IntakeOrigin::LiveMessage,
                     preserve_on_cancel,
-                },
-                origin: super::IntakeOrigin::LiveMessage,
-                preserve_on_cancel,
-                has_nonportable_uploads: !new_message.attachments.is_empty(),
-                preloaded_uploads,
-                // #3905: carry the gate's already-authorized, non-consuming
-                // voice resolution into direct dispatch.
-                voice_announcement: resolved_voice_announcement,
+                    has_nonportable_uploads: false,
+                    attachments: Vec::new(),
+                    preloaded_uploads,
+                    // #3905: carry the gate's already-authorized, non-consuming
+                    // voice resolution into direct dispatch.
+                    voice_announcement: resolved_voice_announcement,
+                }
             };
-            super::dispatch_text_intake(&deps, submission).await?;
+            if let Some(permit) = attachment_local_permit {
+                super::finish_admitted_text_intake(&deps, permit, submission).await?;
+            } else {
+                super::dispatch_text_intake(&deps, submission).await?;
+            }
         }
         _ => {}
     }

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -1734,7 +1734,11 @@ mod live_intake_preserve_wiring_tests {
         let raw_request_window = &module_src[stale_lookup_pos..raw_submission_pos];
         let raw_submission_window = &module_src[raw_submission_pos..live_submission_pos];
         let live_request_window = &module_src[raw_submission_pos..live_submission_pos];
-        let live_submission_window = &module_src[live_submission_pos..];
+        let production_end = module_src[live_submission_pos..]
+            .find("#[cfg(test)]\nmod reply_context_tests")
+            .map(|offset| live_submission_pos + offset)
+            .expect("production intake gate ends before reply-context tests");
+        let live_submission_window = &module_src[live_submission_pos..production_end];
 
         assert!(computation_pos < guard_pos && guard_pos < stale_lookup_pos);
         assert!(

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -958,7 +958,9 @@ pub(in crate::services::discord) async fn handle_event(
                 )
                 .await?;
                 if handled {
-                    if !is_skill_command && !upload_records_appended_to_session {
+                    if (!is_skill_command || attachment_local_permit.is_some())
+                        && !upload_records_appended_to_session
+                    {
                         let _ =
                             append_pending_uploads(&data.shared, channel_id, &upload_records).await;
                     }

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -835,7 +835,7 @@ pub(in crate::services::discord) async fn handle_event(
                         turn_kind,
                         preserve_on_cancel,
                     },
-                    origin: super::IntakeOrigin::LiveMessage,
+                    origin: super::IntakeOrigin::RawAttachment,
                     preserve_on_cancel,
                     has_nonportable_uploads: true,
                     attachments: attachments.clone(),
@@ -1617,6 +1617,7 @@ pub(in crate::services::discord) async fn handle_event(
                 admitted.request.reply_context = reply_context;
                 admitted.request.has_reply_boundary = has_reply_boundary;
                 admitted.request.turn_kind = turn_kind;
+                admitted.origin = super::IntakeOrigin::LiveMessage;
                 admitted.attachments.clear();
                 admitted.preloaded_uploads = preloaded_uploads;
                 admitted.voice_announcement = resolved_voice_announcement;

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -251,7 +251,8 @@ async fn refresh_claimed_runtime_for_launch(
 }
 
 pub(super) use self::attachments::{
-    LocalAttachmentPreparationPermit, describe_attachments, prepare_admitted_local_attachment,
+    AttachmentDescriptor, LocalAttachmentPreparationPermit, describe_attachments,
+    prepare_admitted_local_attachment,
 };
 pub(super) use self::control::{handle_shell_command_raw, handle_text_command};
 #[allow(unused_imports)]

--- a/src/services/discord/router/message_handler/attachments.rs
+++ b/src/services/discord/router/message_handler/attachments.rs
@@ -32,8 +32,8 @@ pub(super) async fn download_discord_attachment(raw_url: &str) -> Result<Vec<u8>
 /// Side-effect-free attachment metadata captured at Discord intake.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::services::discord::router) struct AttachmentDescriptor {
-    filename: String,
-    url: String,
+    pub(in crate::services::discord::router) filename: String,
+    pub(in crate::services::discord::router) url: String,
 }
 
 impl From<&serenity::Attachment> for AttachmentDescriptor {
@@ -53,14 +53,13 @@ pub(in crate::services::discord::router) fn describe_attachments(
 
 /// Opaque capability for the local attachment materialization boundary.
 ///
-/// The current intake site issues this capability at its existing point so this
-/// preparatory slice preserves ordering. The admission coordinator can move
-/// issuance behind local admission without changing the download/save body.
+/// The intake coordinator issues this capability only after central admission
+/// has granted local execution.
 #[derive(Debug)]
 pub(in crate::services::discord::router) struct LocalAttachmentPreparationPermit(());
 
 impl LocalAttachmentPreparationPermit {
-    pub(in crate::services::discord::router) fn preserving_existing_intake_order() -> Self {
+    pub(in crate::services::discord::router) fn after_local_admission() -> Self {
         Self(())
     }
 }
@@ -88,7 +87,7 @@ fn persist_attachment(
 
 /// Download and save attachments at the admitted-local side-effect boundary.
 pub(in crate::services::discord::router) async fn prepare_admitted_local_attachment(
-    ctx: &serenity::Context,
+    http: &Arc<serenity::http::Http>,
     channel_id: serenity::ChannelId,
     attachments: &[AttachmentDescriptor],
     shared: &Arc<SharedData>,
@@ -98,7 +97,7 @@ pub(in crate::services::discord::router) async fn prepare_admitted_local_attachm
     let Some(save_dir) = channel_upload_dir(channel_id) else {
         rate_limit_wait(shared, channel_id).await;
         let _ = channel_id
-            .say(&ctx.http, "Cannot resolve upload directory.")
+            .say(http, "Cannot resolve upload directory.")
             .await;
         return Ok(Vec::new());
     };
@@ -106,10 +105,7 @@ pub(in crate::services::discord::router) async fn prepare_admitted_local_attachm
     if let Err(e) = fs::create_dir_all(&save_dir) {
         rate_limit_wait(shared, channel_id).await;
         let _ = channel_id
-            .say(
-                &ctx.http,
-                format!("Failed to prepare upload directory: {}", e),
-            )
+            .say(http, format!("Failed to prepare upload directory: {}", e))
             .await;
         return Ok(Vec::new());
     }
@@ -128,9 +124,7 @@ pub(in crate::services::discord::router) async fn prepare_admitted_local_attachm
                     "skipping Discord attachment download: {e}"
                 );
                 rate_limit_wait(shared, channel_id).await;
-                let _ = channel_id
-                    .say(&ctx.http, format!("Download failed: {e}"))
-                    .await;
+                let _ = channel_id.say(http, format!("Download failed: {e}")).await;
                 continue;
             }
         };
@@ -142,7 +136,7 @@ pub(in crate::services::discord::router) async fn prepare_admitted_local_attachm
             Err(e) => {
                 rate_limit_wait(shared, channel_id).await;
                 let _ = channel_id
-                    .say(&ctx.http, format!("Failed to save file: {}", e))
+                    .say(http, format!("Failed to save file: {}", e))
                     .await;
                 continue;
             }
@@ -150,7 +144,7 @@ pub(in crate::services::discord::router) async fn prepare_admitted_local_attachm
 
         let msg_text = format!("Saved: {}\n({} bytes)", dest.display(), file_size);
         rate_limit_wait(shared, channel_id).await;
-        let _ = channel_id.say(&ctx.http, &msg_text).await;
+        let _ = channel_id.say(http, &msg_text).await;
         debug_assert!(upload_record.starts_with(&format!("[File uploaded] {file_name} → ")));
         upload_records.push(upload_record);
     }
@@ -209,36 +203,28 @@ mod attachment_tests {
     }
 
     #[test]
-    fn attachment_materialization_requires_opaque_permit_and_keeps_existing_order() {
+    fn attachment_materialization_requires_post_admission_opaque_permit() {
         let source = include_str!("../intake_gate.rs");
-        let restore = source
-            .find("auto_restore_session_with_dm_hint(&data.shared, channel_id")
-            .expect("existing session restore");
         let descriptor = source
             .find("let attachments = super::message_handler::describe_attachments(new_message);")
             .expect("descriptor capture");
-        let permit = source
-            .find("let permit = super::message_handler::LocalAttachmentPreparationPermit::preserving_existing_intake_order();")
-            .expect("opaque permit issuance");
-        let prepare = source
-            .find("super::message_handler::prepare_admitted_local_attachment(")
-            .expect("materialization boundary");
-        let history = source
-            .find("record_upload_history(&data.shared, channel_id, &upload_records).await;")
-            .expect("existing history update");
         let admission = source
-            .find("super::dispatch_text_intake(&deps, submission).await?;")
-            .expect("central admission call");
+            .find("super::admit_text_intake(&deps, &submission).await")
+            .expect("attachment central admission call");
+        let deferred_restore = source
+            .find("if deferred_attachment_unbound_check")
+            .expect("unbound attachment restore guard");
+        let prepare = source
+            .find("super::prepare_admitted_live_attachments(")
+            .expect("post-admission materialization boundary");
 
-        assert!(restore < descriptor);
-        assert!(descriptor < permit && permit < prepare);
-        assert!(prepare < history && history < admission);
+        assert!(
+            descriptor < admission && admission < deferred_restore && deferred_restore < prepare
+        );
         assert_eq!(
-            source
-                .matches("LocalAttachmentPreparationPermit::preserving_existing_intake_order()")
-                .count(),
+            source.matches("prepare_admitted_live_attachments(").count(),
             1,
-            "only the compatibility intake site may issue the preparatory permit"
+            "live attachment materialization has one admitted gate site"
         );
     }
 }

--- a/src/services/discord/router/message_handler/control.rs
+++ b/src/services/discord/router/message_handler/control.rs
@@ -74,6 +74,7 @@ pub(in crate::services::discord::router) async fn handle_text_command(
     channel_id: serenity::ChannelId,
     text: &str,
     preloaded_uploads: &[String],
+    admitted_attachment_permit: &mut Option<super::super::LocalAdmissionPermit>,
 ) -> Result<bool, Error> {
     super::super::super::commands::handle_text_command_with_uploads(
         ctx,
@@ -82,6 +83,7 @@ pub(in crate::services::discord::router) async fn handle_text_command(
         channel_id,
         text,
         preloaded_uploads,
+        admitted_attachment_permit,
     )
     .await
 }

--- a/src/services/discord/router/mod.rs
+++ b/src/services/discord/router/mod.rs
@@ -13,8 +13,8 @@ pub(crate) use authorization::TurnKind;
 pub(crate) use intake_dispatch::{
     IntakeOrigin, IntakeSubmission, LocalAdmissionPermit, QueuedAdmissionDisposition,
     admit_queued_intake, admit_text_intake, dispatch_skill_intake, dispatch_text_intake,
-    finish_admitted_queued_intake, finish_admitted_skill_intake, finish_admitted_text_intake,
-    finish_text_intake_admission, prepare_admitted_live_attachments, resolve_attachment_admission,
+    finish_admitted_queued_intake, finish_admitted_text_intake, finish_text_intake_admission,
+    prepare_admitted_live_attachments, resolve_attachment_admission,
 };
 pub(super) use intake_gate::{handle_event, should_process_turn_message};
 #[cfg(test)]

--- a/src/services/discord/router/mod.rs
+++ b/src/services/discord/router/mod.rs
@@ -11,8 +11,10 @@ mod turn_start;
 
 pub(crate) use authorization::TurnKind;
 pub(crate) use intake_dispatch::{
-    IntakeOrigin, IntakeSubmission, QueuedAdmissionDisposition, admit_queued_intake,
-    dispatch_skill_intake, dispatch_text_intake, finish_admitted_queued_intake,
+    IntakeOrigin, IntakeSubmission, LocalAdmissionPermit, QueuedAdmissionDisposition,
+    admit_queued_intake, admit_text_intake, dispatch_skill_intake, dispatch_text_intake,
+    finish_admitted_queued_intake, finish_admitted_skill_intake, finish_admitted_text_intake,
+    finish_text_intake_admission, prepare_admitted_live_attachments, resolve_attachment_admission,
 };
 pub(super) use intake_gate::{handle_event, should_process_turn_message};
 #[cfg(test)]

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -26,6 +26,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --lib intake_queue_transaction::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib pending_reaction_failure_adapter_tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib intake_dispatch_invariant_queued_entrypoints_promote_markers -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib intake_dispatch::attachment::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib mailbox_reaction_tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres",

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -26,7 +26,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --lib intake_queue_transaction::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib pending_reaction_failure_adapter_tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib intake_dispatch_invariant_queued_entrypoints_promote_markers -- --skip _pg --skip pg_ --skip postgres",
-    "cargo test --lib intake_dispatch::attachment::tests -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib intake_dispatch::attachment::tests attachment_materialization_requires_post_admission_opaque_permit -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib mailbox_reaction_tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres",

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -26,7 +26,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --lib intake_queue_transaction::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib pending_reaction_failure_adapter_tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib intake_dispatch_invariant_queued_entrypoints_promote_markers -- --skip _pg --skip pg_ --skip postgres",
-    "cargo test --lib intake_dispatch::attachment::tests attachment_materialization_requires_post_admission_opaque_permit -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib attachment -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib mailbox_reaction_tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres",


### PR DESCRIPTION
## Summary
- classify raw Discord attachments without side effects, then run central intake admission before any session restore, thread bootstrap, download, upload file write, or upload-history mutation
- consume the local admission permit across attachment and text-skill paths so attachment requests are admitted exactly once
- add fail-closed/non-regression tests and enroll the new module in the retained non-PG test lane without increasing the locked uncovered baseline

## Verification
- `cargo fmt --all -- --check`
- `cargo check --lib`
- `env -u AGENTDESK_ROOT_DIR cargo test --lib cluster` (222 passed)
- `env -u AGENTDESK_ROOT_DIR cargo test --lib intake_dispatch` (12 passed)
- mutation: bypassing nonlocal attachment gate makes `nonlocal_attachment_admission_never_runs_local_materialization` fail; restoring gate passes
- `python3 scripts/generate_inventory_docs.py` + clean diff
- `python3 scripts/check_agent_maintenance_docs.py`
- `bash scripts/ci-script-checks.sh` (coverage baseline remains 701; blind-save baseline remains 1)

## Constraints
- no hotfile changes
- no `src/services/cluster/stream_relay.rs` changes
- no session relay, idle JSONL, delivery record, footer/panel, or E2E harness changes
- auto-merge disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)