### PR TITLE
fix(#4623): preserve confirmed fresh relay outcomes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -421,7 +421,8 @@ src/
 │   │   │   ├── owner_record.rs
 │   │   │   └── session_owner.rs
 │   │   ├── stream_relay/
-│   │   │   └── identity.rs
+│   │   │   ├── identity.rs
+│   │   │   └── terminal_resolution.rs
 │   │   ├── capability_routing.rs
 │   │   ├── intake_preflight.rs
 │   │   ├── intake_router_hook.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1999,9 +1999,6 @@ these contextual numbers to match ordinary LoC churn.
   from #3864 moving SIGTERM queue-restore merge inside the mailbox actor; +10
   from #4018 round-2 adding the distinct `MonitorAutoTurn` active-turn marker
   while keeping monitor turns background for queue-yield/cancel semantics).
-- `src/services/cluster/stream_relay.rs` (tracked giant surface; #4536 carries the
-  ordered idle JSONL range plus wrapper-generation coordinate through the existing
-  producer queue/consumer protocol; keep per `scripts/giant_file_registry.toml`).
 - `src/services/discord/session_relay_sink.rs` (frozen giant surface; +1 from #4046
   S1r-1 conservatively rejecting the dormant fresh-send-only outcome at this
   replace-only caller; -59 from #3998 S1-f2 retiring the A2b rollout getter/cache
@@ -2015,7 +2012,9 @@ these contextual numbers to match ordinary LoC churn.
   until a generation-scoped confirmed delivery commits the durable frontier).
 
 Decomposed below the giant-file threshold (no longer frozen; bugfix-scoped but
-normal test growth is allowed): `src/services/analytics.rs`,
+normal test growth is allowed): `src/services/cluster/stream_relay.rs` (#4623:
+typed terminal resolutions moved to `stream_relay/terminal_resolution.rs`),
+`src/services/analytics.rs`,
 `src/services/provider_hosting.rs`, `src/services/claude_tui/hook_bundle.rs`,
 `src/services/observability/mod.rs`, `src/services/pipeline_override.rs`,
 `src/services/routines/loader.rs`, `src/services/platform/shell.rs`,

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1999,9 +1999,10 @@ these contextual numbers to match ordinary LoC churn.
   from #3864 moving SIGTERM queue-restore merge inside the mailbox actor; +10
   from #4018 round-2 adding the distinct `MonitorAutoTurn` active-turn marker
   while keeping monitor turns background for queue-yield/cancel semantics).
-- `src/services/discord/session_relay_sink.rs` (frozen giant surface; +1 from #4046
-  S1r-1 conservatively rejecting the dormant fresh-send-only outcome at this
-  replace-only caller; -59 from #3998 S1-f2 retiring the A2b rollout getter/cache
+- `src/services/discord/session_relay_sink.rs` (frozen giant surface; #4623
+  replaces the #4046 provisional fresh-send rejection with typed confirmed-fresh
+  provenance carried through the exact-sequence watcher ACK; -59 from #3998 S1-f2
+  retiring the A2b rollout getter/cache
   and flag-OFF pin tests; +7 from #3610 PR-1 passing the terminal anchor into the
   delivered-frontier shadow mirror; -1 prod from #4055 thin
   card-before-answer/context wiring, with task policy extracted to

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -446,6 +446,11 @@
   before merging.
 
 ### Audited touches
+- 2026-07-24 — #4623 confirmed fresh-delivery cutover: the session sink preserves
+  transport-confirmed fresh outcomes through the process-local exact-sequence ring
+  and watcher ACK instead of folding them into sink errors. Existing shared delivery
+  leases and durable frontier authority remain unchanged; this adds no PostgreSQL
+  schema, leader election, worker placement, or cross-node adoption rule.
 - #4488 PR-F destructive E2E controls are worker-local and opt-in: exact-message deletion and one-shot send/delete failure injection resolve the provider runtime registered on the receiving dcserver; the route subtree remains unmounted unless `AGENTDESK_E2E_CONTROL=1`, and every target must be in the boot-bound `AGENTDESK_E2E_CHANNEL_IDS` allowlist. They add no PostgreSQL authority, leader election, lease, worker placement, or cross-node routing rule; the harness targets the node-local loopback control plane for the owning E2E cell.
 - 2026-07-24 — #4536 idle JSONL cursor/commit boundary: temporary active/grace
   suppression now holds uncommitted ordered ranges, and only generation/EOF-checked

--- a/docs/relay-state-contract.md
+++ b/docs/relay-state-contract.md
@@ -334,7 +334,7 @@ plan.
   the mandatory acquire and production-entry regression tests).
 - Consumer rule: a confirmed fresh-message POST returned by the controller is
   preserved as a typed exact-sequence terminal resolution through
-  sym:cluster::stream_relay::RelaySinkOutcome::TerminalFreshDelivered and the
+  `sym:cluster::stream_relay::RelaySinkOutcome::terminal_fresh_delivered` and the
   watcher transport-confirmation predicate.
   `committed_to=None` and `persistence_recorded=false` describe missing frontier
   authority or retry metadata; neither erases confirmed transport or authorizes

--- a/docs/relay-state-contract.md
+++ b/docs/relay-state-contract.md
@@ -334,8 +334,8 @@ plan.
   the mandatory acquire and production-entry regression tests).
 - Consumer rule: a confirmed fresh-message POST returned by the controller is
   preserved as a typed exact-sequence terminal resolution through
-  `RelaySinkOutcome::TerminalFreshDelivered` and
-  `session_bound_ack_confirms_transport`.
+  sym:cluster::stream_relay::RelaySinkOutcome::TerminalFreshDelivered and the
+  watcher transport-confirmation predicate.
   `committed_to=None` and `persistence_recorded=false` describe missing frontier
   authority or retry metadata; neither erases confirmed transport or authorizes
   the watcher to acquire the released lease and POST the same body again.

--- a/docs/relay-state-contract.md
+++ b/docs/relay-state-contract.md
@@ -332,6 +332,16 @@ plan.
   producing a duplicate Discord response.
 - Invariant key: `session_terminal_post_lease_required` (enforced structurally by
   the mandatory acquire and production-entry regression tests).
+- Consumer rule: a confirmed fresh-message POST returned by the controller is
+  preserved as a typed exact-sequence terminal resolution through
+  `RelaySinkOutcome::TerminalFreshDelivered` and
+  `session_bound_ack_confirms_transport`.
+  `committed_to=None` and `persistence_recorded=false` describe missing frontier
+  authority or retry metadata; neither erases confirmed transport or authorizes
+  the watcher to acquire the released lease and POST the same body again.
+- Violation surface: folding confirmed fresh transport into `RelaySinkError` loses
+  its provenance; §3.2 then sees `committed < end`, reacquires the shared lease,
+  and sends a duplicate full response.
 
 ## I10. idle JSONL cursors consume only classified drops or confirmed commits (#4536)
 

--- a/scripts/giant_file_registry.toml
+++ b/scripts/giant_file_registry.toml
@@ -712,14 +712,6 @@ deadline = "2026-10-31"
 decompose_issue = "#4712"
 
 [[entry]]
-# Crossed the threshold in #4536 when ordered idle ranges gained generation
-# coordinates alongside the existing sequence/terminal-fence queue protocol.
-file = "src/services/cluster/stream_relay.rs"
-decision = "keep"
-owner = "discord-relay"
-keep_reason = "The queue, exact-sequence outcome ring, and producer/consumer frame protocol form one ordered delivery boundary; keep them cohesive while #4766 relay lanes establish the ranged commit contract."
-
-[[entry]]
 # Crossed the 1000-prod-LoC threshold when #3017 re-landed the single
 # output-offset relay-dedup authority: the idle-JSONL relay loop now consults
 # `committed_relay_offset` (read-only) with generation-aware watermark resets to

--- a/src/services/cluster/stream_relay.rs
+++ b/src/services/cluster/stream_relay.rs
@@ -55,7 +55,9 @@ use tokio::task::JoinHandle;
 use super::session_matcher::MatchedChannel;
 
 mod identity;
+mod terminal_resolution;
 pub use identity::{RelayDroppedFrame, RelayTurnIdentity};
+pub use terminal_resolution::{DeliveryOutcome, RelaySinkOutcome};
 
 /// Default size of the producer → relay queue. Generous enough to absorb a
 /// burst of provider output (e.g. a long planning block dumping thousands of
@@ -73,33 +75,6 @@ pub const DEFAULT_RELAY_BUFFER: usize = 1024;
 /// (treated by the watcher as "not yet resolved" → it keeps waiting / eventually
 /// times out → reconciles, never a false ACK).
 pub const TERMINAL_OUTCOME_RING_CAPACITY: usize = 64;
-
-/// #3041 P1-3 R5 / P1-5: the EXACT, per-frame terminal resolution recorded for a
-/// single terminal (result-bearing) frame's sequence. Distinct from the
-/// high-water-mark fields (`last_terminal_committed/skipped_sequence`), which a
-/// LATER, higher-sequence terminal can bump — this is keyed to ONE sequence so a
-/// watcher resolves its ACK on ITS OWN terminal frame's outcome, decoupled from
-/// any other turn sharing the same physical chunk.
-///
-/// #3041 P1-5: the CANONICAL cross-actor 3-way delivery outcome. The sink-local
-/// enum stays 2-way (the sink always KNOWS: confirmed POST → `Delivered`;
-/// deterministic decline → `NotDelivered`; failure → `Err`). `Unknown` is a
-/// CROSS-ACTOR state that arises in the relay ring + watcher when the terminal
-/// resolution cannot be confirmed (the watcher's ACK timed out / target was
-/// missing / the frame was dropped or hit a sink error, or the sink POSTed but
-/// could not confirm the commit). Both `NotDelivered` AND `Unknown` MUST flow
-/// through the watcher's committed-offset reconciliation (§3.2) — there is NO
-/// blind skip for `NotDelivered` and NO blind 10s re-send for `Unknown`.
-///
-/// A NEVER-recorded sequence reads back `None` (distinct from `Some(Unknown)`):
-/// `None` means "not yet resolved" (keep waiting), `Some(Unknown)` is an explicit
-/// "resolved but unconfirmed → reconcile NOW" signal the sink/watcher can record.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DeliveryOutcome {
-    Delivered,
-    NotDelivered,
-    Unknown,
-}
 
 /// An opaque stream frame emitted by a provider. Carries enough metadata for
 /// the sink to route + format without re-reading the rollout file.
@@ -353,53 +328,13 @@ pub trait RelaySink: Send + Sync + 'static {
     async fn deliver(&self, frame: &StreamFrame) -> Result<RelaySinkOutcome, RelaySinkError>;
 }
 
-/// Result of accepting a relay frame into the sink. This deliberately
-/// distinguishes "the sink accepted/parsing-counted this frame" from "a
-/// terminal Discord response was actually committed". Watchers must use only
-/// `TerminalDelivered` as delegation success.
-///
-/// #3041 P1-5: the three terminal variants mirror the cross-actor 3-way
-/// `DeliveryOutcome`. `TerminalDelivered` (confirmed POST/edit) → the watcher
-/// treats the turn as delivered. `TerminalNotDelivered` (a deterministic
-/// route-decision decline — foreign-owner lease block, or bridge-owned /
-/// mismatched inflight) and `TerminalUnknown` (the sink POSTed but could not
-/// confirm the commit) BOTH route the watcher through committed-offset
-/// reconciliation (§3.2): NO blind skip for `NotDelivered`, NO blind re-send for
-/// `Unknown`. The session-bound sink itself emits only `Delivered`/`NotDelivered`
-/// (it always knows); `TerminalUnknown` is reserved for a future/optional sink
-/// site that POSTs-without-confirm and for cross-actor symmetry.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum RelaySinkOutcome {
-    FrameAccepted,
-    TerminalDelivered,
-    TerminalNotDelivered,
-    // #3041 P1-5: reserved for a future POST-without-confirm sink + cross-actor
-    // symmetry (see enum doc); the session-bound sink never emits it today.
-    #[allow(dead_code)]
-    TerminalUnknown,
-}
-
-impl RelaySinkOutcome {
-    pub fn terminal_delivered(self) -> bool {
-        matches!(self, Self::TerminalDelivered)
-    }
-
-    pub fn terminal_not_delivered(self) -> bool {
-        matches!(self, Self::TerminalNotDelivered)
-    }
-
-    pub fn terminal_unknown(self) -> bool {
-        matches!(self, Self::TerminalUnknown)
-    }
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum RelaySinkError {
     #[error("transient sink failure: {0}")]
     Transient(String),
-    // Documented permanent-failure arm of the sink error taxonomy; no sink site
-    // produces it yet but it is part of the public RelaySinkError contract.
-    #[allow(dead_code)]
+    // Permanent means non-transient failure, not confirmed transport. Card/history
+    // paths can produce it before a Discord POST, so consumers must not treat the
+    // variant itself as delivery evidence.
     #[error("permanent sink failure: {0}")]
     Permanent(String),
 }
@@ -978,28 +913,29 @@ async fn deliver_frame(
                 metrics
                     .last_terminal_committed_sequence_plus_one
                     .fetch_max(encode_sequence_marker(frame.sequence), Ordering::AcqRel);
-                // #3041 P1-3 R5: record THIS frame's exact-sequence outcome so the
-                // watcher resolves its ACK on its own terminal frame (decoupled
-                // from any co-chunked higher-sequence terminal).
                 metrics.record_terminal_outcome(frame.sequence, DeliveryOutcome::Delivered);
+            }
+            if let Some((committed_to, persistence_recorded)) = outcome.terminal_fresh_delivered() {
+                metrics.terminal_commits.fetch_add(1, Ordering::AcqRel);
+                metrics
+                    .last_terminal_committed_sequence_plus_one
+                    .fetch_max(encode_sequence_marker(frame.sequence), Ordering::AcqRel);
+                metrics.record_terminal_outcome(
+                    frame.sequence,
+                    DeliveryOutcome::FreshDelivered {
+                        committed_to,
+                        persistence_recorded,
+                    },
+                );
             }
             if outcome.terminal_not_delivered() {
                 metrics.terminal_skips.fetch_add(1, Ordering::AcqRel);
                 metrics
                     .last_terminal_skipped_sequence_plus_one
                     .fetch_max(encode_sequence_marker(frame.sequence), Ordering::AcqRel);
-                // #3041 P1-5: a deterministic route-decision decline — recorded as
-                // `NotDelivered` so the watcher reconciles against the committed
-                // offset (§3.2 SendFull-or-Skip), never a blind skip.
                 metrics.record_terminal_outcome(frame.sequence, DeliveryOutcome::NotDelivered);
             }
             if outcome.terminal_unknown() {
-                // #3041 P1-5: the sink POSTed but could not confirm the commit. We
-                // do NOT bump the commit/skip high-water-marks (the outcome is, by
-                // definition, unconfirmed) but DO record the per-sequence `Unknown`
-                // so the watcher's per-sequence ACK resolves immediately to
-                // committed-offset reconciliation instead of waiting out the 10s
-                // ACK timeout. Both `NotDelivered` and `Unknown` flow through §3.2.
                 metrics.record_terminal_outcome(frame.sequence, DeliveryOutcome::Unknown);
             }
         }
@@ -1078,6 +1014,21 @@ mod tests {
                 0 => RelaySinkOutcome::FrameAccepted,
                 1 => RelaySinkOutcome::TerminalNotDelivered,
                 _ => RelaySinkOutcome::TerminalDelivered,
+            })
+        }
+    }
+
+    struct FreshOutcomeSink {
+        committed_to: Option<u64>,
+        persistence_recorded: bool,
+    }
+
+    #[async_trait]
+    impl RelaySink for FreshOutcomeSink {
+        async fn deliver(&self, _frame: &StreamFrame) -> Result<RelaySinkOutcome, RelaySinkError> {
+            Ok(RelaySinkOutcome::TerminalFreshDelivered {
+                committed_to: self.committed_to,
+                persistence_recorded: self.persistence_recorded,
             })
         }
     }
@@ -1440,6 +1391,78 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn confirmed_fresh_outcome_records_exact_terminal_resolution_not_sink_error() {
+        for (committed_to, persistence_recorded) in [
+            (Some(200), true),
+            (Some(200), false),
+            (None, true),
+            (None, false),
+        ] {
+            let sink: Arc<dyn RelaySink> = Arc::new(FreshOutcomeSink {
+                committed_to,
+                persistence_recorded,
+            });
+            let handle = spawn_stream_relay(matched_for("c-fresh-resolution"), sink);
+            let outcome = handle.try_send_frame_with_sequence("fresh".into());
+            let sequence = outcome.sequence.expect("fresh frame sequence");
+            wait_until(
+                || {
+                    handle
+                        .metrics()
+                        .terminal_outcome_for_sequence(sequence)
+                        .is_some()
+                },
+                "fresh outcome recorded",
+            )
+            .await;
+
+            assert_eq!(
+                handle.metrics().terminal_outcome_for_sequence(sequence),
+                Some(DeliveryOutcome::FreshDelivered {
+                    committed_to,
+                    persistence_recorded,
+                })
+            );
+            let snapshot = handle.metrics().snapshot();
+            assert_eq!(snapshot.sink_errors, 0);
+            assert_eq!(snapshot.terminal_commits, 1);
+            handle.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn permanent_sink_error_is_not_misclassified_as_confirmed_fresh() {
+        struct PermanentFailureSink;
+        #[async_trait]
+        impl RelaySink for PermanentFailureSink {
+            async fn deliver(
+                &self,
+                _frame: &StreamFrame,
+            ) -> Result<RelaySinkOutcome, RelaySinkError> {
+                Err(RelaySinkError::Permanent("card/history failure".into()))
+            }
+        }
+
+        let handle = spawn_stream_relay(
+            matched_for("c-permanent-failure"),
+            Arc::new(PermanentFailureSink),
+        );
+        let outcome = handle.try_send_frame_with_sequence("failed".into());
+        let sequence = outcome.sequence.expect("failed frame sequence");
+        wait_until(
+            || handle.metrics().snapshot().sink_errors == 1,
+            "permanent sink error recorded",
+        )
+        .await;
+        assert_eq!(
+            handle.metrics().terminal_outcome_for_sequence(sequence),
+            None,
+            "a Permanent error is not transport confirmation"
+        );
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn frames_carry_full_binding_snapshot_without_reparsing_session_name() {
         let sink = Arc::new(CapturingSink::default());
         let mut m = matched_for("short-session-key");
@@ -1679,6 +1702,18 @@ mod tests {
             assert!(!accepted.terminal_delivered());
             assert!(!accepted.terminal_not_delivered());
             assert!(!accepted.terminal_unknown());
+        }
+
+        #[test]
+        fn a0_fresh_delivered_preserves_confirmation_metadata() {
+            assert_eq!(
+                RelaySinkOutcome::TerminalFreshDelivered {
+                    committed_to: None,
+                    persistence_recorded: false,
+                }
+                .terminal_fresh_delivered(),
+                Some((None, false))
+            );
         }
 
         #[test]

--- a/src/services/cluster/stream_relay/terminal_resolution.rs
+++ b/src/services/cluster/stream_relay/terminal_resolution.rs
@@ -1,0 +1,56 @@
+//! Typed terminal-delivery resolutions shared by relay sinks and ACK consumers.
+
+/// The exact, per-frame terminal resolution retained by the relay ring.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeliveryOutcome {
+    Delivered,
+    /// A fresh-message transport was confirmed. The optional frontier and
+    /// persistence bit describe post-transport authority; neither revokes the
+    /// transport confirmation or authorizes an immediate duplicate POST.
+    FreshDelivered {
+        committed_to: Option<u64>,
+        persistence_recorded: bool,
+    },
+    NotDelivered,
+    Unknown,
+}
+
+/// Result of accepting a relay frame into a sink.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RelaySinkOutcome {
+    FrameAccepted,
+    TerminalDelivered,
+    /// A confirmed fresh-message POST kept outside the sink-error taxonomy so
+    /// the exact-sequence ACK can suppress a same-process fallback POST.
+    TerminalFreshDelivered {
+        committed_to: Option<u64>,
+        persistence_recorded: bool,
+    },
+    TerminalNotDelivered,
+    #[allow(dead_code)]
+    TerminalUnknown,
+}
+
+impl RelaySinkOutcome {
+    pub fn terminal_delivered(self) -> bool {
+        matches!(self, Self::TerminalDelivered)
+    }
+
+    pub fn terminal_fresh_delivered(self) -> Option<(Option<u64>, bool)> {
+        match self {
+            Self::TerminalFreshDelivered {
+                committed_to,
+                persistence_recorded,
+            } => Some((committed_to, persistence_recorded)),
+            _ => None,
+        }
+    }
+
+    pub fn terminal_not_delivered(self) -> bool {
+        matches!(self, Self::TerminalNotDelivered)
+    }
+
+    pub fn terminal_unknown(self) -> bool {
+        matches!(self, Self::TerminalUnknown)
+    }
+}

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -1662,6 +1662,10 @@ mod relay_state_contract_refs {
         let _ = super::turn_parser::SessionRelayParser::ingest_frame;
         let _ = super::SessionBoundDiscordRelaySink::deliver_response;
         let _ = super::SessionBoundDiscordRelaySink::advance_idle_range_after_confirmed_post;
+        let _ = crate::services::cluster::stream_relay::RelaySinkOutcome::TerminalFreshDelivered {
+            committed_to: None,
+            persistence_recorded: false,
+        };
         let _ = super::idle_jsonl::idle_jsonl_suppressed_range_action;
         let _ = crate::services::discord::outbound::delivery_record::commit_ordered_jsonl_range;
     }

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -871,13 +871,14 @@ impl SessionBoundDiscordRelaySink {
                 );
                 Ok(SessionRelayDeliveryOutcome::Delivered)
             }
-            // #4046 S1r-1 P2: FreshDelivered is a confirmed cross-verb POST (dormant
-            // here); its `Permanent` mapping is a non-retry INTENT marker only and does
-            // NOT itself prevent a duplicate POST — the sink consumer is
-            // error-variant-blind (see `delivery_outcome_classify` doc + #4623). Others
-            // are uncommitted → retriable. Classified out-of-line (frozen #3016 giant).
-            non_delivery @ (toc::DeliveryOutcome::FreshDelivered { .. }
-            | toc::DeliveryOutcome::Transient { .. }
+            toc::DeliveryOutcome::FreshDelivered {
+                committed_to,
+                persistence_recorded,
+            } => Ok(SessionRelayDeliveryOutcome::FreshDelivered {
+                committed_to,
+                persistence_recorded,
+            }),
+            non_delivery @ (toc::DeliveryOutcome::Transient { .. }
             | toc::DeliveryOutcome::Unknown { .. }
             | toc::DeliveryOutcome::Skipped) => Err(
                 delivery_outcome_classify::short_replace_non_delivery_error(&non_delivery),
@@ -1324,6 +1325,10 @@ impl SessionBoundDiscordRelaySink {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SessionRelayDeliveryOutcome {
     Delivered,
+    FreshDelivered {
+        committed_to: Option<u64>,
+        persistence_recorded: bool,
+    },
     SentButUncommitted,
     NotDelivered,
 }
@@ -1339,6 +1344,7 @@ impl RelaySink for SessionBoundDiscordRelaySink {
         // (inline in `deliver_response`) — outcome and advance are decoupled.
         let deliveries = self.ingest_frame(frame);
         let mut terminal_delivered = false;
+        let mut terminal_fresh_delivered = None;
         let mut terminal_not_delivered = false;
         for delivery in deliveries {
             match self.deliver_response(delivery).await {
@@ -1346,6 +1352,12 @@ impl RelaySink for SessionBoundDiscordRelaySink {
                     // #3041 P1-3 (B1 CLOSED): the offset advance is owned INLINE by
                     // `deliver_response` — see `advance_after_confirmed_post`.
                     terminal_delivered = true;
+                }
+                Ok(SessionRelayDeliveryOutcome::FreshDelivered {
+                    committed_to,
+                    persistence_recorded,
+                }) => {
+                    terminal_fresh_delivered = Some((committed_to, persistence_recorded));
                 }
                 Ok(SessionRelayDeliveryOutcome::SentButUncommitted) => {
                     return Ok(RelaySinkOutcome::TerminalUnknown);
@@ -1362,6 +1374,11 @@ impl RelaySink for SessionBoundDiscordRelaySink {
         // #3041 P1-5: NO `TerminalUnknown` (the sink always KNOWS its result).
         if terminal_delivered {
             Ok(RelaySinkOutcome::TerminalDelivered)
+        } else if let Some((committed_to, persistence_recorded)) = terminal_fresh_delivered {
+            Ok(RelaySinkOutcome::TerminalFreshDelivered {
+                committed_to,
+                persistence_recorded,
+            })
         } else if terminal_not_delivered {
             Ok(RelaySinkOutcome::TerminalNotDelivered)
         } else {

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -1662,10 +1662,7 @@ mod relay_state_contract_refs {
         let _ = super::turn_parser::SessionRelayParser::ingest_frame;
         let _ = super::SessionBoundDiscordRelaySink::deliver_response;
         let _ = super::SessionBoundDiscordRelaySink::advance_idle_range_after_confirmed_post;
-        let _ = crate::services::cluster::stream_relay::RelaySinkOutcome::TerminalFreshDelivered {
-            committed_to: None,
-            persistence_recorded: false,
-        };
+        let _ = crate::services::cluster::stream_relay::RelaySinkOutcome::terminal_fresh_delivered;
         let _ = super::idle_jsonl::idle_jsonl_suppressed_range_action;
         let _ = crate::services::discord::outbound::delivery_record::commit_ordered_jsonl_range;
     }

--- a/src/services/discord/session_relay_sink/delivery_outcome_classify.rs
+++ b/src/services/discord/session_relay_sink/delivery_outcome_classify.rs
@@ -6,79 +6,25 @@
 use crate::services::cluster::stream_relay::RelaySinkError;
 use crate::services::discord::outbound::turn_output_controller as toc;
 
-/// Classify a short-replace controller outcome that did NOT confirm a placeholder
-/// edit into a sink error, keeping the retry classification pure and unit-testable
-/// (the inline `Delivered`/`NotDelivered` arm in
-/// `SessionBoundDiscordRelaySink::deliver_short_replace_via_controller` carries
-/// metrics/tracing/observability side effects and cannot be exercised in isolation).
-///
-/// `FreshDelivered` is a CONFIRMED POST reached via an impossible cross-verb path
-/// (`SendFresh` is not this stage's short-replace plan). It maps to `Permanent` as a
-/// non-retry INTENT marker, mirroring the control site
-/// `tmux_watcher/terminal_send.rs`, which maps `FreshDelivered` to the conservative
-/// non-retry `WatcherShortReplaceResult::Skipped`. Every other non-delivery here
-/// (ambiguous `PartialContinuationFailure` / transport Err, lost-acquire `Transient`,
-/// empty-body `Skipped`) is genuinely uncommitted (offset NOT advanced) → retriable
-/// `Transient`.
-///
-/// IMPORTANT — this mapping does NOT by itself prevent a duplicate POST. The current
-/// sink consumer is error-variant-blind: `stream_relay.rs::deliver_frame` folds both
-/// `Transient` and `Permanent` into the same sink-error marker, and §3.2 reconciliation
-/// (`session_bound_ack.rs`) re-POSTs via SendFull whenever `committed < end` regardless
-/// of the error variant. (The original P2 diagnosis — that `Transient` triggers a blind
-/// retry — was inaccurate; the real duplicate vector is the §3.2 `committed < end`
-/// SendFull.) The arm is dormant today (no `SendFresh` producer), so this is intent-only
-/// documentation until the S1r-2~5 cutover guarantees `committed == end` or teaches the
-/// consumer to honor the error variant. Tracked in issue #4623.
+/// Classify a short-replace controller outcome that did not confirm any POST.
+/// Confirmed `FreshDelivered` outcomes are success-side terminal resolutions and
+/// must never enter this error classifier.
 pub(super) fn short_replace_non_delivery_error(outcome: &toc::DeliveryOutcome) -> RelaySinkError {
-    match outcome {
-        // Confirmed cross-verb POST → non-retry INTENT marker (`Permanent`). This is a
-        // classification-level intent only; it does NOT prevent a duplicate POST on its
-        // own (the sink consumer is error-variant-blind — see the fn doc and #4623).
-        toc::DeliveryOutcome::FreshDelivered { .. } => RelaySinkError::Permanent(
-            "session-bound short-replace controller returned cross-verb FreshDelivered \
-             (unreachable this stage); non-retry intent marker (see #4623)"
-                .to_string(),
-        ),
-        // Ambiguous / failed / lost-acquire / empty-body: no confirmed POST, offset NOT
-        // advanced → retriable.
-        _ => RelaySinkError::Transient(
-            "session-bound short-replace controller delivery not confirmed".to_string(),
-        ),
-    }
+    debug_assert!(
+        !matches!(outcome, toc::DeliveryOutcome::FreshDelivered { .. }),
+        "confirmed fresh delivery must stay outside the sink-error taxonomy"
+    );
+    RelaySinkError::Transient(
+        "session-bound short-replace controller delivery not confirmed".to_string(),
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// #4046 S1r-1 P2 mutation guard (CLASSIFICATION level): a confirmed cross-verb
-    /// `FreshDelivered` outcome must be classified as the non-retry INTENT marker
-    /// `RelaySinkError::Permanent`, never retriable `Transient`, mirroring the control
-    /// site `tmux_watcher/terminal_send.rs` (`FreshDelivered` →
-    /// `WatcherShortReplaceResult::Skipped`). Reverting the `FreshDelivered` arm of
-    /// `short_replace_non_delivery_error` to `Transient` FAILS this assert.
-    ///
-    /// This guards the CLASSIFICATION only. It does NOT prove end-to-end duplicate-POST
-    /// prevention: the current sink consumer is error-variant-blind and §3.2
-    /// reconciliation re-POSTs on `committed < end` regardless of variant (see the fn
-    /// doc). An end-to-end call-site guard is only possible once a `SendFresh` producer
-    /// exists at cutover (dormant today, zero producer) — tracked in #4623.
     #[test]
-    fn fresh_delivered_short_replace_outcome_is_not_retriable() {
-        // committed + persistence_recorded=false is the dedup-less variant the classifier
-        // must still mark non-retry.
-        let fresh = toc::DeliveryOutcome::FreshDelivered {
-            committed_to: Some(7),
-            persistence_recorded: false,
-        };
-        let err = short_replace_non_delivery_error(&fresh);
-        assert!(
-            matches!(err, RelaySinkError::Permanent(_)),
-            "FreshDelivered must be classified as the non-retry Permanent marker, got {err:?}"
-        );
-
-        // Genuinely-uncommitted outcomes (offset NOT advanced) stay retriable Transient.
+    fn genuinely_uncommitted_short_replace_outcomes_stay_retriable() {
         for uncommitted in [
             toc::DeliveryOutcome::Transient {
                 retry_from_offset: 0,

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1556,7 +1556,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 );
                 session_bound_ack_outcome = ack_outcome;
                 let delivered = session_bound_relay_turn_fully_mirrored
-                    && matches!(ack_outcome, SessionBoundRelayAckOutcome::Delivered);
+                    && session_bound_ack_confirms_transport(ack_outcome);
                 if !delivered {
                     tracing::warn!(
                         provider = watcher_provider.as_str(),

--- a/src/services/discord/tmux_watcher/session_bound_ack.rs
+++ b/src/services/discord/tmux_watcher/session_bound_ack.rs
@@ -50,6 +50,10 @@ use super::supervisor_relay::SessionBoundRelayAckTarget;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum SessionBoundRelayAckOutcome {
     Delivered,
+    FreshDelivered {
+        committed_to: Option<u64>,
+        persistence_recorded: bool,
+    },
     NotDelivered,
     RingUnknown,
     Dropped,
@@ -73,6 +77,13 @@ pub(super) fn session_bound_ack_delivery_outcome(
     use crate::services::cluster::stream_relay::DeliveryOutcome;
     match ack_outcome {
         SessionBoundRelayAckOutcome::Delivered => DeliveryOutcome::Delivered,
+        SessionBoundRelayAckOutcome::FreshDelivered {
+            committed_to,
+            persistence_recorded,
+        } => DeliveryOutcome::FreshDelivered {
+            committed_to,
+            persistence_recorded,
+        },
         SessionBoundRelayAckOutcome::NotDelivered => DeliveryOutcome::NotDelivered,
         SessionBoundRelayAckOutcome::RingUnknown
         | SessionBoundRelayAckOutcome::Dropped
@@ -111,6 +122,15 @@ pub(super) fn session_bound_relay_ack_snapshot_outcome(
     {
         Some(DeliveryOutcome::Delivered) => {
             return Some(SessionBoundRelayAckOutcome::Delivered);
+        }
+        Some(DeliveryOutcome::FreshDelivered {
+            committed_to,
+            persistence_recorded,
+        }) => {
+            return Some(SessionBoundRelayAckOutcome::FreshDelivered {
+                committed_to,
+                persistence_recorded,
+            });
         }
         Some(DeliveryOutcome::NotDelivered) => {
             return Some(SessionBoundRelayAckOutcome::NotDelivered);
@@ -171,11 +191,20 @@ pub(super) fn session_bound_ack_outcome_after_resolve_time_mirror_check(
         return ack_outcome;
     }
     *turn_fully_mirrored = false;
-    if matches!(ack_outcome, SessionBoundRelayAckOutcome::Delivered) {
+    if session_bound_ack_confirms_transport(ack_outcome) {
         SessionBoundRelayAckOutcome::Dropped
     } else {
         ack_outcome
     }
+}
+
+pub(super) fn session_bound_ack_confirms_transport(
+    ack_outcome: SessionBoundRelayAckOutcome,
+) -> bool {
+    matches!(
+        ack_outcome,
+        SessionBoundRelayAckOutcome::Delivered | SessionBoundRelayAckOutcome::FreshDelivered { .. }
+    )
 }
 
 pub(super) fn watcher_should_direct_send_after_session_bound_ack(
@@ -183,7 +212,6 @@ pub(super) fn watcher_should_direct_send_after_session_bound_ack(
     ack_outcome: SessionBoundRelayAckOutcome,
     relay_owner_present: bool,
 ) -> bool {
-    use crate::services::cluster::stream_relay::DeliveryOutcome;
     // #3042 (relay-stability P1, OBSOLETE band-aid — removed by #3041 P1-5): #3042
     // early-`return false`d an ownerless (post-restart restore_inflight gap)
     // `TimedOut` to blanket-suppress the watcher-direct fallback (rationale: the sink
@@ -210,11 +238,7 @@ pub(super) fn watcher_should_direct_send_after_session_bound_ack(
     // is masked downstream by `watcher_terminal_resend_action` (committed-offset
     // reconciliation), so neither gets a blind skip (NotDelivered) nor a blind
     // re-send (Unknown). §3.2 SAFETY INVARIANT.
-    should_direct_send
-        && !matches!(
-            session_bound_ack_delivery_outcome(ack_outcome),
-            DeliveryOutcome::Delivered
-        )
+    should_direct_send && !session_bound_ack_confirms_transport(ack_outcome)
 }
 
 /// #3041 P1-3 (Part b, §3.2): the watcher's terminal re-send DECISION after a

--- a/src/services/discord/tmux_watcher/session_bound_ack.rs
+++ b/src/services/discord/tmux_watcher/session_bound_ack.rs
@@ -191,7 +191,7 @@ pub(super) fn session_bound_ack_outcome_after_resolve_time_mirror_check(
         return ack_outcome;
     }
     *turn_fully_mirrored = false;
-    if session_bound_ack_confirms_transport(ack_outcome) {
+    if matches!(ack_outcome, SessionBoundRelayAckOutcome::Delivered) {
         SessionBoundRelayAckOutcome::Dropped
     } else {
         ack_outcome

--- a/src/services/discord/tmux_watcher/session_bound_ack_tests.rs
+++ b/src/services/discord/tmux_watcher/session_bound_ack_tests.rs
@@ -200,6 +200,7 @@ mod confirmed_fresh_delivery {
     use super::super::{
         SessionBoundRelayAckOutcome, SessionBoundRelayAckTarget,
         session_bound_ack_confirms_transport, session_bound_ack_delivery_outcome,
+        session_bound_ack_outcome_after_resolve_time_mirror_check,
         session_bound_relay_ack_snapshot_outcome,
         watcher_should_direct_send_after_session_bound_ack,
     };
@@ -228,6 +229,36 @@ mod confirmed_fresh_delivery {
         assert!(!session_bound_ack_confirms_transport(
             SessionBoundRelayAckOutcome::NotDelivered
         ));
+    }
+
+    #[test]
+    fn resolve_time_span_drop_preserves_confirmed_fresh_transport() {
+        let metrics = Arc::new(RelayMetrics::default());
+        metrics.record_dropped_sequence_for_test(10);
+        let target = target(metrics, 12);
+        let mut turn_fully_mirrored = true;
+        let ack = SessionBoundRelayAckOutcome::FreshDelivered {
+            committed_to: None,
+            persistence_recorded: false,
+        };
+
+        let resolved = session_bound_ack_outcome_after_resolve_time_mirror_check(
+            ack,
+            &mut turn_fully_mirrored,
+            Some(&target),
+            Some(9),
+        );
+
+        assert_eq!(resolved, ack);
+        assert!(
+            !turn_fully_mirrored,
+            "the span drop still degrades mirror completeness"
+        );
+        assert!(session_bound_ack_confirms_transport(resolved));
+        assert!(
+            !watcher_should_direct_send_after_session_bound_ack(true, resolved, true),
+            "a span drop cannot revoke confirmed fresh transport and authorize a duplicate POST"
+        );
     }
 
     #[test]

--- a/src/services/discord/tmux_watcher/session_bound_ack_tests.rs
+++ b/src/services/discord/tmux_watcher/session_bound_ack_tests.rs
@@ -196,6 +196,119 @@ mod not_attempted_sentinel {
     }
 }
 
+mod confirmed_fresh_delivery {
+    use super::super::{
+        SessionBoundRelayAckOutcome, SessionBoundRelayAckTarget,
+        session_bound_ack_confirms_transport, session_bound_ack_delivery_outcome,
+        session_bound_relay_ack_snapshot_outcome,
+        watcher_should_direct_send_after_session_bound_ack,
+    };
+    use crate::services::cluster::stream_relay::{DeliveryOutcome, RelayMetrics};
+    use std::sync::Arc;
+
+    fn target(metrics: Arc<RelayMetrics>, sequence: u64) -> SessionBoundRelayAckTarget {
+        SessionBoundRelayAckTarget {
+            metrics,
+            sequence,
+            turn_start_offset: Some(100),
+        }
+    }
+
+    #[test]
+    fn delivered_and_fresh_delivered_both_own_terminal_delivery() {
+        assert!(session_bound_ack_confirms_transport(
+            SessionBoundRelayAckOutcome::Delivered
+        ));
+        assert!(session_bound_ack_confirms_transport(
+            SessionBoundRelayAckOutcome::FreshDelivered {
+                committed_to: None,
+                persistence_recorded: false,
+            }
+        ));
+        assert!(!session_bound_ack_confirms_transport(
+            SessionBoundRelayAckOutcome::NotDelivered
+        ));
+    }
+
+    #[test]
+    fn exact_fresh_resolution_suppresses_same_process_fallback_for_all_metadata_shapes() {
+        for (sequence, committed_to, persistence_recorded) in [
+            (41, Some(200), true),
+            (42, Some(200), false),
+            (43, None, true),
+            (44, None, false),
+        ] {
+            let metrics = Arc::new(RelayMetrics::default());
+            metrics.record_terminal_outcome(
+                sequence,
+                DeliveryOutcome::FreshDelivered {
+                    committed_to,
+                    persistence_recorded,
+                },
+            );
+            let ack = session_bound_relay_ack_snapshot_outcome(Some(&target(metrics, sequence)))
+                .expect("fresh resolution must resolve its exact ACK");
+            assert_eq!(
+                ack,
+                SessionBoundRelayAckOutcome::FreshDelivered {
+                    committed_to,
+                    persistence_recorded,
+                }
+            );
+            assert!(
+                !watcher_should_direct_send_after_session_bound_ack(true, ack, true),
+                "confirmed fresh transport must suppress SendFull even without a frontier or persistence record"
+            );
+        }
+    }
+
+    #[test]
+    fn fresh_resolution_is_exact_sequence_and_does_not_suppress_neighbors() {
+        let metrics = Arc::new(RelayMetrics::default());
+        metrics.record_terminal_outcome(
+            50,
+            DeliveryOutcome::FreshDelivered {
+                committed_to: None,
+                persistence_recorded: false,
+            },
+        );
+        metrics.record_terminal_outcome(51, DeliveryOutcome::NotDelivered);
+
+        assert!(matches!(
+            session_bound_relay_ack_snapshot_outcome(Some(&target(metrics.clone(), 50))),
+            Some(SessionBoundRelayAckOutcome::FreshDelivered { .. })
+        ));
+        let neighbor = session_bound_relay_ack_snapshot_outcome(Some(&target(metrics, 51)))
+            .expect("neighbor resolution");
+        assert_eq!(neighbor, SessionBoundRelayAckOutcome::NotDelivered);
+        assert!(watcher_should_direct_send_after_session_bound_ack(
+            true, neighbor, true
+        ));
+    }
+
+    #[test]
+    fn actual_failures_keep_existing_reconciliation_intent() {
+        for ack in [
+            SessionBoundRelayAckOutcome::NotDelivered,
+            SessionBoundRelayAckOutcome::RingUnknown,
+            SessionBoundRelayAckOutcome::Dropped,
+            SessionBoundRelayAckOutcome::SinkError,
+            SessionBoundRelayAckOutcome::TimedOut,
+            SessionBoundRelayAckOutcome::MissingTarget,
+        ] {
+            assert!(
+                watcher_should_direct_send_after_session_bound_ack(true, ack, true),
+                "{ack:?} must retain the existing SendFull-or-Skip reconciliation path"
+            );
+        }
+        assert_eq!(
+            session_bound_ack_delivery_outcome(SessionBoundRelayAckOutcome::SinkError),
+            DeliveryOutcome::Unknown,
+            "a Permanent sink error remains an unconfirmed sink error, never fresh confirmation"
+        );
+    }
+}
+
 /// #3151: the deterministic decision seam for the in-flight sink-delivery
 /// marker gate (`watcher_terminal_resend_action_gated`). Table-drives the gate
 /// over every lease-snapshot variant and asserts the reclaim side-effect flag.


### PR DESCRIPTION
## Summary
- promote confirmed `FreshDelivered` out of `RelaySinkError` into a typed terminal sink resolution
- preserve `committed_to` and `persistence_recorded` through the exact-sequence relay ring and watcher ACK
- treat both `Delivered` and `FreshDelivered` as terminal transport ownership while leaving actual sink errors and unconfirmed outcomes on the existing reconciliation path
- preserve fresh transport confirmation even when a neighboring frame eviction degrades mirror completeness, preventing a NoRange duplicate fallback
- extract terminal resolution types so `stream_relay.rs` falls below the prod-giant threshold and refresh the generated architecture inventory

## Safety contracts
- I9 shared `DeliveryLeaseCell` acquisition and reconciliation are unchanged
- I10 cursor advancement remains limited to intentional drop or current-generation confirmed durable commit
- `committed_to: None` and `persistence_recorded: false` remain confirmed transport evidence and cannot trigger a same-process full-response fallback
- actual `RelaySinkError::Permanent` remains an error and is not classified as transport confirmation
- exact-sequence ACK isolation prevents a neighboring sequence from satisfying the fresh delivery
- the new typed resolution is covered by the compiler-backed relay contract symbol anchor

## Hotfile authorization
`src/services/discord/tmux_watcher.rs` is touched only at the terminal ownership call site: one line is replaced with the named `session_bound_ack_confirms_transport` predicate (`1 insertion, 1 deletion`). This root touch was conditionally authorized by the orchestrator after confirming the #3016 hotfile lane was exclusively held. It is required to preserve typed fresh provenance without collapsing it into `Delivered`, while still finalizing the watcher lifecycle as terminally owned.

The named predicate lives outside the root and recognizes both existing `Delivered` and new `FreshDelivered`; regression tests pin both semantics. Protected concurrent-lane files (`turn_bridge/mod.rs`, `turn_finalizer.rs`, `outbound/delivery_record.rs`, `outbound/turn_output_controller.rs`, `formatting.rs`, `gateway.rs`, and `tmux_watcher/terminal_send.rs`) are untouched.

## Verification
- `cargo fmt --all --check`
- `cargo check --workspace --all-targets`
- `bash scripts/ci-script-checks.sh` (`rc=0`)
- `python3 scripts/generate_inventory_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py`
- contract symbol refs: 36 anchors, doc/code in sync
- test-lane guard: 827 logical modules, 5834 tests, locked uncovered baseline 701
- blind-save ratchet: baseline 1
- `cargo test --lib session_relay`: 93 passed
- `cargo test --lib delivery_record`: 66 passed
- `cargo test --lib tui_prompt_relay`: 196 passed
- `cargo test --lib stream_relay`: 22 passed
- `cargo test --lib orphan`: 155 passed
- corrected `confirmed_fresh_delivery` regressions repeated 3 times: 5 passed each round
- mutation proof: removing the `FreshDelivered` ownership predicate arm fails the dedicated regression (`rc=101`); restoring it passes
- adversarial review found the span-eviction FreshDelivered downgrade vector; commit `38b34387c` corrected it and added a no-duplicate regression

## Exact head
`d61d9aa72cf899362921acd963cf41cf2b9ee7a8`

Closes #4623