### PR TITLE
fix(#4489): keep busy Codex tool turns open

### DIFF
--- a/src/services/codex_tui/input.rs
+++ b/src/services/codex_tui/input.rs
@@ -1397,6 +1397,77 @@ fn pane_looks_ready_for_codex_prompt_with_ansi(pane: &str) -> bool {
 }
 
 fn pane_has_codex_active_turn_in_pane(pane: &str) -> bool {
+    recent_codex_active_turn_marker(pane).is_some()
+}
+
+const CODEX_ACTIVE_TURN_SIGNAL_FRESHNESS: std::time::Duration = std::time::Duration::from_secs(90);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CodexPaneBusySignal {
+    Fresh,
+    Idle,
+    Expired,
+    Unavailable,
+}
+
+#[derive(Debug)]
+pub(crate) struct CodexPaneBusySignalTracker {
+    last_marker: Option<String>,
+    last_marker_changed_at: Option<std::time::Instant>,
+    freshness: std::time::Duration,
+}
+
+impl Default for CodexPaneBusySignalTracker {
+    fn default() -> Self {
+        Self::with_freshness(CODEX_ACTIVE_TURN_SIGNAL_FRESHNESS)
+    }
+}
+
+impl CodexPaneBusySignalTracker {
+    fn with_freshness(freshness: std::time::Duration) -> Self {
+        Self {
+            last_marker: None,
+            last_marker_changed_at: None,
+            freshness,
+        }
+    }
+
+    pub(crate) fn probe_tmux(&mut self, session_name: &str) -> CodexPaneBusySignal {
+        let Some(pane) = crate::services::platform::tmux::capture_pane(session_name, -80) else {
+            return CodexPaneBusySignal::Unavailable;
+        };
+        self.observe_capture_at(&pane, std::time::Instant::now())
+    }
+
+    fn observe_capture_at(
+        &mut self,
+        pane: &str,
+        observed_at: std::time::Instant,
+    ) -> CodexPaneBusySignal {
+        let Some(marker) = recent_codex_active_turn_marker(pane) else {
+            self.last_marker = None;
+            self.last_marker_changed_at = None;
+            return CodexPaneBusySignal::Idle;
+        };
+
+        if self.last_marker.as_deref() != Some(marker.as_str()) {
+            self.last_marker = Some(marker);
+            self.last_marker_changed_at = Some(observed_at);
+            return CodexPaneBusySignal::Fresh;
+        }
+
+        if self
+            .last_marker_changed_at
+            .is_some_and(|changed_at| observed_at.duration_since(changed_at) <= self.freshness)
+        {
+            CodexPaneBusySignal::Fresh
+        } else {
+            CodexPaneBusySignal::Expired
+        }
+    }
+}
+
+fn recent_codex_active_turn_marker(pane: &str) -> Option<String> {
     let recent: Vec<&str> = pane
         .lines()
         .map(str::trim_end)
@@ -1404,7 +1475,11 @@ fn pane_has_codex_active_turn_in_pane(pane: &str) -> bool {
         .rev()
         .take(PROMPT_READY_SCAN_LINES)
         .collect();
-    recent_has_codex_active_turn(&recent)
+    recent
+        .iter()
+        .take(6)
+        .find(|line| line_is_codex_active_turn_marker(line))
+        .map(|line| line.trim().to_string())
 }
 
 fn pane_has_dim_legacy_codex_prompt_in_pane(pane: &str) -> bool {
@@ -1486,11 +1561,13 @@ fn recent_has_codex_active_turn(recent_bottom_up: &[&str]) -> bool {
     recent_bottom_up
         .iter()
         .take(ACTIVE_TURN_BOTTOM_WINDOW)
-        .any(|line| {
-            let trimmed = line.trim_start();
-            (trimmed.starts_with('•') || trimmed.starts_with('◦'))
-                && (trimmed.contains("esc to interrupt") || trimmed.contains("Esc to interrupt"))
-        })
+        .any(|line| line_is_codex_active_turn_marker(line))
+}
+
+fn line_is_codex_active_turn_marker(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    (trimmed.starts_with('•') || trimmed.starts_with('◦'))
+        && (trimmed.contains("esc to interrupt") || trimmed.contains("Esc to interrupt"))
 }
 
 fn line_is_codex_status_with_ansi(line: &str) -> bool {
@@ -2405,6 +2482,38 @@ more output\n\
     fn codex_pane_with_composer_and_footer_is_ready() {
         assert!(pane_looks_ready_for_codex_prompt(CODEX_TUI_READY_PANE));
         assert!(!pane_has_codex_prompt_draft(CODEX_TUI_READY_PANE));
+    }
+
+    #[test]
+    fn codex_pane_busy_signal_expires_when_marker_stops_changing() {
+        let started_at = std::time::Instant::now();
+        let mut tracker =
+            CodexPaneBusySignalTracker::with_freshness(std::time::Duration::from_millis(100));
+        let busy = "• Working (5m 00s • esc to interrupt)";
+
+        assert_eq!(
+            tracker.observe_capture_at(busy, started_at),
+            CodexPaneBusySignal::Fresh
+        );
+        assert_eq!(
+            tracker.observe_capture_at(busy, started_at + std::time::Duration::from_millis(50)),
+            CodexPaneBusySignal::Fresh
+        );
+        assert_eq!(
+            tracker.observe_capture_at(busy, started_at + std::time::Duration::from_millis(101)),
+            CodexPaneBusySignal::Expired
+        );
+        assert_eq!(
+            tracker.observe_capture_at(
+                "• Working (5m 01s • esc to interrupt)",
+                started_at + std::time::Duration::from_millis(102),
+            ),
+            CodexPaneBusySignal::Fresh
+        );
+        assert_eq!(
+            tracker.observe_capture_at(CODEX_TUI_READY_PANE, started_at),
+            CodexPaneBusySignal::Idle
+        );
     }
 
     #[test]

--- a/src/services/codex_tui/rollout_tail.rs
+++ b/src/services/codex_tui/rollout_tail.rs
@@ -80,7 +80,6 @@ pub struct CodexTuiTailResult {
     pub session_id: Option<String>,
 }
 
-#[derive(Debug, Clone)]
 pub struct RolloutTailOptions {
     pub wait_for_rollout: Duration,
     pub terminal_drain: Duration,
@@ -122,6 +121,10 @@ pub struct RolloutTailOptions {
     /// the tail keeps a turn-local copy until the matching rollout user
     /// message is observed.
     pub discord_origin_prompt: Option<String>,
+    /// Optional pane-busy probe. Only `Fresh` vetoes the pending-tool recovery
+    /// Done; idle, expired, and unavailable evidence preserve the legacy
+    /// fail-open completion behavior.
+    pub pane_busy_probe: Option<Box<dyn FnMut() -> super::input::CodexPaneBusySignal + Send>>,
 }
 
 impl Default for RolloutTailOptions {
@@ -140,6 +143,7 @@ impl Default for RolloutTailOptions {
             apply_pending_tool_deadline_without_assistant_text: true,
             tmux_session_name: None,
             discord_origin_prompt: None,
+            pane_busy_probe: None,
         }
     }
 }
@@ -163,6 +167,14 @@ pub(crate) fn rollout_file_matches_cwd(rollout_path: &Path, cwd: &Path) -> bool 
     rollout_session_cwd_matches(rollout_path, &canonical_cwd)
 }
 
+fn pane_busy_probe_for_tmux(
+    tmux_session_name: &str,
+) -> Box<dyn FnMut() -> super::input::CodexPaneBusySignal + Send> {
+    let tmux_session_name = tmux_session_name.to_string();
+    let mut tracker = super::input::CodexPaneBusySignalTracker::default();
+    Box::new(move || tracker.probe_tmux(&tmux_session_name))
+}
+
 pub fn tail_latest_rollout_for_cwd_with_handoff_for_tmux(
     cwd: &Path,
     modified_since: SystemTime,
@@ -175,6 +187,7 @@ pub fn tail_latest_rollout_for_cwd_with_handoff_for_tmux(
     let mut options = RolloutTailOptions::default();
     options.tmux_session_name = Some(tmux_session_name.to_string());
     options.discord_origin_prompt = discord_origin_prompt.map(ToString::to_string);
+    options.pane_busy_probe = Some(pane_busy_probe_for_tmux(tmux_session_name));
     tail_latest_rollout_for_cwd_with_handoff_options(
         cwd,
         modified_since,
@@ -211,21 +224,14 @@ fn tail_latest_rollout_for_cwd_with_handoff_options(
         rollout_session_id.as_deref(),
         Some(0),
     );
-    tail_rollout_file_until_assistant_response(
+    tail_rollout_file_until_assistant_response_with_pane_busy_probe(
         &rollout_path,
         0,
         None,
         &sender,
         cancel_token,
         is_alive,
-        options.terminal_drain,
-        options.assistant_response_deadline,
-        options.pending_tool_call_deadline,
-        options.enable_task_complete_fast_path,
-        options.legacy_terminal_drain,
-        options.apply_pending_tool_deadline_without_assistant_text,
-        options.tmux_session_name,
-        options.discord_origin_prompt,
+        options,
     )
     .map(|(read_result, outcome)| CodexTuiTailResult {
         read_result,
@@ -273,22 +279,56 @@ pub fn tail_rollout_file_from_offset(
     cancel_token: Option<Arc<CancelToken>>,
     is_alive: impl FnMut() -> bool,
 ) -> Result<ReadOutputResult, String> {
-    let defaults = RolloutTailOptions::default();
-    tail_rollout_file_until_assistant_response(
+    tail_rollout_file_from_offset_with_pane_busy_probe(
+        rollout_path,
+        start_offset,
+        session_id,
+        sender,
+        cancel_token,
+        is_alive,
+        None,
+    )
+}
+
+pub fn tail_rollout_file_from_offset_for_tmux(
+    rollout_path: &Path,
+    start_offset: u64,
+    session_id: Option<&str>,
+    sender: Sender<StreamMessage>,
+    cancel_token: Option<Arc<CancelToken>>,
+    is_alive: impl FnMut() -> bool,
+    tmux_session_name: &str,
+) -> Result<ReadOutputResult, String> {
+    tail_rollout_file_from_offset_with_pane_busy_probe(
+        rollout_path,
+        start_offset,
+        session_id,
+        sender,
+        cancel_token,
+        is_alive,
+        Some(pane_busy_probe_for_tmux(tmux_session_name)),
+    )
+}
+
+fn tail_rollout_file_from_offset_with_pane_busy_probe(
+    rollout_path: &Path,
+    start_offset: u64,
+    session_id: Option<&str>,
+    sender: Sender<StreamMessage>,
+    cancel_token: Option<Arc<CancelToken>>,
+    is_alive: impl FnMut() -> bool,
+    pane_busy_probe: Option<Box<dyn FnMut() -> super::input::CodexPaneBusySignal + Send>>,
+) -> Result<ReadOutputResult, String> {
+    let mut defaults = RolloutTailOptions::default();
+    defaults.pane_busy_probe = pane_busy_probe;
+    tail_rollout_file_until_assistant_response_with_pane_busy_probe(
         rollout_path,
         start_offset,
         session_id.map(ToString::to_string),
         &sender,
         cancel_token,
         is_alive,
-        defaults.terminal_drain,
-        defaults.assistant_response_deadline,
-        defaults.pending_tool_call_deadline,
-        defaults.enable_task_complete_fast_path,
-        defaults.legacy_terminal_drain,
-        defaults.apply_pending_tool_deadline_without_assistant_text,
-        defaults.tmux_session_name,
-        defaults.discord_origin_prompt,
+        defaults,
     )
     .map(|result| result.0)
 }
@@ -320,23 +360,17 @@ pub fn tail_warm_followup_rollout_for_tmux(
     let options = RolloutTailOptions {
         tmux_session_name: Some(tmux_session_name.to_string()),
         discord_origin_prompt: Some(discord_origin_prompt.to_string()),
+        pane_busy_probe: Some(pane_busy_probe_for_tmux(tmux_session_name)),
         ..RolloutTailOptions::default()
     };
-    tail_rollout_file_until_assistant_response(
+    tail_rollout_file_until_assistant_response_with_pane_busy_probe(
         rollout_path,
         start_offset,
         Some(session_id.to_string()),
         &sender,
         cancel_token,
         is_alive,
-        options.terminal_drain,
-        options.assistant_response_deadline,
-        options.pending_tool_call_deadline,
-        options.enable_task_complete_fast_path,
-        options.legacy_terminal_drain,
-        options.apply_pending_tool_deadline_without_assistant_text,
-        options.tmux_session_name,
-        options.discord_origin_prompt,
+        options,
     )
     .map(|(read_result, outcome)| CodexTuiTailResult {
         read_result,
@@ -364,6 +398,7 @@ pub fn tail_resumed_rollout_for_session_with_handoff_for_tmux(
     let mut options = RolloutTailOptions::default();
     options.tmux_session_name = Some(tmux_session_name.to_string());
     options.discord_origin_prompt = discord_origin_prompt.map(ToString::to_string);
+    options.pane_busy_probe = Some(pane_busy_probe_for_tmux(tmux_session_name));
     tail_resumed_rollout_for_session_with_handoff_options(
         cwd,
         session_id,
@@ -445,21 +480,14 @@ fn tail_resumed_rollout_for_session_with_handoff_options(
         Some(start_offset),
     );
     let known_session_id = (start_offset > 0).then(|| session_id.to_string());
-    tail_rollout_file_until_assistant_response(
+    tail_rollout_file_until_assistant_response_with_pane_busy_probe(
         &rollout_path,
         start_offset,
         known_session_id,
         &sender,
         cancel_token,
         is_alive,
-        options.terminal_drain,
-        options.assistant_response_deadline,
-        options.pending_tool_call_deadline,
-        options.enable_task_complete_fast_path,
-        options.legacy_terminal_drain,
-        options.apply_pending_tool_deadline_without_assistant_text,
-        options.tmux_session_name,
-        options.discord_origin_prompt,
+        options,
     )
     .map(|(read_result, outcome)| CodexTuiTailResult {
         read_result,
@@ -761,7 +789,7 @@ fn tail_rollout_file_until_assistant_response(
     initial_session_id: Option<String>,
     sender: &Sender<StreamMessage>,
     cancel_token: Option<Arc<CancelToken>>,
-    mut is_alive: impl FnMut() -> bool,
+    is_alive: impl FnMut() -> bool,
     terminal_drain: Duration,
     assistant_response_deadline: Option<Duration>,
     pending_tool_call_deadline: Option<Duration>,
@@ -771,6 +799,48 @@ fn tail_rollout_file_until_assistant_response(
     tmux_session_name: Option<String>,
     discord_origin_prompt: Option<String>,
 ) -> Result<(ReadOutputResult, RolloutTailOutcome), String> {
+    tail_rollout_file_until_assistant_response_with_pane_busy_probe(
+        rollout_path,
+        start_offset,
+        initial_session_id,
+        sender,
+        cancel_token,
+        is_alive,
+        RolloutTailOptions {
+            terminal_drain,
+            assistant_response_deadline,
+            pending_tool_call_deadline,
+            enable_task_complete_fast_path,
+            legacy_terminal_drain,
+            apply_pending_tool_deadline_without_assistant_text,
+            tmux_session_name,
+            discord_origin_prompt,
+            ..RolloutTailOptions::default()
+        },
+    )
+}
+
+fn tail_rollout_file_until_assistant_response_with_pane_busy_probe(
+    rollout_path: &Path,
+    start_offset: u64,
+    initial_session_id: Option<String>,
+    sender: &Sender<StreamMessage>,
+    cancel_token: Option<Arc<CancelToken>>,
+    mut is_alive: impl FnMut() -> bool,
+    options: RolloutTailOptions,
+) -> Result<(ReadOutputResult, RolloutTailOutcome), String> {
+    let RolloutTailOptions {
+        terminal_drain,
+        assistant_response_deadline,
+        pending_tool_call_deadline,
+        enable_task_complete_fast_path,
+        legacy_terminal_drain,
+        apply_pending_tool_deadline_without_assistant_text,
+        tmux_session_name,
+        discord_origin_prompt,
+        mut pane_busy_probe,
+        ..
+    } = options;
     let mut file = std::fs::File::open(rollout_path)
         .map_err(|error| format!("open Codex rollout {}: {error}", rollout_path.display()))?;
     let file_len = file
@@ -888,6 +958,22 @@ fn tail_rollout_file_until_assistant_response(
                     && let Some(deadline) = pending_tool_call_deadline
                     && last_output_at.is_some_and(|at| at.elapsed() >= deadline)
                 {
+                    let busy_signal = pane_busy_probe
+                        .as_mut()
+                        .map_or(super::input::CodexPaneBusySignal::Unavailable, |probe| {
+                            probe()
+                        });
+                    if busy_signal == super::input::CodexPaneBusySignal::Fresh {
+                        last_output_at = Some(Instant::now());
+                        tracing::debug!(
+                            rollout_path = %rollout_path.display(),
+                            pending_keyed = state.pending_tool_calls.len(),
+                            pending_unkeyed = state.pending_tool_calls_unkeyed,
+                            "Codex rollout tail kept pending tool call open because the pane busy signal is fresh"
+                        );
+                        continue;
+                    }
+
                     let elapsed_secs = last_output_at
                         .map(|at| at.elapsed().as_secs())
                         .unwrap_or_default();
@@ -1811,6 +1897,7 @@ mod tests {
                 apply_pending_tool_deadline_without_assistant_text: true,
                 tmux_session_name: None,
                 discord_origin_prompt: None,
+                pane_busy_probe: None,
             },
         )
         .unwrap();
@@ -1872,6 +1959,7 @@ mod tests {
                 apply_pending_tool_deadline_without_assistant_text: true,
                 tmux_session_name: None,
                 discord_origin_prompt: None,
+                pane_busy_probe: None,
             },
         )
         .unwrap();
@@ -2772,6 +2860,135 @@ mod tests {
                 "slow launch prompt",
             ),
             crate::services::tui_prompt_dedupe::PromptObservation::SuppressedRecentDuplicate
+        );
+    }
+
+    fn pending_tool_rollout() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let rollout = dir.path().join("rollout-stuck.jsonl");
+        std::fs::write(
+            &rollout,
+            concat!(
+                r#"{"type":"session_meta","payload":{"id":"stuck-tool","cwd":"/tmp/repo"}}"#,
+                "\n",
+                r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}}"#,
+                "\n",
+                r#"{"type":"response_item","payload":{"type":"function_call","name":"never_returns","arguments":"{}","call_id":"c-stuck"}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        (dir, rollout)
+    }
+
+    #[test]
+    fn fresh_pane_busy_signal_vetoes_pending_tool_deadline_done() {
+        let (_dir, rollout) = pending_tool_rollout();
+        let (tx, rx) = mpsc::channel();
+        let (cancel_tx, cancel_rx) = mpsc::channel();
+        let path = rollout.clone();
+        let handle = std::thread::spawn(move || {
+            tail_rollout_file_until_assistant_response_with_pane_busy_probe(
+                &path,
+                0,
+                None,
+                &tx,
+                None,
+                || true,
+                RolloutTailOptions {
+                    terminal_drain: Duration::from_secs(60),
+                    assistant_response_deadline: Some(Duration::from_secs(60)),
+                    pending_tool_call_deadline: Some(Duration::from_millis(100)),
+                    legacy_terminal_drain: None,
+                    pane_busy_probe: Some(Box::new(move || {
+                        if cancel_rx.try_recv().is_ok() {
+                            super::super::input::CodexPaneBusySignal::Idle
+                        } else {
+                            super::super::input::CodexPaneBusySignal::Fresh
+                        }
+                    })),
+                    ..RolloutTailOptions::default()
+                },
+            )
+        });
+
+        std::thread::sleep(Duration::from_millis(250));
+        let early = rx.try_iter().collect::<Vec<_>>();
+        assert!(
+            early
+                .iter()
+                .all(|message| !matches!(message, StreamMessage::Done { .. })),
+            "fresh pane-busy evidence must veto deadline Done: {early:?}"
+        );
+
+        cancel_tx.send(()).unwrap();
+        let (result, _outcome) = handle.join().unwrap().unwrap();
+        assert!(matches!(result, ReadOutputResult::Completed { .. }));
+        assert!(
+            rx.iter()
+                .any(|message| matches!(message, StreamMessage::Done { .. }))
+        );
+    }
+
+    #[test]
+    fn idle_pane_signal_allows_pending_tool_deadline_done() {
+        let (_dir, rollout) = pending_tool_rollout();
+        let (tx, rx) = mpsc::channel();
+        let (result, _outcome) = tail_rollout_file_until_assistant_response_with_pane_busy_probe(
+            &rollout,
+            0,
+            None,
+            &tx,
+            None,
+            || true,
+            RolloutTailOptions {
+                terminal_drain: Duration::from_secs(60),
+                assistant_response_deadline: Some(Duration::from_secs(60)),
+                pending_tool_call_deadline: Some(Duration::from_millis(100)),
+                legacy_terminal_drain: None,
+                pane_busy_probe: Some(Box::new(|| super::super::input::CodexPaneBusySignal::Idle)),
+                ..RolloutTailOptions::default()
+            },
+        )
+        .unwrap();
+        drop(tx);
+
+        assert!(matches!(result, ReadOutputResult::Completed { .. }));
+        assert!(
+            rx.iter()
+                .any(|message| matches!(message, StreamMessage::Done { .. }))
+        );
+    }
+
+    #[test]
+    fn expired_pane_busy_signal_allows_pending_tool_deadline_done() {
+        let (_dir, rollout) = pending_tool_rollout();
+        let (tx, rx) = mpsc::channel();
+        let (result, _outcome) = tail_rollout_file_until_assistant_response_with_pane_busy_probe(
+            &rollout,
+            0,
+            None,
+            &tx,
+            None,
+            || true,
+            RolloutTailOptions {
+                terminal_drain: Duration::from_secs(60),
+                assistant_response_deadline: Some(Duration::from_secs(60)),
+                pending_tool_call_deadline: Some(Duration::from_millis(100)),
+                legacy_terminal_drain: None,
+                pane_busy_probe: Some(Box::new(|| {
+                    super::super::input::CodexPaneBusySignal::Expired
+                })),
+                ..RolloutTailOptions::default()
+            },
+        )
+        .unwrap();
+        drop(tx);
+
+        assert!(matches!(result, ReadOutputResult::Completed { .. }));
+        assert!(
+            rx.iter()
+                .any(|message| matches!(message, StreamMessage::Done { .. }))
         );
     }
 

--- a/src/services/discord/recovery_engine/rebind_runtime.rs
+++ b/src/services/discord/recovery_engine/rebind_runtime.rs
@@ -475,7 +475,7 @@ pub(super) fn spawn_codex_tui_rebind_relay_output(
             let tail_handle = std::thread::Builder::new()
                 .name("codex_tui_rebind_rollout_tail".to_string())
                 .spawn(move || {
-                    crate::services::codex_tui::rollout_tail::tail_rollout_file_from_offset(
+                    crate::services::codex_tui::rollout_tail::tail_rollout_file_from_offset_for_tmux(
                         &tail_rollout_path,
                         raw_start_offset,
                         tail_session_id.as_deref(),
@@ -488,6 +488,7 @@ pub(super) fn spawn_codex_tui_rebind_relay_output(
                                     &tail_tmux_session_name,
                                 )
                         },
+                        &tail_tmux_session_name,
                     )
                 });
 

--- a/src/services/discord/tui_prompt_relay/codex_idle_rollout.rs
+++ b/src/services/discord/tui_prompt_relay/codex_idle_rollout.rs
@@ -424,7 +424,7 @@ async fn run_codex_idle_response_tail(
         .name("codex_idle_response_tail_reader".to_string())
         .spawn(move || {
             let read_result =
-                crate::services::codex_tui::rollout_tail::tail_rollout_file_from_offset(
+                crate::services::codex_tui::rollout_tail::tail_rollout_file_from_offset_for_tmux(
                     &rollout_for_reader,
                     start_offset,
                     None,
@@ -435,6 +435,7 @@ async fn run_codex_idle_response_tail(
                             &tmux_for_reader,
                         )
                     },
+                    &tmux_for_reader,
                 )
                 .map(|result| match result {
                     ReadOutputResult::Completed { offset }
@@ -571,14 +572,16 @@ fn collect_codex_idle_response(
     tmux_session_name: String,
 ) -> Result<(String, u64), String> {
     let (tx, rx) = mpsc::channel();
-    let read_result = crate::services::codex_tui::rollout_tail::tail_rollout_file_from_offset(
-        &rollout_path,
-        start_offset,
-        None,
-        tx,
-        None,
-        || crate::services::tmux_diagnostics::tmux_session_has_live_pane(&tmux_session_name),
-    )?;
+    let read_result =
+        crate::services::codex_tui::rollout_tail::tail_rollout_file_from_offset_for_tmux(
+            &rollout_path,
+            start_offset,
+            None,
+            tx,
+            None,
+            || crate::services::tmux_diagnostics::tmux_session_has_live_pane(&tmux_session_name),
+            &tmux_session_name,
+        )?;
 
     let mut streamed = String::new();
     let mut done_result: Option<String> = None;


### PR DESCRIPTION
## Summary
- veto pending tool-call deadline `Done` while the Codex pane reports a fresh foreground busy marker
- expire unchanged busy evidence after 90 seconds and fail open for idle, expired, or unavailable pane captures
- wire the probe through fresh, resumed, warm-followup, recovery-rebind, and idle-rollout tmux tails
- add explicit fresh/idle/expired regression coverage and marker freshness tracking tests

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo check --lib`
- [x] Codex rollout tail suite (61 passed)
- [x] Codex input suite (73 passed)
- [x] Codex idle rollout suite (5 passed)
- [x] completion gate suite (62 passed)
- [x] tmux watcher suite (7 passed)
- [x] mutation: disabling the fresh-busy veto makes its assertion fail; restoring it passes
- [x] inventory, agent-maintenance, maintainability, test-lane, blind-save, and `ci-script-checks.sh`

No auto-merge is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)