### PR TITLE
fix(#4900): exclude Node helper from routine loader

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1227,6 +1227,8 @@ src/
 │   │   ├── tuning_aggregate.rs
 │   │   └── worktree_stale.rs
 │   ├── routines/
+│   │   ├── loader/
+│   │   │   └── discovery.rs
 │   │   ├── action.rs
 │   │   ├── agent_executor.rs
 │   │   ├── discord_log.rs

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3183,7 +3183,7 @@ async fn routine_runtime_loop(
     let routine_script_dirs = routines_config.script_dirs();
     let initial_script_dirs = routine_script_dirs.clone();
     let script_loader = match tokio::task::spawn_blocking(move || {
-        let loader = Arc::new(RoutineScriptLoader::new()?);
+        let loader = Arc::new(RoutineScriptLoader::new_shared(&initial_script_dirs)?);
         let count = loader.load_dirs(&initial_script_dirs)?;
         Ok::<_, anyhow::Error>((loader, count))
     })

--- a/src/server/routes/routines/handlers.rs
+++ b/src/server/routes/routines/handlers.rs
@@ -353,7 +353,7 @@ pub async fn run_routine_now(
     let requested_script_ref = routine.script_ref.clone();
     let script_ref_for_task = requested_script_ref.clone();
     let (loader, script) = tokio::task::spawn_blocking(move || {
-        let loader = RoutineScriptLoader::new()
+        let loader = RoutineScriptLoader::new_shared(&script_dirs_for_task)
             .map_err(|error| format!("routine script loader init failed: {error}"))?;
         loader
             .load_dirs(&script_dirs_for_task)

--- a/src/server/routes/routines/helpers.rs
+++ b/src/server/routes/routines/helpers.rs
@@ -43,7 +43,7 @@ pub(super) async fn migrated_launchd_metadata_for_state(
     let requested_script_ref = script_ref.to_string();
     let script_ref_for_task = requested_script_ref.clone();
     let script = tokio::task::spawn_blocking(move || {
-        let loader = RoutineScriptLoader::new()
+        let loader = RoutineScriptLoader::new_shared(&routine_script_dirs)
             .map_err(|error| format!("routine script loader init failed: {error}"))?;
         loader
             .load_dirs(&routine_script_dirs)

--- a/src/services/routines/discord_log.rs
+++ b/src/services/routines/discord_log.rs
@@ -1725,6 +1725,56 @@ mod tests {
     }
 
     #[test]
+    fn run_outcome_message_redacts_secret_but_keeps_diagnostic_class() {
+        let routine = RoutineRecord {
+            id: "routine-123456789".to_string(),
+            agent_id: None,
+            fallback_agent_id: None,
+            max_retries: 0,
+            script_ref: "secret.js".to_string(),
+            name: "Secret Routine".to_string(),
+            status: "enabled".to_string(),
+            execution_strategy: "fresh".to_string(),
+            schedule: None,
+            next_due_at: None,
+            last_run_at: None,
+            last_result: None,
+            checkpoint: None,
+            discord_thread_id: None,
+            timeout_secs: None,
+            in_flight_run_id: None,
+            pause_reason: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let diagnostic = "routine script secret.js tick(ctx) failed: api_key=sk-live-secret";
+        let outcome = RoutineRunOutcome {
+            run_id: "run-123456789".to_string(),
+            routine_id: routine.id.clone(),
+            script_ref: routine.script_ref.clone(),
+            action: "error".to_string(),
+            status: "failed".to_string(),
+            result_json: Some(json!({
+                "error": crate::services::routines::loader::ROUTINE_TICK_ERROR_PUBLIC_REASON,
+                "diagnostic_class": crate::services::routines::loader::ROUTINE_TICK_ERROR_PUBLIC_REASON,
+            })),
+            error: Some(
+                crate::services::routines::loader::ROUTINE_TICK_ERROR_PUBLIC_REASON.to_string(),
+            ),
+            fresh_context_guaranteed: false,
+        };
+
+        let message = run_outcome_message(&routine, &outcome);
+        let api_json = serde_json::to_string(&outcome).unwrap();
+        assert!(message.contains("routine_tick_exception"), "{message}");
+        assert!(api_json.contains("routine_tick_exception"), "{api_json}");
+        assert!(!message.contains("sk-live-secret"), "{message}");
+        assert!(!api_json.contains("sk-live-secret"), "{api_json}");
+        assert!(!message.contains(diagnostic), "{message}");
+        assert!(!api_json.contains(diagnostic), "{api_json}");
+    }
+
+    #[test]
     fn run_outcome_message_includes_result_summary_preview() {
         let routine = RoutineRecord {
             id: "routine-123456789".to_string(),

--- a/src/services/routines/loader.rs
+++ b/src/services/routines/loader.rs
@@ -613,8 +613,9 @@ fn quickjs_exception_detail(ctx: &rquickjs::Ctx<'_>, error: &rquickjs::Error) ->
 
     <rquickjs::convert::Coerced<String> as rquickjs::FromJs>::from_js(ctx, caught)
         .map(|rquickjs::convert::Coerced(detail)| detail)
+        .ok()
         .filter(|detail| !detail.is_empty())
-        .unwrap_or_else(|_| error.to_string())
+        .unwrap_or_else(|| error.to_string())
 }
 
 struct CapturedRoutineRegistration<'js> {

--- a/src/services/routines/loader.rs
+++ b/src/services/routines/loader.rs
@@ -125,12 +125,14 @@ pub struct RoutineTickAgent {
 /// mutating the store, so callers keep the last-known-good registry.
 pub struct RoutineScriptLoader {
     scripts: RoutineScriptStore,
+    failed_script_versions: Mutex<HashMap<PathBuf, String>>,
 }
 
 impl RoutineScriptLoader {
     pub fn new() -> Result<Self> {
         Ok(Self {
             scripts: Arc::new(Mutex::new(HashMap::new())),
+            failed_script_versions: Mutex::new(HashMap::new()),
         })
     }
 
@@ -232,8 +234,44 @@ impl RoutineScriptLoader {
                     selected = Some((script.clone(), false));
                     break;
                 }
+                let source_version = match routine_script_source_version(&candidate.path) {
+                    Ok(version) => version,
+                    Err(e) => {
+                        tracing::error!(
+                            routine_script = %candidate.path.display(),
+                            error = %e,
+                            "failed to read routine script; keeping last-known-good registry"
+                        );
+                        if has_existing {
+                            break;
+                        }
+                        continue;
+                    }
+                };
+                let unchanged_failure = self
+                    .failed_script_versions
+                    .lock()
+                    .unwrap_or_else(recover_poisoned_lock)
+                    .get(&candidate.path)
+                    .is_some_and(|failed_version| failed_version == &source_version);
+                if unchanged_failure {
+                    tracing::debug!(
+                        routine_script = %candidate.path.display(),
+                        script_version = %source_version,
+                        "skipped unchanged routine script after previous load failure"
+                    );
+                    if has_existing {
+                        break;
+                    }
+                    continue;
+                }
+
                 match load_single_routine_script(&candidate.root, &candidate.path) {
                     Ok(script) => {
+                        self.failed_script_versions
+                            .lock()
+                            .unwrap_or_else(recover_poisoned_lock)
+                            .remove(&candidate.path);
                         if candidates.len() > 1 {
                             tracing::info!(
                                 routine_script = %script_ref,
@@ -246,6 +284,10 @@ impl RoutineScriptLoader {
                         break;
                     }
                     Err(e) => {
+                        self.failed_script_versions
+                            .lock()
+                            .unwrap_or_else(recover_poisoned_lock)
+                            .insert(candidate.path.clone(), source_version);
                         tracing::error!(
                             routine_script = %candidate.path.display(),
                             error = %e,
@@ -466,8 +508,22 @@ fn capture_registered_routine<'js>(
     let eval_result: rquickjs::Result<rquickjs::Value> =
         ctx.eval_with_options(source.as_bytes().to_vec(), eval_opts);
     if let Err(e) = eval_result {
+        let exception_detail = ctx
+            .catch()
+            .into_exception()
+            .map(|exception| {
+                let message = exception.message().unwrap_or_default();
+                let stack = exception.stack().unwrap_or_default();
+                if stack.is_empty() {
+                    message
+                } else {
+                    format!("{message}\n{stack}")
+                }
+            })
+            .filter(|detail| !detail.is_empty())
+            .unwrap_or_else(|| e.to_string());
         return Err(anyhow!(
-            "JS eval error in routine script {}: {e}",
+            "JS eval error in routine script {}: {exception_detail}",
             path.display()
         ));
     }
@@ -630,6 +686,12 @@ fn script_ref(root: &Path, path: &Path) -> String {
         .replace('\\', "/")
 }
 
+fn routine_script_source_version(path: &Path) -> Result<String> {
+    let source = std::fs::read_to_string(path)
+        .map_err(|e| anyhow!("read routine script {}: {e}", path.display()))?;
+    Ok(compute_policy_version(&source))
+}
+
 fn add_cached_candidates_for_root(
     existing_scripts: &HashMap<String, LoadedRoutineScript>,
     candidates_by_ref: &mut BTreeMap<String, Vec<RoutineScriptCandidate>>,
@@ -661,11 +723,23 @@ fn collect_routine_script_paths(root: &Path, out: &mut Vec<PathBuf>) -> Result<(
         let path = entry.path();
         if file_type.is_dir() {
             collect_routine_script_paths(&path, out)?;
-        } else if file_type.is_file() && path.extension().is_some_and(|ext| ext == "js") {
+        } else if file_type.is_file()
+            && path.extension().is_some_and(|ext| ext == "js")
+            && !is_node_only_helper(&path)
+        {
             out.push(path);
         }
     }
     Ok(())
+}
+
+fn is_node_only_helper(path: &Path) -> bool {
+    path.file_name()
+        .is_some_and(|name| name == "local_worktree_inventory.js")
+        && path
+            .parent()
+            .and_then(Path::file_name)
+            .is_some_and(|name| name == "monitoring")
 }
 
 #[cfg(test)]
@@ -828,6 +902,64 @@ mod tests {
         assert_eq!(loader.load_dir(dir.path()).unwrap(), 1);
         assert_eq!(loader.script_refs().unwrap(), vec!["ops/daily/summary.js"]);
         assert!(loader.has_script("ops/daily/summary.js").unwrap());
+    }
+
+    #[test]
+    fn load_dir_excludes_node_only_worktree_inventory_helper() {
+        let dir = tempfile::tempdir().unwrap();
+        let monitoring = dir.path().join("monitoring");
+        std::fs::create_dir_all(&monitoring).unwrap();
+        std::fs::write(
+            monitoring.join("local_worktree_inventory.js"),
+            "const fs = require('node:fs'); module.exports = { fs };",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("inventory-routine.js"),
+            "agentdesk.routines.register({ name: 'Inventory', tick() { return { action: 'skip' }; } });",
+        )
+        .unwrap();
+
+        let loader = RoutineScriptLoader::new().unwrap();
+        assert_eq!(loader.load_dir(dir.path()).unwrap(), 1);
+        assert_eq!(loader.script_refs().unwrap(), vec!["inventory-routine.js"]);
+    }
+
+    #[test]
+    fn unchanged_failed_script_is_retried_only_after_content_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recoverable.js");
+        let broken =
+            "globalThis.__attempts = (globalThis.__attempts || 0) + 1; throw new Error('broken');";
+        std::fs::write(&path, broken).unwrap();
+
+        let loader = RoutineScriptLoader::new().unwrap();
+        assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+        assert_eq!(loader.failed_script_versions.lock().unwrap().len(), 1);
+        assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+        assert_eq!(loader.failed_script_versions.lock().unwrap().len(), 1);
+
+        std::fs::write(
+            &path,
+            "agentdesk.routines.register({ name: 'Recovered', tick() { return { action: 'skip' }; } });",
+        )
+        .unwrap();
+        assert_eq!(loader.load_dir(dir.path()).unwrap(), 1);
+        assert!(loader.failed_script_versions.lock().unwrap().is_empty());
+        assert_eq!(
+            loader.get_script("recoverable.js").unwrap().unwrap().name,
+            "Recovered"
+        );
+    }
+
+    #[test]
+    fn quickjs_eval_error_includes_exception_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("node-only.js");
+        std::fs::write(&path, "require('node:fs');").unwrap();
+
+        let error = load_single_routine_script(dir.path(), &path).unwrap_err();
+        assert!(error.to_string().contains("require is not defined"));
     }
 
     #[test]

--- a/src/services/routines/loader.rs
+++ b/src/services/routines/loader.rs
@@ -3,7 +3,7 @@ use rquickjs::{Context, Function, Runtime};
 use serde::Serialize;
 use serde_json::{Map, Number, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
@@ -72,9 +72,31 @@ struct RoutineScriptFailure {
     warning_emitted: bool,
 }
 
-type RoutineFailureRegistry = Arc<Mutex<HashMap<PathBuf, RoutineScriptFailure>>>;
+struct SharedRoutineLoaderState {
+    scripts: RoutineScriptStore,
+    failed_scripts: Mutex<HashMap<PathBuf, RoutineScriptFailure>>,
+    load_gate: Mutex<()>,
+    #[cfg(test)]
+    evaluation_attempts: std::sync::atomic::AtomicUsize,
+    #[cfg(test)]
+    load_error_emissions: std::sync::atomic::AtomicUsize,
+}
 
-static SHARED_FAILURE_REGISTRIES: LazyLock<Mutex<HashMap<PathBuf, RoutineFailureRegistry>>> =
+impl SharedRoutineLoaderState {
+    fn new() -> Self {
+        Self {
+            scripts: Arc::new(Mutex::new(HashMap::new())),
+            failed_scripts: Mutex::new(HashMap::new()),
+            load_gate: Mutex::new(()),
+            #[cfg(test)]
+            evaluation_attempts: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
+            load_error_emissions: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+}
+
+static SHARED_LOADER_STATES: LazyLock<Mutex<HashMap<PathBuf, Arc<SharedRoutineLoaderState>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Debug, Clone, Serialize)]
@@ -148,56 +170,45 @@ pub struct RoutineTickAgent {
 /// are always retried within one hour instead of remaining disabled for the
 /// process lifetime.
 pub struct RoutineScriptLoader {
-    scripts: RoutineScriptStore,
-    failed_scripts: RoutineFailureRegistry,
-    #[cfg(test)]
-    evaluation_attempts: std::sync::atomic::AtomicUsize,
+    state: Arc<SharedRoutineLoaderState>,
     #[cfg(test)]
     source_read_hook: Mutex<Option<Arc<dyn Fn(&Path) + Send + Sync>>>,
     #[cfg(test)]
     source_reader: Mutex<Option<Arc<dyn Fn(&Path) -> std::io::Result<String> + Send + Sync>>>,
-    #[cfg(test)]
-    load_error_emissions: std::sync::atomic::AtomicUsize,
 }
 
 impl RoutineScriptLoader {
     pub fn new() -> Result<Self> {
-        Ok(Self::with_failure_registry(Arc::new(Mutex::new(
-            HashMap::new(),
-        ))))
+        Ok(Self::with_state(Arc::new(SharedRoutineLoaderState::new())))
     }
 
     pub fn new_shared(roots: &[PathBuf]) -> Result<Self> {
         let key = routine_roots_identity(roots);
-        let mut registries = SHARED_FAILURE_REGISTRIES
+        let mut states = SHARED_LOADER_STATES
             .lock()
             .unwrap_or_else(recover_poisoned_lock);
-        registries.retain(|_, registry| Arc::strong_count(registry) > 1);
-        let registry = registries
+        states.retain(|_, state| Arc::strong_count(state) > 1);
+        let state = states
             .entry(key)
-            .or_insert_with(|| Arc::new(Mutex::new(HashMap::new())))
+            .or_insert_with(|| Arc::new(SharedRoutineLoaderState::new()))
             .clone();
-        Ok(Self::with_failure_registry(registry))
+        Ok(Self::with_state(state))
     }
 
-    fn with_failure_registry(failed_scripts: RoutineFailureRegistry) -> Self {
+    fn with_state(state: Arc<SharedRoutineLoaderState>) -> Self {
         Self {
-            scripts: Arc::new(Mutex::new(HashMap::new())),
-            failed_scripts,
-            #[cfg(test)]
-            evaluation_attempts: std::sync::atomic::AtomicUsize::new(0),
+            state,
             #[cfg(test)]
             source_read_hook: Mutex::new(None),
             #[cfg(test)]
             source_reader: Mutex::new(None),
-            #[cfg(test)]
-            load_error_emissions: std::sync::atomic::AtomicUsize::new(0),
         }
     }
 
     #[cfg(test)]
     pub fn load_script(&self, root: &Path, path: &Path) -> Result<String> {
-        self.evaluation_attempts
+        self.state
+            .evaluation_attempts
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let script = load_single_routine_script(root, path)?;
         tracing::debug!(
@@ -208,7 +219,8 @@ impl RoutineScriptLoader {
             "loaded routine script"
         );
         let script_ref = script.script_ref.clone();
-        self.scripts
+        self.state
+            .scripts
             .lock()
             .unwrap_or_else(recover_poisoned_lock)
             .insert(script_ref.clone(), script);
@@ -223,9 +235,15 @@ impl RoutineScriptLoader {
     }
 
     pub fn load_dirs(&self, roots: &[PathBuf]) -> Result<usize> {
+        let _load_permit = self
+            .state
+            .load_gate
+            .lock()
+            .unwrap_or_else(recover_poisoned_lock);
         let mut seen_refs = HashSet::new();
         let mut candidates_by_ref: BTreeMap<String, Vec<RoutineScriptCandidate>> = BTreeMap::new();
         let existing_scripts: HashMap<String, LoadedRoutineScript> = self
+            .state
             .scripts
             .lock()
             .unwrap_or_else(recover_poisoned_lock)
@@ -287,7 +305,11 @@ impl RoutineScriptLoader {
         let existing_refs: HashSet<String> = existing_scripts.keys().cloned().collect();
         let candidate_paths: HashSet<PathBuf> = candidates_by_ref
             .values()
-            .flat_map(|candidates| candidates.iter().map(|candidate| candidate.path.clone()))
+            .flat_map(|candidates| {
+                candidates
+                    .iter()
+                    .map(|candidate| candidate_failure_key(&candidate.path))
+            })
             .collect();
 
         let mut loaded = 0;
@@ -296,6 +318,7 @@ impl RoutineScriptLoader {
             let has_existing = existing_refs.contains(&script_ref);
             let mut selected = None;
             for candidate in candidates.iter().rev() {
+                let candidate_key = candidate_failure_key(&candidate.path);
                 if let Some(script) = &candidate.cached {
                     tracing::warn!(
                         routine_script = %script_ref,
@@ -324,10 +347,11 @@ impl RoutineScriptLoader {
                     Ok(source) => source,
                     Err(e) => {
                         let now = Instant::now();
-                        if self.should_retry_candidate(&candidate.path, None, now, has_existing) {
-                            let retry_delay = self.record_failure(&candidate.path, None, now);
+                        if self.should_retry_candidate(&candidate_key, None, now, has_existing) {
+                            let retry_delay = self.record_failure(&candidate_key, None, now);
                             #[cfg(test)]
-                            self.load_error_emissions
+                            self.state
+                                .load_error_emissions
                                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                             tracing::error!(
                                 routine_script = %candidate.path.display(),
@@ -354,7 +378,7 @@ impl RoutineScriptLoader {
                 }
                 let now = Instant::now();
                 if !self.should_retry_candidate(
-                    &candidate.path,
+                    &candidate_key,
                     Some(&source_version),
                     now,
                     has_existing,
@@ -366,7 +390,8 @@ impl RoutineScriptLoader {
                 }
 
                 #[cfg(test)]
-                self.evaluation_attempts
+                self.state
+                    .evaluation_attempts
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 match load_single_routine_script_from_source(
                     &candidate.root,
@@ -374,10 +399,11 @@ impl RoutineScriptLoader {
                     source,
                 ) {
                     Ok(script) => {
-                        self.failed_scripts
+                        self.state
+                            .failed_scripts
                             .lock()
                             .unwrap_or_else(recover_poisoned_lock)
-                            .remove(&candidate.path);
+                            .remove(&candidate_key);
                         if candidates.len() > 1 {
                             tracing::info!(
                                 routine_script = %script_ref,
@@ -391,9 +417,10 @@ impl RoutineScriptLoader {
                     }
                     Err(e) => {
                         let retry_delay =
-                            self.record_failure(&candidate.path, Some(source_version.clone()), now);
+                            self.record_failure(&candidate_key, Some(source_version.clone()), now);
                         #[cfg(test)]
-                        self.load_error_emissions
+                        self.state
+                            .load_error_emissions
                             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         tracing::error!(
                             routine_script = %candidate.path.display(),
@@ -421,7 +448,8 @@ impl RoutineScriptLoader {
             }
         }
 
-        self.failed_scripts
+        self.state
+            .failed_scripts
             .lock()
             .unwrap_or_else(recover_poisoned_lock)
             .retain(|path, _| candidate_paths.contains(path));
@@ -441,6 +469,7 @@ impl RoutineScriptLoader {
         has_existing: bool,
     ) -> bool {
         let mut failures = self
+            .state
             .failed_scripts
             .lock()
             .unwrap_or_else(recover_poisoned_lock);
@@ -481,6 +510,7 @@ impl RoutineScriptLoader {
         now: Instant,
     ) -> Duration {
         let mut failures = self
+            .state
             .failed_scripts
             .lock()
             .unwrap_or_else(recover_poisoned_lock);
@@ -506,7 +536,11 @@ impl RoutineScriptLoader {
     }
 
     pub fn get_script(&self, script_ref: &str) -> Result<Option<LoadedRoutineScript>> {
-        let scripts = self.scripts.lock().unwrap_or_else(recover_poisoned_lock);
+        let scripts = self
+            .state
+            .scripts
+            .lock()
+            .unwrap_or_else(recover_poisoned_lock);
         if let Some(script) = scripts.get(script_ref).cloned() {
             return Ok(Some(script));
         }
@@ -533,6 +567,7 @@ impl RoutineScriptLoader {
     #[cfg(test)]
     pub fn has_script(&self, script_ref: &str) -> Result<bool> {
         Ok(self
+            .state
             .scripts
             .lock()
             .unwrap_or_else(recover_poisoned_lock)
@@ -541,6 +576,7 @@ impl RoutineScriptLoader {
 
     pub fn script_refs(&self) -> Result<Vec<String>> {
         let mut refs: Vec<String> = self
+            .state
             .scripts
             .lock()
             .unwrap_or_else(recover_poisoned_lock)
@@ -556,20 +592,17 @@ impl RoutineScriptLoader {
         loaded_scripts: Vec<LoadedRoutineScript>,
         seen_refs: &HashSet<String>,
     ) -> Result<usize> {
-        let mut scripts = self.scripts.lock().unwrap_or_else(recover_poisoned_lock);
+        let mut scripts = self
+            .state
+            .scripts
+            .lock()
+            .unwrap_or_else(recover_poisoned_lock);
         for script in loaded_scripts {
             scripts.insert(script.script_ref.clone(), script);
         }
         let before = scripts.len();
         scripts.retain(|script_ref, _| seen_refs.contains(script_ref));
         Ok(before.saturating_sub(scripts.len()))
-    }
-}
-
-impl Drop for RoutineScriptLoader {
-    fn drop(&mut self) {
-        let mut scripts = self.scripts.lock().unwrap_or_else(recover_poisoned_lock);
-        scripts.clear();
     }
 }
 
@@ -887,11 +920,40 @@ fn ensure_acyclic_js_value<'js>(
     Ok(())
 }
 
+fn stable_absolute_path(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn root_config_identity(root: &Path) -> PathBuf {
+    stable_absolute_path(root)
+}
+
+fn candidate_failure_key(path: &Path) -> PathBuf {
+    path.canonicalize()
+        .unwrap_or_else(|_| stable_absolute_path(path))
+}
+
 fn routine_roots_identity(roots: &[PathBuf]) -> PathBuf {
     let identities = roots
         .iter()
-        .map(|root| root.canonicalize().unwrap_or_else(|_| root.clone()))
-        .map(|root| root.to_string_lossy().into_owned())
+        .map(|root| root_config_identity(root).to_string_lossy().into_owned())
         .collect::<Vec<_>>()
         .join("\0");
     PathBuf::from(full_source_version(&identities))
@@ -973,6 +1035,7 @@ fn is_bundled_node_only_helper(root: &Path, path: &Path) -> bool {
 mod tests {
     use super::*;
     use std::io::{self, Write};
+    use std::sync::Barrier;
     use std::thread;
     use tracing_subscriber::fmt::writer::MakeWriter;
 
@@ -1195,7 +1258,7 @@ mod tests {
             assert_eq!(loader.load_dir(dir.path()).unwrap(), 1);
         });
         assert_eq!(loader.script_refs().unwrap(), vec!["inventory-routine.js"]);
-        assert!(loader.failed_scripts.lock().unwrap().is_empty());
+        assert!(loader.state.failed_scripts.lock().unwrap().is_empty());
         assert!(
             logs.contains("excluded Node-only worktree inventory helper from QuickJS discovery"),
             "logs={logs}"
@@ -1223,10 +1286,11 @@ mod tests {
         assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
         assert_eq!(
             loader
+                .state
                 .failed_scripts
                 .lock()
                 .unwrap()
-                .get(&path)
+                .get(&candidate_failure_key(&path))
                 .unwrap()
                 .source_version,
             Some(full_source_version("throw new Error('broken snapshot');"))
@@ -1294,7 +1358,7 @@ mod tests {
                 .unwrap(),
             0
         );
-        assert!(loader.failed_scripts.lock().unwrap().is_empty());
+        assert!(loader.state.failed_scripts.lock().unwrap().is_empty());
         assert!(loader.script_refs().unwrap().is_empty());
     }
 
@@ -1329,29 +1393,46 @@ mod tests {
     }
 
     #[test]
-    fn separate_loaders_share_backoff_and_content_change_recovers() {
+    fn request_loader_reuses_runtime_lkg_during_backoff_and_recovers() {
         let dir = tempfile::tempdir().unwrap();
         let roots = vec![dir.path().to_path_buf()];
         let path = dir.path().join("request-routine.js");
-        std::fs::write(&path, "throw new Error('request failure');").unwrap();
+        std::fs::write(
+            &path,
+            "agentdesk.routines.register({ name: 'Last Known Good', tick() { return { action: 'skip', reason: 'lkg' }; } });",
+        )
+        .unwrap();
 
-        let first = RoutineScriptLoader::new_shared(&roots).unwrap();
-        assert_eq!(first.load_dirs(&roots).unwrap(), 0);
+        let runtime = RoutineScriptLoader::new_shared(&roots).unwrap();
+        assert_eq!(runtime.load_dirs(&roots).unwrap(), 1);
+        std::fs::write(&path, "throw new Error('transient request failure');").unwrap();
+        assert_eq!(runtime.load_dirs(&roots).unwrap(), 0);
         assert_eq!(
-            first
+            runtime
+                .state
                 .evaluation_attempts
                 .load(std::sync::atomic::Ordering::Relaxed),
-            1
+            2
         );
 
-        let second = RoutineScriptLoader::new_shared(&roots).unwrap();
-        assert_eq!(second.load_dirs(&roots).unwrap(), 0);
+        let request = RoutineScriptLoader::new_shared(&roots).unwrap();
+        assert!(Arc::ptr_eq(&runtime.state, &request.state));
+        assert_eq!(request.load_dirs(&roots).unwrap(), 0);
         assert_eq!(
-            second
+            request
+                .state
                 .evaluation_attempts
                 .load(std::sync::atomic::Ordering::Relaxed),
-            0,
-            "a second request loader must observe the shared backoff"
+            2,
+            "a request during backoff must not re-evaluate the transient failure"
+        );
+        assert_eq!(
+            request
+                .get_script("request-routine.js")
+                .unwrap()
+                .unwrap()
+                .name,
+            "Last Known Good"
         );
 
         std::fs::write(
@@ -1372,6 +1453,99 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_shared_loaders_singleflight_one_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let roots = vec![dir.path().to_path_buf()];
+        let path = dir.path().join("concurrent.js");
+        std::fs::write(&path, "throw new Error('singleflight failure');").unwrap();
+
+        let loaders = (0..8)
+            .map(|_| Arc::new(RoutineScriptLoader::new_shared(&roots).unwrap()))
+            .collect::<Vec<_>>();
+        let state = Arc::clone(&loaders[0].state);
+        let barrier = Arc::new(Barrier::new(loaders.len()));
+        let handles = loaders
+            .into_iter()
+            .map(|loader| {
+                let roots = roots.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    loader.load_dirs(&roots).unwrap()
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            assert_eq!(handle.join().unwrap(), 0);
+        }
+        assert_eq!(
+            state
+                .evaluation_attempts
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+        let failure = state
+            .failed_scripts
+            .lock()
+            .unwrap()
+            .get(&candidate_failure_key(&path))
+            .unwrap()
+            .clone();
+        assert_eq!(failure.consecutive_failures, 1);
+        let retry_delay = failure.retry_at.saturating_duration_since(Instant::now());
+        assert!(retry_delay <= ROUTINE_LOAD_RETRY_BASE);
+        assert!(retry_delay > Duration::ZERO);
+    }
+
+    #[test]
+    fn missing_relative_root_keeps_shared_authority_after_creation() {
+        let relative =
+            PathBuf::from("target").join(format!("routine-root-{}", uuid::Uuid::new_v4()));
+        let absolute = stable_absolute_path(&relative);
+        let configured = vec![relative.clone()];
+        let before = RoutineScriptLoader::new_shared(&configured).unwrap();
+
+        std::fs::create_dir_all(&absolute).unwrap();
+        std::fs::write(
+            absolute.join("created.js"),
+            "agentdesk.routines.register({ name: 'Created Later', tick() { return { action: 'skip' }; } });",
+        )
+        .unwrap();
+        let after = RoutineScriptLoader::new_shared(&[absolute.clone()]).unwrap();
+
+        assert!(Arc::ptr_eq(&before.state, &after.state));
+        assert_eq!(after.load_dirs(&[absolute.clone()]).unwrap(), 1);
+        assert!(before.has_script("created.js").unwrap());
+        std::fs::remove_dir_all(absolute).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn real_and_symlink_alias_candidate_records_one_failure() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let alias_parent = tempfile::tempdir().unwrap();
+        let path = root.path().join("broken.js");
+        std::fs::write(&path, "throw new Error('alias failure');").unwrap();
+        let alias = alias_parent.path().join("root-alias");
+        symlink(root.path(), &alias).unwrap();
+        let roots = vec![root.path().to_path_buf(), alias];
+
+        let loader = RoutineScriptLoader::new().unwrap();
+        assert_eq!(loader.load_dirs(&roots).unwrap(), 0);
+        assert_eq!(
+            loader
+                .state
+                .evaluation_attempts
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+        assert_eq!(loader.state.failed_scripts.lock().unwrap().len(), 1);
+    }
+
+    #[test]
     fn failed_script_backoff_skips_eval_until_due_and_content_change_bypasses_it() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("recoverable.js");
@@ -1381,6 +1555,7 @@ mod tests {
         assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
         assert_eq!(
             loader
+                .state
                 .evaluation_attempts
                 .load(std::sync::atomic::Ordering::Relaxed),
             1
@@ -1388,6 +1563,7 @@ mod tests {
         assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
         assert_eq!(
             loader
+                .state
                 .evaluation_attempts
                 .load(std::sync::atomic::Ordering::Relaxed),
             1,
@@ -1395,15 +1571,17 @@ mod tests {
         );
 
         loader
+            .state
             .failed_scripts
             .lock()
             .unwrap()
-            .get_mut(&path)
+            .get_mut(&candidate_failure_key(&path))
             .unwrap()
             .retry_at = Instant::now();
         assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
         assert_eq!(
             loader
+                .state
                 .evaluation_attempts
                 .load(std::sync::atomic::Ordering::Relaxed),
             2,
@@ -1416,7 +1594,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(loader.load_dir(dir.path()).unwrap(), 1);
-        assert!(loader.failed_scripts.lock().unwrap().is_empty());
+        assert!(loader.state.failed_scripts.lock().unwrap().is_empty());
         assert_eq!(
             loader.get_script("recoverable.js").unwrap().unwrap().name,
             "Recovered"
@@ -1451,7 +1629,10 @@ mod tests {
             .unwrap();
         assert!(!detail.trim().is_empty(), "{detail:?}");
         assert_eq!(detail, detail.trim_start(), "{detail:?}");
-        assert!(detail.contains("at <eval>"), "{detail:?}");
+        assert!(
+            detail.lines().any(|line| !line.trim().is_empty()),
+            "{detail:?}"
+        );
     }
 
     #[test]
@@ -1651,18 +1832,19 @@ mod tests {
         assert_eq!(loader.script_refs().unwrap(), vec!["retained.js"]);
         assert_eq!(
             loader
+                .state
                 .failed_scripts
                 .lock()
                 .unwrap()
                 .keys()
                 .cloned()
                 .collect::<Vec<_>>(),
-            vec![retained.clone()]
+            vec![candidate_failure_key(&retained)]
         );
 
         std::fs::remove_file(&retained).unwrap();
         assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
-        assert!(loader.failed_scripts.lock().unwrap().is_empty());
+        assert!(loader.state.failed_scripts.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -1698,6 +1880,7 @@ mod tests {
         );
         assert_eq!(
             loader
+                .state
                 .load_error_emissions
                 .load(std::sync::atomic::Ordering::Relaxed),
             1,
@@ -1705,10 +1888,11 @@ mod tests {
         );
         assert_eq!(read_attempts.load(std::sync::atomic::Ordering::Relaxed), 2);
         let failure = loader
+            .state
             .failed_scripts
             .lock()
             .unwrap()
-            .get(&path)
+            .get(&candidate_failure_key(&path))
             .unwrap()
             .clone();
         assert_eq!(failure.source_version, None);
@@ -3045,7 +3229,7 @@ mod tests {
 
         let loader_clone = Arc::clone(&loader);
         let result = thread::spawn(move || {
-            let _lock = loader_clone.scripts.lock().unwrap();
+            let _lock = loader_clone.state.scripts.lock().unwrap();
             panic!("intentional panic to poison the lock");
         })
         .join();

--- a/src/services/routines/loader.rs
+++ b/src/services/routines/loader.rs
@@ -3,11 +3,17 @@ use rquickjs::{Context, Function, Runtime};
 use serde::Serialize;
 use serde_json::{Map, Number, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
 use crate::engine::loader::compute_policy_version;
+
+mod discovery;
+use discovery::{
+    add_cached_candidates_for_root, candidate_failure_key, collect_routine_script_paths,
+    routine_roots_identity, script_ref, stable_absolute_path,
+};
 
 fn full_source_version(source: &str) -> String {
     use sha2::{Digest, Sha256};
@@ -918,117 +924,6 @@ fn ensure_acyclic_js_value<'js>(
         return Err(anyhow!("{label} cycle check failed: {detail}"));
     }
     Ok(())
-}
-
-fn stable_absolute_path(path: &Path) -> PathBuf {
-    let absolute = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        std::env::current_dir()
-            .unwrap_or_else(|_| PathBuf::from("."))
-            .join(path)
-    };
-    let mut normalized = PathBuf::new();
-    for component in absolute.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            other => normalized.push(other.as_os_str()),
-        }
-    }
-    normalized
-}
-
-fn root_config_identity(root: &Path) -> PathBuf {
-    stable_absolute_path(root)
-}
-
-fn candidate_failure_key(path: &Path) -> PathBuf {
-    path.canonicalize()
-        .unwrap_or_else(|_| stable_absolute_path(path))
-}
-
-fn routine_roots_identity(roots: &[PathBuf]) -> PathBuf {
-    let identities = roots
-        .iter()
-        .map(|root| root_config_identity(root).to_string_lossy().into_owned())
-        .collect::<Vec<_>>()
-        .join("\0");
-    PathBuf::from(full_source_version(&identities))
-}
-
-fn script_ref(root: &Path, path: &Path) -> String {
-    path.strip_prefix(root)
-        .unwrap_or(path)
-        .to_string_lossy()
-        .replace('\\', "/")
-}
-
-fn add_cached_candidates_for_root(
-    existing_scripts: &HashMap<String, LoadedRoutineScript>,
-    candidates_by_ref: &mut BTreeMap<String, Vec<RoutineScriptCandidate>>,
-    seen_refs: &mut HashSet<String>,
-    root_index: usize,
-    root: &Path,
-) {
-    for (script_ref, script) in existing_scripts
-        .iter()
-        .filter(|(_, script)| script.file.starts_with(root))
-    {
-        seen_refs.insert(script_ref.clone());
-        candidates_by_ref
-            .entry(script_ref.clone())
-            .or_default()
-            .push(RoutineScriptCandidate {
-                root_index,
-                root: root.to_path_buf(),
-                path: script.file.clone(),
-                cached: Some(script.clone()),
-            });
-    }
-}
-
-fn collect_routine_script_paths(
-    root: &Path,
-    exclude_bundled_node_helpers: bool,
-    out: &mut Vec<PathBuf>,
-) -> Result<()> {
-    collect_routine_script_paths_inner(root, root, exclude_bundled_node_helpers, out)
-}
-
-fn collect_routine_script_paths_inner(
-    root: &Path,
-    current_dir: &Path,
-    exclude_bundled_node_helpers: bool,
-    out: &mut Vec<PathBuf>,
-) -> Result<()> {
-    for entry in std::fs::read_dir(current_dir)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
-        let path = entry.path();
-        if file_type.is_dir() {
-            collect_routine_script_paths_inner(root, &path, exclude_bundled_node_helpers, out)?;
-        } else if file_type.is_file() && path.extension().is_some_and(|ext| ext == "js") {
-            if exclude_bundled_node_helpers && is_bundled_node_only_helper(root, &path) {
-                tracing::debug!(
-                    routine_script = %path.display(),
-                    "excluded Node-only worktree inventory helper from QuickJS discovery"
-                );
-            } else {
-                out.push(path);
-            }
-        }
-    }
-    Ok(())
-}
-
-// #4900/#4902: `local-worktree-gc.js` executes this bundled read-only helper with Node.
-fn is_bundled_node_only_helper(root: &Path, path: &Path) -> bool {
-    path.strip_prefix(root).is_ok_and(|relative| {
-        relative == Path::new("monitoring").join("local_worktree_inventory.js")
-    })
 }
 
 #[cfg(test)]

--- a/src/services/routines/loader.rs
+++ b/src/services/routines/loader.rs
@@ -4,10 +4,15 @@ use serde::Serialize;
 use serde_json::{Map, Number, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, PoisonError};
+use std::sync::{Arc, LazyLock, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
 use crate::engine::loader::compute_policy_version;
+
+fn full_source_version(source: &str) -> String {
+    use sha2::{Digest, Sha256};
+    hex::encode(Sha256::digest(source.as_bytes()))
+}
 
 #[inline]
 fn recover_poisoned_lock<T>(e: PoisonError<T>) -> T {
@@ -52,6 +57,7 @@ pub const MAX_OBSERVATIONS_PER_TICK: usize = 100;
 pub const MAX_OBSERVATION_PAYLOAD_BYTES: usize = 65536;
 pub const MAX_AUTOMATION_INVENTORY_ITEMS: usize = 100;
 pub const MAX_AUTOMATION_INVENTORY_PAYLOAD_BYTES: usize = 32768;
+pub const ROUTINE_TICK_ERROR_PUBLIC_REASON: &str = "routine_tick_exception";
 const LEGACY_AUTOMATION_CANDIDATE_EXECUTOR_REF: &str = "monitoring/automation-executor-v2.js";
 const CANONICAL_AUTOMATION_CANDIDATE_EXECUTOR_REF: &str =
     "monitoring/automation-candidate-executor.js";
@@ -65,6 +71,11 @@ struct RoutineScriptFailure {
     retry_at: Instant,
     warning_emitted: bool,
 }
+
+type RoutineFailureRegistry = Arc<Mutex<HashMap<PathBuf, RoutineScriptFailure>>>;
+
+static SHARED_FAILURE_REGISTRIES: LazyLock<Mutex<HashMap<PathBuf, RoutineFailureRegistry>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -138,27 +149,50 @@ pub struct RoutineTickAgent {
 /// process lifetime.
 pub struct RoutineScriptLoader {
     scripts: RoutineScriptStore,
-    failed_scripts: Mutex<HashMap<PathBuf, RoutineScriptFailure>>,
+    failed_scripts: RoutineFailureRegistry,
     #[cfg(test)]
     evaluation_attempts: std::sync::atomic::AtomicUsize,
     #[cfg(test)]
     source_read_hook: Mutex<Option<Arc<dyn Fn(&Path) + Send + Sync>>>,
     #[cfg(test)]
     source_reader: Mutex<Option<Arc<dyn Fn(&Path) -> std::io::Result<String> + Send + Sync>>>,
+    #[cfg(test)]
+    load_error_emissions: std::sync::atomic::AtomicUsize,
 }
 
 impl RoutineScriptLoader {
     pub fn new() -> Result<Self> {
-        Ok(Self {
+        Ok(Self::with_failure_registry(Arc::new(Mutex::new(
+            HashMap::new(),
+        ))))
+    }
+
+    pub fn new_shared(roots: &[PathBuf]) -> Result<Self> {
+        let key = routine_roots_identity(roots);
+        let mut registries = SHARED_FAILURE_REGISTRIES
+            .lock()
+            .unwrap_or_else(recover_poisoned_lock);
+        registries.retain(|_, registry| Arc::strong_count(registry) > 1);
+        let registry = registries
+            .entry(key)
+            .or_insert_with(|| Arc::new(Mutex::new(HashMap::new())))
+            .clone();
+        Ok(Self::with_failure_registry(registry))
+    }
+
+    fn with_failure_registry(failed_scripts: RoutineFailureRegistry) -> Self {
+        Self {
             scripts: Arc::new(Mutex::new(HashMap::new())),
-            failed_scripts: Mutex::new(HashMap::new()),
+            failed_scripts,
             #[cfg(test)]
             evaluation_attempts: std::sync::atomic::AtomicUsize::new(0),
             #[cfg(test)]
             source_read_hook: Mutex::new(None),
             #[cfg(test)]
             source_reader: Mutex::new(None),
-        })
+            #[cfg(test)]
+            load_error_emissions: std::sync::atomic::AtomicUsize::new(0),
+        }
     }
 
     #[cfg(test)]
@@ -197,6 +231,7 @@ impl RoutineScriptLoader {
             .unwrap_or_else(recover_poisoned_lock)
             .clone();
 
+        let primary_root_identity = roots.first().and_then(|root| root.canonicalize().ok());
         for (root_index, root) in roots.iter().enumerate() {
             if !root.exists() {
                 tracing::warn!("Routines directory does not exist: {}", root.display());
@@ -210,8 +245,14 @@ impl RoutineScriptLoader {
                 continue;
             }
 
+            let exclude_bundled_node_helpers = root
+                .canonicalize()
+                .ok()
+                .is_some_and(|identity| primary_root_identity.as_ref() == Some(&identity));
             let mut entries = Vec::new();
-            if let Err(e) = collect_routine_script_paths(root, root_index == 0, &mut entries) {
+            if let Err(e) =
+                collect_routine_script_paths(root, exclude_bundled_node_helpers, &mut entries)
+            {
                 tracing::warn!(
                     routines_dir = %root.display(),
                     error = %e,
@@ -285,6 +326,9 @@ impl RoutineScriptLoader {
                         let now = Instant::now();
                         if self.should_retry_candidate(&candidate.path, None, now, has_existing) {
                             let retry_delay = self.record_failure(&candidate.path, None, now);
+                            #[cfg(test)]
+                            self.load_error_emissions
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                             tracing::error!(
                                 routine_script = %candidate.path.display(),
                                 error = %e,
@@ -298,7 +342,7 @@ impl RoutineScriptLoader {
                         continue;
                     }
                 };
-                let source_version = compute_policy_version(&source);
+                let source_version = full_source_version(&source);
                 #[cfg(test)]
                 if let Some(hook) = self
                     .source_read_hook
@@ -348,6 +392,9 @@ impl RoutineScriptLoader {
                     Err(e) => {
                         let retry_delay =
                             self.record_failure(&candidate.path, Some(source_version.clone()), now);
+                        #[cfg(test)]
+                        self.load_error_emissions
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         tracing::error!(
                             routine_script = %candidate.path.display(),
                             script_version = %source_version,
@@ -636,7 +683,7 @@ fn quickjs_exception_detail(ctx: &rquickjs::Ctx<'_>, error: &rquickjs::Error) ->
         return match (message.is_empty(), stack.is_empty()) {
             (false, false) => format!("{message}\n{stack}"),
             (false, true) => message,
-            (true, false) => stack,
+            (true, false) => stack.trim_start().to_string(),
             (true, true) => error.to_string(),
         };
     }
@@ -838,6 +885,16 @@ fn ensure_acyclic_js_value<'js>(
         return Err(anyhow!("{label} cycle check failed: {detail}"));
     }
     Ok(())
+}
+
+fn routine_roots_identity(roots: &[PathBuf]) -> PathBuf {
+    let identities = roots
+        .iter()
+        .map(|root| root.canonicalize().unwrap_or_else(|_| root.clone()))
+        .map(|root| root.to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("\0");
+    PathBuf::from(full_source_version(&identities))
 }
 
 fn script_ref(root: &Path, path: &Path) -> String {
@@ -1172,9 +1229,7 @@ mod tests {
                 .get(&path)
                 .unwrap()
                 .source_version,
-            Some(compute_policy_version(
-                "throw new Error('broken snapshot');"
-            ))
+            Some(full_source_version("throw new Error('broken snapshot');"))
         );
         assert!(!loader.has_script("atomic-source.js").unwrap());
     }
@@ -1215,6 +1270,45 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn additional_alias_of_primary_root_keeps_bundled_helper_excluded() {
+        use std::os::unix::fs::symlink;
+
+        let bundled = tempfile::tempdir().unwrap();
+        let alias_parent = tempfile::tempdir().unwrap();
+        let monitoring = bundled.path().join("monitoring");
+        std::fs::create_dir_all(&monitoring).unwrap();
+        std::fs::write(
+            monitoring.join("local_worktree_inventory.js"),
+            "const fs = require('node:fs'); module.exports = { fs };",
+        )
+        .unwrap();
+        let alias = alias_parent.path().join("bundled-alias");
+        symlink(bundled.path(), &alias).unwrap();
+
+        let loader = RoutineScriptLoader::new().unwrap();
+        assert_eq!(
+            loader
+                .load_dirs(&[bundled.path().to_path_buf(), alias])
+                .unwrap(),
+            0
+        );
+        assert!(loader.failed_scripts.lock().unwrap().is_empty());
+        assert!(loader.script_refs().unwrap().is_empty());
+    }
+
+    #[test]
+    fn source_failure_identity_uses_full_sha256() {
+        let first = full_source_version("routine source one");
+        let second = full_source_version("routine source two");
+
+        assert_eq!(first.len(), 64);
+        assert_eq!(second.len(), 64);
+        assert_ne!(first, second);
+        assert_eq!(first, full_source_version("routine source one"));
+    }
+
     #[test]
     fn failure_backoff_doubles_and_caps_at_one_hour() {
         let loader = RoutineScriptLoader::new().unwrap();
@@ -1232,6 +1326,49 @@ mod tests {
         assert_eq!(delays[2], Duration::from_secs(120));
         assert_eq!(delays[7], Duration::from_secs(60 * 60));
         assert_eq!(delays[9], Duration::from_secs(60 * 60));
+    }
+
+    #[test]
+    fn separate_loaders_share_backoff_and_content_change_recovers() {
+        let dir = tempfile::tempdir().unwrap();
+        let roots = vec![dir.path().to_path_buf()];
+        let path = dir.path().join("request-routine.js");
+        std::fs::write(&path, "throw new Error('request failure');").unwrap();
+
+        let first = RoutineScriptLoader::new_shared(&roots).unwrap();
+        assert_eq!(first.load_dirs(&roots).unwrap(), 0);
+        assert_eq!(
+            first
+                .evaluation_attempts
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+
+        let second = RoutineScriptLoader::new_shared(&roots).unwrap();
+        assert_eq!(second.load_dirs(&roots).unwrap(), 0);
+        assert_eq!(
+            second
+                .evaluation_attempts
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "a second request loader must observe the shared backoff"
+        );
+
+        std::fs::write(
+            &path,
+            "agentdesk.routines.register({ name: 'Recovered Request', tick() { return { action: 'skip' }; } });",
+        )
+        .unwrap();
+        let recovered = RoutineScriptLoader::new_shared(&roots).unwrap();
+        assert_eq!(recovered.load_dirs(&roots).unwrap(), 1);
+        assert_eq!(
+            recovered
+                .get_script("request-routine.js")
+                .unwrap()
+                .unwrap()
+                .name,
+            "Recovered Request"
+        );
     }
 
     #[test]
@@ -1312,8 +1449,9 @@ mod tests {
                 path.display()
             ))
             .unwrap();
-        assert!(detail.starts_with("Error"), "{detail:?}");
-        assert!(!detail.starts_with('\n'), "{detail:?}");
+        assert!(!detail.trim().is_empty(), "{detail:?}");
+        assert_eq!(detail, detail.trim_start(), "{detail:?}");
+        assert!(detail.contains("at <eval>"), "{detail:?}");
     }
 
     #[test]
@@ -1528,7 +1666,7 @@ mod tests {
     }
 
     #[test]
-    fn source_less_read_failure_uses_the_same_bounded_backoff() {
+    fn read_failure_emits_one_error_during_backoff() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("unreadable.js");
         std::fs::write(
@@ -1548,33 +1686,33 @@ mod tests {
             ))
         }));
 
-        assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
-        assert_eq!(read_attempts.load(std::sync::atomic::Ordering::Relaxed), 1);
-        let first = loader
-            .failed_scripts
-            .lock()
-            .unwrap()
-            .get(&path)
-            .unwrap()
-            .clone();
-        assert_eq!(first.source_version, None);
-        assert_eq!(first.consecutive_failures, 1);
-
-        assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+        let logs = capture_debug_logs(|| {
+            assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+            assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+        });
         assert_eq!(
-            read_attempts.load(std::sync::atomic::Ordering::Relaxed),
-            2,
-            "read must be retried to determine whether the source became available"
+            logs.matches("failed to read routine script; keeping last-known-good registry")
+                .count(),
+            1,
+            "logs={logs}"
         );
-        let second = loader
+        assert_eq!(
+            loader
+                .load_error_emissions
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "only the first failed read may emit an ERROR during backoff"
+        );
+        assert_eq!(read_attempts.load(std::sync::atomic::Ordering::Relaxed), 2);
+        let failure = loader
             .failed_scripts
             .lock()
             .unwrap()
             .get(&path)
             .unwrap()
             .clone();
-        assert_eq!(second.consecutive_failures, 1);
-        assert_eq!(second.retry_at, first.retry_at);
+        assert_eq!(failure.source_version, None);
+        assert_eq!(failure.consecutive_failures, 1);
     }
 
     #[test]

--- a/src/services/routines/loader.rs
+++ b/src/services/routines/loader.rs
@@ -141,6 +141,8 @@ pub struct RoutineScriptLoader {
     failed_scripts: Mutex<HashMap<PathBuf, RoutineScriptFailure>>,
     #[cfg(test)]
     evaluation_attempts: std::sync::atomic::AtomicUsize,
+    #[cfg(test)]
+    source_read_hook: Mutex<Option<Arc<dyn Fn(&Path) + Send + Sync>>>,
 }
 
 impl RoutineScriptLoader {
@@ -150,6 +152,8 @@ impl RoutineScriptLoader {
             failed_scripts: Mutex::new(HashMap::new()),
             #[cfg(test)]
             evaluation_attempts: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
+            source_read_hook: Mutex::new(None),
         })
     }
 
@@ -203,7 +207,7 @@ impl RoutineScriptLoader {
             }
 
             let mut entries = Vec::new();
-            if let Err(e) = collect_routine_script_paths(root, &mut entries) {
+            if let Err(e) = collect_routine_script_paths(root, root_index == 0, &mut entries) {
                 tracing::warn!(
                     routines_dir = %root.display(),
                     error = %e,
@@ -278,6 +282,15 @@ impl RoutineScriptLoader {
                     }
                 };
                 let source_version = compute_policy_version(&source);
+                #[cfg(test)]
+                if let Some(hook) = self
+                    .source_read_hook
+                    .lock()
+                    .unwrap_or_else(recover_poisoned_lock)
+                    .clone()
+                {
+                    hook(&candidate.path);
+                }
                 let now = Instant::now();
                 if !self.should_retry_candidate(
                     &candidate.path,
@@ -841,15 +854,28 @@ fn add_cached_candidates_for_root(
     }
 }
 
-fn collect_routine_script_paths(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
-    for entry in std::fs::read_dir(root)? {
+fn collect_routine_script_paths(
+    root: &Path,
+    exclude_bundled_node_helpers: bool,
+    out: &mut Vec<PathBuf>,
+) -> Result<()> {
+    collect_routine_script_paths_inner(root, root, exclude_bundled_node_helpers, out)
+}
+
+fn collect_routine_script_paths_inner(
+    root: &Path,
+    current_dir: &Path,
+    exclude_bundled_node_helpers: bool,
+    out: &mut Vec<PathBuf>,
+) -> Result<()> {
+    for entry in std::fs::read_dir(current_dir)? {
         let entry = entry?;
         let file_type = entry.file_type()?;
         let path = entry.path();
         if file_type.is_dir() {
-            collect_routine_script_paths(&path, out)?;
+            collect_routine_script_paths_inner(root, &path, exclude_bundled_node_helpers, out)?;
         } else if file_type.is_file() && path.extension().is_some_and(|ext| ext == "js") {
-            if is_node_only_helper(&path) {
+            if exclude_bundled_node_helpers && is_bundled_node_only_helper(root, &path) {
                 tracing::debug!(
                     routine_script = %path.display(),
                     "excluded Node-only worktree inventory helper from QuickJS discovery"
@@ -862,20 +888,60 @@ fn collect_routine_script_paths(root: &Path, out: &mut Vec<PathBuf>) -> Result<(
     Ok(())
 }
 
-// #4900/#4902: `local-worktree-gc.js` executes this read-only helper with Node.
-fn is_node_only_helper(path: &Path) -> bool {
-    path.file_name()
-        .is_some_and(|name| name == "local_worktree_inventory.js")
-        && path
-            .parent()
-            .and_then(Path::file_name)
-            .is_some_and(|name| name == "monitoring")
+// #4900/#4902: `local-worktree-gc.js` executes this bundled read-only helper with Node.
+fn is_bundled_node_only_helper(root: &Path, path: &Path) -> bool {
+    path.strip_prefix(root).is_ok_and(|relative| {
+        relative == Path::new("monitoring").join("local_worktree_inventory.js")
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{self, Write};
     use std::thread;
+    use tracing_subscriber::fmt::writer::MakeWriter;
+
+    #[derive(Clone)]
+    struct CapturingWriter {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl Write for CapturingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.buffer.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CapturingWriter {
+        type Writer = CapturingWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn capture_debug_logs<F>(emit: F) -> String
+    where
+        F: FnOnce(),
+    {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_ansi(false)
+            .without_time()
+            .with_writer(CapturingWriter {
+                buffer: buffer.clone(),
+            })
+            .finish();
+        tracing::subscriber::with_default(subscriber, emit);
+        String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
+    }
 
     fn fixture_routines_root() -> PathBuf {
         std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -1051,9 +1117,85 @@ mod tests {
         .unwrap();
 
         let loader = RoutineScriptLoader::new().unwrap();
-        assert_eq!(loader.load_dir(dir.path()).unwrap(), 1);
+        let logs = capture_debug_logs(|| {
+            assert_eq!(loader.load_dir(dir.path()).unwrap(), 1);
+        });
         assert_eq!(loader.script_refs().unwrap(), vec!["inventory-routine.js"]);
         assert!(loader.failed_scripts.lock().unwrap().is_empty());
+        assert!(
+            logs.contains("excluded Node-only worktree inventory helper from QuickJS discovery"),
+            "logs={logs}"
+        );
+    }
+
+    #[test]
+    fn load_dir_hashes_and_evaluates_the_same_source_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("atomic-source.js");
+        std::fs::write(&path, "throw new Error('broken snapshot');").unwrap();
+
+        let loader = RoutineScriptLoader::new().unwrap();
+        let replacement_path = path.clone();
+        *loader.source_read_hook.lock().unwrap() = Some(Arc::new(move |candidate| {
+            if candidate == replacement_path {
+                std::fs::write(
+                    candidate,
+                    "agentdesk.routines.register({ name: 'Replacement', tick() { return { action: 'skip' }; } });",
+                )
+                .unwrap();
+            }
+        }));
+
+        assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+        assert_eq!(
+            loader
+                .failed_scripts
+                .lock()
+                .unwrap()
+                .get(&path)
+                .unwrap()
+                .source_version,
+            Some(compute_policy_version(
+                "throw new Error('broken snapshot');"
+            ))
+        );
+        assert!(!loader.has_script("atomic-source.js").unwrap());
+    }
+
+    #[test]
+    fn operator_root_can_define_the_bundled_helper_relative_path_as_a_routine() {
+        let bundled = tempfile::tempdir().unwrap();
+        let operator = tempfile::tempdir().unwrap();
+        let bundled_monitoring = bundled.path().join("monitoring");
+        let operator_monitoring = operator.path().join("monitoring");
+        std::fs::create_dir_all(&bundled_monitoring).unwrap();
+        std::fs::create_dir_all(&operator_monitoring).unwrap();
+        std::fs::write(
+            bundled_monitoring.join("local_worktree_inventory.js"),
+            "const fs = require('node:fs'); module.exports = { fs };",
+        )
+        .unwrap();
+        std::fs::write(
+            operator_monitoring.join("local_worktree_inventory.js"),
+            "agentdesk.routines.register({ name: 'Operator Inventory', tick() { return { action: 'skip' }; } });",
+        )
+        .unwrap();
+
+        let loader = RoutineScriptLoader::new().unwrap();
+        assert_eq!(
+            loader
+                .load_dirs(&[bundled.path().to_path_buf(), operator.path().to_path_buf()])
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            loader
+                .get_script("monitoring/local_worktree_inventory.js")
+                .unwrap()
+                .unwrap()
+                .name,
+            "Operator Inventory"
+        );
     }
 
     #[test]
@@ -1137,6 +1279,24 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("require is not defined"), "{message}");
         assert!(message.contains("at <eval>"), "{message}");
+    }
+
+    #[test]
+    fn quickjs_eval_error_with_empty_message_starts_with_stack() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty-message.js");
+        std::fs::write(&path, "const error = new Error(''); throw error;").unwrap();
+
+        let error = load_single_routine_script(dir.path(), &path).unwrap_err();
+        let message = error.to_string();
+        let detail = message
+            .strip_prefix(&format!(
+                "JS eval error in routine script {}: ",
+                path.display()
+            ))
+            .unwrap();
+        assert!(detail.starts_with("Error"), "{detail:?}");
+        assert!(!detail.starts_with('\n'), "{detail:?}");
     }
 
     #[test]
@@ -1342,8 +1502,12 @@ mod tests {
                 .keys()
                 .cloned()
                 .collect::<Vec<_>>(),
-            vec![retained]
+            vec![retained.clone()]
         );
+
+        std::fs::remove_file(&retained).unwrap();
+        assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+        assert!(loader.failed_scripts.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -1436,6 +1600,52 @@ mod tests {
             }
             other => panic!("unexpected action: {other:?}"),
         }
+    }
+
+    #[test]
+    fn tick_error_includes_primitive_throw_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("primitive-tick.js");
+        std::fs::write(
+            &path,
+            "agentdesk.routines.register({ name: 'Primitive Tick', tick() { throw 'tick unavailable'; } });",
+        )
+        .unwrap();
+
+        let loader = RoutineScriptLoader::new().unwrap();
+        loader.load_script(dir.path(), &path).unwrap();
+        let error = loader
+            .execute_tick(
+                "primitive-tick.js",
+                RoutineTickContext {
+                    routine: RoutineTickRoutine {
+                        id: "routine-1".to_string(),
+                        agent_id: None,
+                        script_ref: "primitive-tick.js".to_string(),
+                        name: "Primitive Tick".to_string(),
+                        execution_strategy: "fresh".to_string(),
+                        fresh_context_guaranteed: false,
+                    },
+                    run: RoutineTickRun {
+                        id: "run-1".to_string(),
+                        lease_expires_at: chrono::Utc::now(),
+                    },
+                    agent: None,
+                    checkpoint: None,
+                    now: chrono::Utc::now(),
+                    observations: None,
+                    automation_inventory: None,
+                    limits: ObservationLimits::default(),
+                },
+            )
+            .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("tick unavailable"), "{message}");
+        assert!(
+            !message.contains("Exception generated by QuickJS"),
+            "{message}"
+        );
     }
 
     #[test]

--- a/src/services/routines/loader.rs
+++ b/src/services/routines/loader.rs
@@ -1057,6 +1057,25 @@ mod tests {
     }
 
     #[test]
+    fn failure_backoff_doubles_and_caps_at_one_hour() {
+        let loader = RoutineScriptLoader::new().unwrap();
+        let path = Path::new("broken.js");
+        let version = Some("version-1".to_string());
+        let now = Instant::now();
+
+        let mut delays = Vec::new();
+        for _ in 0..10 {
+            delays.push(loader.record_failure(path, version.clone(), now));
+        }
+
+        assert_eq!(delays[0], Duration::from_secs(30));
+        assert_eq!(delays[1], Duration::from_secs(60));
+        assert_eq!(delays[2], Duration::from_secs(120));
+        assert_eq!(delays[7], Duration::from_secs(60 * 60));
+        assert_eq!(delays[9], Duration::from_secs(60 * 60));
+    }
+
+    #[test]
     fn failed_script_backoff_skips_eval_until_due_and_content_change_bypasses_it() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("recoverable.js");
@@ -1327,44 +1346,31 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
-    fn unreadable_script_uses_the_same_bounded_backoff() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("unreadable.js");
-        std::fs::write(
-            &path,
-            "agentdesk.routines.register({ name: 'Unreadable', tick() { return { action: 'skip' }; } });",
-        )
-        .unwrap();
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
-
+    fn source_less_read_failure_uses_the_same_bounded_backoff() {
+        let path = Path::new("unreadable.js");
         let loader = RoutineScriptLoader::new().unwrap();
-        assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+        loader.record_failure(path, None, Instant::now());
         let first = loader
             .failed_scripts
             .lock()
             .unwrap()
-            .get(&path)
+            .get(path)
             .unwrap()
             .clone();
         assert_eq!(first.source_version, None);
         assert_eq!(first.consecutive_failures, 1);
 
-        assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+        assert!(!loader.should_retry_candidate(path, None, Instant::now(), false));
         let second = loader
             .failed_scripts
             .lock()
             .unwrap()
-            .get(&path)
+            .get(path)
             .unwrap()
             .clone();
         assert_eq!(second.consecutive_failures, 1);
         assert_eq!(second.retry_at, first.retry_at);
-
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
     }
 
     #[test]

--- a/src/services/routines/loader.rs
+++ b/src/services/routines/loader.rs
@@ -55,6 +55,16 @@ pub const MAX_AUTOMATION_INVENTORY_PAYLOAD_BYTES: usize = 32768;
 const LEGACY_AUTOMATION_CANDIDATE_EXECUTOR_REF: &str = "monitoring/automation-executor-v2.js";
 const CANONICAL_AUTOMATION_CANDIDATE_EXECUTOR_REF: &str =
     "monitoring/automation-candidate-executor.js";
+const ROUTINE_LOAD_RETRY_BASE: Duration = Duration::from_secs(30);
+const ROUTINE_LOAD_RETRY_MAX: Duration = Duration::from_secs(60 * 60);
+
+#[derive(Debug, Clone)]
+struct RoutineScriptFailure {
+    source_version: Option<String>,
+    consecutive_failures: u32,
+    retry_at: Instant,
+    warning_emitted: bool,
+}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -122,22 +132,31 @@ pub struct RoutineTickAgent {
 ///
 /// This intentionally does not use the PolicyEngine store or
 /// `agentdesk.registerPolicy()` namespace. Failed loads return an error before
-/// mutating the store, so callers keep the last-known-good registry.
+/// mutating the store, so callers keep the last-known-good registry. Read and
+/// evaluation failures use bounded exponential backoff; unchanged candidates
+/// are always retried within one hour instead of remaining disabled for the
+/// process lifetime.
 pub struct RoutineScriptLoader {
     scripts: RoutineScriptStore,
-    failed_script_versions: Mutex<HashMap<PathBuf, String>>,
+    failed_scripts: Mutex<HashMap<PathBuf, RoutineScriptFailure>>,
+    #[cfg(test)]
+    evaluation_attempts: std::sync::atomic::AtomicUsize,
 }
 
 impl RoutineScriptLoader {
     pub fn new() -> Result<Self> {
         Ok(Self {
             scripts: Arc::new(Mutex::new(HashMap::new())),
-            failed_script_versions: Mutex::new(HashMap::new()),
+            failed_scripts: Mutex::new(HashMap::new()),
+            #[cfg(test)]
+            evaluation_attempts: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 
     #[cfg(test)]
     pub fn load_script(&self, root: &Path, path: &Path) -> Result<String> {
+        self.evaluation_attempts
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let script = load_single_routine_script(root, path)?;
         tracing::debug!(
             routine_script = %script.script_ref,
@@ -217,6 +236,10 @@ impl RoutineScriptLoader {
         }
 
         let existing_refs: HashSet<String> = existing_scripts.keys().cloned().collect();
+        let candidate_paths: HashSet<PathBuf> = candidates_by_ref
+            .values()
+            .flat_map(|candidates| candidates.iter().map(|candidate| candidate.path.clone()))
+            .collect();
 
         let mut loaded = 0;
         let mut loaded_scripts = Vec::new();
@@ -234,41 +257,50 @@ impl RoutineScriptLoader {
                     selected = Some((script.clone(), false));
                     break;
                 }
-                let source_version = match routine_script_source_version(&candidate.path) {
-                    Ok(version) => version,
+
+                let source = match std::fs::read_to_string(&candidate.path) {
+                    Ok(source) => source,
                     Err(e) => {
-                        tracing::error!(
-                            routine_script = %candidate.path.display(),
-                            error = %e,
-                            "failed to read routine script; keeping last-known-good registry"
-                        );
+                        let now = Instant::now();
+                        if self.should_retry_candidate(&candidate.path, None, now, has_existing) {
+                            let retry_delay = self.record_failure(&candidate.path, None, now);
+                            tracing::error!(
+                                routine_script = %candidate.path.display(),
+                                error = %e,
+                                retry_after_seconds = retry_delay.as_secs(),
+                                "failed to read routine script; keeping last-known-good registry"
+                            );
+                        }
                         if has_existing {
                             break;
                         }
                         continue;
                     }
                 };
-                let unchanged_failure = self
-                    .failed_script_versions
-                    .lock()
-                    .unwrap_or_else(recover_poisoned_lock)
-                    .get(&candidate.path)
-                    .is_some_and(|failed_version| failed_version == &source_version);
-                if unchanged_failure {
-                    tracing::debug!(
-                        routine_script = %candidate.path.display(),
-                        script_version = %source_version,
-                        "skipped unchanged routine script after previous load failure"
-                    );
+                let source_version = compute_policy_version(&source);
+                let now = Instant::now();
+                if !self.should_retry_candidate(
+                    &candidate.path,
+                    Some(&source_version),
+                    now,
+                    has_existing,
+                ) {
                     if has_existing {
                         break;
                     }
                     continue;
                 }
 
-                match load_single_routine_script(&candidate.root, &candidate.path) {
+                #[cfg(test)]
+                self.evaluation_attempts
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                match load_single_routine_script_from_source(
+                    &candidate.root,
+                    &candidate.path,
+                    source,
+                ) {
                     Ok(script) => {
-                        self.failed_script_versions
+                        self.failed_scripts
                             .lock()
                             .unwrap_or_else(recover_poisoned_lock)
                             .remove(&candidate.path);
@@ -284,12 +316,12 @@ impl RoutineScriptLoader {
                         break;
                     }
                     Err(e) => {
-                        self.failed_script_versions
-                            .lock()
-                            .unwrap_or_else(recover_poisoned_lock)
-                            .insert(candidate.path.clone(), source_version);
+                        let retry_delay =
+                            self.record_failure(&candidate.path, Some(source_version.clone()), now);
                         tracing::error!(
                             routine_script = %candidate.path.display(),
+                            script_version = %source_version,
+                            retry_after_seconds = retry_delay.as_secs(),
                             error = %e,
                             "failed to load routine script; keeping last-known-good registry"
                         );
@@ -312,12 +344,88 @@ impl RoutineScriptLoader {
             }
         }
 
+        self.failed_scripts
+            .lock()
+            .unwrap_or_else(recover_poisoned_lock)
+            .retain(|path, _| candidate_paths.contains(path));
         let pruned = self.apply_dir_reload(loaded_scripts, &seen_refs)?;
         if pruned > 0 {
             tracing::info!(count = pruned, "pruned missing routine scripts");
         }
 
         Ok(loaded)
+    }
+
+    fn should_retry_candidate(
+        &self,
+        path: &Path,
+        source_version: Option<&String>,
+        now: Instant,
+        has_existing: bool,
+    ) -> bool {
+        let mut failures = self
+            .failed_scripts
+            .lock()
+            .unwrap_or_else(recover_poisoned_lock);
+        let Some(failure) = failures.get_mut(path) else {
+            return true;
+        };
+        if failure.source_version.as_ref() != source_version {
+            return true;
+        }
+        if now >= failure.retry_at {
+            return true;
+        }
+
+        let retry_after = failure.retry_at.saturating_duration_since(now);
+        if !has_existing && !failure.warning_emitted {
+            tracing::warn!(
+                routine_script = %path.display(),
+                retry_after_seconds = retry_after.as_secs(),
+                consecutive_failures = failure.consecutive_failures,
+                "routine script is not loaded; retry deferred by failure backoff"
+            );
+            failure.warning_emitted = true;
+        } else {
+            tracing::debug!(
+                routine_script = %path.display(),
+                retry_after_seconds = retry_after.as_secs(),
+                consecutive_failures = failure.consecutive_failures,
+                "skipped routine script until failure backoff expires"
+            );
+        }
+        false
+    }
+
+    fn record_failure(
+        &self,
+        path: &Path,
+        source_version: Option<String>,
+        now: Instant,
+    ) -> Duration {
+        let mut failures = self
+            .failed_scripts
+            .lock()
+            .unwrap_or_else(recover_poisoned_lock);
+        let consecutive_failures = failures
+            .get(path)
+            .filter(|failure| failure.source_version == source_version)
+            .map_or(1, |failure| failure.consecutive_failures.saturating_add(1));
+        let exponent = consecutive_failures.saturating_sub(1).min(31);
+        let retry_delay = ROUTINE_LOAD_RETRY_BASE
+            .checked_mul(1_u32 << exponent)
+            .unwrap_or(ROUTINE_LOAD_RETRY_MAX)
+            .min(ROUTINE_LOAD_RETRY_MAX);
+        failures.insert(
+            path.to_path_buf(),
+            RoutineScriptFailure {
+                source_version,
+                consecutive_failures,
+                retry_at: now + retry_delay,
+                warning_emitted: false,
+            },
+        );
+        retry_delay
     }
 
     pub fn get_script(&self, script_ref: &str) -> Result<Option<LoadedRoutineScript>> {
@@ -391,6 +499,14 @@ impl Drop for RoutineScriptLoader {
 pub fn load_single_routine_script(root: &Path, path: &Path) -> Result<LoadedRoutineScript> {
     let source = std::fs::read_to_string(path)
         .map_err(|e| anyhow!("read routine script {}: {e}", path.display()))?;
+    load_single_routine_script_from_source(root, path, source)
+}
+
+fn load_single_routine_script_from_source(
+    root: &Path,
+    path: &Path,
+    source: String,
+) -> Result<LoadedRoutineScript> {
     let fallback_name = path
         .file_stem()
         .unwrap_or_default()
@@ -462,10 +578,16 @@ fn evaluate_tick_action(
         let js_context: rquickjs::Value = ctx
             .eval(format!("JSON.parse({context_literal})"))
             .map_err(|e| anyhow!("build routine tick context: {e}"))?;
-        let action_value: rquickjs::Value = registration
-            .tick
-            .call((js_context,))
-            .map_err(|e| anyhow!("routine script {} tick(ctx) failed: {e}", script.script_ref))?;
+        let action_value: rquickjs::Value = match registration.tick.call((js_context,)) {
+            Ok(value) => value,
+            Err(e) => {
+                let detail = quickjs_exception_detail(&ctx, &e);
+                return Err(anyhow!(
+                    "routine script {} tick(ctx) failed: {detail}",
+                    script.script_ref
+                ));
+            }
+        };
         ensure_acyclic_js_value(ctx, action_value.clone(), "routine action")?;
         js_value_to_json(action_value)
     })
@@ -474,6 +596,25 @@ fn evaluate_tick_action(
 fn install_interrupt_handler(runtime: &Runtime, timeout: Duration) {
     let started = Instant::now();
     runtime.set_interrupt_handler(Some(Box::new(move || started.elapsed() > timeout)));
+}
+
+fn quickjs_exception_detail(ctx: &rquickjs::Ctx<'_>, error: &rquickjs::Error) -> String {
+    let caught = ctx.catch();
+    if let Some(exception) = caught.clone().into_exception() {
+        let message = exception.message().unwrap_or_default();
+        let stack = exception.stack().unwrap_or_default();
+        return match (message.is_empty(), stack.is_empty()) {
+            (false, false) => format!("{message}\n{stack}"),
+            (false, true) => message,
+            (true, false) => stack,
+            (true, true) => error.to_string(),
+        };
+    }
+
+    <rquickjs::convert::Coerced<String> as rquickjs::FromJs>::from_js(ctx, caught)
+        .map(|rquickjs::convert::Coerced(detail)| detail)
+        .filter(|detail| !detail.is_empty())
+        .unwrap_or_else(|_| error.to_string())
 }
 
 struct CapturedRoutineRegistration<'js> {
@@ -508,20 +649,7 @@ fn capture_registered_routine<'js>(
     let eval_result: rquickjs::Result<rquickjs::Value> =
         ctx.eval_with_options(source.as_bytes().to_vec(), eval_opts);
     if let Err(e) = eval_result {
-        let exception_detail = ctx
-            .catch()
-            .into_exception()
-            .map(|exception| {
-                let message = exception.message().unwrap_or_default();
-                let stack = exception.stack().unwrap_or_default();
-                if stack.is_empty() {
-                    message
-                } else {
-                    format!("{message}\n{stack}")
-                }
-            })
-            .filter(|detail| !detail.is_empty())
-            .unwrap_or_else(|| e.to_string());
+        let exception_detail = quickjs_exception_detail(&ctx, &e);
         return Err(anyhow!(
             "JS eval error in routine script {}: {exception_detail}",
             path.display()
@@ -674,9 +802,11 @@ fn ensure_acyclic_js_value<'js>(
             "#,
         )
         .map_err(|e| anyhow!("routine action cycle checker init failed: {e}"))?;
-    checker
-        .call::<_, ()>((value,))
-        .map_err(|e| anyhow!("{label} cycle check failed: {e}"))
+    if let Err(e) = checker.call::<_, ()>((value,)) {
+        let detail = quickjs_exception_detail(&ctx, &e);
+        return Err(anyhow!("{label} cycle check failed: {detail}"));
+    }
+    Ok(())
 }
 
 fn script_ref(root: &Path, path: &Path) -> String {
@@ -684,12 +814,6 @@ fn script_ref(root: &Path, path: &Path) -> String {
         .unwrap_or(path)
         .to_string_lossy()
         .replace('\\', "/")
-}
-
-fn routine_script_source_version(path: &Path) -> Result<String> {
-    let source = std::fs::read_to_string(path)
-        .map_err(|e| anyhow!("read routine script {}: {e}", path.display()))?;
-    Ok(compute_policy_version(&source))
 }
 
 fn add_cached_candidates_for_root(
@@ -723,16 +847,21 @@ fn collect_routine_script_paths(root: &Path, out: &mut Vec<PathBuf>) -> Result<(
         let path = entry.path();
         if file_type.is_dir() {
             collect_routine_script_paths(&path, out)?;
-        } else if file_type.is_file()
-            && path.extension().is_some_and(|ext| ext == "js")
-            && !is_node_only_helper(&path)
-        {
-            out.push(path);
+        } else if file_type.is_file() && path.extension().is_some_and(|ext| ext == "js") {
+            if is_node_only_helper(&path) {
+                tracing::debug!(
+                    routine_script = %path.display(),
+                    "excluded Node-only worktree inventory helper from QuickJS discovery"
+                );
+            } else {
+                out.push(path);
+            }
         }
     }
     Ok(())
 }
 
+// #4900/#4902: `local-worktree-gc.js` executes this read-only helper with Node.
 fn is_node_only_helper(path: &Path) -> bool {
     path.file_name()
         .is_some_and(|name| name == "local_worktree_inventory.js")
@@ -923,21 +1052,47 @@ mod tests {
         let loader = RoutineScriptLoader::new().unwrap();
         assert_eq!(loader.load_dir(dir.path()).unwrap(), 1);
         assert_eq!(loader.script_refs().unwrap(), vec!["inventory-routine.js"]);
+        assert!(loader.failed_scripts.lock().unwrap().is_empty());
     }
 
     #[test]
-    fn unchanged_failed_script_is_retried_only_after_content_changes() {
+    fn failed_script_backoff_skips_eval_until_due_and_content_change_bypasses_it() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("recoverable.js");
-        let broken =
-            "globalThis.__attempts = (globalThis.__attempts || 0) + 1; throw new Error('broken');";
-        std::fs::write(&path, broken).unwrap();
+        std::fs::write(&path, "throw new Error('broken');").unwrap();
 
         let loader = RoutineScriptLoader::new().unwrap();
         assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
-        assert_eq!(loader.failed_script_versions.lock().unwrap().len(), 1);
+        assert_eq!(
+            loader
+                .evaluation_attempts
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
         assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
-        assert_eq!(loader.failed_script_versions.lock().unwrap().len(), 1);
+        assert_eq!(
+            loader
+                .evaluation_attempts
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "unchanged script must not be evaluated during backoff"
+        );
+
+        loader
+            .failed_scripts
+            .lock()
+            .unwrap()
+            .get_mut(&path)
+            .unwrap()
+            .retry_at = Instant::now();
+        assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+        assert_eq!(
+            loader
+                .evaluation_attempts
+                .load(std::sync::atomic::Ordering::Relaxed),
+            2,
+            "script must be retried after backoff expires"
+        );
 
         std::fs::write(
             &path,
@@ -945,7 +1100,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(loader.load_dir(dir.path()).unwrap(), 1);
-        assert!(loader.failed_script_versions.lock().unwrap().is_empty());
+        assert!(loader.failed_scripts.lock().unwrap().is_empty());
         assert_eq!(
             loader.get_script("recoverable.js").unwrap().unwrap().name,
             "Recovered"
@@ -953,13 +1108,25 @@ mod tests {
     }
 
     #[test]
-    fn quickjs_eval_error_includes_exception_message() {
+    fn quickjs_eval_error_includes_exception_message_and_stack() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("node-only.js");
         std::fs::write(&path, "require('node:fs');").unwrap();
 
         let error = load_single_routine_script(dir.path(), &path).unwrap_err();
-        assert!(error.to_string().contains("require is not defined"));
+        let message = error.to_string();
+        assert!(message.contains("require is not defined"), "{message}");
+        assert!(message.contains("at <eval>"), "{message}");
+    }
+
+    #[test]
+    fn quickjs_eval_error_includes_primitive_throw_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("primitive-throw.js");
+        std::fs::write(&path, "throw 'bad config';").unwrap();
+
+        let error = load_single_routine_script(dir.path(), &path).unwrap_err();
+        assert!(error.to_string().contains("bad config"));
     }
 
     #[test]
@@ -1147,6 +1314,56 @@ mod tests {
 
         assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
         assert_eq!(loader.script_refs().unwrap(), vec!["retained.js"]);
+        assert_eq!(
+            loader
+                .failed_scripts
+                .lock()
+                .unwrap()
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![retained]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_script_uses_the_same_bounded_backoff() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("unreadable.js");
+        std::fs::write(
+            &path,
+            "agentdesk.routines.register({ name: 'Unreadable', tick() { return { action: 'skip' }; } });",
+        )
+        .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let loader = RoutineScriptLoader::new().unwrap();
+        assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+        let first = loader
+            .failed_scripts
+            .lock()
+            .unwrap()
+            .get(&path)
+            .unwrap()
+            .clone();
+        assert_eq!(first.source_version, None);
+        assert_eq!(first.consecutive_failures, 1);
+
+        assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+        let second = loader
+            .failed_scripts
+            .lock()
+            .unwrap()
+            .get(&path)
+            .unwrap()
+            .clone();
+        assert_eq!(second.consecutive_failures, 1);
+        assert_eq!(second.retry_at, first.retry_at);
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
     }
 
     #[test]

--- a/src/services/routines/loader.rs
+++ b/src/services/routines/loader.rs
@@ -12,7 +12,7 @@ use crate::engine::loader::compute_policy_version;
 mod discovery;
 use discovery::{
     add_cached_candidates_for_root, candidate_failure_key, collect_routine_script_paths,
-    routine_roots_identity, script_ref, stable_absolute_path,
+    routine_roots_identity, script_ref,
 };
 
 fn full_source_version(source: &str) -> String {
@@ -928,6 +928,7 @@ fn ensure_acyclic_js_value<'js>(
 
 #[cfg(test)]
 mod tests {
+    use super::discovery::stable_absolute_path;
     use super::*;
     use std::io::{self, Write};
     use std::sync::Barrier;

--- a/src/services/routines/loader.rs
+++ b/src/services/routines/loader.rs
@@ -143,6 +143,8 @@ pub struct RoutineScriptLoader {
     evaluation_attempts: std::sync::atomic::AtomicUsize,
     #[cfg(test)]
     source_read_hook: Mutex<Option<Arc<dyn Fn(&Path) + Send + Sync>>>,
+    #[cfg(test)]
+    source_reader: Mutex<Option<Arc<dyn Fn(&Path) -> std::io::Result<String> + Send + Sync>>>,
 }
 
 impl RoutineScriptLoader {
@@ -154,6 +156,8 @@ impl RoutineScriptLoader {
             evaluation_attempts: std::sync::atomic::AtomicUsize::new(0),
             #[cfg(test)]
             source_read_hook: Mutex::new(None),
+            #[cfg(test)]
+            source_reader: Mutex::new(None),
         })
     }
 
@@ -262,7 +266,20 @@ impl RoutineScriptLoader {
                     break;
                 }
 
-                let source = match std::fs::read_to_string(&candidate.path) {
+                #[cfg(test)]
+                let source_result = if let Some(reader) = self
+                    .source_reader
+                    .lock()
+                    .unwrap_or_else(recover_poisoned_lock)
+                    .clone()
+                {
+                    reader(&candidate.path)
+                } else {
+                    std::fs::read_to_string(&candidate.path)
+                };
+                #[cfg(not(test))]
+                let source_result = std::fs::read_to_string(&candidate.path);
+                let source = match source_result {
                     Ok(source) => source,
                     Err(e) => {
                         let now = Instant::now();
@@ -1512,25 +1529,48 @@ mod tests {
 
     #[test]
     fn source_less_read_failure_uses_the_same_bounded_backoff() {
-        let path = Path::new("unreadable.js");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("unreadable.js");
+        std::fs::write(
+            &path,
+            "agentdesk.routines.register({ name: 'Unreadable', tick() { return { action: 'skip' }; } });",
+        )
+        .unwrap();
+
         let loader = RoutineScriptLoader::new().unwrap();
-        loader.record_failure(path, None, Instant::now());
+        let read_attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let observed_attempts = Arc::clone(&read_attempts);
+        *loader.source_reader.lock().unwrap() = Some(Arc::new(move |_| {
+            observed_attempts.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "test read failure",
+            ))
+        }));
+
+        assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+        assert_eq!(read_attempts.load(std::sync::atomic::Ordering::Relaxed), 1);
         let first = loader
             .failed_scripts
             .lock()
             .unwrap()
-            .get(path)
+            .get(&path)
             .unwrap()
             .clone();
         assert_eq!(first.source_version, None);
         assert_eq!(first.consecutive_failures, 1);
 
-        assert!(!loader.should_retry_candidate(path, None, Instant::now(), false));
+        assert_eq!(loader.load_dir(dir.path()).unwrap(), 0);
+        assert_eq!(
+            read_attempts.load(std::sync::atomic::Ordering::Relaxed),
+            2,
+            "read must be retried to determine whether the source became available"
+        );
         let second = loader
             .failed_scripts
             .lock()
             .unwrap()
-            .get(path)
+            .get(&path)
             .unwrap()
             .clone();
         assert_eq!(second.consecutive_failures, 1);

--- a/src/services/routines/loader/discovery.rs
+++ b/src/services/routines/loader/discovery.rs
@@ -1,0 +1,115 @@
+use super::{LoadedRoutineScript, RoutineScriptCandidate, full_source_version};
+use anyhow::Result;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Component, Path, PathBuf};
+
+pub(super) fn stable_absolute_path(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn root_config_identity(root: &Path) -> PathBuf {
+    stable_absolute_path(root)
+}
+
+pub(super) fn candidate_failure_key(path: &Path) -> PathBuf {
+    path.canonicalize()
+        .unwrap_or_else(|_| stable_absolute_path(path))
+}
+
+pub(super) fn routine_roots_identity(roots: &[PathBuf]) -> PathBuf {
+    let identities = roots
+        .iter()
+        .map(|root| root_config_identity(root).to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("\0");
+    PathBuf::from(full_source_version(&identities))
+}
+
+pub(super) fn script_ref(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+pub(super) fn add_cached_candidates_for_root(
+    existing_scripts: &HashMap<String, LoadedRoutineScript>,
+    candidates_by_ref: &mut BTreeMap<String, Vec<RoutineScriptCandidate>>,
+    seen_refs: &mut HashSet<String>,
+    root_index: usize,
+    root: &Path,
+) {
+    for (script_ref, script) in existing_scripts
+        .iter()
+        .filter(|(_, script)| script.file.starts_with(root))
+    {
+        seen_refs.insert(script_ref.clone());
+        candidates_by_ref
+            .entry(script_ref.clone())
+            .or_default()
+            .push(RoutineScriptCandidate {
+                root_index,
+                root: root.to_path_buf(),
+                path: script.file.clone(),
+                cached: Some(script.clone()),
+            });
+    }
+}
+
+pub(super) fn collect_routine_script_paths(
+    root: &Path,
+    exclude_bundled_node_helpers: bool,
+    out: &mut Vec<PathBuf>,
+) -> Result<()> {
+    collect_routine_script_paths_inner(root, root, exclude_bundled_node_helpers, out)
+}
+
+fn collect_routine_script_paths_inner(
+    root: &Path,
+    current_dir: &Path,
+    exclude_bundled_node_helpers: bool,
+    out: &mut Vec<PathBuf>,
+) -> Result<()> {
+    for entry in std::fs::read_dir(current_dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_dir() {
+            collect_routine_script_paths_inner(root, &path, exclude_bundled_node_helpers, out)?;
+        } else if file_type.is_file() && path.extension().is_some_and(|ext| ext == "js") {
+            if exclude_bundled_node_helpers && is_bundled_node_only_helper(root, &path) {
+                tracing::debug!(
+                    routine_script = %path.display(),
+                    "excluded Node-only worktree inventory helper from QuickJS discovery"
+                );
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    Ok(())
+}
+
+// #4900/#4902: `local-worktree-gc.js` executes this bundled read-only helper with Node.
+fn is_bundled_node_only_helper(root: &Path, path: &Path) -> bool {
+    path.strip_prefix(root).is_ok_and(|relative| {
+        relative == Path::new("monitoring").join("local_worktree_inventory.js")
+    })
+}

--- a/src/services/routines/runtime.rs
+++ b/src/services/routines/runtime.rs
@@ -258,18 +258,14 @@ pub async fn execute_claimed_script_run(
         Ok(action) => action,
         Err(error) => {
             let diagnostic = error.to_string();
+            let (public_reason, result_json) =
+                public_tick_failure(&diagnostic, &claimed.script_ref);
             tracing::error!(
                 routine_run_id = %claimed.run_id,
                 routine_script = %claimed.script_ref,
                 error = %diagnostic,
                 "routine tick evaluation failed"
             );
-            let public_reason = ROUTINE_TICK_ERROR_PUBLIC_REASON.to_string();
-            let result_json = Some(json!({
-                "error": public_reason,
-                "diagnostic_class": ROUTINE_TICK_ERROR_PUBLIC_REASON,
-                "script_ref": claimed.script_ref,
-            }));
             let closed = if terminal_failure_should_pause(pause_on_terminal_failure) {
                 store
                     .fail_run_and_pause_routine(
@@ -639,6 +635,16 @@ fn pre_provider_fresh_context_guaranteed() -> bool {
     false
 }
 
+fn public_tick_failure(_diagnostic: &str, script_ref: &str) -> (String, Option<Value>) {
+    let public_reason = ROUTINE_TICK_ERROR_PUBLIC_REASON.to_string();
+    let result_json = Some(json!({
+        "error": public_reason,
+        "diagnostic_class": ROUTINE_TICK_ERROR_PUBLIC_REASON,
+        "script_ref": script_ref,
+    }));
+    (public_reason, result_json)
+}
+
 async fn close_action(
     store: &RoutineStore,
     agent_executor: Option<&RoutineAgentExecutor>,
@@ -890,9 +896,31 @@ mod tests {
 
     use super::{
         action_detail, merge_loaded_script_automation_inventory,
-        pre_provider_fresh_context_guaranteed, validate_claimed_migrated_launchd_run,
+        pre_provider_fresh_context_guaranteed, public_tick_failure,
+        validate_claimed_migrated_launchd_run,
     };
     use crate::services::routines::{RoutineAction, RoutineScriptLoader, store::ClaimedRoutineRun};
+
+    #[test]
+    fn tick_failure_public_projection_never_contains_diagnostic() {
+        let diagnostic = "routine tick failed: api_key=sk-live-secret";
+        let (reason, result_json) = public_tick_failure(diagnostic, "secret.js");
+        let outcome = RoutineRunOutcome {
+            run_id: "run-1".to_string(),
+            routine_id: "routine-1".to_string(),
+            script_ref: "secret.js".to_string(),
+            action: "error".to_string(),
+            status: "failed".to_string(),
+            result_json,
+            error: Some(reason),
+            fresh_context_guaranteed: false,
+        };
+        let api_json = serde_json::to_string(&outcome).unwrap();
+
+        assert!(api_json.contains("routine_tick_exception"), "{api_json}");
+        assert!(!api_json.contains("sk-live-secret"), "{api_json}");
+        assert!(!api_json.contains(diagnostic), "{api_json}");
+    }
 
     #[test]
     fn pre_provider_paths_cannot_claim_fresh_context() {

--- a/src/services/routines/runtime.rs
+++ b/src/services/routines/runtime.rs
@@ -10,7 +10,8 @@ use super::discord_log::RoutineDiscordLogger;
 use super::loader::{
     MAX_AUTOMATION_INVENTORY_ITEMS, MAX_AUTOMATION_INVENTORY_PAYLOAD_BYTES,
     MAX_OBSERVATION_PAYLOAD_BYTES, MAX_OBSERVATIONS_PER_TICK, ObservationLimits,
-    RoutineScriptLoader, RoutineTickAgent, RoutineTickContext, RoutineTickRoutine, RoutineTickRun,
+    ROUTINE_TICK_ERROR_PUBLIC_REASON, RoutineScriptLoader, RoutineTickAgent, RoutineTickContext,
+    RoutineTickRoutine, RoutineTickRun,
 };
 use super::migrated::{is_migrated_launchd_script_ref, validate_migrated_launchd_activation};
 use super::store::{ClaimedRoutineRun, RoutineStore, terminal_failure_should_pause};
@@ -256,18 +257,30 @@ pub async fn execute_claimed_script_run(
     let action = match loader.execute_tick(&claimed.script_ref, context) {
         Ok(action) => action,
         Err(error) => {
-            let message = error.to_string();
+            let diagnostic = error.to_string();
+            tracing::error!(
+                routine_run_id = %claimed.run_id,
+                routine_script = %claimed.script_ref,
+                error = %diagnostic,
+                "routine tick evaluation failed"
+            );
+            let public_reason = ROUTINE_TICK_ERROR_PUBLIC_REASON.to_string();
             let result_json = Some(json!({
-                "error": message,
+                "error": public_reason,
+                "diagnostic_class": ROUTINE_TICK_ERROR_PUBLIC_REASON,
                 "script_ref": claimed.script_ref,
             }));
             let closed = if terminal_failure_should_pause(pause_on_terminal_failure) {
                 store
-                    .fail_run_and_pause_routine(&claimed.run_id, &message, result_json.clone())
+                    .fail_run_and_pause_routine(
+                        &claimed.run_id,
+                        &public_reason,
+                        result_json.clone(),
+                    )
                     .await?
             } else {
                 store
-                    .fail_run(&claimed.run_id, &message, result_json.clone(), None)
+                    .fail_run(&claimed.run_id, &public_reason, result_json.clone(), None)
                     .await?
             };
             if !closed {
@@ -280,7 +293,7 @@ pub async fn execute_claimed_script_run(
                 action: "error".to_string(),
                 status: "failed".to_string(),
                 result_json,
-                error: Some(message),
+                error: Some(public_reason),
                 fresh_context_guaranteed: pre_provider_fresh_context_guaranteed(),
             }));
         }

--- a/src/services/routines/runtime.rs
+++ b/src/services/routines/runtime.rs
@@ -895,7 +895,7 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        action_detail, merge_loaded_script_automation_inventory,
+        RoutineRunOutcome, action_detail, merge_loaded_script_automation_inventory,
         pre_provider_fresh_context_guaranteed, public_tick_failure,
         validate_claimed_migrated_launchd_run,
     };


### PR DESCRIPTION
## 원인

`routines/monitoring/local_worktree_inventory.js`는 QuickJS routine이 아니라 `routines/local-worktree-gc.js`가 fresh agent turn에서 Node로 실행하는 read-only helper입니다. 최초 실패는 다음 Node API 의존 지점입니다.

```js
const fs = require("node:fs");
```

QuickJS routine sandbox에는 `require`, `process`, `module`, Node filesystem/child-process API가 없습니다. 따라서 문법 오류나 파일 손상·누락이 아니라 **의존 API 부재**가 원인입니다. 이 helper는 Node에서 `node --check`와 실제 실행이 모두 성공합니다.

## 72회 반복 이유

- recursive discovery가 routine root 아래 모든 `.js`를 QuickJS 후보로 취급했습니다.
- routine runtime이 매 30초 hot-reload tick마다 후보를 다시 로드했습니다.
- 실패 content에 대한 negative cache나 backoff가 없었습니다.

그 결과 동일 helper가 30초마다 QuickJS에서 재평가되어 ERROR로 기록됐습니다.

## 기능 영향

실제 스케줄러 `routines/local-worktree-gc.js`는 정상 로드 중이므로 worktree inventory 기능 자체가 중단된 것은 아닙니다. 실패 파일은 애초 routine registry 대상이 아니었습니다.

영향은 다음과 같습니다.

- ERROR 신호 오염: 35분 관찰 구간 ERROR 74건 중 72건
- 불필요한 QuickJS eval 비용
- 실제 last-known-good routine이 없는 helper에 대한 오해성 `keeping last-known-good registry` 로그

## 수정

- Node-only `monitoring/local_worktree_inventory.js`를 QuickJS routine discovery에서 제외했습니다.
- 실패한 script content hash를 negative-cache하여 동일 content는 다음 hot-reload tick에서 재평가하지 않습니다.
- 파일 내용이 바뀌면 즉시 재평가하여 hot-reload 복구성을 유지합니다.
- QuickJS 오류의 Display 문자열만 기록하지 않고 `ctx.catch()`에서 exception message와 stack을 추출합니다. 이제 `require is not defined`와 stack이 로그에 포함됩니다.
- helper 제외, 동일 실패 억제, content 변경 후 복구, exception 상세 회귀 테스트를 추가했습니다.

## CI 배선

새 loader 테스트는 기존 `justfile`의 main-push `test-non-pg` 명령 `cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres`에 포함됩니다. `.github/workflows/ci-main.yml`은 `just check`를 실행하고, `tests/test_fast_check_ci_wiring.py`가 해당 retained lane의 exact command manifest를 검증하며 `scripts/ci-script-checks.sh`가 그 미러 테스트를 실행합니다. 별도 배선 변경은 필요하지 않습니다.

## 구조적 후속 작업

이번 경로 하드코딩 제외는 현재 사고를 최소 범위로 차단하지만, `.js` 확장자만으로 QuickJS entrypoint를 판정하는 discovery 설계는 Node helper 추가 시 같은 사고를 재현할 수 있습니다. 디렉터리 컨벤션, manifest, 또는 명시적 marker로 runtime 유형을 구조적으로 구분하는 후속 작업을 #4902로 분리했습니다.

## 게이트

모든 heavy command는 `/tmp/adk-build-token.lock` exclusive build token 아래에서 직렬 실행했고 파이프 없이 rc를 캡처했습니다.

- `cargo fmt --all --check`: rc=0
- `cargo check --lib`: rc=0
- `env -u AGENTDESK_ROOT_DIR cargo test --lib services::routines::loader`: rc=0 (34 passed)
- `node --test policies/__tests__/local-worktree-gc.test.js`: rc=0 (10 passed)
- `python3 scripts/generate_inventory_docs.py`: rc=0 (tracked output diff 없음)
- `python3 scripts/check_agent_maintenance_docs.py`: rc=0 (`agent-maintenance freshness check passed`)
- `git diff --check`: rc=0

Closes #4900

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Dual-review follow-up

The agreed review findings are addressed as follows:

- Replaced the permanent failed-content cache with bounded exponential retry: 30s, 60s, 120s, ... capped at 1 hour. A never-loaded routine emits a periodic WARN when a deferred scan observes it; existing last-known-good entries remain debug-only during backoff.
- Unified source hashing and QuickJS evaluation on one `read_to_string` result, removing the hash/eval TOCTOU and doubled I/O.
- Applied the same bounded backoff to source read failures.
- Pruned failure state to candidate paths seen in the current scan.
- Added a debug record and #4900/#4902 rationale for the Node-only helper exclusion.
- Added primitive/non-`Error` throw coercion, stack assertions, clean message/stack formatting, and reused the extractor for `tick(ctx)` and cycle-check failures.
- Documented the actual bounded-retry/last-known-good contract on `RoutineScriptLoader`.

The request-scoped loader lifetime finding is intentionally separated as #4905 because sharing loader ownership requires broader `AppState`/HTTP lifecycle rewiring. This PR still removes the request-path double read.

### Mutation proof

- Removing the backoff skip behavior makes `failed_script_backoff_skips_eval_until_due_and_content_change_bypasses_it` fail on its evaluation-count assertion; restored code passes.
- Removing the Node-helper exclusion makes `load_dir_excludes_node_only_worktree_inventory_helper` fail on `failed_scripts.is_empty()`; restored code passes.

### Updated gates

- `cargo fmt --all --check`: rc=0
- `cargo check --lib`: rc=0
- `env -u AGENTDESK_ROOT_DIR cargo test --lib services::routines::loader`: rc=0 (37 passed)
- `node --test policies/__tests__/local-worktree-gc.test.js`: rc=0 (10 passed)
- `python3 scripts/generate_inventory_docs.py`: rc=0 (tracked output clean)
- `python3 scripts/check_agent_maintenance_docs.py`: rc=0 (`agent-maintenance freshness check passed`)
