### PR TITLE
obs(#4220): discord 디렉터리 warn 레벨 재분류 — 44 warn→info, 2 warn→error

### DIFF
--- a/src/services/discord/catch_up.rs
+++ b/src/services/discord/catch_up.rs
@@ -904,7 +904,7 @@ async fn run_catch_up_sweep<A: CatchUpDiscordApi + ?Sized>(deps: CatchUpDeps<'_,
     let pruned = prune_stale_checkpoint_files(&dir, max_checkpoint_age);
     if pruned > 0 {
         let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::warn!("  [{ts}] 🧹 catch-up: pruned {pruned} stale checkpoint(s) (>10min old)");
+        tracing::info!("  [{ts}] 🧹 catch-up: pruned {pruned} stale checkpoint(s) (>10min old)");
     }
 
     let mut candidates = collect_catch_up_channel_candidates(&dir, provider);
@@ -984,7 +984,7 @@ async fn run_catch_up_sweep<A: CatchUpDiscordApi + ?Sized>(deps: CatchUpDeps<'_,
             RuntimeChannelBindingStatus::Owned => {}
             RuntimeChannelBindingStatus::Unowned => {
                 let ts = chrono::Local::now().format("%H:%M:%S");
-                tracing::warn!(
+                tracing::info!(
                     "  [{ts}] ⏭ catch-up: dropping stale checkpoint for unowned channel {} ({})",
                     channel_id,
                     candidate

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -1613,7 +1613,7 @@ pub fn spawn_watchdog(port: u16) {
                 if ok {
                     if consecutive_failures > 0 {
                         let ts = chrono::Local::now().format("%H:%M:%S");
-                        tracing::warn!(
+                        tracing::info!(
                             "  [{ts}] 🩺 watchdog: health recovered after {consecutive_failures} failure(s)"
                         );
                     }

--- a/src/services/discord/inflight/removal.rs
+++ b/src/services/discord/inflight/removal.rs
@@ -268,7 +268,7 @@ pub(super) fn stale_removal_reason(
                     && let Some(name) = state.tmux_session_name.as_deref()
                     && tmux_pane_alive_for_stale_check(name)
                 {
-                    tracing::warn!(
+                    tracing::info!(
                         "  ⚠ inflight stale-age ({age_secs}s > {max_age}s) overridden — tmux pane '{name}' still alive (channel {})",
                         state.channel_id
                     );
@@ -286,7 +286,7 @@ pub(super) fn stale_removal_reason(
                 if let Some(name) = state.tmux_session_name.as_deref()
                     && tmux_pane_alive_for_stale_check(name)
                 {
-                    tracing::warn!(
+                    tracing::info!(
                         "  ⚠ inflight stale-age ({age_secs}s > {INFLIGHT_MAX_AGE_SECS}s) overridden — tmux pane '{name}' still alive (channel {})",
                         state.channel_id
                     );

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -3524,7 +3524,7 @@ async fn mailbox_take_next_soft_intervention(
                 .await
         {
             let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::warn!(
+            tracing::info!(
                 "  [{ts}] ⏭ DISPATCH-GUARD: dropped queued terminal dispatch {} in channel {} (status={})",
                 stale.dispatch_id,
                 channel_id,

--- a/src/services/discord/prompt_builder/mod.rs
+++ b/src/services/discord/prompt_builder/mod.rs
@@ -350,7 +350,7 @@ pub(super) fn build_system_prompt_with_manifest(
             if let Some(shared_prompt) = load_shared_prompt_for_profile(shared_profile) {
                 let shared_rules = format!("\n\n[Shared Agent Rules]\n{shared_prompt}");
                 if dedupe_tracker.record("shared_agent_rules", &shared_rules) {
-                    tracing::warn!(
+                    tracing::info!(
                         "  [role-map] Injected {} shared agent rules ({} chars) for channel {}",
                         shared_profile,
                         shared_rules.len(),
@@ -371,7 +371,7 @@ pub(super) fn build_system_prompt_with_manifest(
                 // workspace actually is an AgentDesk checkout. Compute once and
                 // reuse for both the log and the append.
                 let shared_rules = shared_agent_rules_lookup(current_path);
-                tracing::warn!(
+                tracing::info!(
                     "  [role-map] Injected compact shared rule index ({} chars) for channel {}",
                     shared_rules.len(),
                     channel_id.get()
@@ -411,7 +411,7 @@ pub(super) fn build_system_prompt_with_manifest(
                         PromptContentVisibility::AdkProvided,
                         role_binding_contract,
                     ));
-                    tracing::warn!(
+                    tracing::info!(
                         "  [role-map] Applied role '{}' for channel {}",
                         binding.role_id,
                         channel_id.get()

--- a/src/services/discord/recovery_engine/restore_inflight.rs
+++ b/src/services/discord/recovery_engine/restore_inflight.rs
@@ -1710,7 +1710,7 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                 continue;
             }
             let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::warn!(
+            tracing::info!(
                 provider = %provider.as_str(),
                 channel_id = state.channel_id,
                 user_msg_id = state.user_msg_id,
@@ -2199,7 +2199,7 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                     let ts = chrono::Local::now().format("%H:%M:%S");
                     if pane_alive {
                         // Session is alive but idle — hand off to watcher instead of retrying
-                        tracing::warn!(
+                        tracing::info!(
                             "  [{ts}] ↻ Recovery: session idle but pane alive — handing off to watcher (channel {})",
                             retry_channel_id
                         );

--- a/src/services/discord/recovery_engine/runtime.rs
+++ b/src/services/discord/recovery_engine/runtime.rs
@@ -201,7 +201,7 @@ async fn reregister_active_turn_from_inflight_inner(
         return false;
     };
     if recovery_terminal_delivery_already_committed(state) {
-        tracing::warn!(
+        tracing::info!(
             provider = %provider.as_str(),
             channel_id = state.channel_id,
             finalizer_turn_id,

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -748,7 +748,7 @@ pub(in crate::services::discord) async fn handle_event(
                         .await
             {
                 let ts = chrono::Local::now().format("%H:%M:%S");
-                tracing::warn!(
+                tracing::info!(
                     "  [{ts}] ⏭ DISPATCH-GUARD: skipped terminal dispatch message {} in channel {} (dispatch={}, status={})",
                     new_message.id,
                     channel_id,

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -1381,7 +1381,7 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
                 } else {
                     "unknown panic".to_string()
                 };
-                tracing::warn!("  [headless streaming] PANIC: {}", msg);
+                tracing::error!("  [headless streaming] PANIC: {}", msg);
                 let _ = tx.send(StreamMessage::Error {
                     message: format!("Internal error (panic): {}", msg),
                     stdout: String::new(),

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2030,7 +2030,7 @@ pub(super) async fn handle_text_message(
                         .load(std::sync::atomic::Ordering::Relaxed),
                 ) {
                     (_, _, true) => {
-                        tracing::warn!(
+                        tracing::info!(
                             channel_id = channel_id.get(),
                             user_msg_id = user_msg_id.get(),
                             tmux_session_name = %initial_diagnostic.tmux_session_name,
@@ -2163,7 +2163,7 @@ pub(super) async fn handle_text_message(
                 );
             }
         }
-        tracing::warn!(
+        tracing::info!(
             channel_id = channel_id.get(),
             user_msg_id = user_msg_id.get(),
             diagnostics = %diagnostic_json,
@@ -2535,7 +2535,7 @@ pub(super) async fn handle_text_message(
                 } else {
                     "unknown panic".to_string()
                 };
-                tracing::warn!("  [streaming] PANIC: {}", msg);
+                tracing::error!("  [streaming] PANIC: {}", msg);
                 let _ = tx.send(StreamMessage::Error {
                     message: format!("Internal error (panic): {}", msg),
                     stdout: String::new(),

--- a/src/services/discord/router/message_handler/intake_turn/stale_dispatch_guard.rs
+++ b/src/services/discord/router/message_handler/intake_turn/stale_dispatch_guard.rs
@@ -38,7 +38,7 @@ pub(super) async fn abort_terminal_dispatch_at_turn_start(
         .await
     {
         let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::warn!(
+        tracing::info!(
             "  [{ts}] ⏭ DISPATCH-GUARD: aborted terminal dispatch at turn start in channel {} (dispatch={}, status={})",
             channel_id,
             stale.dispatch_id,

--- a/src/services/discord/router/message_handler/provider_isolation.rs
+++ b/src/services/discord/router/message_handler/provider_isolation.rs
@@ -223,7 +223,7 @@ pub(super) async fn restore_live_tui_provider_session_from_binding(
         .await;
     }
     let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::warn!(
+    tracing::info!(
         "  [{ts}] ↻ Recovered provider session_id from live TUI runtime binding for channel {}: tmux={} transcript={}",
         channel_id.get(),
         tmux_session_name.unwrap_or("(none)"),

--- a/src/services/discord/runtime_bootstrap/gateway_lease.rs
+++ b/src/services/discord/runtime_bootstrap/gateway_lease.rs
@@ -376,7 +376,7 @@ pub(super) async fn run_bot_acquire_gateway_lease(
                     )
                     .await;
                     let ts = chrono::Local::now().format("%H:%M:%S");
-                    tracing::warn!(
+                    tracing::info!(
                         "  [{ts}] ⏭ GATEWAY-LEASE: {} launch skipped — singleton lease held elsewhere",
                         provider.display_name()
                     );
@@ -538,7 +538,7 @@ pub(super) fn run_bot_spawn_gateway_lease_keepalive(
                         .await
                         {
                             let ts = chrono::Local::now().format("%H:%M:%S");
-                            tracing::warn!(
+                            tracing::info!(
                                 "  [{ts}] 🤝 GATEWAY-LEASE: {} yielding gateway to preferred node {} — self-fencing",
                                 provider_for_lease.display_name(),
                                 pref.preferred_instance_id

--- a/src/services/discord/runtime_bootstrap/orphan_recovery.rs
+++ b/src/services/discord/runtime_bootstrap/orphan_recovery.rs
@@ -263,7 +263,7 @@ async fn clear_stale_session_dispatch_links(pg_pool: Option<&sqlx::PgPool>) {
                     })
                     .collect::<Vec<_>>()
                     .join(", ");
-                tracing::warn!(
+                tracing::info!(
                     cleared = rows.len(),
                     sample = %sample,
                     "cleared stale terminal active_dispatch_id links during startup recovery"
@@ -310,7 +310,7 @@ async fn clear_stale_session_dispatch_links(pg_pool: Option<&sqlx::PgPool>) {
                     .filter_map(|row| row.try_get::<String, _>("session_key").ok())
                     .collect::<Vec<_>>()
                     .join(", ");
-                tracing::warn!(
+                tracing::info!(
                     cleared = rows.len(),
                     sample = %sample,
                     "cleared missing active_dispatch_id links during startup recovery"

--- a/src/services/discord/runtime_bootstrap/recovery_flush.rs
+++ b/src/services/discord/runtime_bootstrap/recovery_flush.rs
@@ -289,7 +289,7 @@ pub(super) fn run_bot_spawn_recovery_and_flush_restart_reports(
                 let stale_count = filter_outcome.stale_count;
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 if stale_count > 0 {
-                    tracing::warn!(
+                    tracing::info!(
                         "  [{ts}] 📋 FLUSH: restored {live_count} queued-placeholder mapping(s) from disk; pruned {stale_count} stale mapping(s) with no live queue entry"
                     );
                 } else {

--- a/src/services/discord/runtime_bootstrap/spawns.rs
+++ b/src/services/discord/runtime_bootstrap/spawns.rs
@@ -209,7 +209,7 @@ pub(super) fn run_bot_spawn_deferred_restart_poller(
                     }
                     if restart_request_matches(&root, "restart_cancelled", &nonce) {
                         rollback_deferred_restart(&shared_for_deferred);
-                        tracing::warn!(
+                        tracing::info!(
                             provider = provider_for_deferred.as_str(),
                             "restart request cancelled; intake admission restored"
                         );

--- a/src/services/discord/task_supervisor.rs
+++ b/src/services/discord/task_supervisor.rs
@@ -62,7 +62,7 @@ impl Drop for TmuxWatcherTaskGuard {
             .tmux_watchers
             .remove_tmux_session_if_current(&self.tmux_session_name, &self.cancel)
         {
-            tracing::warn!(
+            tracing::info!(
                 channel_id = owner_channel_id.get(),
                 tmux_session_name = %self.tmux_session_name,
                 "tmux watcher task exited; removed matching watcher registry entry"

--- a/src/services/discord/tmux_output_stream.rs
+++ b/src/services/discord/tmux_output_stream.rs
@@ -203,7 +203,7 @@ pub(in crate::services::discord) fn process_watcher_lines_for_turn(
                 line_start_offset,
                 terminal_kind_for_json_evidence(&val),
             ) {
-                tracing::warn!(
+                tracing::info!(
                     terminal_kind = skip.terminal_kind.as_str(),
                     evidence_offset = skip.evidence_offset,
                     turn_start_offset = skip.turn_start_offset,
@@ -583,7 +583,7 @@ pub(in crate::services::discord) fn process_watcher_lines_for_turn(
                 line_start_offset,
                 Some(WatcherTerminalKind::AuthError),
             ) {
-                tracing::warn!(
+                tracing::info!(
                     terminal_kind = skip.terminal_kind.as_str(),
                     evidence_offset = skip.evidence_offset,
                     turn_start_offset = skip.turn_start_offset,
@@ -625,7 +625,7 @@ pub(in crate::services::discord) fn process_watcher_lines_for_turn(
                 line_start_offset,
                 Some(WatcherTerminalKind::ProviderOverload),
             ) {
-                tracing::warn!(
+                tracing::info!(
                     terminal_kind = skip.terminal_kind.as_str(),
                     evidence_offset = skip.evidence_offset,
                     turn_start_offset = skip.turn_start_offset,

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -793,7 +793,7 @@ async fn submit_stale_foreign_inflight_cancel(
         return false;
     }
     let Some(current) = super::inflight::load_inflight_state(provider, channel_id.get()) else {
-        tracing::warn!(
+        tracing::info!(
             provider = %provider.as_str(),
             channel_id = channel_id.get(),
             finalizer_turn_id,
@@ -810,7 +810,7 @@ async fn submit_stale_foreign_inflight_cancel(
         || current.updated_at != probe.updated_at
         || current.save_generation != probe.save_generation
     {
-        tracing::warn!(
+        tracing::info!(
             provider = %provider.as_str(),
             channel_id = channel_id.get(),
             expected_finalizer_turn_id = finalizer_turn_id,
@@ -880,7 +880,7 @@ async fn submit_committed_foreign_inflight_complete(
         return false;
     }
     let Some(current) = super::inflight::load_inflight_state(provider, channel_id.get()) else {
-        tracing::warn!(
+        tracing::info!(
             provider = %provider.as_str(),
             channel_id = channel_id.get(),
             finalizer_turn_id,
@@ -901,7 +901,7 @@ async fn submit_committed_foreign_inflight_complete(
         || current.updated_at != probe.updated_at
         || current.save_generation != probe.save_generation
     {
-        tracing::warn!(
+        tracing::info!(
             provider = %provider.as_str(),
             channel_id = channel_id.get(),
             expected_finalizer_turn_id = finalizer_turn_id,

--- a/src/services/discord/tui_prompt_relay/relay_ownership.rs
+++ b/src/services/discord/tui_prompt_relay/relay_ownership.rs
@@ -276,7 +276,7 @@ pub(super) fn resolved_codex_idle_relay_binding(
                 channel_id.get(),
                 fresh.clone(),
             );
-            tracing::warn!(
+            tracing::info!(
                 tmux_session_name = %tmux_session_name,
                 channel_id = channel_id.get(),
                 stale_output_path = %binding.output_path,

--- a/src/services/discord/turn_bridge/recovery_text.rs
+++ b/src/services/discord/turn_bridge/recovery_text.rs
@@ -803,7 +803,7 @@ pub(in crate::services::discord) async fn auto_retry_with_history(
     // Dedup guard: prevent turn_bridge + watcher from both firing
     // auto-retry for the same channel simultaneously.
     if !RETRY_PENDING.insert(channel_id.get()) {
-        tracing::warn!("  [{ts}] ⏭ auto-retry: skipped (dedup) for channel {channel_id}");
+        tracing::info!("  [{ts}] ⏭ auto-retry: skipped (dedup) for channel {channel_id}");
         return;
     }
     // #2452 H6 graduation: the lockout release is now driven by an
@@ -822,7 +822,7 @@ pub(in crate::services::discord) async fn auto_retry_with_history(
         RETRY_PENDING.remove(&ch_id);
     });
 
-    tracing::warn!("  [{ts}] ↻ auto-retry: fetching last 10 messages for channel {channel_id}");
+    tracing::info!("  [{ts}] ↻ auto-retry: fetching last 10 messages for channel {channel_id}");
 
     // Fetch last 10 messages from Discord
     let recovery_context = match channel_id
@@ -922,7 +922,7 @@ pub(in crate::services::discord) async fn auto_retry_with_history(
     )
     .await;
     if !enqueued {
-        tracing::warn!("  [{ts}] ⏭ auto-retry: follow-up deduped for channel {channel_id}");
+        tracing::info!("  [{ts}] ⏭ auto-retry: follow-up deduped for channel {channel_id}");
     }
 }
 

--- a/src/services/discord/turn_bridge/runtime_handoff_loop.rs
+++ b/src/services/discord/turn_bridge/runtime_handoff_loop.rs
@@ -305,7 +305,7 @@ pub(super) async fn handle_runtime_handoff_loop_message(
                             ));
                         } else {
                             let ts = chrono::Local::now().format("%H:%M:%S");
-                            tracing::warn!(
+                            tracing::info!(
                                 "  [{ts}] ⚠ standby relay skipped: no Http source for channel {}",
                                 channel_id
                             );
@@ -878,7 +878,7 @@ fn handle_watcher_runtime_handoff(
                     // delivery suppression for the current turn.
                 } else {
                     let ts = chrono::Local::now().format("%H:%M:%S");
-                    tracing::warn!(
+                    tracing::info!(
                         "  [{ts}] ⚠ standby relay skipped: no Http source for channel {}",
                         channel_id
                     );

--- a/src/services/discord/turn_bridge/terminal_controller_cutover.rs
+++ b/src/services/discord/turn_bridge/terminal_controller_cutover.rs
@@ -514,7 +514,7 @@ pub(super) async fn apply_bridge_long_chunks_legacy(
 ) {
     if matches!(lease_acquire, BridgeLeaseAcquire::Skip) {
         let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::warn!(
+        tracing::info!(
             channel_id = channel_id.get(),
             "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate long terminal send (channel {})",
             channel_id

--- a/src/services/discord/turn_bridge/terminal_outcome_delivery.rs
+++ b/src/services/discord/turn_bridge/terminal_outcome_delivery.rs
@@ -665,7 +665,7 @@ pub(super) async fn run_terminal_outcome_delivery(
                             };
                         if matches!(lease_acquire, BridgeLeaseAcquire::Skip) {
                             let ts = chrono::Local::now().format("%H:%M:%S");
-                            tracing::warn!(
+                            tracing::info!(
                                 channel_id = channel_id.get(),
                                 "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate terminal replace (channel {})",
                                 channel_id

--- a/src/services/discord/turn_bridge/terminal_outcome_delivery/cancel_prompt_replace.rs
+++ b/src/services/discord/turn_bridge/terminal_outcome_delivery/cancel_prompt_replace.rs
@@ -245,7 +245,7 @@ pub(super) async fn handle_cancel_prompt_replace(
         );
         if matches!(stop_lease_acquire, BridgeLeaseAcquire::Skip) {
             let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::warn!(
+            tracing::info!(
                 channel_id = channel_id.get(),
                 "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate cancel/stop terminal replace (channel {})",
                 channel_id
@@ -351,7 +351,7 @@ pub(super) async fn handle_cancel_prompt_replace(
         );
         if matches!(plt_lease_acquire, BridgeLeaseAcquire::Skip) {
             let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::warn!(
+            tracing::info!(
                 channel_id = channel_id.get(),
                 "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate prompt-too-long terminal replace (channel {})",
                 channel_id

--- a/src/services/discord/turn_bridge/terminal_outcome_delivery/empty_response_recovery/handler.rs
+++ b/src/services/discord/turn_bridge/terminal_outcome_delivery/empty_response_recovery/handler.rs
@@ -167,7 +167,7 @@ pub(in crate::services::discord::turn_bridge::terminal_outcome_delivery) async f
             // turn and must never be attributed to the queued follow-up.
             if quick_empty_resume || preserve_busy_claude_followup(claude_tui_followup_busy_readiness_timeout) {
                 let ts = chrono::Local::now().format("%H:%M:%S");
-                tracing::warn!(
+                tracing::info!(
                     "  [{ts}] ⏭ Skipping output file recovery after quick empty resume exit or busy follow-up timeout (channel {})",
                     channel_id
                 );
@@ -178,7 +178,7 @@ pub(in crate::services::discord::turn_bridge::terminal_outcome_delivery) async f
                 );
                 if !recovered.trim().is_empty() {
                     let ts = chrono::Local::now().format("%H:%M:%S");
-                    tracing::warn!(
+                    tracing::info!(
                         "  [{ts}] ↻ Recovered {} chars from output file for channel {}",
                         recovered.len(),
                         channel_id
@@ -438,7 +438,7 @@ pub(in crate::services::discord::turn_bridge::terminal_outcome_delivery) async f
                     // Skip — identity-guard the epilogue save (no resurrect).
                     bridge_skip_holder_owns_inflight = true;
                     let ts = chrono::Local::now().format("%H:%M:%S");
-                    tracing::warn!(
+                    tracing::info!(
                         channel_id = channel_id.get(),
                         "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge silent_turn skipped offset advance, left turn retry-able (channel {})",
                         channel_id


### PR DESCRIPTION
Closes #4220

## 재분류 기준
- **warn**: 운영자가 봐야 할 비정상 (복구됐지만 조사 가치)
- **info**: 정상 동작 서술 (예상 가능한 스킵/중재/복구 성공 서사)
- **debug**: 개발 진단
- **error**: 기능 실패

## 변경 요약 (로그 레벨만 변경 — 메시지/필드/제어 흐름 무변)
- **warn→info 44건**: delivery lease 중재 스킵(#3041 B2, 5곳 — 이슈 명시 사례), standby relay no-Http-source 스킵(2곳 — 이슈 명시 사례), "Skipping output file recovery after quick empty resume"(이슈 명시 사례), DISPATCH-GUARD 정상 드롭(3곳), gateway lease standby 스킵/양보, 스타트업 리커버리 청소 서술, pre-turn evidence offset 가드(3곳), stale FOREIGN no-op(4곳), auto-retry dedup/진행 서술, busy follow-up 큐잉, idempotent inflight clear 등
- **warn→error 2건**: streaming task PANIC catch 사이트 (intake_turn.rs, headless_turn.rs) — 실제 턴 실패
- 애매한 건 전부 유지 (보수적): 의도적 warn 주석(#1137 post-terminal continuation), 보안 allow 결정(send_gate), standby 승격(gateway_lease_recovery), leak 청소(#3629) 등

## 실측 카운트 (rg 실측, src/services/discord)
| level | before | after |
|---|---|---|
| warn | 942 | 896 (-46) |
| info | 718 | 762 (+44) |
| debug | 171 | 171 |
| error | 68 | 70 (+2) |

## 제외 파일 잔여 warn (후속 이슈화용, 총 68건)
- 핫파일: tmux_watcher.rs 20, session_relay_sink.rs 3, turn_bridge/mod.rs 2, turn_finalizer.rs 0
- #4860 레인: tmux_watcher/streaming_status_tick.rs 10, two_message_panel.rs 3종 합 9, turn_bridge/single_message_footer.rs 1, completion_footer_metadata.rs 0, placeholder_live_events/* 0 (status_panel_singleton_store.rs는 트리에 미존재)
- #4863 레인: formatting.rs 8, outbound/turn_output_controller.rs 2 + turn_output_controller/fresh_send.rs 7, delivery_record.rs 3, tmux_watcher/terminal_direct_fallback.rs 3, gateway.rs 0, terminal_send.rs 0

## 검증
- cargo fmt --check 클린, cargo check --lib 클린
- 대표 스위트 전부 ok: router 195, health 185, recovery_engine 156, turn_bridge 322, inflight 226, catch_up 69, tui_direct_pending_start 39 (0 failed)
- scripts/ci-script-checks.sh rc=0
- 로그 레벨 assert 테스트 없음 확인 (메시지 문자열 교차 참조 grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)