### PR TITLE
refactor(auto-queue): unify phase-gate verdict reducer in Rust

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -65,6 +65,7 @@ src/
 │   │   ├── consultation.rs
 │   │   ├── entries.rs
 │   │   ├── mod.rs
+│   │   ├── phase_gate_verdict.rs
 │   │   ├── phase_gates.rs
 │   │   ├── queries.rs
 │   │   ├── runs.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1729,7 +1729,11 @@
     reconciliation, production LoC; PG-backed tests for `current_batch_phase_pg`
     + `reconcile_phase_gate_for_terminal_dispatch_on_pg_tx` live in a
     `#[cfg(test)] mod`. Split the test module out into a sibling
-    `phase_gates_tests.rs` before adding new feature logic).
+    `phase_gates_tests.rs` before adding new feature logic). Verdict extraction,
+    checks inference, expected-verdict selection, and diagnostic preservation are
+    owned by the split-friendly sibling `src/db/auto_queue/phase_gate_verdict.rs`;
+    changes to either surface require reducer unit coverage plus PG reconciler
+    coverage for primary and sibling dispatches.
   - `src/db/dispatches/mod.rs` (frozen giant surface; dispatch slot/thread binding and
     outbox-adjacent PG helpers, pushed over the giant-file threshold by
     #2778/#2783 slot-isolation recovery. Split slot allocation helpers before

--- a/src/db/auto_queue/mod.rs
+++ b/src/db/auto_queue/mod.rs
@@ -1,6 +1,7 @@
 pub mod claim;
 pub mod consultation;
 pub mod entries;
+pub mod phase_gate_verdict;
 pub mod phase_gates;
 pub mod queries;
 pub mod runs;

--- a/src/db/auto_queue/phase_gate_verdict.rs
+++ b/src/db/auto_queue/phase_gate_verdict.rs
@@ -328,7 +328,9 @@ mod tests {
     /// "pass"}` read as a failure there and as a pass in the reconciler.
     #[test]
     fn empty_status_falls_back_to_result_alias() {
-        assert!(check_entry_is_pass(&json!({ "status": "", "result": "pass" })));
+        assert!(check_entry_is_pass(
+            &json!({ "status": "", "result": "pass" })
+        ));
         assert!(check_entry_is_pass(&json!({ "status": "PASSED" })));
         assert!(check_entry_is_pass(&json!("pass")));
         assert!(!check_entry_is_pass(&json!({ "status": "fail" })));
@@ -387,7 +389,10 @@ mod tests {
             pass_verdict_of(&json!({ "pass_verdict": "  " })),
             DEFAULT_PASS_VERDICT
         );
-        assert_eq!(pass_verdict_of(&json!({ "pass_verdict": "gate_ok" })), "gate_ok");
+        assert_eq!(
+            pass_verdict_of(&json!({ "pass_verdict": "gate_ok" })),
+            "gate_ok"
+        );
     }
 
     #[test]
@@ -408,15 +413,30 @@ mod tests {
             Some(&context),
             Some(&failing)
         ));
-        assert!(!verdict_matches(Some("pass"), "gate_ok", Some(&context), None));
+        assert!(!verdict_matches(
+            Some("pass"),
+            "gate_ok",
+            Some(&context),
+            None
+        ));
         assert!(verdict_matches(
             Some(" gate_ok "),
             "gate_ok",
             None,
             Some(&passing)
         ));
-        assert!(!verdict_matches(None, "gate_ok", Some(&context), Some(&passing)));
-        assert!(!verdict_matches(Some("   "), "gate_ok", Some(&context), Some(&passing)));
+        assert!(!verdict_matches(
+            None,
+            "gate_ok",
+            Some(&context),
+            Some(&passing)
+        ));
+        assert!(!verdict_matches(
+            Some("   "),
+            "gate_ok",
+            Some(&context),
+            Some(&passing)
+        ));
     }
 
     #[test]

--- a/src/db/auto_queue/phase_gate_verdict.rs
+++ b/src/db/auto_queue/phase_gate_verdict.rs
@@ -209,7 +209,7 @@ pub fn verdict_matches(
     context: Option<&Value>,
     result: Option<&Value>,
 ) -> bool {
-    let Some(actual) = actual.map(str::trim).filter(|value| !value.is_empty()) else {
+    let Some(actual) = actual.filter(|value| !value.is_empty()) else {
         return false;
     };
     if actual == expected {
@@ -469,7 +469,7 @@ mod tests {
             Some(&context),
             None
         ));
-        assert!(verdict_matches(
+        assert!(!verdict_matches(
             Some(" gate_ok "),
             "gate_ok",
             None,
@@ -486,6 +486,32 @@ mod tests {
             "gate_ok",
             Some(&context),
             Some(&passing)
+        ));
+    }
+
+    #[test]
+    fn raw_whitespace_pass_verdict_matches_consistently() {
+        let context = gate_context(json!(["build_passed"]), " gate_ok ");
+        let result = json!({
+            "verdict": " gate_ok ",
+            "checks": {"build_passed": "pass"}
+        });
+        let resolution = resolve_verdict(Some(&context), &result);
+        assert_eq!(
+            resolution,
+            VerdictResolution::Explicit(" gate_ok ".to_string())
+        );
+        assert!(verdict_matches(
+            resolution.verdict(),
+            " gate_ok ",
+            Some(&context),
+            Some(&result)
+        ));
+        assert!(!verdict_matches(
+            resolution.verdict(),
+            "gate_ok",
+            Some(&context),
+            Some(&result)
         ));
     }
 

--- a/src/db/auto_queue/phase_gate_verdict.rs
+++ b/src/db/auto_queue/phase_gate_verdict.rs
@@ -61,14 +61,14 @@ impl VerdictResolution {
 /// including values that are not strings. Matching JS here matters because the
 /// policy hook and the durable path must not disagree about whether a result
 /// "already decided".
-pub fn has_explicit_verdict(result: &Value) -> bool {
+fn has_explicit_verdict(result: &Value) -> bool {
     first_explicit_value(result).is_some()
 }
 
 /// Trimmed, non-empty string form of the first truthy explicit verdict, if it
 /// is a string. A truthy non-string value blocks later keys, matching the JS
 /// `verdict || decision || phase_gate_verdict` precedence chain.
-pub fn explicit_verdict(result: &Value) -> Option<String> {
+fn explicit_verdict(result: &Value) -> Option<String> {
     first_explicit_value(result)
         .and_then(Value::as_str)
         .map(str::trim)
@@ -82,7 +82,7 @@ pub fn explicit_verdict(result: &Value) -> Option<String> {
 /// "pass"}` alias, and a bare `"pass"` string. `status` is only consulted when
 /// it is a non-empty string so an empty `status` falls through to `result`,
 /// mirroring the JS `entry.status || entry.result` chain (#2048 F12).
-pub fn check_entry_is_pass(entry: &Value) -> bool {
+fn check_entry_is_pass(entry: &Value) -> bool {
     let raw = match entry {
         Value::String(text) => Some(text.as_str()),
         Value::Object(map) => map
@@ -115,7 +115,7 @@ pub fn pass_verdict_of(phase_gate: &Value) -> String {
 /// Refuses to infer when the gate context is not an object, when no checks are
 /// reported, when a declared check is missing from `result.checks`, or when any
 /// declared-or-present check does not pass.
-pub fn infer_pass_verdict_in_gate(phase_gate: &Value, result: &Value) -> Option<String> {
+fn infer_pass_verdict_in_gate(phase_gate: &Value, result: &Value) -> Option<String> {
     if !phase_gate.is_object() {
         return None;
     }
@@ -148,13 +148,14 @@ pub fn infer_pass_verdict_in_gate(phase_gate: &Value, result: &Value) -> Option<
 }
 
 /// Checks-only inference against a full dispatch context (`context.phase_gate`).
-pub fn infer_pass_verdict_from_checks(context: Option<&Value>, result: &Value) -> Option<String> {
+fn infer_pass_verdict_from_checks(context: Option<&Value>, result: &Value) -> Option<String> {
     infer_pass_verdict_in_gate(context?.get("phase_gate")?, result)
 }
 
 /// Full inference: never overrides an explicit verdict (even an explicit
 /// failure), otherwise falls back to checks-only inference.
-pub fn infer_pass_verdict(context: Option<&Value>, result: &Value) -> Option<String> {
+#[cfg(test)]
+pub(super) fn infer_pass_verdict(context: Option<&Value>, result: &Value) -> Option<String> {
     if has_explicit_verdict(result) {
         return None;
     }

--- a/src/db/auto_queue/phase_gate_verdict.rs
+++ b/src/db/auto_queue/phase_gate_verdict.rs
@@ -352,7 +352,10 @@ mod tests {
     fn missing_declared_check_refuses_inference() {
         let context = gate_context(json!(["merge_verified", "issue_closed"]), "gate_ok");
         let result = json!({ "checks": { "merge_verified": { "status": "pass" } } });
-        assert_eq!(resolve_verdict(Some(&context), &result), VerdictResolution::Missing);
+        assert_eq!(
+            resolve_verdict(Some(&context), &result),
+            VerdictResolution::Missing
+        );
     }
 
     #[test]
@@ -364,7 +367,10 @@ mod tests {
                 "issue_closed": { "status": "fail" },
             }
         });
-        assert_eq!(resolve_verdict(Some(&context), &result), VerdictResolution::Missing);
+        assert_eq!(
+            resolve_verdict(Some(&context), &result),
+            VerdictResolution::Missing
+        );
     }
 
     #[test]

--- a/src/db/auto_queue/phase_gate_verdict.rs
+++ b/src/db/auto_queue/phase_gate_verdict.rs
@@ -33,6 +33,26 @@ pub const DEFAULT_PASS_VERDICT: &str = "phase_gate_passed";
 /// chain.
 const EXPLICIT_VERDICT_KEYS: [&str; 3] = ["verdict", "decision", "phase_gate_verdict"];
 
+/// The canonical result of reducing phase-gate context and result evidence.
+///
+/// `Explicit(None)` is intentional: a truthy non-string value blocks checks
+/// inference but cannot be compared with the gate's string pass verdict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerdictResolution {
+    Explicit(Option<String>),
+    Inferred(String),
+    Missing,
+}
+
+impl VerdictResolution {
+    pub fn verdict(&self) -> Option<&str> {
+        match self {
+            Self::Explicit(Some(verdict)) | Self::Inferred(verdict) => Some(verdict),
+            Self::Explicit(None) | Self::Missing => None,
+        }
+    }
+}
+
 /// JS-style truthiness for `result.verdict || result.decision ||
 /// result.phase_gate_verdict`.
 ///
@@ -42,25 +62,18 @@ const EXPLICIT_VERDICT_KEYS: [&str; 3] = ["verdict", "decision", "phase_gate_ver
 /// policy hook and the durable path must not disagree about whether a result
 /// "already decided".
 pub fn has_explicit_verdict(result: &Value) -> bool {
-    EXPLICIT_VERDICT_KEYS
-        .iter()
-        .filter_map(|key| result.get(*key))
-        .any(is_js_truthy)
+    first_explicit_value(result).is_some()
 }
 
-/// Trimmed, non-empty string form of the explicit verdict, if the result
-/// carries one. Non-string explicit values (which still block inference via
-/// [`has_explicit_verdict`]) have no string form and yield `None`.
+/// Trimmed, non-empty string form of the first truthy explicit verdict, if it
+/// is a string. A truthy non-string value blocks later keys, matching the JS
+/// `verdict || decision || phase_gate_verdict` precedence chain.
 pub fn explicit_verdict(result: &Value) -> Option<String> {
-    for key in EXPLICIT_VERDICT_KEYS {
-        if let Some(text) = result.get(key).and_then(Value::as_str) {
-            let trimmed = text.trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_string());
-            }
-        }
-    }
-    None
+    first_explicit_value(result)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 /// Whether a single `result.checks` entry reports a pass.
@@ -148,10 +161,15 @@ pub fn infer_pass_verdict(context: Option<&Value>, result: &Value) -> Option<Str
     infer_pass_verdict_from_checks(context, result)
 }
 
-/// The verdict a dispatch result carries: the explicit one when present,
-/// otherwise the checks-inferred pass verdict.
-pub fn resolve_verdict(context: Option<&Value>, result: &Value) -> Option<String> {
-    explicit_verdict(result).or_else(|| infer_pass_verdict(context, result))
+/// Resolve explicit evidence first, then checks-only inference.
+pub fn resolve_verdict(context: Option<&Value>, result: &Value) -> VerdictResolution {
+    if has_explicit_verdict(result) {
+        return VerdictResolution::Explicit(explicit_verdict(result));
+    }
+    match infer_pass_verdict_from_checks(context, result) {
+        Some(verdict) => VerdictResolution::Inferred(verdict),
+        None => VerdictResolution::Missing,
+    }
 }
 
 /// Whether `actual` satisfies the gate's `expected` pass verdict.
@@ -178,6 +196,13 @@ pub fn verdict_matches(
         .and_then(|result| infer_pass_verdict_from_checks(context, result))
         .as_deref()
         == Some(expected)
+}
+
+fn first_explicit_value(result: &Value) -> Option<&Value> {
+    EXPLICIT_VERDICT_KEYS
+        .iter()
+        .filter_map(|key| result.get(*key))
+        .find(|value| is_js_truthy(value))
 }
 
 fn is_js_truthy(value: &Value) -> bool {
@@ -241,8 +266,9 @@ mod tests {
             "checks": { "merge_verified": { "status": "pass" } },
         });
         assert_eq!(infer_pass_verdict(Some(&context), &result), None);
+        let resolution = resolve_verdict(Some(&context), &result);
         assert!(!verdict_matches(
-            resolve_verdict(Some(&context), &result).as_deref(),
+            resolution.verdict(),
             "phase_gate_passed",
             Some(&context),
             Some(&result),
@@ -258,7 +284,27 @@ mod tests {
                 "checks": { "build_passed": "pass" },
             });
             assert_eq!(infer_pass_verdict(Some(&context), &result), None);
+            assert_eq!(
+                resolve_verdict(Some(&context), &result),
+                VerdictResolution::Explicit(None),
+            );
         }
+    }
+
+    #[test]
+    fn truthy_non_string_verdict_prevents_later_decision_from_winning() {
+        let context = gate_context(json!(["build_passed"]), "gate_ok");
+        let result = json!({
+            "verdict": true,
+            "decision": "gate_ok",
+            "checks": { "build_passed": "pass" },
+        });
+
+        assert_eq!(explicit_verdict(&result), None);
+        assert_eq!(
+            resolve_verdict(Some(&context), &result),
+            VerdictResolution::Explicit(None),
+        );
     }
 
     #[test]
@@ -377,17 +423,20 @@ mod tests {
         let context = gate_context(json!(["build_passed"]), "gate_ok");
         let explicit = json!({ "decision": "gate_failed", "checks": { "build_passed": "pass" } });
         assert_eq!(
-            resolve_verdict(Some(&context), &explicit).as_deref(),
-            Some("gate_failed")
+            resolve_verdict(Some(&context), &explicit),
+            VerdictResolution::Explicit(Some("gate_failed".to_string()))
         );
 
         let inferred = json!({ "checks": { "build_passed": "pass" } });
         assert_eq!(
-            resolve_verdict(Some(&context), &inferred).as_deref(),
-            Some("gate_ok")
+            resolve_verdict(Some(&context), &inferred),
+            VerdictResolution::Inferred("gate_ok".to_string())
         );
 
         let undecided = json!({ "checks": { "build_passed": "fail" } });
-        assert_eq!(resolve_verdict(Some(&context), &undecided), None);
+        assert_eq!(
+            resolve_verdict(Some(&context), &undecided),
+            VerdictResolution::Missing
+        );
     }
 }

--- a/src/db/auto_queue/phase_gate_verdict.rs
+++ b/src/db/auto_queue/phase_gate_verdict.rs
@@ -183,18 +183,26 @@ pub fn resolve_verdict(context: Option<&Value>, result: &Value) -> VerdictResolu
     }
 }
 
-/// Preserve the most useful explicit payload for durable failure diagnostics.
+/// Preserve the most useful explicit class for durable failure diagnostics.
 ///
 /// The reducer's inferred/string verdict remains authoritative for matching. If
-/// resolution is missing, a truthy non-string explicit field is serialized so
-/// operators see the supplied payload instead of the lossy `got none` message.
+/// resolution is missing, a truthy non-string explicit field is represented by
+/// a closed JSON-type label. Never serialize the payload itself: verdict values
+/// can contain credentials or other untrusted data that reaches DB and logs.
 pub fn diagnostic_verdict(result: &Value, resolution: &VerdictResolution) -> Option<String> {
     resolution.verdict().map(str::to_string).or_else(|| {
         EXPLICIT_VERDICT_KEYS
             .iter()
             .filter_map(|key| result.get(*key))
             .find(|value| is_js_truthy(value))
-            .map(Value::to_string)
+            .map(|value| match value {
+                Value::Bool(_) => "<non-string:boolean>",
+                Value::Number(_) => "<non-string:number>",
+                Value::Array(_) => "<non-string:array>",
+                Value::Object(_) => "<non-string:object>",
+                Value::Null | Value::String(_) => "<non-string:unknown>",
+            })
+            .map(str::to_string)
     })
 }
 
@@ -293,6 +301,26 @@ mod tests {
                 VerdictResolution::Inferred("phase_gate_passed".to_string()),
             );
         }
+    }
+
+    #[test]
+    fn non_string_diagnostic_reports_only_closed_json_type() {
+        let context = gate_context(json!(["build_passed"]), "phase_gate_passed");
+        let result = json!({
+            "verdict": {"authorization": "Bearer secret"},
+            "checks": {"build_passed": "fail"},
+        });
+        let resolution = resolve_verdict(Some(&context), &result);
+
+        assert_eq!(resolution, VerdictResolution::Missing);
+        let diagnostic = diagnostic_verdict(&result, &resolution);
+        assert_eq!(diagnostic.as_deref(), Some("<non-string:object>"));
+        assert!(
+            diagnostic.as_deref().is_none_or(|value| {
+                !value.contains("authorization") && !value.contains("Bearer secret")
+            }),
+            "diagnostic must not contain arbitrary verdict payload: {diagnostic:?}"
+        );
     }
 
     #[test]

--- a/src/db/auto_queue/phase_gate_verdict.rs
+++ b/src/db/auto_queue/phase_gate_verdict.rs
@@ -109,8 +109,8 @@ pub fn pass_verdict_of(phase_gate: &Value) -> String {
 }
 
 /// Checks-only inference against an already-extracted `phase_gate` context
-/// object. Ignores any explicit verdict on `result` — callers that must honour
-/// an explicit verdict use [`infer_pass_verdict`] instead.
+/// object. Ignores any explicit verdict on `result`; the canonical
+/// [`resolve_verdict`] entry point checks explicit evidence first.
 ///
 /// Refuses to infer when the gate context is not an object, when no checks are
 /// reported, when a declared check is missing from `result.checks`, or when any

--- a/src/db/auto_queue/phase_gate_verdict.rs
+++ b/src/db/auto_queue/phase_gate_verdict.rs
@@ -65,10 +65,6 @@ fn explicit_verdict(result: &Value) -> Option<String> {
         .map(str::to_string)
 }
 
-fn has_explicit_verdict(result: &Value) -> bool {
-    explicit_verdict(result).is_some()
-}
-
 fn is_js_truthy(value: &Value) -> bool {
     match value {
         Value::Null => false,
@@ -250,10 +246,6 @@ mod tests {
                 key: "fail",
                 "checks": { "merge_verified": { "status": "pass" } },
             });
-            assert!(
-                has_explicit_verdict(&result),
-                "{key} should count as explicit"
-            );
             assert_eq!(
                 resolve_verdict(Some(&context), &result),
                 VerdictResolution::Explicit("fail".to_string()),

--- a/src/db/auto_queue/phase_gate_verdict.rs
+++ b/src/db/auto_queue/phase_gate_verdict.rs
@@ -18,10 +18,10 @@
 //! unit-tested without Postgres and reused from both the dispatch layer and
 //! the db layer.
 //!
-//! The semantics deliberately mirror
-//! `policies/lib/auto-queue-phase-gate.js::_inferPhaseGatePassVerdict` so the
-//! JS policy hook and the durable Rust path agree while the JS reducer is
-//! still live.
+//! Rust preserves the established finalize-path compatibility contract while
+//! the JavaScript reducer is still live. In particular, non-string values in
+//! explicit verdict fields are ignored for inference, as they were before
+//! #4884; see the known JavaScript deltas below.
 
 use serde_json::Value;
 
@@ -34,12 +34,9 @@ pub const DEFAULT_PASS_VERDICT: &str = "phase_gate_passed";
 const EXPLICIT_VERDICT_KEYS: [&str; 3] = ["verdict", "decision", "phase_gate_verdict"];
 
 /// The canonical result of reducing phase-gate context and result evidence.
-///
-/// `Explicit(None)` is intentional: a truthy non-string value blocks checks
-/// inference but cannot be compared with the gate's string pass verdict.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VerdictResolution {
-    Explicit(Option<String>),
+    Explicit(String),
     Inferred(String),
     Missing,
 }
@@ -47,41 +44,54 @@ pub enum VerdictResolution {
 impl VerdictResolution {
     pub fn verdict(&self) -> Option<&str> {
         match self {
-            Self::Explicit(Some(verdict)) | Self::Inferred(verdict) => Some(verdict),
-            Self::Explicit(None) | Self::Missing => None,
+            Self::Explicit(verdict) | Self::Inferred(verdict) => Some(verdict),
+            Self::Missing => None,
         }
     }
 }
 
-/// JS-style truthiness for `result.verdict || result.decision ||
-/// result.phase_gate_verdict`.
+/// Non-empty string form of the first explicit verdict field.
 ///
-/// Any non-falsy value (boolean `true`, non-zero number, non-empty string, any
-/// array/object) counts as an explicit verdict and therefore blocks inference —
-/// including values that are not strings. Matching JS here matters because the
-/// policy hook and the durable path must not disagree about whether a result
-/// "already decided".
-fn has_explicit_verdict(result: &Value) -> bool {
-    first_explicit_value(result).is_some()
+/// Non-string values intentionally do not block inference. This preserves the
+/// pre-#4884 finalize behavior, where `as_str()` treated them as absent and an
+/// all-passing checks payload received the configured pass verdict. Strings are
+/// kept byte-for-byte so blank and whitespace-only values retain the historical
+/// behavior instead of silently changing verdict matching.
+fn explicit_verdict(result: &Value) -> Option<String> {
+    EXPLICIT_VERDICT_KEYS
+        .iter()
+        .filter_map(|key| result.get(*key).and_then(Value::as_str))
+        .find(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
-/// Trimmed, non-empty string form of the first truthy explicit verdict, if it
-/// is a string. A truthy non-string value blocks later keys, matching the JS
-/// `verdict || decision || phase_gate_verdict` precedence chain.
-fn explicit_verdict(result: &Value) -> Option<String> {
-    first_explicit_value(result)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
+fn has_explicit_verdict(result: &Value) -> bool {
+    explicit_verdict(result).is_some()
+}
+
+fn is_js_truthy(value: &Value) -> bool {
+    match value {
+        Value::Null => false,
+        Value::Bool(flag) => *flag,
+        Value::String(text) => !text.is_empty(),
+        Value::Number(number) => number
+            .as_f64()
+            .map(|raw| raw != 0.0 && !raw.is_nan())
+            .unwrap_or(false),
+        Value::Array(_) | Value::Object(_) => true,
+    }
 }
 
 /// Whether a single `result.checks` entry reports a pass.
 ///
 /// Accepts the canonical `{"status": "pass"}` object form, the `{"result":
 /// "pass"}` alias, and a bare `"pass"` string. `status` is only consulted when
-/// it is a non-empty string so an empty `status` falls through to `result`,
-/// mirroring the JS `entry.status || entry.result` chain (#2048 F12).
+/// it is a non-empty string so an empty `status` falls through to `result`
+/// (#2048 F12).
+///
+/// Known JavaScript delta: a truthy non-string `status` blocks the JavaScript
+/// `result` fallback, while Rust ignores non-string status values and may use a
+/// string `result` alias. This reducer preserves the pre-#4884 Rust behavior.
 fn check_entry_is_pass(entry: &Value) -> bool {
     let raw = match entry {
         Value::String(text) => Some(text.as_str()),
@@ -102,8 +112,6 @@ pub fn pass_verdict_of(phase_gate: &Value) -> String {
     phase_gate
         .get("pass_verdict")
         .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
         .unwrap_or(DEFAULT_PASS_VERDICT)
         .to_string()
 }
@@ -115,6 +123,11 @@ pub fn pass_verdict_of(phase_gate: &Value) -> String {
 /// Refuses to infer when the gate context is not an object, when no checks are
 /// reported, when a declared check is missing from `result.checks`, or when any
 /// declared-or-present check does not pass.
+///
+/// Known JavaScript deltas: JavaScript accepts an array as `result.checks`, and
+/// skips falsy declared-check items. Rust requires an object map and rejects any
+/// non-string declared item. The stricter declaration handling prevents a future
+/// descriptor migration from silently dropping the completeness guard (#4882).
 fn infer_pass_verdict_in_gate(phase_gate: &Value, result: &Value) -> Option<String> {
     if !phase_gate.is_object() {
         return None;
@@ -124,17 +137,28 @@ fn infer_pass_verdict_in_gate(phase_gate: &Value, result: &Value) -> Option<Stri
         return None;
     }
 
-    if let Some(declared) = phase_gate.get("checks").and_then(Value::as_array) {
-        for required in declared {
-            let Some(name) = required.as_str() else {
-                continue;
-            };
-            let Some(entry) = checks.get(name) else {
-                return None;
-            };
-            if !check_entry_is_pass(entry) {
-                return None;
-            }
+    let Some(declared) = phase_gate.get("checks").and_then(Value::as_array) else {
+        tracing::warn!(
+            "[phase_gate] refusing verdict inference without an explicit declared-check array"
+        );
+        return None;
+    };
+    if declared.is_empty() {
+        return None;
+    }
+    for required in declared {
+        let Some(name) = required.as_str() else {
+            tracing::warn!(
+                declared_check = %required,
+                "[phase_gate] refusing verdict inference for non-string declared check"
+            );
+            return None;
+        };
+        let Some(entry) = checks.get(name) else {
+            return None;
+        };
+        if !check_entry_is_pass(entry) {
+            return None;
         }
     }
 
@@ -152,25 +176,30 @@ fn infer_pass_verdict_from_checks(context: Option<&Value>, result: &Value) -> Op
     infer_pass_verdict_in_gate(context?.get("phase_gate")?, result)
 }
 
-/// Full inference: never overrides an explicit verdict (even an explicit
-/// failure), otherwise falls back to checks-only inference.
-#[cfg(test)]
-pub(super) fn infer_pass_verdict(context: Option<&Value>, result: &Value) -> Option<String> {
-    if has_explicit_verdict(result) {
-        return None;
-    }
-    infer_pass_verdict_from_checks(context, result)
-}
-
 /// Resolve explicit evidence first, then checks-only inference.
 pub fn resolve_verdict(context: Option<&Value>, result: &Value) -> VerdictResolution {
-    if has_explicit_verdict(result) {
-        return VerdictResolution::Explicit(explicit_verdict(result));
+    if let Some(verdict) = explicit_verdict(result) {
+        return VerdictResolution::Explicit(verdict);
     }
     match infer_pass_verdict_from_checks(context, result) {
         Some(verdict) => VerdictResolution::Inferred(verdict),
         None => VerdictResolution::Missing,
     }
+}
+
+/// Preserve the most useful explicit payload for durable failure diagnostics.
+///
+/// The reducer's inferred/string verdict remains authoritative for matching. If
+/// resolution is missing, a truthy non-string explicit field is serialized so
+/// operators see the supplied payload instead of the lossy `got none` message.
+pub fn diagnostic_verdict(result: &Value, resolution: &VerdictResolution) -> Option<String> {
+    resolution.verdict().map(str::to_string).or_else(|| {
+        EXPLICIT_VERDICT_KEYS
+            .iter()
+            .filter_map(|key| result.get(*key))
+            .find(|value| is_js_truthy(value))
+            .map(Value::to_string)
+    })
 }
 
 /// Whether `actual` satisfies the gate's `expected` pass verdict.
@@ -197,26 +226,6 @@ pub fn verdict_matches(
         .and_then(|result| infer_pass_verdict_from_checks(context, result))
         .as_deref()
         == Some(expected)
-}
-
-fn first_explicit_value(result: &Value) -> Option<&Value> {
-    EXPLICIT_VERDICT_KEYS
-        .iter()
-        .filter_map(|key| result.get(*key))
-        .find(|value| is_js_truthy(value))
-}
-
-fn is_js_truthy(value: &Value) -> bool {
-    match value {
-        Value::Null => false,
-        Value::Bool(flag) => *flag,
-        Value::String(text) => !text.is_empty(),
-        Value::Number(number) => number
-            .as_f64()
-            .map(|raw| raw != 0.0 && !raw.is_nan())
-            .unwrap_or(false),
-        Value::Array(_) | Value::Object(_) => true,
-    }
 }
 
 #[cfg(test)]
@@ -246,8 +255,8 @@ mod tests {
                 "{key} should count as explicit"
             );
             assert_eq!(
-                infer_pass_verdict(Some(&context), &result),
-                None,
+                resolve_verdict(Some(&context), &result),
+                VerdictResolution::Explicit("fail".to_string()),
                 "{key} must not be overridden by checks-only inference"
             );
             assert_eq!(explicit_verdict(&result).as_deref(), Some("fail"));
@@ -266,8 +275,11 @@ mod tests {
             "phase_gate_verdict": "phase_gate_failed",
             "checks": { "merge_verified": { "status": "pass" } },
         });
-        assert_eq!(infer_pass_verdict(Some(&context), &result), None);
         let resolution = resolve_verdict(Some(&context), &result);
+        assert_eq!(
+            resolution,
+            VerdictResolution::Explicit("phase_gate_failed".to_string())
+        );
         assert!(!verdict_matches(
             resolution.verdict(),
             "phase_gate_passed",
@@ -277,34 +289,32 @@ mod tests {
     }
 
     #[test]
-    fn non_string_truthy_explicit_verdict_blocks_inference() {
-        let context = gate_context(json!([]), "phase_gate_passed");
+    fn non_string_explicit_fields_preserve_finalize_inference_compatibility() {
+        let context = gate_context(json!(["build_passed"]), "phase_gate_passed");
         for explicit in [json!(true), json!(1), json!({ "nested": 1 })] {
             let result = json!({
                 "verdict": explicit,
                 "checks": { "build_passed": "pass" },
             });
-            assert_eq!(infer_pass_verdict(Some(&context), &result), None);
             assert_eq!(
                 resolve_verdict(Some(&context), &result),
-                VerdictResolution::Explicit(None),
+                VerdictResolution::Inferred("phase_gate_passed".to_string()),
             );
         }
     }
 
     #[test]
-    fn truthy_non_string_verdict_prevents_later_decision_from_winning() {
+    fn non_string_verdict_allows_later_string_decision() {
         let context = gate_context(json!(["build_passed"]), "gate_ok");
         let result = json!({
             "verdict": true,
-            "decision": "gate_ok",
+            "decision": "manual_hold",
             "checks": { "build_passed": "pass" },
         });
 
-        assert_eq!(explicit_verdict(&result), None);
         assert_eq!(
             resolve_verdict(Some(&context), &result),
-            VerdictResolution::Explicit(None),
+            VerdictResolution::Explicit("manual_hold".to_string()),
         );
     }
 
@@ -317,8 +327,8 @@ mod tests {
                 "checks": { "build_passed": "pass" },
             });
             assert_eq!(
-                infer_pass_verdict(Some(&context), &result).as_deref(),
-                Some("phase_gate_passed"),
+                resolve_verdict(Some(&context), &result),
+                VerdictResolution::Inferred("phase_gate_passed".to_string()),
             );
         }
     }
@@ -342,7 +352,7 @@ mod tests {
     fn missing_declared_check_refuses_inference() {
         let context = gate_context(json!(["merge_verified", "issue_closed"]), "gate_ok");
         let result = json!({ "checks": { "merge_verified": { "status": "pass" } } });
-        assert_eq!(infer_pass_verdict(Some(&context), &result), None);
+        assert_eq!(resolve_verdict(Some(&context), &result), VerdictResolution::Missing);
     }
 
     #[test]
@@ -354,44 +364,86 @@ mod tests {
                 "issue_closed": { "status": "fail" },
             }
         });
-        assert_eq!(infer_pass_verdict(Some(&context), &result), None);
+        assert_eq!(resolve_verdict(Some(&context), &result), VerdictResolution::Missing);
+    }
+
+    #[test]
+    fn absent_or_invalid_declared_checks_fail_closed() {
+        let passing = json!({ "checks": { "merge_verified": "pass" } });
+        for declared in [json!(null), json!("merge_verified"), json!([])] {
+            let context = gate_context(declared, "gate_ok");
+            assert_eq!(
+                resolve_verdict(Some(&context), &passing),
+                VerdictResolution::Missing,
+            );
+        }
+    }
+
+    #[test]
+    fn non_string_declared_check_fails_closed() {
+        let context = gate_context(json!([{"name": "merge_verified"}]), "gate_ok");
+        let result = json!({ "checks": { "merge_verified": "pass" } });
+        assert_eq!(
+            resolve_verdict(Some(&context), &result),
+            VerdictResolution::Missing,
+        );
+    }
+
+    #[test]
+    fn truthy_non_string_status_does_not_hide_string_result_alias() {
+        let context = gate_context(json!(["merge_verified"]), "gate_ok");
+        for status in [json!(true), json!(1)] {
+            let result = json!({
+                "checks": {
+                    "merge_verified": { "status": status, "result": "pass" }
+                }
+            });
+            assert_eq!(
+                resolve_verdict(Some(&context), &result),
+                VerdictResolution::Inferred("gate_ok".to_string()),
+            );
+        }
     }
 
     #[test]
     fn empty_or_absent_checks_refuse_inference() {
         let context = gate_context(json!([]), "gate_ok");
         assert_eq!(
-            infer_pass_verdict(Some(&context), &json!({ "checks": {} })),
-            None
+            resolve_verdict(Some(&context), &json!({ "checks": {} })),
+            VerdictResolution::Missing
         );
-        assert_eq!(infer_pass_verdict(Some(&context), &json!({})), None);
         assert_eq!(
-            infer_pass_verdict(Some(&context), &json!({ "checks": [] })),
-            None
+            resolve_verdict(Some(&context), &json!({})),
+            VerdictResolution::Missing
+        );
+        assert_eq!(
+            resolve_verdict(Some(&context), &json!({ "checks": [] })),
+            VerdictResolution::Missing
         );
     }
 
     #[test]
     fn missing_phase_gate_context_refuses_inference() {
         let result = json!({ "checks": { "build_passed": "pass" } });
-        assert_eq!(infer_pass_verdict(None, &result), None);
-        assert_eq!(infer_pass_verdict(Some(&json!({})), &result), None);
+        assert_eq!(resolve_verdict(None, &result), VerdictResolution::Missing);
         assert_eq!(
-            infer_pass_verdict(Some(&json!({ "phase_gate": "nope" })), &result),
-            None
+            resolve_verdict(Some(&json!({})), &result),
+            VerdictResolution::Missing
+        );
+        assert_eq!(
+            resolve_verdict(Some(&json!({ "phase_gate": "nope" })), &result),
+            VerdictResolution::Missing
         );
     }
 
     #[test]
-    fn pass_verdict_defaults_when_absent_or_blank() {
+    fn pass_verdict_defaults_only_when_absent_and_preserves_raw_strings() {
         assert_eq!(pass_verdict_of(&json!({})), DEFAULT_PASS_VERDICT);
+        assert_eq!(pass_verdict_of(&json!({ "pass_verdict": "" })), "");
+        assert_eq!(pass_verdict_of(&json!({ "pass_verdict": "  " })), "  ");
         assert_eq!(
-            pass_verdict_of(&json!({ "pass_verdict": "  " })),
-            DEFAULT_PASS_VERDICT
-        );
-        assert_eq!(
-            pass_verdict_of(&json!({ "pass_verdict": "gate_ok" })),
-            "gate_ok"
+            pass_verdict_of(&json!({ "pass_verdict": " gate_ok " })),
+            " gate_ok "
         );
     }
 
@@ -445,7 +497,7 @@ mod tests {
         let explicit = json!({ "decision": "gate_failed", "checks": { "build_passed": "pass" } });
         assert_eq!(
             resolve_verdict(Some(&context), &explicit),
-            VerdictResolution::Explicit(Some("gate_failed".to_string()))
+            VerdictResolution::Explicit("gate_failed".to_string())
         );
 
         let inferred = json!({ "checks": { "build_passed": "pass" } });

--- a/src/db/auto_queue/phase_gate_verdict.rs
+++ b/src/db/auto_queue/phase_gate_verdict.rs
@@ -1,0 +1,393 @@
+//! #4884: canonical phase-gate verdict reducer inputs.
+//!
+//! Every durable phase-gate decision — the finalize path's verdict injection
+//! (`src/dispatch/dispatch_status.rs`), the reconciler that runs for CRUD /
+//! watcher / bridge-recovery completions
+//! (`reconcile_phase_gate_for_terminal_dispatch_on_pg_tx`), and the sibling
+//! aggregation inside that reconciler — must answer the same two questions the
+//! same way:
+//!
+//!   1. does this dispatch result already carry an explicit verdict?
+//!   2. if not, do the reported `checks` justify inferring the gate's
+//!      `pass_verdict`?
+//!
+//! Before this module those questions had two divergent Rust answers, so the
+//! same dispatch result could pass on one completion entry point and fail on
+//! another (see the module tests for the two concrete divergences that were
+//! fixed). This module is the single Rust authority; it is pure, so it can be
+//! unit-tested without Postgres and reused from both the dispatch layer and
+//! the db layer.
+//!
+//! The semantics deliberately mirror
+//! `policies/lib/auto-queue-phase-gate.js::_inferPhaseGatePassVerdict` so the
+//! JS policy hook and the durable Rust path agree while the JS reducer is
+//! still live.
+
+use serde_json::Value;
+
+/// Gate verdict used when a `phase_gate` context omits `pass_verdict`.
+pub const DEFAULT_PASS_VERDICT: &str = "phase_gate_passed";
+
+/// Result keys that carry an explicit verdict, in the same precedence order as
+/// the JS `result.verdict || result.decision || result.phase_gate_verdict`
+/// chain.
+const EXPLICIT_VERDICT_KEYS: [&str; 3] = ["verdict", "decision", "phase_gate_verdict"];
+
+/// JS-style truthiness for `result.verdict || result.decision ||
+/// result.phase_gate_verdict`.
+///
+/// Any non-falsy value (boolean `true`, non-zero number, non-empty string, any
+/// array/object) counts as an explicit verdict and therefore blocks inference —
+/// including values that are not strings. Matching JS here matters because the
+/// policy hook and the durable path must not disagree about whether a result
+/// "already decided".
+pub fn has_explicit_verdict(result: &Value) -> bool {
+    EXPLICIT_VERDICT_KEYS
+        .iter()
+        .filter_map(|key| result.get(*key))
+        .any(is_js_truthy)
+}
+
+/// Trimmed, non-empty string form of the explicit verdict, if the result
+/// carries one. Non-string explicit values (which still block inference via
+/// [`has_explicit_verdict`]) have no string form and yield `None`.
+pub fn explicit_verdict(result: &Value) -> Option<String> {
+    for key in EXPLICIT_VERDICT_KEYS {
+        if let Some(text) = result.get(key).and_then(Value::as_str) {
+            let trimmed = text.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Whether a single `result.checks` entry reports a pass.
+///
+/// Accepts the canonical `{"status": "pass"}` object form, the `{"result":
+/// "pass"}` alias, and a bare `"pass"` string. `status` is only consulted when
+/// it is a non-empty string so an empty `status` falls through to `result`,
+/// mirroring the JS `entry.status || entry.result` chain (#2048 F12).
+pub fn check_entry_is_pass(entry: &Value) -> bool {
+    let raw = match entry {
+        Value::String(text) => Some(text.as_str()),
+        Value::Object(map) => map
+            .get("status")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .or_else(|| map.get("result").and_then(Value::as_str)),
+        _ => None,
+    };
+    raw.map(|status| status.eq_ignore_ascii_case("pass") || status.eq_ignore_ascii_case("passed"))
+        .unwrap_or(false)
+}
+
+/// The `pass_verdict` declared by a `phase_gate` context object, falling back
+/// to [`DEFAULT_PASS_VERDICT`].
+pub fn pass_verdict_of(phase_gate: &Value) -> String {
+    phase_gate
+        .get("pass_verdict")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_PASS_VERDICT)
+        .to_string()
+}
+
+/// Checks-only inference against an already-extracted `phase_gate` context
+/// object. Ignores any explicit verdict on `result` — callers that must honour
+/// an explicit verdict use [`infer_pass_verdict`] instead.
+///
+/// Refuses to infer when the gate context is not an object, when no checks are
+/// reported, when a declared check is missing from `result.checks`, or when any
+/// declared-or-present check does not pass.
+pub fn infer_pass_verdict_in_gate(phase_gate: &Value, result: &Value) -> Option<String> {
+    if !phase_gate.is_object() {
+        return None;
+    }
+    let checks = result.get("checks")?.as_object()?;
+    if checks.is_empty() {
+        return None;
+    }
+
+    if let Some(declared) = phase_gate.get("checks").and_then(Value::as_array) {
+        for required in declared {
+            let Some(name) = required.as_str() else {
+                continue;
+            };
+            let Some(entry) = checks.get(name) else {
+                return None;
+            };
+            if !check_entry_is_pass(entry) {
+                return None;
+            }
+        }
+    }
+
+    // Every *present* entry must also pass: a partial payload where the
+    // declared checks pass but an extra check fails must not advance the gate.
+    if !checks.values().all(check_entry_is_pass) {
+        return None;
+    }
+
+    Some(pass_verdict_of(phase_gate))
+}
+
+/// Checks-only inference against a full dispatch context (`context.phase_gate`).
+pub fn infer_pass_verdict_from_checks(context: Option<&Value>, result: &Value) -> Option<String> {
+    infer_pass_verdict_in_gate(context?.get("phase_gate")?, result)
+}
+
+/// Full inference: never overrides an explicit verdict (even an explicit
+/// failure), otherwise falls back to checks-only inference.
+pub fn infer_pass_verdict(context: Option<&Value>, result: &Value) -> Option<String> {
+    if has_explicit_verdict(result) {
+        return None;
+    }
+    infer_pass_verdict_from_checks(context, result)
+}
+
+/// The verdict a dispatch result carries: the explicit one when present,
+/// otherwise the checks-inferred pass verdict.
+pub fn resolve_verdict(context: Option<&Value>, result: &Value) -> Option<String> {
+    explicit_verdict(result).or_else(|| infer_pass_verdict(context, result))
+}
+
+/// Whether `actual` satisfies the gate's `expected` pass verdict.
+///
+/// A generic `pass` / `passed` verdict is accepted only when the reported
+/// checks independently justify `expected`, so a bare `"pass"` cannot advance a
+/// gate whose checks did not actually pass.
+pub fn verdict_matches(
+    actual: Option<&str>,
+    expected: &str,
+    context: Option<&Value>,
+    result: Option<&Value>,
+) -> bool {
+    let Some(actual) = actual.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    if actual == expected {
+        return true;
+    }
+    if !matches!(actual, "pass" | "passed") {
+        return false;
+    }
+    result
+        .and_then(|result| infer_pass_verdict_from_checks(context, result))
+        .as_deref()
+        == Some(expected)
+}
+
+fn is_js_truthy(value: &Value) -> bool {
+    match value {
+        Value::Null => false,
+        Value::Bool(flag) => *flag,
+        Value::String(text) => !text.is_empty(),
+        Value::Number(number) => number
+            .as_f64()
+            .map(|raw| raw != 0.0 && !raw.is_nan())
+            .unwrap_or(false),
+        Value::Array(_) | Value::Object(_) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn gate_context(checks: Value, pass_verdict: &str) -> Value {
+        json!({
+            "phase_gate": {
+                "checks": checks,
+                "pass_verdict": pass_verdict,
+            }
+        })
+    }
+
+    #[test]
+    fn explicit_verdict_blocks_inference_across_all_three_keys() {
+        let context = gate_context(json!(["merge_verified"]), "phase_gate_passed");
+        for key in ["verdict", "decision", "phase_gate_verdict"] {
+            let result = json!({
+                key: "fail",
+                "checks": { "merge_verified": { "status": "pass" } },
+            });
+            assert!(
+                has_explicit_verdict(&result),
+                "{key} should count as explicit"
+            );
+            assert_eq!(
+                infer_pass_verdict(Some(&context), &result),
+                None,
+                "{key} must not be overridden by checks-only inference"
+            );
+            assert_eq!(explicit_verdict(&result).as_deref(), Some("fail"));
+        }
+    }
+
+    /// #4884 divergence 1: the finalize path only inspected `verdict` /
+    /// `decision`, so a result whose explicit failure lived on
+    /// `phase_gate_verdict` had a pass verdict injected over it while the
+    /// durable reconciler refused to infer. Same evidence, opposite outcome
+    /// depending on the completion entry point.
+    #[test]
+    fn phase_gate_verdict_key_is_honoured_as_explicit() {
+        let context = gate_context(json!(["merge_verified"]), "phase_gate_passed");
+        let result = json!({
+            "phase_gate_verdict": "phase_gate_failed",
+            "checks": { "merge_verified": { "status": "pass" } },
+        });
+        assert_eq!(infer_pass_verdict(Some(&context), &result), None);
+        assert!(!verdict_matches(
+            resolve_verdict(Some(&context), &result).as_deref(),
+            "phase_gate_passed",
+            Some(&context),
+            Some(&result),
+        ));
+    }
+
+    #[test]
+    fn non_string_truthy_explicit_verdict_blocks_inference() {
+        let context = gate_context(json!([]), "phase_gate_passed");
+        for explicit in [json!(true), json!(1), json!({ "nested": 1 })] {
+            let result = json!({
+                "verdict": explicit,
+                "checks": { "build_passed": "pass" },
+            });
+            assert_eq!(infer_pass_verdict(Some(&context), &result), None);
+        }
+    }
+
+    #[test]
+    fn falsy_explicit_verdict_does_not_block_inference() {
+        let context = gate_context(json!(["build_passed"]), "phase_gate_passed");
+        for falsy in [json!(null), json!(false), json!(0), json!("")] {
+            let result = json!({
+                "verdict": falsy,
+                "checks": { "build_passed": "pass" },
+            });
+            assert_eq!(
+                infer_pass_verdict(Some(&context), &result).as_deref(),
+                Some("phase_gate_passed"),
+            );
+        }
+    }
+
+    /// #4884 divergence 2: the finalize path short-circuited on the presence of
+    /// a `status` key even when it was empty, so `{"status": "", "result":
+    /// "pass"}` read as a failure there and as a pass in the reconciler.
+    #[test]
+    fn empty_status_falls_back_to_result_alias() {
+        assert!(check_entry_is_pass(&json!({ "status": "", "result": "pass" })));
+        assert!(check_entry_is_pass(&json!({ "status": "PASSED" })));
+        assert!(check_entry_is_pass(&json!("pass")));
+        assert!(!check_entry_is_pass(&json!({ "status": "fail" })));
+        assert!(!check_entry_is_pass(&json!({})));
+        assert!(!check_entry_is_pass(&json!(7)));
+    }
+
+    #[test]
+    fn missing_declared_check_refuses_inference() {
+        let context = gate_context(json!(["merge_verified", "issue_closed"]), "gate_ok");
+        let result = json!({ "checks": { "merge_verified": { "status": "pass" } } });
+        assert_eq!(infer_pass_verdict(Some(&context), &result), None);
+    }
+
+    #[test]
+    fn extra_failing_check_refuses_inference() {
+        let context = gate_context(json!(["merge_verified"]), "gate_ok");
+        let result = json!({
+            "checks": {
+                "merge_verified": { "status": "pass" },
+                "issue_closed": { "status": "fail" },
+            }
+        });
+        assert_eq!(infer_pass_verdict(Some(&context), &result), None);
+    }
+
+    #[test]
+    fn empty_or_absent_checks_refuse_inference() {
+        let context = gate_context(json!([]), "gate_ok");
+        assert_eq!(
+            infer_pass_verdict(Some(&context), &json!({ "checks": {} })),
+            None
+        );
+        assert_eq!(infer_pass_verdict(Some(&context), &json!({})), None);
+        assert_eq!(
+            infer_pass_verdict(Some(&context), &json!({ "checks": [] })),
+            None
+        );
+    }
+
+    #[test]
+    fn missing_phase_gate_context_refuses_inference() {
+        let result = json!({ "checks": { "build_passed": "pass" } });
+        assert_eq!(infer_pass_verdict(None, &result), None);
+        assert_eq!(infer_pass_verdict(Some(&json!({})), &result), None);
+        assert_eq!(
+            infer_pass_verdict(Some(&json!({ "phase_gate": "nope" })), &result),
+            None
+        );
+    }
+
+    #[test]
+    fn pass_verdict_defaults_when_absent_or_blank() {
+        assert_eq!(pass_verdict_of(&json!({})), DEFAULT_PASS_VERDICT);
+        assert_eq!(
+            pass_verdict_of(&json!({ "pass_verdict": "  " })),
+            DEFAULT_PASS_VERDICT
+        );
+        assert_eq!(pass_verdict_of(&json!({ "pass_verdict": "gate_ok" })), "gate_ok");
+    }
+
+    #[test]
+    fn generic_pass_matches_only_when_checks_justify_it() {
+        let context = gate_context(json!(["merge_verified"]), "gate_ok");
+        let passing = json!({ "checks": { "merge_verified": { "status": "pass" } } });
+        let failing = json!({ "checks": { "merge_verified": { "status": "fail" } } });
+
+        assert!(verdict_matches(
+            Some("pass"),
+            "gate_ok",
+            Some(&context),
+            Some(&passing)
+        ));
+        assert!(!verdict_matches(
+            Some("pass"),
+            "gate_ok",
+            Some(&context),
+            Some(&failing)
+        ));
+        assert!(!verdict_matches(Some("pass"), "gate_ok", Some(&context), None));
+        assert!(verdict_matches(
+            Some(" gate_ok "),
+            "gate_ok",
+            None,
+            Some(&passing)
+        ));
+        assert!(!verdict_matches(None, "gate_ok", Some(&context), Some(&passing)));
+        assert!(!verdict_matches(Some("   "), "gate_ok", Some(&context), Some(&passing)));
+    }
+
+    #[test]
+    fn resolve_verdict_prefers_explicit_then_inferred() {
+        let context = gate_context(json!(["build_passed"]), "gate_ok");
+        let explicit = json!({ "decision": "gate_failed", "checks": { "build_passed": "pass" } });
+        assert_eq!(
+            resolve_verdict(Some(&context), &explicit).as_deref(),
+            Some("gate_failed")
+        );
+
+        let inferred = json!({ "checks": { "build_passed": "pass" } });
+        assert_eq!(
+            resolve_verdict(Some(&context), &inferred).as_deref(),
+            Some("gate_ok")
+        );
+
+        let undecided = json!({ "checks": { "build_passed": "fail" } });
+        assert_eq!(resolve_verdict(Some(&context), &undecided), None);
+    }
+}

--- a/src/db/auto_queue/phase_gates.rs
+++ b/src/db/auto_queue/phase_gates.rs
@@ -1931,11 +1931,11 @@ mod reconcile_phase_gate_pg_tests {
         .bind(phase)
         .fetch_one(pool)
         .await
-        .expect("gate failure diagnostic");
+        .expect("gate failure diagnostic"); // agentdesk-audit: allow-unwrap — test-only PG assertion in #[cfg(test)] module
         (
-            row.try_get("verdict").expect("decode verdict"),
+            row.try_get("verdict").expect("decode verdict"), // agentdesk-audit: allow-unwrap — test-only PG assertion in #[cfg(test)] module
             row.try_get("failure_reason")
-                .expect("decode failure reason"),
+                .expect("decode failure reason"), // agentdesk-audit: allow-unwrap — test-only PG assertion in #[cfg(test)] module
         )
     }
 
@@ -2319,7 +2319,7 @@ mod reconcile_phase_gate_pg_tests {
             },
         )
         .await
-        .expect("seed gate state");
+        .expect("seed gate state"); // agentdesk-audit: allow-unwrap — test-only PG fixture in #[cfg(test)] module
 
         let outcome =
             run_reconcile(&pool, "dsp-diagnostic", "completed", context, Some(result)).await;
@@ -2387,7 +2387,7 @@ mod reconcile_phase_gate_pg_tests {
             },
         )
         .await
-        .expect("seed mixed gate groups");
+        .expect("seed mixed gate groups"); // agentdesk-audit: allow-unwrap — test-only PG fixture in #[cfg(test)] module
 
         let outcome = run_reconcile(
             &pool,
@@ -3127,7 +3127,7 @@ mod reconcile_phase_gate_pg_tests {
             },
         )
         .await
-        .expect("seed reducer path fixture");
+        .expect("seed reducer path fixture"); // agentdesk-audit: allow-unwrap — test-only PG fixture in #[cfg(test)] module
 
         let outcome = run_reconcile(
             &pool,

--- a/src/db/auto_queue/phase_gates.rs
+++ b/src/db/auto_queue/phase_gates.rs
@@ -2282,7 +2282,7 @@ mod reconcile_phase_gate_pg_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn non_string_explicit_payload_is_preserved_in_failure_diagnostics() {
+    async fn non_string_explicit_payload_is_redacted_in_failure_diagnostics() {
         let pg_db = TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
         fixture(&pool).await;
@@ -2296,7 +2296,7 @@ mod reconcile_phase_gate_pg_tests {
             }
         });
         let result = json!({
-            "verdict": {"blocked_by": "operator"},
+            "verdict": {"authorization": "Bearer secret"},
             "checks": {"build_passed": {"status": "fail"}}
         });
         insert_dispatch(
@@ -2323,18 +2323,43 @@ mod reconcile_phase_gate_pg_tests {
 
         let outcome =
             run_reconcile(&pool, "dsp-diagnostic", "completed", context, Some(result)).await;
-        assert!(matches!(
-            outcome,
-            PhaseGateReconciliation::MarkedFailed { .. }
-        ));
+        let outcome_reason = match &outcome {
+            PhaseGateReconciliation::MarkedFailed { failed_reason, .. } => Some(failed_reason),
+            _ => None,
+        };
+        assert!(
+            outcome_reason.is_some_and(|reason| reason.contains("<non-string:object>")),
+            "outcome should retain only the verdict class: {outcome:?}"
+        );
+        assert!(
+            outcome_reason.is_some_and(|reason| {
+                !reason.contains("authorization") && !reason.contains("Bearer secret")
+            }),
+            "outcome must redact verdict keys and values: {outcome:?}"
+        );
+
         let (verdict, reason) = gate_failure_diagnostic(&pool, "run-pg-test", 0).await;
-        assert_eq!(verdict.as_deref(), Some(r#"{"blocked_by":"operator"}"#));
+        assert_eq!(verdict.as_deref(), Some("<non-string:object>"));
         assert!(
             reason
                 .as_deref()
-                .is_some_and(|reason| reason.contains(r#"{"blocked_by":"operator"}"#)),
-            "failure reason should retain the original payload: {reason:?}"
+                .is_some_and(|reason| reason.contains("<non-string:object>")),
+            "failure reason should retain only the verdict class: {reason:?}"
         );
+        for forbidden in ["authorization", "Bearer secret"] {
+            assert!(
+                verdict
+                    .as_deref()
+                    .is_none_or(|verdict| !verdict.contains(forbidden)),
+                "persisted verdict leaked {forbidden}: {verdict:?}"
+            );
+            assert!(
+                reason
+                    .as_deref()
+                    .is_none_or(|reason| !reason.contains(forbidden)),
+                "persisted failure reason leaked {forbidden}: {reason:?}"
+            );
+        }
 
         pool.close().await;
         pg_db.drop().await;

--- a/src/db/auto_queue/phase_gates.rs
+++ b/src/db/auto_queue/phase_gates.rs
@@ -1947,6 +1947,7 @@ mod reconcile_phase_gate_pg_tests {
                 "pass_verdict": "phase_gate_passed",
                 "next_phase": 1,
                 "final_phase": false,
+                "checks": ["merge_verified", "issue_closed", "build_passed"],
             }
         })
     }

--- a/src/db/auto_queue/phase_gates.rs
+++ b/src/db/auto_queue/phase_gates.rs
@@ -1431,7 +1431,10 @@ async fn load_sibling_phase_gate_dispatches_on_pg_tx(
                 .unwrap_or_else(|| {
                     format!(
                         "expected verdict {expected_verdict}, got {}",
-                        diagnostic_verdict.as_deref().or(actual_verdict).unwrap_or("none")
+                        diagnostic_verdict
+                            .as_deref()
+                            .or(actual_verdict)
+                            .unwrap_or("none")
                     )
                 });
             summary.failed_sibling = Some(FailedSibling {
@@ -1817,7 +1820,7 @@ mod reconcile_phase_gate_pg_tests {
     use crate::db::auto_queue::phase_gate_verdict::{VerdictResolution, resolve_verdict};
     use crate::db::auto_queue::test_support::TestPostgresDb;
     use serde_json::json;
-    use sqlx::PgPool;
+    use sqlx::{PgPool, Row};
     use std::sync::Arc;
     use tokio::sync::Barrier;
 
@@ -1931,7 +1934,8 @@ mod reconcile_phase_gate_pg_tests {
         .expect("gate failure diagnostic");
         (
             row.try_get("verdict").expect("decode verdict"),
-            row.try_get("failure_reason").expect("decode failure reason"),
+            row.try_get("failure_reason")
+                .expect("decode failure reason"),
         )
     }
 
@@ -2316,15 +2320,12 @@ mod reconcile_phase_gate_pg_tests {
         .await
         .expect("seed gate state");
 
-        let outcome = run_reconcile(
-            &pool,
-            "dsp-diagnostic",
-            "completed",
-            context,
-            Some(result),
-        )
-        .await;
-        assert!(matches!(outcome, PhaseGateReconciliation::MarkedFailed { .. }));
+        let outcome =
+            run_reconcile(&pool, "dsp-diagnostic", "completed", context, Some(result)).await;
+        assert!(matches!(
+            outcome,
+            PhaseGateReconciliation::MarkedFailed { .. }
+        ));
         let (verdict, reason) = gate_failure_diagnostic(&pool, "run-pg-test", 0).await;
         assert_eq!(verdict.as_deref(), Some(r#"{"blocked_by":"operator"}"#));
         assert!(

--- a/src/db/auto_queue/phase_gates.rs
+++ b/src/db/auto_queue/phase_gates.rs
@@ -572,16 +572,19 @@ async fn reconcile_phase_gate_for_terminal_dispatch_on_pg_tx_inner(
     // #1980 + #699: legacy / checks-only results do not carry an explicit
     // verdict, so `resolve_verdict` falls back to checks inference — the same
     // fallback the dispatch finalize path applies before persisting a result.
-    let verdict = result_value
+    let verdict_resolution = result_value
         .as_ref()
-        .and_then(|result| resolve_verdict(context_value.as_ref(), result));
+        .map(|result| resolve_verdict(context_value.as_ref(), result));
+    let verdict = verdict_resolution
+        .as_ref()
+        .and_then(|resolution| resolution.verdict());
 
     // Treat any non-`completed` terminal status (`failed`/`cancelled`) as a
     // gate failure regardless of verdict — the dispatch never produced a
     // verdict so we cannot pretend it passed.
     if dispatch_status != "completed"
         || !phase_gate_verdict_matches(
-            verdict.as_deref(),
+            verdict,
             &pass_verdict,
             context_value.as_ref(),
             result_value.as_ref(),
@@ -590,7 +593,7 @@ async fn reconcile_phase_gate_for_terminal_dispatch_on_pg_tx_inner(
         let failed_reason = compose_failed_reason(
             dispatch_status,
             dispatch_result_json,
-            verdict.as_deref(),
+            verdict,
             &pass_verdict,
         );
         mark_phase_gate_row_failed_on_pg_tx(
@@ -598,7 +601,7 @@ async fn reconcile_phase_gate_for_terminal_dispatch_on_pg_tx_inner(
             &gate.run_id,
             gate.phase,
             dispatch_id,
-            verdict.as_deref(),
+            verdict,
             &failed_reason,
         )
         .await?;
@@ -1388,11 +1391,14 @@ async fn load_sibling_phase_gate_dispatches_on_pg_tx(
         // Sibling rows go through the same explicit-or-inferred resolution as
         // the primary dispatch so an aggregate gate decision cannot disagree
         // with the per-dispatch one (#699 round 2, #4884).
-        let actual_verdict = result_value
+        let actual_resolution = result_value
             .as_ref()
-            .and_then(|result| resolve_verdict(context_value.as_ref(), result));
+            .map(|result| resolve_verdict(context_value.as_ref(), result));
+        let actual_verdict = actual_resolution
+            .as_ref()
+            .and_then(|resolution| resolution.verdict());
         if !phase_gate_verdict_matches(
-            actual_verdict.as_deref(),
+            actual_verdict,
             &expected_verdict,
             context_value.as_ref(),
             result_value.as_ref(),
@@ -1408,12 +1414,12 @@ async fn load_sibling_phase_gate_dispatches_on_pg_tx(
                 .unwrap_or_else(|| {
                     format!(
                         "expected verdict {expected_verdict}, got {}",
-                        actual_verdict.as_deref().unwrap_or("none")
+                        actual_verdict.unwrap_or("none")
                     )
                 });
             summary.failed_sibling = Some(FailedSibling {
                 dispatch_id,
-                verdict: actual_verdict,
+                verdict: actual_verdict.map(str::to_string),
                 reason,
             });
             return Ok(summary);

--- a/src/db/auto_queue/phase_gates.rs
+++ b/src/db/auto_queue/phase_gates.rs
@@ -2,6 +2,14 @@ use serde_json::Value;
 use sqlx::{PgPool, Row as SqlxRow};
 use thiserror::Error;
 
+// #4884: verdict inference lives in exactly one place. The aliases keep this
+// module's long-standing local names while the bodies moved to the canonical
+// reducer shared with the dispatch finalize path.
+use super::phase_gate_verdict::{
+    DEFAULT_PASS_VERDICT, pass_verdict_of, resolve_verdict,
+    verdict_matches as phase_gate_verdict_matches,
+};
+
 pub async fn current_batch_phase_pg(
     pool: &PgPool,
     run_id: &str,
@@ -546,7 +554,7 @@ async fn reconcile_phase_gate_for_terminal_dispatch_on_pg_tx_inner(
     }
 
     let pass_verdict = if gate.pass_verdict.is_empty() {
-        "phase_gate_passed".to_string()
+        DEFAULT_PASS_VERDICT.to_string()
     } else {
         gate.pass_verdict.clone()
     };
@@ -561,15 +569,12 @@ async fn reconcile_phase_gate_for_terminal_dispatch_on_pg_tx_inner(
         .map(str::trim)
         .filter(|raw| !raw.is_empty())
         .and_then(|raw| serde_json::from_str(raw).ok());
-    let mut verdict = result_value.as_ref().and_then(extract_explicit_verdict);
-    if verdict.is_none()
-        && let Some(result) = result_value.as_ref()
-    {
-        // #1980 + #699: legacy / checks-only results do not include an
-        // explicit verdict. Mirror the JS hook's inference so the durable
-        // Rust path does not spuriously fail those gates.
-        verdict = infer_phase_gate_pass_verdict(context_value.as_ref(), result);
-    }
+    // #1980 + #699: legacy / checks-only results do not carry an explicit
+    // verdict, so `resolve_verdict` falls back to checks inference — the same
+    // fallback the dispatch finalize path applies before persisting a result.
+    let verdict = result_value
+        .as_ref()
+        .and_then(|result| resolve_verdict(context_value.as_ref(), result));
 
     // Treat any non-`completed` terminal status (`failed`/`cancelled`) as a
     // gate failure regardless of verdict — the dispatch never produced a
@@ -1209,153 +1214,6 @@ fn numeric_i64(value: &Value) -> Option<i64> {
     None
 }
 
-fn extract_explicit_verdict(result: &Value) -> Option<String> {
-    for key in ["verdict", "decision", "phase_gate_verdict"] {
-        if let Some(text) = result.get(key).and_then(Value::as_str) {
-            let trimmed = text.trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_string());
-            }
-        }
-    }
-    None
-}
-
-/// Mirror of the JS `_inferPhaseGatePassVerdict` helper in
-/// `policies/auto-queue.js`. When a phase-gate dispatch result is missing an
-/// explicit `verdict` / `decision` / `phase_gate_verdict`, but reports check entries that all pass,
-/// fall back to the gate's `pass_verdict` (default `phase_gate_passed`). This
-/// keeps legacy / checks-only results from being reconciled as failures by
-/// the durable Rust path.
-///
-/// Refuses to infer if any check fails, if any declared check is missing, if
-/// no checks are reported, or if `result.verdict` / `result.decision` /
-/// `result.phase_gate_verdict` is
-/// already set to anything truthy (mirroring JS's `||` operator semantics —
-/// numbers, booleans, objects all count as explicit just like in JS).
-fn infer_phase_gate_pass_verdict(context: Option<&Value>, result: &Value) -> Option<String> {
-    if has_js_truthy_explicit_verdict(result) {
-        return None;
-    }
-    infer_phase_gate_pass_verdict_from_checks(context, result)
-}
-
-fn infer_phase_gate_pass_verdict_from_checks(
-    context: Option<&Value>,
-    result: &Value,
-) -> Option<String> {
-    let phase_gate = context?.get("phase_gate")?;
-    if !phase_gate.is_object() {
-        return None;
-    }
-    let checks = result.get("checks")?.as_object()?;
-    if checks.is_empty() {
-        return None;
-    }
-
-    if let Some(declared) = phase_gate.get("checks").and_then(Value::as_array) {
-        for required in declared {
-            let Some(name) = required.as_str() else {
-                continue;
-            };
-            let Some(entry) = checks.get(name) else {
-                return None;
-            };
-            if !js_check_entry_is_pass(entry) {
-                return None;
-            }
-        }
-    }
-
-    for entry in checks.values() {
-        if !js_check_entry_is_pass(entry) {
-            return None;
-        }
-    }
-
-    let pass_verdict = phase_gate
-        .get("pass_verdict")
-        .and_then(Value::as_str)
-        .map(str::to_string)
-        .unwrap_or_else(|| "phase_gate_passed".to_string());
-    Some(pass_verdict)
-}
-
-fn phase_gate_verdict_matches(
-    actual_verdict: Option<&str>,
-    expected_verdict: &str,
-    context: Option<&Value>,
-    result: Option<&Value>,
-) -> bool {
-    let Some(actual_verdict) = actual_verdict
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    else {
-        return false;
-    };
-    if actual_verdict == expected_verdict {
-        return true;
-    }
-    if !matches!(actual_verdict, "pass" | "passed") {
-        return false;
-    }
-    result
-        .and_then(|result| infer_phase_gate_pass_verdict_from_checks(context, result))
-        .as_deref()
-        == Some(expected_verdict)
-}
-
-/// JS-style truthiness check for `result.verdict || result.decision || result.phase_gate_verdict`.
-/// Mirrors the `||` short-circuit in `policies/auto-queue.js:47` so any
-/// non-falsy value (boolean true, non-zero number, non-empty string, any
-/// object/array) blocks inference.
-fn has_js_truthy_explicit_verdict(result: &Value) -> bool {
-    for key in ["verdict", "decision", "phase_gate_verdict"] {
-        if let Some(value) = result.get(key)
-            && is_js_truthy(value)
-        {
-            return true;
-        }
-    }
-    false
-}
-
-fn is_js_truthy(value: &Value) -> bool {
-    match value {
-        Value::Null => false,
-        Value::Bool(b) => *b,
-        Value::String(s) => !s.is_empty(),
-        Value::Number(n) => n.as_f64().map(|f| f != 0.0 && !f.is_nan()).unwrap_or(false),
-        Value::Array(_) | Value::Object(_) => true,
-    }
-}
-
-/// Mirrors `entryIsPass` from `policies/auto-queue.js`. Notably, JS does NOT
-/// trim whitespace before comparing — only lowercases via `String(...)`. We
-/// match that exactly so a status like `" pass "` is rejected here and in JS.
-fn js_check_entry_is_pass(entry: &Value) -> bool {
-    // #2048 F12: mirror JS `entry.status || entry.result` truthiness. JS
-    // treats an empty string as falsy and falls through to `entry.result`;
-    // the previous Rust port short-circuited on `status` key presence even
-    // when its value was `""`, causing a Rust→JS verdict divergence. Now
-    // we ignore empty strings on the `status` side and fall back to
-    // `result` just like JS.
-    let raw = match entry {
-        Value::String(text) => Some(text.as_str()),
-        Value::Object(map) => map
-            .get("status")
-            .and_then(Value::as_str)
-            .filter(|value| !value.is_empty())
-            .or_else(|| map.get("result").and_then(Value::as_str)),
-        _ => None,
-    };
-    raw.map(|status| {
-        let lower = status.to_ascii_lowercase();
-        lower == "pass" || lower == "passed"
-    })
-    .unwrap_or(false)
-}
-
 fn compose_failed_reason(
     dispatch_status: &str,
     dispatch_result_json: Option<&str>,
@@ -1524,19 +1382,15 @@ async fn load_sibling_phase_gate_dispatches_on_pg_tx(
 
         let expected_verdict = context_value
             .as_ref()
-            .and_then(|v| v.get("phase_gate"))
-            .and_then(|gate| gate.get("pass_verdict"))
-            .and_then(Value::as_str)
-            .map(str::to_string)
-            .unwrap_or_else(|| "phase_gate_passed".to_string());
-        let mut actual_verdict = result_value.as_ref().and_then(extract_explicit_verdict);
-        if actual_verdict.is_none()
-            && let Some(result) = result_value.as_ref()
-        {
-            // Mirror the JS hook's #699-round-2 inference for legacy sibling
-            // rows that completed before the server fix shipped.
-            actual_verdict = infer_phase_gate_pass_verdict(context_value.as_ref(), result);
-        }
+            .and_then(|value| value.get("phase_gate"))
+            .map(pass_verdict_of)
+            .unwrap_or_else(|| DEFAULT_PASS_VERDICT.to_string());
+        // Sibling rows go through the same explicit-or-inferred resolution as
+        // the primary dispatch so an aggregate gate decision cannot disagree
+        // with the per-dispatch one (#699 round 2, #4884).
+        let actual_verdict = result_value
+            .as_ref()
+            .and_then(|result| resolve_verdict(context_value.as_ref(), result));
         if !phase_gate_verdict_matches(
             actual_verdict.as_deref(),
             &expected_verdict,
@@ -1933,10 +1787,11 @@ mod current_batch_phase_pg_tests {
 mod reconcile_phase_gate_pg_tests {
     use super::{
         PhaseGateReconciliation, PhaseGateRepairOptions, PhaseGateStateWrite,
-        infer_phase_gate_pass_verdict, parse_phase_gate_context, phase_gate_verdict_matches,
+        parse_phase_gate_context, phase_gate_verdict_matches,
         reconcile_phase_gate_for_terminal_dispatch_on_pg_tx, repair_phase_gates_for_run_on_pg,
         save_phase_gate_state_on_pg,
     };
+    use crate::db::auto_queue::phase_gate_verdict::infer_pass_verdict as infer_phase_gate_pass_verdict;
     use crate::db::auto_queue::test_support::TestPostgresDb;
     use serde_json::json;
     use sqlx::PgPool;

--- a/src/db/auto_queue/phase_gates.rs
+++ b/src/db/auto_queue/phase_gates.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 // module's long-standing local names while the bodies moved to the canonical
 // reducer shared with the dispatch finalize path.
 use super::phase_gate_verdict::{
-    DEFAULT_PASS_VERDICT, pass_verdict_of, resolve_verdict,
+    DEFAULT_PASS_VERDICT, diagnostic_verdict, pass_verdict_of, resolve_verdict,
     verdict_matches as phase_gate_verdict_matches,
 };
 
@@ -553,14 +553,8 @@ async fn reconcile_phase_gate_for_terminal_dispatch_on_pg_tx_inner(
         return Ok(PhaseGateReconciliation::AlreadyFailed);
     }
 
-    let pass_verdict = if gate.pass_verdict.is_empty() {
-        DEFAULT_PASS_VERDICT.to_string()
-    } else {
-        gate.pass_verdict.clone()
-    };
-
-    // Parse JSON once so we can reuse it for both explicit verdict extraction
-    // and checks-only inference.
+    // Parse JSON once so we can reuse it for expected-verdict selection,
+    // explicit verdict extraction, and checks-only inference.
     let result_value: Option<Value> = dispatch_result_json
         .map(str::trim)
         .filter(|raw| !raw.is_empty())
@@ -569,6 +563,21 @@ async fn reconcile_phase_gate_for_terminal_dispatch_on_pg_tx_inner(
         .map(str::trim)
         .filter(|raw| !raw.is_empty())
         .and_then(|raw| serde_json::from_str(raw).ok());
+    // Each dispatch context is the authority for its own expected verdict.
+    // A phase may contain multiple gate groups with different pass verdicts;
+    // using the first persisted gate-row value here makes primary and sibling
+    // reconciliation disagree for the same dispatch.
+    let pass_verdict = context_value
+        .as_ref()
+        .and_then(|context| context.get("phase_gate"))
+        .map(pass_verdict_of)
+        .unwrap_or_else(|| {
+            if gate.pass_verdict.is_empty() {
+                DEFAULT_PASS_VERDICT.to_string()
+            } else {
+                gate.pass_verdict.clone()
+            }
+        });
     // #1980 + #699: legacy / checks-only results do not carry an explicit
     // verdict, so `resolve_verdict` falls back to checks inference — the same
     // fallback the dispatch finalize path applies before persisting a result.
@@ -578,6 +587,10 @@ async fn reconcile_phase_gate_for_terminal_dispatch_on_pg_tx_inner(
     let verdict = verdict_resolution
         .as_ref()
         .and_then(|resolution| resolution.verdict());
+    let diagnostic_verdict = result_value
+        .as_ref()
+        .zip(verdict_resolution.as_ref())
+        .and_then(|(result, resolution)| diagnostic_verdict(result, resolution));
 
     // Treat any non-`completed` terminal status (`failed`/`cancelled`) as a
     // gate failure regardless of verdict — the dispatch never produced a
@@ -593,7 +606,7 @@ async fn reconcile_phase_gate_for_terminal_dispatch_on_pg_tx_inner(
         let failed_reason = compose_failed_reason(
             dispatch_status,
             dispatch_result_json,
-            verdict,
+            diagnostic_verdict.as_deref().or(verdict),
             &pass_verdict,
         );
         mark_phase_gate_row_failed_on_pg_tx(
@@ -601,7 +614,7 @@ async fn reconcile_phase_gate_for_terminal_dispatch_on_pg_tx_inner(
             &gate.run_id,
             gate.phase,
             dispatch_id,
-            verdict,
+            diagnostic_verdict.as_deref().or(verdict),
             &failed_reason,
         )
         .await?;
@@ -1397,6 +1410,10 @@ async fn load_sibling_phase_gate_dispatches_on_pg_tx(
         let actual_verdict = actual_resolution
             .as_ref()
             .and_then(|resolution| resolution.verdict());
+        let diagnostic_verdict = result_value
+            .as_ref()
+            .zip(actual_resolution.as_ref())
+            .and_then(|(result, resolution)| diagnostic_verdict(result, resolution));
         if !phase_gate_verdict_matches(
             actual_verdict,
             &expected_verdict,
@@ -1414,12 +1431,12 @@ async fn load_sibling_phase_gate_dispatches_on_pg_tx(
                 .unwrap_or_else(|| {
                     format!(
                         "expected verdict {expected_verdict}, got {}",
-                        actual_verdict.unwrap_or("none")
+                        diagnostic_verdict.as_deref().or(actual_verdict).unwrap_or("none")
                     )
                 });
             summary.failed_sibling = Some(FailedSibling {
                 dispatch_id,
-                verdict: actual_verdict.map(str::to_string),
+                verdict: diagnostic_verdict.or_else(|| actual_verdict.map(str::to_string)),
                 reason,
             });
             return Ok(summary);
@@ -1797,7 +1814,7 @@ mod reconcile_phase_gate_pg_tests {
         reconcile_phase_gate_for_terminal_dispatch_on_pg_tx, repair_phase_gates_for_run_on_pg,
         save_phase_gate_state_on_pg,
     };
-    use crate::db::auto_queue::phase_gate_verdict::infer_pass_verdict as infer_phase_gate_pass_verdict;
+    use crate::db::auto_queue::phase_gate_verdict::{VerdictResolution, resolve_verdict};
     use crate::db::auto_queue::test_support::TestPostgresDb;
     use serde_json::json;
     use sqlx::PgPool;
@@ -1898,6 +1915,26 @@ mod reconcile_phase_gate_pg_tests {
         .expect("gate status")
     }
 
+    async fn gate_failure_diagnostic(
+        pool: &PgPool,
+        run_id: &str,
+        phase: i64,
+    ) -> (Option<String>, Option<String>) {
+        let row = sqlx::query(
+            "SELECT verdict, failure_reason FROM auto_queue_phase_gates
+             WHERE run_id = $1 AND phase = $2 LIMIT 1",
+        )
+        .bind(run_id)
+        .bind(phase)
+        .fetch_one(pool)
+        .await
+        .expect("gate failure diagnostic");
+        (
+            row.try_get("verdict").expect("decode verdict"),
+            row.try_get("failure_reason").expect("decode failure reason"),
+        )
+    }
+
     fn gate_context() -> serde_json::Value {
         json!({
             "phase_gate": {
@@ -1945,7 +1982,10 @@ mod reconcile_phase_gate_pg_tests {
             }
         });
 
-        assert_eq!(infer_phase_gate_pass_verdict(Some(&context), &result), None);
+        assert_eq!(
+            resolve_verdict(Some(&context), &result),
+            VerdictResolution::Explicit("manual_hold".to_string())
+        );
         assert!(!phase_gate_verdict_matches(
             Some("manual_hold"),
             "phase_gate_passed",
@@ -2231,6 +2271,138 @@ mod reconcile_phase_gate_pg_tests {
         }
         assert_eq!(gate_status(&pool, "run-pg-test", 0).await, "failed");
         assert_eq!(run_status(&pool, "run-pg-test").await, "paused");
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn non_string_explicit_payload_is_preserved_in_failure_diagnostics() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        fixture(&pool).await;
+
+        let context = json!({
+            "phase_gate": {
+                "run_id": "run-pg-test",
+                "batch_phase": 0,
+                "pass_verdict": "gate_ok",
+                "checks": ["build_passed"]
+            }
+        });
+        let result = json!({
+            "verdict": {"blocked_by": "operator"},
+            "checks": {"build_passed": {"status": "fail"}}
+        });
+        insert_dispatch(
+            &pool,
+            "dsp-diagnostic",
+            "completed",
+            context.clone(),
+            Some(result.clone()),
+        )
+        .await;
+        save_phase_gate_state_on_pg(
+            &pool,
+            "run-pg-test",
+            0,
+            &PhaseGateStateWrite {
+                status: "pending".into(),
+                pass_verdict: "gate_ok".into(),
+                dispatch_ids: vec!["dsp-diagnostic".into()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("seed gate state");
+
+        let outcome = run_reconcile(
+            &pool,
+            "dsp-diagnostic",
+            "completed",
+            context,
+            Some(result),
+        )
+        .await;
+        assert!(matches!(outcome, PhaseGateReconciliation::MarkedFailed { .. }));
+        let (verdict, reason) = gate_failure_diagnostic(&pool, "run-pg-test", 0).await;
+        assert_eq!(verdict.as_deref(), Some(r#"{"blocked_by":"operator"}"#));
+        assert!(
+            reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains(r#"{"blocked_by":"operator"}"#)),
+            "failure reason should retain the original payload: {reason:?}"
+        );
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn mixed_group_pass_verdict_uses_each_dispatch_context() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        fixture(&pool).await;
+
+        let context_a = json!({
+            "phase_gate": {
+                "run_id": "run-pg-test",
+                "batch_phase": 0,
+                "pass_verdict": "gate_ok",
+                "checks": ["tests"]
+            }
+        });
+        let context_b = json!({
+            "phase_gate": {
+                "run_id": "run-pg-test",
+                "batch_phase": 0,
+                "pass_verdict": "phase_gate_passed",
+                "checks": ["tests"]
+            }
+        });
+        for (id, context, verdict) in [
+            ("dsp-group-a", context_a.clone(), "gate_ok"),
+            ("dsp-group-b", context_b.clone(), "phase_gate_passed"),
+        ] {
+            insert_dispatch(
+                &pool,
+                id,
+                "completed",
+                context.clone(),
+                Some(json!({"verdict": verdict, "checks": {"tests": "pass"}})),
+            )
+            .await;
+        }
+        save_phase_gate_state_on_pg(
+            &pool,
+            "run-pg-test",
+            0,
+            &PhaseGateStateWrite {
+                status: "pending".into(),
+                pass_verdict: "gate_ok".into(),
+                dispatch_ids: vec!["dsp-group-a".into(), "dsp-group-b".into()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("seed mixed gate groups");
+
+        let outcome = run_reconcile(
+            &pool,
+            "dsp-group-b",
+            "completed",
+            context_b,
+            Some(json!({
+                "verdict": "phase_gate_passed",
+                "checks": {"tests": "pass"}
+            })),
+        )
+        .await;
+        assert!(
+            matches!(outcome, PhaseGateReconciliation::Cleared { .. }),
+            "primary and sibling paths must use each dispatch context: {outcome:?}"
+        );
+        assert_eq!(gate_count(&pool, "run-pg-test", 0).await, 0);
 
         pool.close().await;
         pg_db.drop().await;
@@ -2756,21 +2928,23 @@ mod reconcile_phase_gate_pg_tests {
         pg_db.drop().await;
     }
 
-    /// #1980 + codex v2 MED #5 parity: any truthy explicit `verdict`/`decision`
-    /// (including non-string values like numbers or booleans) must block
-    /// inference, matching JS's `||` operator semantics. The result here has
-    /// `verdict: 1` plus all-passing checks — JS would refuse to infer, so
-    /// Rust must too.
+    /// Preserve the pre-#4884 finalize contract: non-string explicit fields are
+    /// ignored and passing declared checks may still infer the pass verdict.
     #[test]
-    fn truthy_non_string_explicit_verdict_blocks_inference() {
-        let context = json!({"phase_gate": {"pass_verdict": "phase_gate_passed"}});
+    fn non_string_explicit_verdict_preserves_checks_inference() {
+        let context = json!({
+            "phase_gate": {
+                "pass_verdict": "phase_gate_passed",
+                "checks": ["tests"]
+            }
+        });
         let result = json!({
             "verdict": 1,
             "checks": { "tests": "pass" },
         });
-        assert!(
-            infer_phase_gate_pass_verdict(Some(&context), &result).is_none(),
-            "truthy non-string verdict must block inference"
+        assert_eq!(
+            resolve_verdict(Some(&context), &result),
+            VerdictResolution::Inferred("phase_gate_passed".to_string())
         );
     }
 
@@ -2782,8 +2956,9 @@ mod reconcile_phase_gate_pg_tests {
         let context =
             json!({"phase_gate": {"pass_verdict": "phase_gate_passed", "checks": ["tests"]}});
         let result = json!({"checks": {"tests": " pass "}});
-        assert!(
-            infer_phase_gate_pass_verdict(Some(&context), &result).is_none(),
+        assert_eq!(
+            resolve_verdict(Some(&context), &result),
+            VerdictResolution::Missing,
             "whitespace-padded status must not be inferred (JS parity)"
         );
     }

--- a/src/db/auto_queue/phase_gates.rs
+++ b/src/db/auto_queue/phase_gates.rs
@@ -3085,6 +3085,68 @@ mod reconcile_phase_gate_pg_tests {
         pg_db.drop().await;
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn primary_and_sibling_checks_only_evidence_use_same_reducer() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        fixture(&pool).await;
+
+        let context = json!({
+            "phase_gate": {
+                "run_id": "run-pg-test",
+                "batch_phase": 0,
+                "pass_verdict": "gate_ok",
+                "checks": ["merge_verified", "issue_closed"]
+            }
+        });
+        let checks_only = json!({
+            "checks": {
+                "merge_verified": {"status": "pass"},
+                "issue_closed": {"status": "", "result": "passed"}
+            }
+        });
+        for id in ["dsp-reducer-primary", "dsp-reducer-sibling"] {
+            insert_dispatch(
+                &pool,
+                id,
+                "completed",
+                context.clone(),
+                Some(checks_only.clone()),
+            )
+            .await;
+        }
+        save_phase_gate_state_on_pg(
+            &pool,
+            "run-pg-test",
+            0,
+            &PhaseGateStateWrite {
+                status: "pending".into(),
+                pass_verdict: "gate_ok".into(),
+                dispatch_ids: vec!["dsp-reducer-primary".into(), "dsp-reducer-sibling".into()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("seed reducer path fixture");
+
+        let outcome = run_reconcile(
+            &pool,
+            "dsp-reducer-primary",
+            "completed",
+            context,
+            Some(checks_only),
+        )
+        .await;
+        assert!(
+            matches!(outcome, PhaseGateReconciliation::Cleared { .. }),
+            "primary and sibling checks-only rows must both infer gate_ok: {outcome:?}"
+        );
+        assert_eq!(gate_count(&pool, "run-pg-test", 0).await, 0);
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
     /// #1980 fix #2: callers may write `status='completed'` without a `result`
     /// (CRUD route). Reconciliation must fall back to the persisted dispatch
     /// row's result so a previously-recorded passing verdict is honored.

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use serde_json::json;
 use sqlx::{PgPool, Row};
 
+use crate::db::auto_queue::phase_gate_verdict;
 use crate::engine::PolicyEngine;
 
 use super::dispatch_query::query_dispatch_row_pg;
@@ -438,7 +439,7 @@ fn infer_effective_completion_result(
     let res = result?;
     context_text
         .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
-        .and_then(|ctx| ctx.get("phase_gate").and_then(|v| v.as_object()).cloned())
+        .and_then(|ctx| ctx.get("phase_gate").cloned())
         .and_then(|phase_gate_ctx| infer_phase_gate_verdict(dispatch_id, &phase_gate_ctx, res))
 }
 
@@ -1038,7 +1039,7 @@ async fn maybe_inject_phase_gate_verdict_pg(
     .flatten()
     .flatten()?;
     let ctx = serde_json::from_str::<serde_json::Value>(&context_raw).ok()?;
-    let phase_gate_ctx = ctx.get("phase_gate").and_then(|v| v.as_object())?;
+    let phase_gate_ctx = ctx.get("phase_gate")?;
     infer_phase_gate_verdict(dispatch_id, phase_gate_ctx, result)
 }
 
@@ -1336,75 +1337,28 @@ fn complete_dispatch_inner_with_backends(
     Ok(dispatch)
 }
 
-/// #699: inject `verdict = context.phase_gate.pass_verdict` into a phase-gate
-/// dispatch result when every declared `checks.*` entry passed but the caller
-/// forgot the explicit verdict field.
+/// #699 / #4884: inject `verdict = context.phase_gate.pass_verdict` into a
+/// phase-gate dispatch result when every declared `checks.*` entry passed but
+/// the caller forgot the explicit verdict field.
 ///
 /// Returns `Some(enriched)` only when an injection happened — callers should
-/// fall back to the original `result` otherwise. Never overrides an explicit
-/// verdict/decision (even `"fail"`) and never injects when any check is not
-/// `pass`.
+/// fall back to the original `result` otherwise.
+///
+/// The pass/fail decision itself is delegated to
+/// `crate::db::auto_queue::phase_gate_verdict`, the single Rust authority also
+/// used by the durable reconciler that runs for CRUD / watcher / bridge
+/// recovery completions. This path only owns the *side effect* of persisting
+/// the inferred verdict onto the result payload; it must never reach a
+/// different verdict than the reconciler would for the same evidence.
 fn infer_phase_gate_verdict(
     dispatch_id: &str,
-    phase_gate_ctx: &serde_json::Map<String, serde_json::Value>,
+    phase_gate_ctx: &serde_json::Value,
     result: &serde_json::Value,
 ) -> Option<serde_json::Value> {
-    // Explicit verdict/decision already present — never override, even for
-    // explicit "fail" cases.
-    let has_verdict = result
-        .get("verdict")
-        .and_then(|v| v.as_str())
-        .map(|s| !s.is_empty())
-        .unwrap_or(false);
-    let has_decision = result
-        .get("decision")
-        .and_then(|v| v.as_str())
-        .map(|s| !s.is_empty())
-        .unwrap_or(false);
-    if has_verdict || has_decision {
+    if phase_gate_verdict::has_explicit_verdict(result) {
         return None;
     }
-
-    let checks_obj = result.get("checks").and_then(|v| v.as_object())?;
-    if checks_obj.is_empty() {
-        return None;
-    }
-
-    // Round-2 fix: when the dispatch context declares a list of required
-    // checks, every one of those keys must be present in `result.checks` and
-    // pass. Missing keys are treated as no-verdict/failure so a partial
-    // payload cannot advance the gate.
-    let declared_checks: Vec<String> = phase_gate_ctx
-        .get("checks")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                .collect()
-        })
-        .unwrap_or_default();
-    for required in &declared_checks {
-        match checks_obj.get(required) {
-            Some(entry) if check_entry_is_pass(entry) => {}
-            _ => return None,
-        }
-    }
-
-    // Also require every *present* check entry to pass — never infer a pass
-    // on the strength of partial "pass"es when some keys report fail/other.
-    for (_name, entry) in checks_obj.iter() {
-        if !check_entry_is_pass(entry) {
-            return None;
-        }
-    }
-
-    // Resolve `pass_verdict` from the dispatch's own phase_gate context, with
-    // the system default as a last resort.
-    let pass_verdict = phase_gate_ctx
-        .get("pass_verdict")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| "phase_gate_passed".to_string());
+    let pass_verdict = phase_gate_verdict::infer_pass_verdict_in_gate(phase_gate_ctx, result)?;
 
     let mut enriched = result.clone();
     if !enriched.is_object() {
@@ -1422,28 +1376,12 @@ fn infer_phase_gate_verdict(
     }
 
     tracing::info!(
-        "[dispatch] #699 inferring phase-gate verdict '{}' for dispatch {} (all {} declared checks passed, {} entries total)",
+        "[dispatch] #699 inferring phase-gate verdict '{}' for dispatch {} (all declared checks passed)",
         pass_verdict,
         dispatch_id,
-        declared_checks.len(),
-        checks_obj.len(),
     );
 
     Some(enriched)
-}
-
-fn check_entry_is_pass(entry: &serde_json::Value) -> bool {
-    // Accept either `{"status": "pass"}` (canonical) or a bare string "pass".
-    if let Some(status) = entry.get("status").and_then(|v| v.as_str()) {
-        return status.eq_ignore_ascii_case("pass") || status.eq_ignore_ascii_case("passed");
-    }
-    if let Some(outcome) = entry.get("result").and_then(|v| v.as_str()) {
-        return outcome.eq_ignore_ascii_case("pass") || outcome.eq_ignore_ascii_case("passed");
-    }
-    if let Some(s) = entry.as_str() {
-        return s.eq_ignore_ascii_case("pass") || s.eq_ignore_ascii_case("passed");
-    }
-    false
 }
 
 #[cfg(test)]

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -1605,7 +1605,7 @@ mod phase_gate_finalize_wrapper_tests {
         for explicit in [json!(true), json!({"blocked_by": "operator"})] {
             let result = json!({ "verdict": explicit, "checks": passing_checks() });
             let injected = infer_phase_gate_verdict("dsp-finalize-non-string", &gate(), &result)
-                .expect("non-string verdict must preserve checks-based injection");
+                .expect("non-string verdict must preserve checks-based injection"); // agentdesk-audit: allow-unwrap — test-only assertion in #[cfg(test)] module
             assert_eq!(
                 injected.get("verdict").and_then(|value| value.as_str()),
                 Some("phase_gate_passed")
@@ -1632,7 +1632,7 @@ mod phase_gate_finalize_wrapper_tests {
             Some(&context),
             Some(&result),
         )
-        .expect("non-string decision must preserve checks-based injection");
+        .expect("non-string decision must preserve checks-based injection"); // agentdesk-audit: allow-unwrap — test-only assertion in #[cfg(test)] module
         assert_eq!(
             injected.get("verdict").and_then(|value| value.as_str()),
             Some("phase_gate_passed")

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -1377,10 +1377,20 @@ fn infer_phase_gate_verdict(
         );
     }
 
+    let declared_check_count = phase_gate_ctx
+        .get("checks")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+    let reported_check_count = result
+        .get("checks")
+        .and_then(serde_json::Value::as_object)
+        .map_or(0, serde_json::Map::len);
     tracing::info!(
-        "[dispatch] #699 inferring phase-gate verdict '{}' for dispatch {} (all declared checks passed)",
-        pass_verdict,
         dispatch_id,
+        pass_verdict = %pass_verdict,
+        declared_check_count,
+        reported_check_count,
+        "[dispatch] #699 inferred phase-gate verdict because all declared checks passed",
     );
 
     Some(enriched)
@@ -1584,6 +1594,57 @@ mod auto_queue_terminal_sync_policy_tests {
 mod auto_queue_phase_gate_finalize_wrapper_tests {
     use super::{infer_effective_completion_result, infer_phase_gate_verdict};
     use serde_json::json;
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::writer::MakeWriter;
+
+    #[derive(Clone)]
+    struct CapturingWriter {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl Write for CapturingWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.buffer
+                .lock()
+                .expect("capture phase-gate log bytes")
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CapturingWriter {
+        type Writer = CapturingWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn capture_info_logs(emit: impl FnOnce()) -> String {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .with_ansi(false)
+            .without_time()
+            .with_target(false)
+            .with_writer(CapturingWriter {
+                buffer: buffer.clone(),
+            })
+            .finish();
+        tracing::subscriber::with_default(subscriber, emit);
+        String::from_utf8(
+            buffer
+                .lock()
+                .expect("read captured phase-gate log bytes")
+                .clone(),
+        )
+        .expect("phase-gate logs must be UTF-8")
+    }
 
     fn gate() -> serde_json::Value {
         json!({
@@ -1637,6 +1698,20 @@ mod auto_queue_phase_gate_finalize_wrapper_tests {
             injected.get("verdict").and_then(|value| value.as_str()),
             Some("phase_gate_passed")
         );
+    }
+
+    #[test]
+    fn inferred_verdict_log_preserves_check_cardinality_fields() {
+        let result = json!({ "checks": passing_checks() });
+        let logs = capture_info_logs(|| {
+            let injected = infer_phase_gate_verdict("dsp-log-fields", &gate(), &result);
+            assert!(injected.is_some());
+        });
+
+        assert!(logs.contains("dispatch_id=\"dsp-log-fields\""), "{logs}");
+        assert!(logs.contains("pass_verdict=phase_gate_passed"), "{logs}");
+        assert!(logs.contains("declared_check_count=3"), "{logs}");
+        assert!(logs.contains("reported_check_count=3"), "{logs}");
     }
 
     #[test]

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -1581,7 +1581,7 @@ mod auto_queue_terminal_sync_policy_tests {
 }
 
 #[cfg(test)]
-mod phase_gate_finalize_wrapper_tests {
+mod auto_queue_phase_gate_finalize_wrapper_tests {
     use super::{infer_effective_completion_result, infer_phase_gate_verdict};
     use serde_json::json;
 

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -1355,10 +1355,12 @@ fn infer_phase_gate_verdict(
     phase_gate_ctx: &serde_json::Value,
     result: &serde_json::Value,
 ) -> Option<serde_json::Value> {
-    if phase_gate_verdict::has_explicit_verdict(result) {
+    let context = serde_json::json!({ "phase_gate": phase_gate_ctx });
+    let phase_gate_verdict::VerdictResolution::Inferred(pass_verdict) =
+        phase_gate_verdict::resolve_verdict(Some(&context), result)
+    else {
         return None;
-    }
-    let pass_verdict = phase_gate_verdict::infer_pass_verdict_in_gate(phase_gate_ctx, result)?;
+    };
 
     let mut enriched = result.clone();
     if !enriched.is_object() {

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -1581,66 +1581,73 @@ mod auto_queue_terminal_sync_policy_tests {
 }
 
 #[cfg(test)]
-mod phase_gate_verdict_path_equivalence_tests {
-    use super::infer_phase_gate_verdict;
-    use crate::db::auto_queue::phase_gate_verdict::{VerdictResolution, resolve_verdict};
+mod phase_gate_finalize_wrapper_tests {
+    use super::{infer_effective_completion_result, infer_phase_gate_verdict};
     use serde_json::json;
 
-    #[test]
-    fn checks_only_completion_resolves_identically_before_and_after_injection() {
-        let gate = json!({
-            "checks": ["merge_verified", "issue_closed"],
-            "pass_verdict": "gate_ok",
-        });
-        let context = json!({ "phase_gate": gate.clone() });
-        let raw = json!({
-            "checks": {
-                "merge_verified": { "status": "pass" },
-                "issue_closed": { "status": "", "result": "passed" },
-            }
-        });
+    fn gate() -> serde_json::Value {
+        json!({
+            "checks": ["merge_verified", "issue_closed", "build_passed"],
+            "pass_verdict": "phase_gate_passed",
+        })
+    }
 
-        let injected = infer_phase_gate_verdict("dsp-path-equivalence", &gate, &raw)
-            .expect("finalize path should persist the reducer's inferred verdict");
-        assert_eq!(
-            resolve_verdict(Some(&context), &raw),
-            VerdictResolution::Inferred("gate_ok".to_string()),
-        );
+    fn passing_checks() -> serde_json::Value {
+        json!({
+            "merge_verified": { "status": "pass" },
+            "issue_closed": { "status": "pass" },
+            "build_passed": { "status": "pass" },
+        })
+    }
+
+    #[test]
+    fn finalize_wrapper_overwrites_truthy_non_string_verdict_for_compatibility() {
+        for explicit in [json!(true), json!({"blocked_by": "operator"})] {
+            let result = json!({ "verdict": explicit, "checks": passing_checks() });
+            let injected = infer_phase_gate_verdict("dsp-finalize-non-string", &gate(), &result)
+                .expect("non-string verdict must preserve checks-based injection");
+            assert_eq!(
+                injected.get("verdict").and_then(|value| value.as_str()),
+                Some("phase_gate_passed")
+            );
+            assert_eq!(
+                injected
+                    .get("verdict_inferred")
+                    .and_then(|value| value.as_bool()),
+                Some(true)
+            );
+        }
+    }
+
+    #[test]
+    fn finalize_wrapper_overwrites_truthy_non_string_decision_for_compatibility() {
+        let result = json!({
+            "decision": {"blocked_by": "operator"},
+            "checks": passing_checks(),
+        });
+        let context = json!({ "phase_gate": gate() }).to_string();
+        let injected = infer_effective_completion_result(
+            "dsp-finalize-decision",
+            "completed",
+            Some(&context),
+            Some(&result),
+        )
+        .expect("non-string decision must preserve checks-based injection");
         assert_eq!(
             injected.get("verdict").and_then(|value| value.as_str()),
-            Some("gate_ok")
-        );
-        assert_eq!(
-            injected
-                .get("verdict_inferred")
-                .and_then(|value| value.as_bool()),
-            Some(true),
-        );
-        assert_eq!(
-            resolve_verdict(Some(&context), &injected),
-            VerdictResolution::Explicit(Some("gate_ok".to_string())),
+            Some("phase_gate_passed")
         );
     }
 
     #[test]
-    fn explicit_failure_is_identical_for_finalize_and_bypass_paths() {
-        let gate = json!({
-            "checks": ["merge_verified"],
-            "pass_verdict": "gate_ok",
-        });
-        let context = json!({ "phase_gate": gate.clone() });
+    fn explicit_string_failure_is_not_overridden() {
         let result = json!({
             "phase_gate_verdict": "manual_hold",
-            "checks": { "merge_verified": { "status": "pass" } },
+            "checks": passing_checks(),
         });
-
         assert_eq!(
-            infer_phase_gate_verdict("dsp-explicit", &gate, &result),
+            infer_phase_gate_verdict("dsp-explicit", &gate(), &result),
             None
-        );
-        assert_eq!(
-            resolve_verdict(Some(&context), &result),
-            VerdictResolution::Explicit(Some("manual_hold".to_string())),
         );
     }
 }

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -1592,7 +1592,9 @@ mod auto_queue_terminal_sync_policy_tests {
 
 #[cfg(test)]
 mod auto_queue_phase_gate_finalize_wrapper_tests {
-    use super::{infer_effective_completion_result, infer_phase_gate_verdict};
+    use super::{
+        infer_effective_completion_result, infer_phase_gate_verdict, log_phase_gate_reconciliation,
+    };
     use serde_json::json;
     use std::io::{self, Write};
     use std::sync::{Arc, Mutex};
@@ -1700,6 +1702,47 @@ mod auto_queue_phase_gate_finalize_wrapper_tests {
                 .and_then(|value| value.get("verdict"))
                 .and_then(|value| value.as_str()),
             Some("phase_gate_passed")
+        );
+    }
+
+    #[test]
+    fn failed_reconciliation_log_does_not_emit_verdict_payload() {
+        let result = json!({
+            "verdict": {"authorization": "Bearer secret"},
+            "checks": {"build_passed": "fail"},
+        });
+        let resolution = crate::db::auto_queue::phase_gate_verdict::resolve_verdict(None, &result);
+        assert_eq!(
+            resolution,
+            crate::db::auto_queue::phase_gate_verdict::VerdictResolution::Missing
+        );
+        let failed_reason = match crate::db::auto_queue::phase_gate_verdict::diagnostic_verdict(
+            &result,
+            &resolution,
+        ) {
+            Some(diagnostic) => format!("expected verdict gate_ok, got {diagnostic}"),
+            None => "expected verdict gate_ok, got none".to_string(),
+        };
+        let outcome = crate::db::auto_queue::PhaseGateReconciliation::MarkedFailed {
+            run_id: "run-log-redaction".to_string(),
+            phase: 0,
+            failed_dispatch_id: "dsp-log-redaction".to_string(),
+            failed_reason,
+        };
+        let logs = capture_info_logs(|| {
+            log_phase_gate_reconciliation("dsp-log-redaction", &outcome);
+        });
+
+        assert!(
+            logs.as_ref()
+                .is_ok_and(|logs| logs.contains("<non-string:object>")),
+            "{logs:?}"
+        );
+        assert!(
+            logs.as_ref().is_ok_and(|logs| {
+                !logs.contains("authorization") && !logs.contains("Bearer secret")
+            }),
+            "failed reconciliation log leaked verdict payload: {logs:?}"
         );
     }
 

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -1579,3 +1579,60 @@ mod auto_queue_terminal_sync_policy_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod phase_gate_verdict_path_equivalence_tests {
+    use super::infer_phase_gate_verdict;
+    use crate::db::auto_queue::phase_gate_verdict::{VerdictResolution, resolve_verdict};
+    use serde_json::json;
+
+    #[test]
+    fn checks_only_completion_resolves_identically_before_and_after_injection() {
+        let gate = json!({
+            "checks": ["merge_verified", "issue_closed"],
+            "pass_verdict": "gate_ok",
+        });
+        let context = json!({ "phase_gate": gate.clone() });
+        let raw = json!({
+            "checks": {
+                "merge_verified": { "status": "pass" },
+                "issue_closed": { "status": "", "result": "passed" },
+            }
+        });
+
+        let injected = infer_phase_gate_verdict("dsp-path-equivalence", &gate, &raw)
+            .expect("finalize path should persist the reducer's inferred verdict");
+        assert_eq!(
+            resolve_verdict(Some(&context), &raw),
+            VerdictResolution::Inferred("gate_ok".to_string()),
+        );
+        assert_eq!(injected.get("verdict").and_then(|value| value.as_str()), Some("gate_ok"));
+        assert_eq!(
+            injected.get("verdict_inferred").and_then(|value| value.as_bool()),
+            Some(true),
+        );
+        assert_eq!(
+            resolve_verdict(Some(&context), &injected),
+            VerdictResolution::Explicit(Some("gate_ok".to_string())),
+        );
+    }
+
+    #[test]
+    fn explicit_failure_is_identical_for_finalize_and_bypass_paths() {
+        let gate = json!({
+            "checks": ["merge_verified"],
+            "pass_verdict": "gate_ok",
+        });
+        let context = json!({ "phase_gate": gate.clone() });
+        let result = json!({
+            "phase_gate_verdict": "manual_hold",
+            "checks": { "merge_verified": { "status": "pass" } },
+        });
+
+        assert_eq!(infer_phase_gate_verdict("dsp-explicit", &gate, &result), None);
+        assert_eq!(
+            resolve_verdict(Some(&context), &result),
+            VerdictResolution::Explicit(Some("manual_hold".to_string())),
+        );
+    }
+}

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -1606,9 +1606,14 @@ mod phase_gate_verdict_path_equivalence_tests {
             resolve_verdict(Some(&context), &raw),
             VerdictResolution::Inferred("gate_ok".to_string()),
         );
-        assert_eq!(injected.get("verdict").and_then(|value| value.as_str()), Some("gate_ok"));
         assert_eq!(
-            injected.get("verdict_inferred").and_then(|value| value.as_bool()),
+            injected.get("verdict").and_then(|value| value.as_str()),
+            Some("gate_ok")
+        );
+        assert_eq!(
+            injected
+                .get("verdict_inferred")
+                .and_then(|value| value.as_bool()),
             Some(true),
         );
         assert_eq!(
@@ -1629,7 +1634,10 @@ mod phase_gate_verdict_path_equivalence_tests {
             "checks": { "merge_verified": { "status": "pass" } },
         });
 
-        assert_eq!(infer_phase_gate_verdict("dsp-explicit", &gate, &result), None);
+        assert_eq!(
+            infer_phase_gate_verdict("dsp-explicit", &gate, &result),
+            None
+        );
         assert_eq!(
             resolve_verdict(Some(&context), &result),
             VerdictResolution::Explicit(Some("manual_hold".to_string())),

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -1605,10 +1605,10 @@ mod auto_queue_phase_gate_finalize_wrapper_tests {
 
     impl Write for CapturingWriter {
         fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-            self.buffer
-                .lock()
-                .expect("capture phase-gate log bytes")
-                .extend_from_slice(bytes);
+            match self.buffer.lock() {
+                Ok(mut buffer) => buffer.extend_from_slice(bytes),
+                Err(poisoned) => poisoned.into_inner().extend_from_slice(bytes),
+            }
             Ok(bytes.len())
         }
 
@@ -1637,13 +1637,14 @@ mod auto_queue_phase_gate_finalize_wrapper_tests {
             })
             .finish();
         tracing::subscriber::with_default(subscriber, emit);
-        String::from_utf8(
-            buffer
-                .lock()
-                .expect("read captured phase-gate log bytes")
-                .clone(),
-        )
-        .expect("phase-gate logs must be UTF-8")
+        let bytes = match buffer.lock() {
+            Ok(buffer) => buffer.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        };
+        match String::from_utf8(bytes) {
+            Ok(logs) => logs,
+            Err(error) => panic!("phase-gate logs must be UTF-8: {error}"),
+        }
     }
 
     fn gate() -> serde_json::Value {

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -1625,7 +1625,7 @@ mod auto_queue_phase_gate_finalize_wrapper_tests {
         }
     }
 
-    fn capture_info_logs(emit: impl FnOnce()) -> String {
+    fn capture_info_logs(emit: impl FnOnce()) -> Result<String, std::string::FromUtf8Error> {
         let buffer = Arc::new(Mutex::new(Vec::new()));
         let subscriber = tracing_subscriber::fmt()
             .with_max_level(tracing::Level::INFO)
@@ -1641,10 +1641,7 @@ mod auto_queue_phase_gate_finalize_wrapper_tests {
             Ok(buffer) => buffer.clone(),
             Err(poisoned) => poisoned.into_inner().clone(),
         };
-        match String::from_utf8(bytes) {
-            Ok(logs) => logs,
-            Err(error) => panic!("phase-gate logs must be UTF-8: {error}"),
-        }
+        String::from_utf8(bytes)
     }
 
     fn gate() -> serde_json::Value {
@@ -1666,15 +1663,18 @@ mod auto_queue_phase_gate_finalize_wrapper_tests {
     fn finalize_wrapper_overwrites_truthy_non_string_verdict_for_compatibility() {
         for explicit in [json!(true), json!({"blocked_by": "operator"})] {
             let result = json!({ "verdict": explicit, "checks": passing_checks() });
-            let injected = infer_phase_gate_verdict("dsp-finalize-non-string", &gate(), &result)
-                .expect("non-string verdict must preserve checks-based injection"); // agentdesk-audit: allow-unwrap — test-only assertion in #[cfg(test)] module
+            let injected = infer_phase_gate_verdict("dsp-finalize-non-string", &gate(), &result);
             assert_eq!(
-                injected.get("verdict").and_then(|value| value.as_str()),
+                injected
+                    .as_ref()
+                    .and_then(|value| value.get("verdict"))
+                    .and_then(|value| value.as_str()),
                 Some("phase_gate_passed")
             );
             assert_eq!(
                 injected
-                    .get("verdict_inferred")
+                    .as_ref()
+                    .and_then(|value| value.get("verdict_inferred"))
                     .and_then(|value| value.as_bool()),
                 Some(true)
             );
@@ -1693,10 +1693,12 @@ mod auto_queue_phase_gate_finalize_wrapper_tests {
             "completed",
             Some(&context),
             Some(&result),
-        )
-        .expect("non-string decision must preserve checks-based injection"); // agentdesk-audit: allow-unwrap — test-only assertion in #[cfg(test)] module
+        );
         assert_eq!(
-            injected.get("verdict").and_then(|value| value.as_str()),
+            injected
+                .as_ref()
+                .and_then(|value| value.get("verdict"))
+                .and_then(|value| value.as_str()),
             Some("phase_gate_passed")
         );
     }
@@ -1709,10 +1711,26 @@ mod auto_queue_phase_gate_finalize_wrapper_tests {
             assert!(injected.is_some());
         });
 
-        assert!(logs.contains("dispatch_id=\"dsp-log-fields\""), "{logs}");
-        assert!(logs.contains("pass_verdict=phase_gate_passed"), "{logs}");
-        assert!(logs.contains("declared_check_count=3"), "{logs}");
-        assert!(logs.contains("reported_check_count=3"), "{logs}");
+        assert!(
+            logs.as_ref()
+                .is_ok_and(|logs| logs.contains("dispatch_id=\"dsp-log-fields\"")),
+            "{logs:?}"
+        );
+        assert!(
+            logs.as_ref()
+                .is_ok_and(|logs| logs.contains("pass_verdict=phase_gate_passed")),
+            "{logs:?}"
+        );
+        assert!(
+            logs.as_ref()
+                .is_ok_and(|logs| logs.contains("declared_check_count=3")),
+            "{logs:?}"
+        );
+        assert!(
+            logs.as_ref()
+                .is_ok_and(|logs| logs.contains("reported_check_count=3")),
+            "{logs:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Phase-gate verdict extraction was duplicated across finalize injection, durable-primary reconciliation, and sibling aggregation. Those Rust paths could disagree about explicit-field precedence, check aliases, expected verdicts, and malformed declarations. This PR centralizes the Rust verdict decision, but it does not yet transfer the full lifecycle away from the live JavaScript hook.

## Fix

- Add `src/db/auto_queue/phase_gate_verdict.rs` as the canonical Rust verdict reducer.
- Route finalize verdict injection, durable-primary reconciliation, and sibling aggregation through it.
- Preserve pre-#4884 finalize compatibility: non-string `verdict` / `decision` fields are treated as absent, so all-passing declared checks still inject the configured string pass verdict.
- Preserve raw `pass_verdict` strings instead of trimming/defaulting them; primary and sibling reconciliation now both read the expected verdict from each dispatch context.
- Fail closed when the declared checks array is absent, empty, malformed, or contains non-string entries. This prevents a descriptor migration from silently disabling completeness validation.
- Preserve non-string explicit payloads in durable failure verdict/reason diagnostics.
- Document the known JavaScript deltas instead of claiming exact mirroring:
  - JavaScript accepts array-valued `result.checks`; Rust requires an object map.
  - JavaScript lets truthy non-string `status` block `result`; Rust ignores non-string status and may use a string result alias.
  - JavaScript skips falsy declared-check items; Rust rejects non-string declarations.
- Add finalize-wrapper tests for truthy non-string `verdict` and `decision`, reducer mutation-sensitive falsy coverage, and PG reconciler tests for diagnostics and mixed pass-verdict groups.
- Update the maintenance surface ownership documentation.

## Scope and remaining acceptance criteria

This PR is a reducer extraction/hardening slice and therefore **Refs #4884** rather than closing it.

- [x] One Rust verdict reducer is shared by finalize, primary reconciliation, and sibling aggregation.
- [x] Primary and sibling paths use each dispatch context as the expected-verdict source.
- [x] Malformed or missing declared checks fail closed.
- [ ] Remove the duplicate JavaScript inference implementation and make one reducer authoritative across JS and Rust.
- [ ] Remove `assume_external_phase_gate_lifecycle` / external lifecycle ownership split.
- [ ] Make normal finalize and CRUD/watcher/recovery perform identical `issue_closed` remediation and re-entry.
- [ ] Prove identical durable DB state across actual finalize and reconciliation entry points.
- [ ] Activate the next phase exactly once on every path.
- [ ] Complete the executable kind-to-check registry so deploy gates require deploy evidence.

Follow-ups:

- #4897 — unify phase-gate lifecycle/remediation/activation across finalize and recovery paths.
- #4898 — bind gate kinds to executable required checks and require `deploy_verified` for deploy gates.

## Verification

The review-fix round runs the repository gates serially under the shared build token; final rc values are reported in the PR comment / completion report.

Refs #4884

🤖 Generated with [Claude Code](https://claude.com/claude-code)
