### PR TITLE
feat(#4219): structure commands/ panel logs (slice 1/N)

### DIFF
--- a/src/services/discord/commands/config.rs
+++ b/src/services/discord/commands/config.rs
@@ -685,8 +685,7 @@ pub(in crate::services::discord) async fn cmd_allowedtools(ctx: Context<'_>) -> 
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /allowedtools");
+    log_command_received!(ctx.channel_id().get(), user_name, "/allowedtools");
 
     let tools = {
         let settings = ctx.data().shared.settings.read().await;
@@ -731,8 +730,7 @@ pub(in crate::services::discord) async fn cmd_allowed(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /allowed {action}");
+    log_command_received!(ctx.channel_id().get(), user_name, "/allowed", action = %action);
 
     let arg = action.trim();
     let (op, raw_name) = if let Some(name) = arg.strip_prefix('+') {
@@ -815,8 +813,7 @@ pub(in crate::services::discord) async fn cmd_adduser(
     let target_id = user.id.get();
     let target_name = &user.name;
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{author_name}] /adduser {target_name}");
+    log_command_received!(ctx.channel_id().get(), author_name, "/adduser", target_user = %target_name);
 
     {
         let mut settings = ctx.data().shared.settings.write().await;
@@ -831,7 +828,13 @@ pub(in crate::services::discord) async fn cmd_adduser(
 
     ctx.say(format!("Added `{}` as authorized user.", target_name))
         .await?;
-    tracing::info!("  [{ts}] ▶ Added user: {target_name} (id:{target_id})");
+    log_info_event!(
+        "discord_user_access_added",
+        channel_id = ctx.channel_id().get(),
+        user_id = target_id,
+        user_name = %target_name,
+        status = "added",
+    );
     Ok(())
 }
 
@@ -861,8 +864,7 @@ pub(in crate::services::discord) async fn cmd_removeuser(
     let target_id = user.id.get();
     let target_name = &user.name;
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{author_name}] /removeuser {target_name}");
+    log_command_received!(ctx.channel_id().get(), author_name, "/removeuser", target_user = %target_name);
 
     {
         let mut settings = ctx.data().shared.settings.write().await;
@@ -878,7 +880,13 @@ pub(in crate::services::discord) async fn cmd_removeuser(
 
     ctx.say(format!("Removed `{}` from authorized users.", target_name))
         .await?;
-    tracing::info!("  [{ts}] ▶ Removed user: {target_name} (id:{target_id})");
+    log_info_event!(
+        "discord_user_access_removed",
+        channel_id = ctx.channel_id().get(),
+        user_id = target_id,
+        user_name = %target_name,
+        status = "removed",
+    );
     Ok(())
 }
 
@@ -905,8 +913,12 @@ pub(in crate::services::discord) async fn cmd_allowall(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{author_name}] /allowall {enabled}");
+    log_command_received!(
+        ctx.channel_id().get(),
+        author_name,
+        "/allowall",
+        enabled = enabled
+    );
 
     let response = {
         let mut settings = ctx.data().shared.settings.write().await;
@@ -929,7 +941,11 @@ pub(in crate::services::discord) async fn cmd_allowall(
     let policy_note = build_allowall_policy_note();
     let combined = format!("{response}\n\n{policy_note}");
     ctx.say(&combined).await?;
-    tracing::info!("  [{ts}] ▶ {response}");
+    log_info_event!(
+        "discord_public_access_changed",
+        channel_id = ctx.channel_id().get(),
+        status = if enabled { "enabled" } else { "disabled" },
+    );
     Ok(())
 }
 

--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -504,8 +504,7 @@ pub(in crate::services::discord) async fn cmd_stop(ctx: Context<'_>) -> Result<(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /stop");
+    log_command_received!(ctx.channel_id().get(), user_name, "/stop");
 
     let channel_id = ctx.channel_id();
     let forward_context =
@@ -522,7 +521,12 @@ pub(in crate::services::discord) async fn cmd_stop(ctx: Context<'_>) -> Result<(
     {
         Ok(Some(_)) => {
             ctx.say(super::STOPPING_RESPONSE).await?;
-            tracing::info!("  [{ts}] ■ Remote cancel acknowledged");
+            log_info_event!(
+                "discord_cancel_acknowledged",
+                channel_id = channel_id.get(),
+                provider = ctx.data().provider.as_str(),
+                status = "acknowledged",
+            );
             return Ok(());
         }
         Ok(None) => {}
@@ -571,7 +575,12 @@ pub(in crate::services::discord) async fn cmd_stop(ctx: Context<'_>) -> Result<(
                 "/stop",
             )
             .await;
-            tracing::info!("  [{ts}] ■ Cancel signal sent");
+            log_info_event!(
+                "discord_cancel_signal_sent",
+                channel_id = channel_id.get(),
+                provider = ctx.data().provider.as_str(),
+                status = "sent",
+            );
         }
         None => {
             ctx.say(super::NO_ACTIVE_TURN_RESPONSE).await?;
@@ -645,8 +654,7 @@ pub(in crate::services::discord) async fn cmd_clear(ctx: Context<'_>) -> Result<
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /clear");
+    log_command_received!(ctx.channel_id().get(), user_name, "/clear");
 
     let http = ctx.serenity_context().http.clone();
     clear_channel_session_state(
@@ -660,7 +668,13 @@ pub(in crate::services::discord) async fn cmd_clear(ctx: Context<'_>) -> Result<
     .await?;
 
     ctx.say(super::SESSION_CLEARED_RESPONSE).await?;
-    tracing::info!("  [{ts}] ▶ [{user_name}] Session cleared");
+    log_info_event!(
+        "discord_session_cleared",
+        channel_id = ctx.channel_id().get(),
+        provider = ctx.data().provider.as_str(),
+        user_name = %user_name,
+        status = "cleared",
+    );
     Ok(())
 }
 
@@ -744,8 +758,7 @@ pub(in crate::services::discord) async fn cmd_down(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /down {file}");
+    log_command_received!(ctx.channel_id().get(), user_name, "/down", path = %file);
 
     let file_path = file.trim();
     if file_path.is_empty() {
@@ -810,9 +823,8 @@ pub(in crate::services::discord) async fn cmd_shell(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
     let preview = truncate_str(&command, 60);
-    tracing::info!("  [{ts}] ◀ [{user_name}] /shell {preview}");
+    log_command_received!(ctx.channel_id().get(), user_name, "/shell", command_preview = %preview);
 
     // Defer for potentially long-running commands
     ctx.defer().await?;
@@ -877,7 +889,12 @@ pub(in crate::services::discord) async fn cmd_shell(
     };
 
     send_long_message_ctx(ctx, &response).await?;
-    tracing::info!("  [{ts}] ▶ [{user_name}] Shell done");
+    log_info_event!(
+        "discord_shell_command_completed",
+        channel_id = ctx.channel_id().get(),
+        user_name = %user_name,
+        status = "completed",
+    );
     Ok(())
 }
 

--- a/src/services/discord/commands/diagnostics/mod.rs
+++ b/src/services/discord/commands/diagnostics/mod.rs
@@ -67,8 +67,7 @@ pub(in crate::services::discord) async fn cmd_metrics(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /metrics");
+    log_command_received!(ctx.channel_id().get(), user_name, "/metrics");
 
     let data = match &date {
         Some(d) => metrics::load_date(d),
@@ -89,8 +88,7 @@ pub(in crate::services::discord) async fn cmd_health(ctx: Context<'_>) -> Result
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /health");
+    log_command_received!(ctx.channel_id().get(), user_name, "/health");
 
     let text =
         build_health_report(&ctx.data().shared, &ctx.data().provider, ctx.channel_id()).await;
@@ -107,8 +105,7 @@ pub(in crate::services::discord) async fn cmd_sessions(ctx: Context<'_>) -> Resu
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /sessions");
+    log_command_received!(ctx.channel_id().get(), user_name, "/sessions");
 
     if ctx.data().provider != ProviderKind::Gemini {
         ctx.say("`/sessions` is currently supported only when the active provider is Gemini.")
@@ -152,8 +149,7 @@ pub(in crate::services::discord) async fn cmd_status(ctx: Context<'_>) -> Result
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /status");
+    log_command_received!(ctx.channel_id().get(), user_name, "/status");
 
     let text =
         build_status_report(&ctx.data().shared, &ctx.data().provider, ctx.channel_id()).await;
@@ -178,10 +174,11 @@ pub(in crate::services::discord) async fn cmd_deletesession(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!(
-        "  [{ts}] ◀ [{user_name}] /deletesession identifier={}",
-        identifier
+    log_command_received!(
+        ctx.channel_id().get(),
+        user_name,
+        "/deletesession",
+        session_identifier = %identifier
     );
 
     if ctx.data().provider != ProviderKind::Gemini {
@@ -258,8 +255,7 @@ pub(in crate::services::discord) async fn cmd_inflight(ctx: Context<'_>) -> Resu
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /inflight");
+    log_command_received!(ctx.channel_id().get(), user_name, "/inflight");
 
     let text =
         build_inflight_report(&ctx.data().shared, &ctx.data().provider, ctx.channel_id()).await;
@@ -279,8 +275,7 @@ pub(in crate::services::discord) async fn cmd_queue(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /queue");
+    log_command_received!(ctx.channel_id().get(), user_name, "/queue");
 
     let show_all = all.unwrap_or(false);
     let text = build_queue_report(
@@ -311,8 +306,7 @@ pub(in crate::services::discord) async fn cmd_adk_phase(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /adk-phase");
+    log_command_received!(ctx.channel_id().get(), user_name, "/adk-phase");
 
     let detailed = details.unwrap_or(false);
     let text = build_adk_phase_report(&ctx.data().shared, detailed).await;
@@ -378,12 +372,15 @@ pub(in crate::services::discord) async fn cmd_debug(ctx: Context<'_>) -> Result<
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /debug");
+    log_command_received!(ctx.channel_id().get(), user_name, "/debug");
 
     let new_state = claude::toggle_debug();
     let status = if new_state { "ON" } else { "OFF" };
     ctx.say(format!("Debug logging: **{}**", status)).await?;
-    tracing::info!("  [{ts}] ▶ Debug logging toggled to {status}");
+    log_info_event!(
+        "discord_debug_logging_changed",
+        channel_id = ctx.channel_id().get(),
+        status = status,
+    );
     Ok(())
 }

--- a/src/services/discord/commands/fast_mode.rs
+++ b/src/services/discord/commands/fast_mode.rs
@@ -36,8 +36,7 @@ pub(in crate::services::discord) async fn cmd_fast(ctx: Context<'_>) -> Result<(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /fast");
+    log_command_received!(ctx.channel_id().get(), user_name, "/fast");
 
     let channel_id = ctx.channel_id();
     let channel_name_hint = fallback_channel_name_for_feature_toggle(ctx, channel_id).await;

--- a/src/services/discord/commands/goals.rs
+++ b/src/services/discord/commands/goals.rs
@@ -28,8 +28,7 @@ pub(in crate::services::discord) async fn cmd_goals(ctx: Context<'_>) -> Result<
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /goals");
+    log_command_received!(ctx.channel_id().get(), user_name, "/goals");
 
     let channel_id = ctx.channel_id();
     let channel_name_hint = fallback_channel_name_for_feature_toggle(ctx, channel_id).await;

--- a/src/services/discord/commands/inspect/mod.rs
+++ b/src/services/discord/commands/inspect/mod.rs
@@ -68,8 +68,12 @@ async fn cmd_adk_inspect(
     #[description = "View: last / session / prompt / context / recovery"] view: InspectView,
 ) -> Result<(), Error> {
     let user_name = &ctx.author().name;
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /adk inspect {}", view.as_str());
+    log_command_received!(
+        ctx.channel_id().get(),
+        user_name,
+        "/adk inspect",
+        view = view.as_str()
+    );
 
     ctx.defer().await?;
 

--- a/src/services/discord/commands/meeting_cmd.rs
+++ b/src/services/discord/commands/meeting_cmd.rs
@@ -16,10 +16,15 @@ pub(in crate::services::discord) async fn cmd_meeting(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
     let channel_id = ctx.channel_id();
     let agenda_str = agenda.as_deref().unwrap_or("");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /meeting {action} {agenda_str}");
+    log_command_received!(
+        channel_id.get(),
+        user_name,
+        "/meeting",
+        action = %action,
+        agenda = %agenda_str
+    );
 
     ctx.defer().await?;
 
@@ -63,13 +68,22 @@ pub(in crate::services::discord) async fn cmd_meeting(
                 .await
                 {
                     Ok(Some(id)) => {
-                        let ts = chrono::Local::now().format("%H:%M:%S");
-                        tracing::info!("  [{ts}] ✅ Meeting completed: {id}");
+                        log_info_event!(
+                            "discord_meeting_completed",
+                            channel_id = channel_id.get(),
+                            meeting_id = %id,
+                            status = "completed",
+                        );
                     }
                     Ok(None) => {}
                     Err(e) => {
-                        let ts = chrono::Local::now().format("%H:%M:%S");
-                        tracing::warn!("  [{ts}] ❌ Meeting error: {e}");
+                        tracing::warn!(
+                            event = "discord_meeting_failed",
+                            channel_id = channel_id.get(),
+                            reason = %e,
+                            status = "failed",
+                            "discord_meeting_failed"
+                        );
                         let _ = meeting::send_meeting_message(
                             &http,
                             channel_id,

--- a/src/services/discord/commands/mod.rs
+++ b/src/services/discord/commands/mod.rs
@@ -1,3 +1,21 @@
+macro_rules! log_command_received {
+    ($channel_id:expr, $user_name:expr, $command:expr $(, $($fields:tt)+)?) => {
+        log_info_event!(
+            "discord_command_received",
+            channel_id = $channel_id,
+            user_name = %$user_name,
+            command = %$command,
+            $($($fields)+,)?
+        );
+    };
+}
+
+macro_rules! log_info_event {
+    ($event:literal, $($fields:tt)*) => {
+        tracing::info!(event = $event, $($fields)* $event)
+    };
+}
+
 mod command_policy;
 mod config;
 mod control;
@@ -231,13 +249,15 @@ pub(in crate::services::discord) async fn enforce_slash_command_policy(
     let high_risk_enabled = high_risk_enabled_via_env();
     let decision = evaluate_policy(risk, is_owner, high_risk_enabled);
     if let Some(reply) = decision.denial_message(slash_cmd) {
-        let ts = chrono::Local::now().format("%H:%M:%S");
         tracing::warn!(
-            "  [{ts}] ⛔ CommandPolicy denied {} for {} (id:{}) — risk={:?}",
-            slash_cmd,
-            ctx.author().name,
-            ctx.author().id.get(),
-            risk,
+            event = "discord_command_denied",
+            channel_id = ctx.channel_id().get(),
+            user_id = ctx.author().id.get(),
+            user_name = %ctx.author().name,
+            command = slash_cmd,
+            reason = "command_policy",
+            risk = ?risk,
+            "discord_command_denied"
         );
         ctx.say(reply).await?;
         return Ok(false);

--- a/src/services/discord/commands/model_picker.rs
+++ b/src/services/discord/commands/model_picker.rs
@@ -124,11 +124,17 @@ async fn run_model_command(ctx: Context<'_>) -> Result<(), Error> {
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
     let channel_id = ctx.channel_id();
 
     if !provider_supports_model_override(&ctx.data().provider) {
-        tracing::info!("  [{ts}] ◀ [{user_name}] /model (unsupported provider)");
+        log_info_event!(
+            "discord_command_received",
+            channel_id = channel_id.get(),
+            user_name = %user_name,
+            command = "/model",
+            provider = ctx.data().provider.as_str(),
+            status = "unsupported",
+        );
         ctx.say(
             "Model override is only supported for Claude, Codex, Gemini, OpenCode, and Qwen channels.",
         )
@@ -136,7 +142,12 @@ async fn run_model_command(ctx: Context<'_>) -> Result<(), Error> {
         return Ok(());
     }
 
-    tracing::info!("  [{ts}] ◀ [{user_name}] /model");
+    log_command_received!(
+        channel_id.get(),
+        user_name,
+        "/model",
+        provider = ctx.data().provider.as_str()
+    );
     match resolve_channel_kind(ctx.serenity_context(), channel_id).await {
         Some(serenity::ChannelType::Forum) => {
             let posted = create_model_picker_forum_post(

--- a/src/services/discord/commands/node.rs
+++ b/src/services/discord/commands/node.rs
@@ -287,8 +287,7 @@ pub(in crate::services::discord) async fn cmd_node(ctx: Context<'_>) -> Result<(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /node");
+    log_command_received!(ctx.channel_id().get(), user_name, "/node");
 
     let intake_routing = effective_intake_routing_config();
     if !intake_routing_enforced(&intake_routing) {

--- a/src/services/discord/commands/receipt.rs
+++ b/src/services/discord/commands/receipt.rs
@@ -20,8 +20,7 @@ pub(in crate::services::discord) async fn cmd_receipt(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] \u{25c0} [{user_name}] /receipt");
+    log_command_received!(ctx.channel_id().get(), user_name, "/receipt");
 
     ctx.defer().await?;
 
@@ -117,7 +116,13 @@ pub(in crate::services::discord) async fn cmd_receipt(
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            tracing::warn!("  [{ts}] \u{2716} Playwright error for {label}: {stderr}");
+            tracing::warn!(
+                event = "discord_receipt_render_failed",
+                channel_id = ctx.channel_id().get(),
+                provider = %label,
+                reason = %stderr,
+                "discord_receipt_render_failed"
+            );
             continue;
         }
 
@@ -144,10 +149,13 @@ pub(in crate::services::discord) async fn cmd_receipt(
         let _ = std::fs::remove_file(f);
     }
 
-    tracing::info!(
-        "  [{ts}] \u{25b6} [{user_name}] Receipt sent ({} providers, total: {})",
-        to_render.len(),
-        receipt_fmt_cost(data.total)
+    log_info_event!(
+        "discord_receipt_sent",
+        channel_id = ctx.channel_id().get(),
+        user_name = %user_name,
+        provider_count = to_render.len(),
+        total_cost = %receipt_fmt_cost(data.total),
+        status = "completed",
     );
     Ok(())
 }
@@ -164,8 +172,7 @@ pub(in crate::services::discord) async fn cmd_usage(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] \u{25c0} [{user_name}] /usage");
+    log_command_received!(ctx.channel_id().get(), user_name, "/usage");
 
     ctx.defer().await?;
 

--- a/src/services/discord/commands/recovery_ops.rs
+++ b/src/services/discord/commands/recovery_ops.rs
@@ -248,10 +248,11 @@ async fn run_recovery(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!(
-        "  [{ts}] ◀ [{user_name}] {command_label} kind={:?}",
-        kind.name()
+    log_command_received!(
+        ctx.channel_id().get(),
+        user_name,
+        command_label,
+        recovery_kind = kind.name()
     );
 
     ctx.defer().await?;
@@ -314,7 +315,14 @@ async fn run_recovery(
     };
 
     send_long_message_ctx(ctx, &response).await?;
-    tracing::info!("  [{ts}] ▶ [{user_name}] {command_label} done");
+    log_info_event!(
+        "discord_recovery_command_completed",
+        channel_id = ctx.channel_id().get(),
+        user_name = %user_name,
+        command = %command_label,
+        recovery_kind = kind.name(),
+        status = "completed",
+    );
     Ok(())
 }
 

--- a/src/services/discord/commands/restart.rs
+++ b/src/services/discord/commands/restart.rs
@@ -179,8 +179,7 @@ async fn run_restart(ctx: Context<'_>, command_name: &'static str) -> Result<(),
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] {command_name}");
+    log_command_received!(ctx.channel_id().get(), user_name, command_name);
     ctx.say("♻ 세션 재시작 중...").await?;
 
     let channel_id = ctx.channel_id();
@@ -228,9 +227,13 @@ async fn run_restart(ctx: Context<'_>, command_name: &'static str) -> Result<(),
         &seed_status,
     ))
     .await?;
-    tracing::info!(
-        "  [{ts}] ▶ [{user_name}] {command_name} triggered (provider={}, seed_status={seed_status:?})",
-        ctx.data().provider.as_str()
+    log_info_event!(
+        "discord_restart_triggered",
+        channel_id = channel_id.get(),
+        user_name = %user_name,
+        command = %command_name,
+        provider = ctx.data().provider.as_str(),
+        status = ?seed_status,
     );
     Ok(())
 }

--- a/src/services/discord/commands/session.rs
+++ b/src/services/discord/commands/session.rs
@@ -21,8 +21,7 @@ pub(in crate::services::discord) async fn cmd_start(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /start path={:?}", path);
+    log_command_received!(ctx.channel_id().get(), user_name, "/start", path = ?path);
 
     let path_str = path.as_deref().unwrap_or("").trim();
 
@@ -83,11 +82,12 @@ pub(in crate::services::discord) async fn cmd_start(
             let ch = ch_name.as_deref().unwrap_or("unknown");
             match create_git_worktree(&canonical_path, ch, &provider_str) {
                 Ok((wt_path, branch)) => {
-                    let ts = chrono::Local::now().format("%H:%M:%S");
-                    tracing::info!(
-                        "  [{ts}] 🌿 Worktree conflict: {} already uses {}. Created worktree.",
-                        conflicting_channel,
-                        canonical_path
+                    log_info_event!(
+                        "discord_worktree_created",
+                        channel_id = ctx.channel_id().get(),
+                        conflicting_channel_id = conflicting_channel,
+                        path = %canonical_path,
+                        status = "created",
                     );
                     Some(WorktreeInfo {
                         original_path: canonical_path.clone(),
@@ -96,8 +96,12 @@ pub(in crate::services::discord) async fn cmd_start(
                     })
                 }
                 Err(e) => {
-                    let ts = chrono::Local::now().format("%H:%M:%S");
-                    tracing::info!("  [{ts}] 🌿 Worktree creation skipped: {e}");
+                    log_info_event!(
+                        "discord_worktree_creation_skipped",
+                        channel_id = ctx.channel_id().get(),
+                        reason = %e,
+                        status = "skipped",
+                    );
                     None
                 }
             }
@@ -154,14 +158,22 @@ pub(in crate::services::discord) async fn cmd_start(
         let has_existing_session = session.session_id.is_some();
 
         if has_existing_session {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ▶ Session restored: {effective_path}");
+            log_info_event!(
+                "discord_session_restored",
+                channel_id = channel_id.get(),
+                path = %effective_path,
+                status = "restored",
+            );
             response_lines.push(super::session_restored_response(&effective_path));
         } else {
             session.history.clear();
 
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ▶ Session started: {effective_path}");
+            log_info_event!(
+                "discord_session_started",
+                channel_id = channel_id.get(),
+                path = %effective_path,
+                status = "started",
+            );
             response_lines.push(super::session_started_response(&effective_path));
         }
 
@@ -218,8 +230,13 @@ pub(in crate::services::discord) async fn cmd_resume(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /resume session_id={session_id:?} cwd={cwd:?}");
+    log_command_received!(
+        ctx.channel_id().get(),
+        user_name,
+        "/resume",
+        provider_session_id = ?session_id,
+        cwd = ?cwd
+    );
 
     let shared = &ctx.data().shared;
     let provider = &ctx.data().provider;
@@ -296,8 +313,15 @@ pub(in crate::services::discord) async fn cmd_resume(
         }
         lines.push("다음 메시지부터 이 세션의 맥락으로 이어집니다.".to_string());
         send_long_message_ctx(ctx, &lines.join("\n")).await?;
-        tracing::info!(
-            "  [{ts}] ▶ [{user_name}] /resume rebound → {target_session_id} @ {target_cwd}"
+        log_info_event!(
+            "discord_session_rebound",
+            channel_id = channel_id.get(),
+            provider = provider.as_str(),
+            session_key = %session_key,
+            provider_session_id = target_session_id,
+            path = target_cwd,
+            user_name = %user_name,
+            status = "completed",
         );
     } else {
         let message = body
@@ -320,8 +344,7 @@ pub(in crate::services::discord) async fn cmd_pwd(ctx: Context<'_>) -> Result<()
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /pwd");
+    log_command_received!(ctx.channel_id().get(), user_name, "/pwd");
 
     // Auto-restore session
     auto_restore_session(&ctx.data().shared, ctx.channel_id(), ctx.serenity_context()).await;

--- a/src/services/discord/commands/sidecar.rs
+++ b/src/services/discord/commands/sidecar.rs
@@ -15,8 +15,7 @@ pub(in crate::services::discord) async fn cmd_sidecar(ctx: Context<'_>) -> Resul
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] /sidecar");
+    log_command_received!(ctx.channel_id().get(), user_name, "/sidecar");
 
     // Start with the host Mac pre-selected and its device list; selecting a
     // different Mac re-queries that Mac and re-renders the device dropdown.

--- a/src/services/discord/commands/skill.rs
+++ b/src/services/discord/commands/skill.rs
@@ -141,9 +141,14 @@ async fn run_skill_slash_command(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
     let args_str = args.as_deref().unwrap_or("");
-    tracing::info!("  [{ts}] ◀ [{user_name}] {invoked_as} {skill} {args_str}");
+    log_command_received!(
+        ctx.channel_id().get(),
+        user_name,
+        invoked_as,
+        skill = %skill,
+        args = %args_str
+    );
 
     // Handle built-in commands directly instead of sending to AI
     match skill.as_str() {
@@ -177,7 +182,12 @@ async fn run_skill_slash_command(
                         &format!("{invoked_as} stop"),
                     )
                     .await;
-                    tracing::info!("  [{ts}] ■ Cancel signal sent");
+                    log_info_event!(
+                        "discord_cancel_signal_sent",
+                        channel_id = ctx.channel_id().get(),
+                        provider = ctx.data().provider.as_str(),
+                        status = "sent",
+                    );
                 }
                 None => {
                     ctx.say(super::NO_ACTIVE_TURN_RESPONSE).await?;

--- a/src/services/discord/commands/text_commands.rs
+++ b/src/services/discord/commands/text_commands.rs
@@ -157,13 +157,15 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
         let high_risk_enabled = super::high_risk_enabled_via_env();
         let decision = super::evaluate_policy(risk, is_owner, high_risk_enabled);
         if let Some(reply) = decision.denial_message(cmd) {
-            let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::warn!(
-                "  [{ts}] ⛔ CommandPolicy denied {} for {} (id:{}) — risk={:?}",
-                cmd,
-                msg.author.name,
-                msg.author.id.get(),
-                risk,
+                event = "discord_command_denied",
+                channel_id = channel_id.get(),
+                user_id = msg.author.id.get(),
+                user_name = %msg.author.name,
+                command = cmd,
+                reason = "command_policy",
+                risk = ?risk,
+                "discord_command_denied"
             );
             let _ = msg.reply(&ctx.http, reply).await;
             return Ok(true);
@@ -217,12 +219,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                 return Ok(true);
             }
 
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!(
-                "  [{ts}] ◀ [{}] !start path={}",
-                msg.author.name,
-                effective_path
-            );
+            log_command_received!(channel_id.get(), msg.author.name, "!start", path = %effective_path);
 
             let (ch_name, cat_name) =
                 resolve_channel_category(&ctx.http, Some(&ctx.cache), channel_id).await;
@@ -253,8 +250,11 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                 session.last_active = tokio::time::Instant::now();
             }
 
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ▶ Session started: {}", effective_path);
+            log_info_event!(
+                "discord_session_started",
+                channel_id = channel_id.get(),
+                path = %effective_path,
+            );
             let _ = msg
                 .reply(&ctx.http, super::session_started_response(&effective_path))
                 .await;
@@ -279,11 +279,12 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                         agenda
                     };
 
-                    let ts = chrono::Local::now().format("%H:%M:%S");
-                    tracing::info!(
-                        "  [{ts}] ◀ [{}] !meeting start {}",
+                    log_command_received!(
+                        channel_id.get(),
                         msg.author.name,
-                        agenda_text
+                        "!meeting",
+                        action = "start",
+                        agenda = %agenda_text
                     );
 
                     let http = ctx.http.clone();
@@ -314,15 +315,12 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                         )
                         .await
                         {
-                            Ok(Some(id)) => {
-                                let ts = chrono::Local::now().format("%H:%M:%S");
-                                tracing::info!("  [{ts}] ✅ Meeting completed: {id}");
-                            }
+                            Ok(Some(id)) => log_info_event!(
+                                "discord_meeting_completed",
+                                meeting_id = %id,
+                            ),
                             Ok(None) => {}
-                            Err(e) => {
-                                let ts = chrono::Local::now().format("%H:%M:%S");
-                                tracing::info!("  [{ts}] ❌ Meeting error: {e}");
-                            }
+                            Err(e) => log_info_event!("discord_meeting_failed", reason = %e,),
                         }
                     });
                     return Ok(true);
@@ -341,8 +339,13 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                         let _ = msg.reply(&ctx.http, "사용법: `!meeting <안건>`").await;
                         return Ok(true);
                     }
-                    let ts = chrono::Local::now().format("%H:%M:%S");
-                    tracing::info!("  [{ts}] ◀ [{}] !meeting {}", msg.author.name, full_agenda);
+                    log_command_received!(
+                        channel_id.get(),
+                        msg.author.name,
+                        "!meeting",
+                        action = "start",
+                        agenda = %full_agenda
+                    );
 
                     let http = ctx.http.clone();
                     let shared = data.shared.clone();
@@ -372,15 +375,12 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                         )
                         .await
                         {
-                            Ok(Some(id)) => {
-                                let ts = chrono::Local::now().format("%H:%M:%S");
-                                tracing::info!("  [{ts}] ✅ Meeting completed: {id}");
-                            }
+                            Ok(Some(id)) => log_info_event!(
+                                "discord_meeting_completed",
+                                meeting_id = %id,
+                            ),
                             Ok(None) => {}
-                            Err(e) => {
-                                let ts = chrono::Local::now().format("%H:%M:%S");
-                                tracing::info!("  [{ts}] ❌ Meeting error: {e}");
-                            }
+                            Err(e) => log_info_event!("discord_meeting_failed", reason = %e,),
                         }
                     });
                     return Ok(true);
@@ -448,8 +448,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
         }
 
         "!pwd" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ◀ [{}] !pwd", msg.author.name);
+            log_command_received!(channel_id.get(), msg.author.name, "!pwd");
 
             auto_restore_session(&data.shared, channel_id, ctx).await;
 
@@ -467,8 +466,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
         }
 
         "!health" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ◀ [{}] !health", msg.author.name);
+            log_command_received!(channel_id.get(), msg.author.name, "!health");
 
             let text = super::build_health_report(&data.shared, &data.provider, channel_id).await;
             send_long_message_raw(&ctx.http, channel_id, &text, &data.shared).await?;
@@ -476,8 +474,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
         }
 
         "!status" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ◀ [{}] !status", msg.author.name);
+            log_command_received!(channel_id.get(), msg.author.name, "!status");
 
             let text = super::build_status_report(&data.shared, &data.provider, channel_id).await;
             send_long_message_raw(&ctx.http, channel_id, &text, &data.shared).await?;
@@ -485,8 +482,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
         }
 
         "!inflight" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ◀ [{}] !inflight", msg.author.name);
+            log_command_received!(channel_id.get(), msg.author.name, "!inflight");
 
             let text = super::build_inflight_report(&data.shared, &data.provider, channel_id).await;
             send_long_message_raw(&ctx.http, channel_id, &text, &data.shared).await?;
@@ -494,8 +490,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
         }
 
         "!queue" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ◀ [{}] !queue", msg.author.name);
+            log_command_received!(channel_id.get(), msg.author.name, "!queue");
 
             let show_all = *arg1 == "all";
             let text =
@@ -505,8 +500,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
         }
 
         "!metrics" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ◀ [{}] !metrics", msg.author.name);
+            log_command_received!(channel_id.get(), msg.author.name, "!metrics");
 
             let metrics_data = if arg1.is_empty() {
                 super::super::metrics::load_today()
@@ -520,22 +514,24 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
         }
 
         "!debug" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ◀ [{}] !debug", msg.author.name);
+            log_command_received!(channel_id.get(), msg.author.name, "!debug");
 
             let new_state = crate::services::claude::toggle_debug();
             let status = if new_state { "ON" } else { "OFF" };
             let _ = msg
                 .reply(&ctx.http, format!("Debug logging: **{}**", status))
                 .await;
-            tracing::info!("  [{ts}] ▶ Debug logging toggled to {status}");
+            log_info_event!(
+                "discord_debug_logging_changed",
+                channel_id = channel_id.get(),
+                status = status,
+            );
             return Ok(true);
         }
 
         "!escalation" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
             let rest = text.strip_prefix("!escalation").unwrap_or("").trim();
-            tracing::info!("  [{ts}] ◀ [{}] !escalation {}", msg.author.name, rest);
+            log_command_received!(channel_id.get(), msg.author.name, "!escalation", action = %rest);
 
             if !check_owner(msg.author.id, &data.shared).await {
                 let _ = msg
@@ -667,8 +663,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
         }
 
         "!help" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ◀ [{}] !help", msg.author.name);
+            log_command_received!(channel_id.get(), msg.author.name, "!help");
 
             let provider_name = data.provider.display_name();
             let claude_tui_settings = if matches!(
@@ -746,8 +741,7 @@ Any other message is sent to {p}.
         }
 
         "!allowedtools" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ◀ [{}] !allowedtools", msg.author.name);
+            log_command_received!(channel_id.get(), msg.author.name, "!allowedtools");
 
             let tools = {
                 let settings = data.shared.settings.read().await;
@@ -774,8 +768,7 @@ Any other message is sent to {p}.
         }
 
         "!allowed" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ◀ [{}] !allowed {}", msg.author.name, arg1);
+            log_command_received!(channel_id.get(), msg.author.name, "!allowed", action = %arg1);
 
             let arg = arg1.trim();
             let (op, raw_name) = if let Some(name) = arg.strip_prefix('+') {
@@ -837,8 +830,7 @@ Any other message is sent to {p}.
         }
 
         "!adduser" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ◀ [{}] !adduser {}", msg.author.name, arg1);
+            log_command_received!(channel_id.get(), msg.author.name, "!adduser", target_user = %arg1);
 
             if !check_owner(msg.author.id, &data.shared).await {
                 let _ = msg.reply(&ctx.http, "Only the owner can add users.").await;
@@ -878,13 +870,17 @@ Any other message is sent to {p}.
                     format!("Added `{}` as authorized user.", target_id),
                 )
                 .await;
-            tracing::info!("  [{ts}] ▶ Added user: {target_id}");
+            log_info_event!(
+                "discord_user_access_added",
+                channel_id = channel_id.get(),
+                user_id = target_id,
+                status = "added",
+            );
             return Ok(true);
         }
 
         "!allowall" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ◀ [{}] !allowall {}", msg.author.name, arg1);
+            log_command_received!(channel_id.get(), msg.author.name, "!allowall", enabled = %arg1);
 
             if !check_owner(msg.author.id, &data.shared).await {
                 let _ = msg
@@ -939,13 +935,16 @@ Any other message is sent to {p}.
             // Issue #1005: pin the policy reminder to the toggle response too.
             let combined = format!("{response}\n\n{}", super::build_allowall_policy_note());
             let _ = msg.reply(&ctx.http, combined).await;
-            tracing::info!("  [{ts}] ▶ {response}");
+            log_info_event!(
+                "discord_public_access_changed",
+                channel_id = channel_id.get(),
+                status = if enabled { "enabled" } else { "disabled" },
+            );
             return Ok(true);
         }
 
         "!removeuser" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!("  [{ts}] ◀ [{}] !removeuser {}", msg.author.name, arg1);
+            log_command_received!(channel_id.get(), msg.author.name, "!removeuser", target_user = %arg1);
 
             if !check_owner(msg.author.id, &data.shared).await {
                 let _ = msg
@@ -994,14 +993,18 @@ Any other message is sent to {p}.
                     format!("Removed `{}` from authorized users.", target_id),
                 )
                 .await;
-            tracing::info!("  [{ts}] ▶ Removed user: {target_id}");
+            log_info_event!(
+                "discord_user_access_removed",
+                channel_id = channel_id.get(),
+                user_id = target_id,
+                status = "removed",
+            );
             return Ok(true);
         }
 
         "!down" => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
             let file_arg = text.strip_prefix("!down").unwrap_or("").trim();
-            tracing::info!("  [{ts}] ◀ [{}] !down {}", msg.author.name, file_arg);
+            log_command_received!(channel_id.get(), msg.author.name, "!down", path = %file_arg);
 
             if file_arg.is_empty() {
                 let _ = msg
@@ -1060,9 +1063,8 @@ Any other message is sent to {p}.
 
         "!shell" => {
             let cmd_str = text.strip_prefix("!shell").unwrap_or("").trim();
-            let ts = chrono::Local::now().format("%H:%M:%S");
             let preview = truncate_str(cmd_str, 60);
-            tracing::info!("  [{ts}] ◀ [{}] !shell {}", msg.author.name, preview);
+            log_command_received!(channel_id.get(), msg.author.name, "!shell", command_preview = %preview);
 
             if cmd_str.is_empty() {
                 let _ = msg
@@ -1206,12 +1208,11 @@ Any other message is sent to {p}.
                 }
                 _ => unreachable!("outer match arm guards command name"),
             };
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!(
-                "  [{ts}] ◀ [{}] {} (kind={})",
+            log_command_received!(
+                channel_id.get(),
                 msg.author.name,
                 cmd,
-                kind.name()
+                recovery_kind = kind.name()
             );
             let script = build_recovery_script(&kind);
             let working_dir = dirs::home_dir()
@@ -1281,13 +1282,12 @@ Any other message is sent to {p}.
                 .strip_prefix(&skill)
                 .unwrap_or("")
                 .trim();
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!(
-                "  [{ts}] ◀ [{}] {} {} {}",
+            log_command_received!(
+                channel_id.get(),
                 msg.author.name,
                 invoked_as,
-                skill,
-                args_str
+                skill = %skill,
+                args = %args_str
             );
 
             if skill.is_empty() {
@@ -1323,12 +1323,14 @@ Any other message is sent to {p}.
                         "!cc stop"
                     };
                     if let Some(reply) = alias_decision.denial_message(&stop_reason) {
-                        let ts = chrono::Local::now().format("%H:%M:%S");
                         tracing::warn!(
-                            "  [{ts}] ⛔ CommandPolicy denied {} for {} (id:{})",
-                            stop_reason,
-                            msg.author.name,
-                            msg.author.id.get(),
+                            event = "discord_command_denied",
+                            channel_id = channel_id.get(),
+                            user_id = msg.author.id.get(),
+                            user_name = %msg.author.name,
+                            command = %stop_reason,
+                            reason = "command_policy",
+                            "discord_command_denied"
                         );
                         let _ = msg.reply(&ctx.http, reply).await;
                         return Ok(true);

--- a/src/services/discord/commands/tui_passthrough.rs
+++ b/src/services/discord/commands/tui_passthrough.rs
@@ -234,8 +234,7 @@ async fn run_claude_passthrough(
         return Ok(());
     }
 
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!("  [{ts}] ◀ [{user_name}] {}", command.prompt());
+    log_command_received!(ctx.channel_id().get(), user_name, command.prompt());
 
     let (effective_provider, tmux_name) = resolve_effective_provider_and_tmux_name(ctx).await;
     if let Some(notice) = provider_preflight_notice(&effective_provider, command) {


### PR DESCRIPTION
## Summary
- structure all 88 human-panel tracing sites under `src/services/discord/commands/` across 18 files
- replace embedded local timestamps, emoji, and free-form messages with stable `discord_*` events and typed tracing fields
- preserve control flow, emission conditions, and log levels; leave the two `inspect/render_{prompt,last}.rs` user-output formatters unchanged

## Scope
This is the commands-only first slice of #4219. It does not modify tracing formatter configuration, introduce spans (#4221), create new correlation authority, or touch relay/hot-file surfaces.

Remaining #4219 slices will cover the non-commands panel-log surfaces in independently reviewable groups.

## Daily digest compatibility
- `routines/monitoring/daily_log_digest.py` accepts ISO timestamps emitted by the unchanged default `tracing_subscriber::fmt()` subscriber
- severity remains supplied by that formatter; no formatter or digest parser code changed
- `python3 -m unittest tests.test_daily_log_digest`: 24 tests passed

## Verification
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --lib commands 2>&1 | grep \"test result\"`
- [x] `./scripts/ci-script-checks.sh` (rc=0)
- [x] `python3 scripts/generate_inventory_docs.py`
- [x] `python3 scripts/check_agent_maintenance_docs.py` (`agent-maintenance freshness check passed`)
- [x] generated inventory remained unchanged

Test result: `test result: ok. 66 passed; 0 failed; 0 ignored; 0 measured; 6863 filtered out; finished in 0.04s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)