### PR TITLE
refactor(#4712): de-giant manual_rebind/mod.rs — pure-move test-barrier cluster (1001 -> 911 prod)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -626,6 +626,7 @@ src/
 │   │   │   │   ├── episode_handoff.rs
 │   │   │   │   ├── mod.rs
 │   │   │   │   ├── post_adoption_guard_tests.rs
+│   │   │   │   ├── test_barriers.rs
 │   │   │   │   └── watcher_claim.rs
 │   │   │   ├── rebind_runtime/
 │   │   │   │   └── codex_relay_generation.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1246,7 +1246,10 @@
   - `src/services/discord/recovery_engine/completion_delivery.rs` (sub-1000;
     behavior-preserving #3834 r2 extraction of recovery terminal relay,
     visible completion/status-panel completion helpers, and their tests.)
-  - `src/services/discord/recovery_engine/manual_rebind/mod.rs` (frozen giant surface; keeps the manual rebind entrypoints,
+  - `src/services/discord/recovery_engine/manual_rebind/mod.rs` (911 prod lines
+    after the #4712 pure-move extraction of the test-only race-seam barrier
+    cluster into `manual_rebind/test_barriers.rs` (114 prod lines); no longer a
+    prod giant. Keeps the manual rebind entrypoints,
     rollback carrier, session refresh, active-turn re-registration hook, and
     watcher claim/spawn path. #4465's durable automatic lane performs the
     blocking exact-episode adoption on `spawn_blocking`, retains that same
@@ -1260,7 +1263,8 @@
     (363 prod lines) owns the Codex-TUI replay/resume helper cluster, and
     `src/services/discord/recovery_engine/manual_rebind/adoption.rs` (95 prod
     lines) owns transcript-adoption offset and binding decisions. The retired
-    `manual_rebind.rs` giant registration was removed from
+    `manual_rebind.rs` giant registration and the later `manual_rebind/mod.rs`
+    shrink entry (de-gianted by #4712) were removed from
     scripts/giant_file_registry.toml.)
   - `src/services/discord/recovery_engine/rebind_runtime.rs` (below the giant threshold
     after #4455) owns provider runtime resolution

--- a/scripts/giant_file_registry.toml
+++ b/scripts/giant_file_registry.toml
@@ -870,15 +870,6 @@ deadline = "2026-10-31"
 decompose_issue = "#4712"
 
 [[entry]]
-# Crossed the giant threshold while #4706 backfilled explicit decision metadata.
-# Keep the manual-rebind authority cohesive until #3405 extracts the recovery
-# admission and execution halves behind one typed plan boundary.
-file = "src/services/discord/recovery_engine/manual_rebind/mod.rs"
-owner = "discord-relay"
-deadline = "2026-10-31"
-decompose_issue = "#4712"
-
-[[entry]]
 # Crossed the 1000-prod-LoC giant threshold while catch-up phase1/phase2
 # admission semantics were aligned for #4107. Decomposition should split the
 # scan/admission commit paths from durable cleanup and checkpoint bookkeeping.

--- a/src/services/discord/recovery_engine/manual_rebind/episode_handoff.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/episode_handoff.rs
@@ -90,7 +90,7 @@ pub(super) async fn commit_episode_side_effects(
 
     #[cfg(test)]
     if locked_episode.is_some() {
-        super::await_episode_authority_held_barrier().await;
+        super::test_barriers::await_episode_authority_held_barrier().await;
     }
 
     let finish_mailbox_on_completion = if existing_inflight_present {

--- a/src/services/discord/recovery_engine/manual_rebind/mod.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/mod.rs
@@ -18,14 +18,15 @@
 use super::manual_rebind_output_path::saved_output_path_for_rebind_resolution;
 use super::manual_rebind_override::upsert_rebind_session_id_override;
 use super::*;
-#[cfg(test)]
-use std::sync::{Mutex, OnceLock};
 
 mod adoption;
 mod codex_tui_replay;
 mod episode_handoff;
+mod test_barriers;
 #[cfg(unix)]
 mod watcher_claim;
+#[cfg(test)]
+use test_barriers::await_post_adoption_claim_barrier;
 #[cfg(unix)]
 use watcher_claim::claim_rebind_watcher;
 
@@ -44,6 +45,11 @@ pub(crate) use self::codex_tui_replay::{
     codex_tui_rebind_replays_existing_raw_bytes,
     codex_tui_rebind_should_load_existing_normalized_replay_events,
     codex_tui_rebind_start_after_crossed_provider_turn,
+};
+#[cfg(test)]
+pub(crate) use self::test_barriers::{
+    EpisodeAuthorityHeldBarrier, PostAdoptionClaimBarrier, install_episode_authority_held_barrier,
+    install_post_adoption_claim_barrier,
 };
 
 #[allow(clippy::large_enum_variant)]
@@ -122,102 +128,6 @@ impl PendingRebindInflightRollback {
                 format!("clear_rebind_origin:{outcome:?}")
             }
         }
-    }
-}
-
-#[cfg(test)]
-#[derive(Clone)]
-pub(crate) struct PostAdoptionClaimBarrier {
-    pub(crate) reached: std::sync::Arc<tokio::sync::Barrier>,
-    pub(crate) resume: std::sync::Arc<tokio::sync::Barrier>,
-}
-
-#[cfg(test)]
-#[derive(Clone)]
-pub(crate) struct EpisodeAuthorityHeldBarrier {
-    pub(crate) reached: std::sync::Arc<tokio::sync::Barrier>,
-    pub(crate) resume: std::sync::Arc<tokio::sync::Barrier>,
-}
-
-#[cfg(test)]
-fn post_adoption_claim_barrier_slot() -> &'static Mutex<Option<PostAdoptionClaimBarrier>> {
-    static SLOT: OnceLock<Mutex<Option<PostAdoptionClaimBarrier>>> = OnceLock::new();
-    SLOT.get_or_init(|| Mutex::new(None))
-}
-
-#[cfg(test)]
-fn episode_authority_held_barrier_slot() -> &'static Mutex<Option<EpisodeAuthorityHeldBarrier>> {
-    static SLOT: OnceLock<Mutex<Option<EpisodeAuthorityHeldBarrier>>> = OnceLock::new();
-    SLOT.get_or_init(|| Mutex::new(None))
-}
-
-#[cfg(test)]
-pub(crate) struct PostAdoptionClaimBarrierGuard(Option<PostAdoptionClaimBarrier>);
-
-#[cfg(test)]
-pub(crate) struct EpisodeAuthorityHeldBarrierGuard(Option<EpisodeAuthorityHeldBarrier>);
-
-#[cfg(test)]
-impl Drop for PostAdoptionClaimBarrierGuard {
-    fn drop(&mut self) {
-        *post_adoption_claim_barrier_slot()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner()) = self.0.take();
-    }
-}
-
-#[cfg(test)]
-impl Drop for EpisodeAuthorityHeldBarrierGuard {
-    fn drop(&mut self) {
-        *episode_authority_held_barrier_slot()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner()) = self.0.take();
-    }
-}
-
-#[cfg(test)]
-pub(crate) fn install_post_adoption_claim_barrier(
-    barrier: PostAdoptionClaimBarrier,
-) -> PostAdoptionClaimBarrierGuard {
-    let previous = post_adoption_claim_barrier_slot()
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner())
-        .replace(barrier);
-    PostAdoptionClaimBarrierGuard(previous)
-}
-
-#[cfg(test)]
-pub(crate) fn install_episode_authority_held_barrier(
-    barrier: EpisodeAuthorityHeldBarrier,
-) -> EpisodeAuthorityHeldBarrierGuard {
-    let previous = episode_authority_held_barrier_slot()
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner())
-        .replace(barrier);
-    EpisodeAuthorityHeldBarrierGuard(previous)
-}
-
-#[cfg(test)]
-async fn await_post_adoption_claim_barrier() {
-    let barrier = post_adoption_claim_barrier_slot()
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner())
-        .clone();
-    if let Some(barrier) = barrier {
-        barrier.reached.wait().await;
-        barrier.resume.wait().await;
-    }
-}
-
-#[cfg(test)]
-async fn await_episode_authority_held_barrier() {
-    let barrier = episode_authority_held_barrier_slot()
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner())
-        .clone();
-    if let Some(barrier) = barrier {
-        barrier.reached.wait().await;
-        barrier.resume.wait().await;
     }
 }
 

--- a/src/services/discord/recovery_engine/manual_rebind/test_barriers.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/test_barriers.rs
@@ -1,0 +1,114 @@
+//! Test-only synchronization barriers for the manual-rebind race seams
+//! (#4712 de-giant split from `manual_rebind/mod.rs`).
+//!
+//! Pure move — zero logic change: the `PostAdoptionClaimBarrier` /
+//! `EpisodeAuthorityHeldBarrier` pair, their process-global install slots,
+//! restore-on-drop guards, and the `await_*` seam hooks that
+//! `rebind_inflight_for_channel_inner` / `episode_handoff` call under
+//! `#[cfg(test)]`. Every item keeps its own `#[cfg(test)]` gate exactly as it
+//! had in the parent module, so this file stays a plain (ungated) submodule and
+//! introduces no new logical test module. The two `await_*` hooks were private
+//! to the parent module and are elevated to `pub(super)` — the minimum surface
+//! for the parent and its `episode_handoff` sibling to keep calling them; the
+//! barrier types and `install_*` fns keep their original `pub(crate)`
+//! visibility (re-exported by the parent for the `recovery_engine` root and
+//! `post_adoption_guard_tests`).
+
+#[cfg(test)]
+use std::sync::{Mutex, OnceLock};
+
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct PostAdoptionClaimBarrier {
+    pub(crate) reached: std::sync::Arc<tokio::sync::Barrier>,
+    pub(crate) resume: std::sync::Arc<tokio::sync::Barrier>,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct EpisodeAuthorityHeldBarrier {
+    pub(crate) reached: std::sync::Arc<tokio::sync::Barrier>,
+    pub(crate) resume: std::sync::Arc<tokio::sync::Barrier>,
+}
+
+#[cfg(test)]
+fn post_adoption_claim_barrier_slot() -> &'static Mutex<Option<PostAdoptionClaimBarrier>> {
+    static SLOT: OnceLock<Mutex<Option<PostAdoptionClaimBarrier>>> = OnceLock::new();
+    SLOT.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(test)]
+fn episode_authority_held_barrier_slot() -> &'static Mutex<Option<EpisodeAuthorityHeldBarrier>> {
+    static SLOT: OnceLock<Mutex<Option<EpisodeAuthorityHeldBarrier>>> = OnceLock::new();
+    SLOT.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(test)]
+pub(crate) struct PostAdoptionClaimBarrierGuard(Option<PostAdoptionClaimBarrier>);
+
+#[cfg(test)]
+pub(crate) struct EpisodeAuthorityHeldBarrierGuard(Option<EpisodeAuthorityHeldBarrier>);
+
+#[cfg(test)]
+impl Drop for PostAdoptionClaimBarrierGuard {
+    fn drop(&mut self) {
+        *post_adoption_claim_barrier_slot()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = self.0.take();
+    }
+}
+
+#[cfg(test)]
+impl Drop for EpisodeAuthorityHeldBarrierGuard {
+    fn drop(&mut self) {
+        *episode_authority_held_barrier_slot()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = self.0.take();
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn install_post_adoption_claim_barrier(
+    barrier: PostAdoptionClaimBarrier,
+) -> PostAdoptionClaimBarrierGuard {
+    let previous = post_adoption_claim_barrier_slot()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .replace(barrier);
+    PostAdoptionClaimBarrierGuard(previous)
+}
+
+#[cfg(test)]
+pub(crate) fn install_episode_authority_held_barrier(
+    barrier: EpisodeAuthorityHeldBarrier,
+) -> EpisodeAuthorityHeldBarrierGuard {
+    let previous = episode_authority_held_barrier_slot()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .replace(barrier);
+    EpisodeAuthorityHeldBarrierGuard(previous)
+}
+
+#[cfg(test)]
+pub(super) async fn await_post_adoption_claim_barrier() {
+    let barrier = post_adoption_claim_barrier_slot()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .clone();
+    if let Some(barrier) = barrier {
+        barrier.reached.wait().await;
+        barrier.resume.wait().await;
+    }
+}
+
+#[cfg(test)]
+pub(super) async fn await_episode_authority_held_barrier() {
+    let barrier = episode_authority_held_barrier_slot()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .clone();
+    if let Some(barrier) = barrier {
+        barrier.reached.wait().await;
+        barrier.resume.wait().await;
+    }
+}


### PR DESCRIPTION
## Summary

#4712 소형 decompose 후속 (스카우트 코멘트 D19 저가 win: https://github.com/itismyfield/AgentDesk/issues/4712#issuecomment-5067017710).

`src/services/discord/recovery_engine/manual_rebind/mod.rs`가 prod 1001줄로 giant threshold(1000)를 1줄 초과한 상태였다. 응집 클러스터 하나 — test-only race-seam barrier 인프라(`PostAdoptionClaimBarrier` / `EpisodeAuthorityHeldBarrier` 타입, process-global install slot, restore-on-drop guard, `install_*` / `await_*` 훅) — 를 새 서브모듈 `manual_rebind/test_barriers.rs`로 **순수 이동(pure move, 동작 무변)** 하여 임계 아래로 내렸다.

- `mod.rs`: **1001 → 911 prod LoC** (재접근 마진 89줄)
- `test_barriers.rs`: 114 prod LoC 신규

## Pure-move 증명

- mod.rs에서 제거된 비공백 86줄 전부가 test_barriers.rs에 문자 그대로 존재(스크립트 대조: verbatim 불일치 0건)
- 허용 델타 2건뿐: 이전에 module-private였던 `await_post_adoption_claim_barrier` / `await_episode_authority_held_barrier`를 `pub(super)`로 최소 승격 (부모 mod.rs와 `episode_handoff.rs` 형제가 계속 호출하기 위한 최소 표면)
- 모든 아이템이 아이템별 `#[cfg(test)]` 게이트를 그대로 유지 → 새 logical test module 없음, **test-lane baseline 성장 없음** (`check_test_lane_coverage.py`: 700 uncovered == locked baseline 정확 일치)
- `recovery_engine.rs` 루트 re-export 표면 무접촉: pub(crate) 4종(`EpisodeAuthorityHeldBarrier`, `PostAdoptionClaimBarrier`, `install_*` 2종)은 mod.rs에서 chain re-export
- `episode_handoff.rs`는 호출 경로 1줄만 조정 (`super::` → `super::test_barriers::`)

## 동반 수정 (change-surfaces 규칙)

- `scripts/giant_file_registry.toml`: manual_rebind/mod.rs shrink `[[entry]]` 제거 (ghost-registration 규칙; frozen baseline 목록엔 원래 없음)
- `docs/agent-maintenance/change-surfaces.md`: frozen giant surface 마커 해제 + 추출 내역 반영
- `ARCHITECTURE.md`: 인벤토리 생성기 트리 동기화(+1줄)

## 검증 (출력 원문)

- 모듈 테스트 추출 전(main@1665d8aca, stash 기준): `test result: ok. 55 passed; 0 failed; 0 ignored; 0 measured; 6858 filtered out`
- 모듈 테스트 추출 후: `test result: ok. 55 passed; 0 failed; 0 ignored; 0 measured; 6858 filtered out` — **동일 카운트**
- `cargo fmt --all --check` 클린 / `cargo check --lib` 클린 (manual_rebind/test_barriers 신규 경고 0)
- `scripts/ci-script-checks.sh` → `ci_rc=0`
- `check_agent_maintenance_docs.py --warning-only --line-count-gate` → `agent-maintenance freshness check passed`
- 핫파일 4종 / #4860 / #4863 / #4220 레인 파일 무접촉

🤖 Generated with [Claude Code](https://claude.com/claude-code)