### PR TITLE
fix(#4759): preserve healthy watcher across turn starts

### DIFF
--- a/justfile
+++ b/justfile
@@ -35,6 +35,7 @@ test-non-pg:
     cargo test --lib server::routes::e2e_control::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib formatting -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib delivery_record -- --skip _pg --skip pg_ --skip postgres
+    env -u AGENTDESK_ROOT_DIR cargo test --lib watchers::lifecycle -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib server::claude_oauth_usage_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib tui_task_card::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib server::routes::message_outbox::tests -- --skip _pg --skip pg_ --skip postgres

--- a/justfile
+++ b/justfile
@@ -35,7 +35,7 @@ test-non-pg:
     cargo test --lib server::routes::e2e_control::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib formatting -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib delivery_record -- --skip _pg --skip pg_ --skip postgres
-    env -u AGENTDESK_ROOT_DIR cargo test --lib watchers::lifecycle -- --skip _pg --skip pg_ --skip postgres
+    env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tmux::watcher_lifecycle::tests::tests::turn_starts_reuse_healthy_runtime_path_incumbent_after_handoff -- --exact
     cargo test --lib server::claude_oauth_usage_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib tui_task_card::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib server::routes::message_outbox::tests -- --skip _pg --skip pg_ --skip postgres

--- a/src/services/discord/watchers/lifecycle/claims.rs
+++ b/src/services/discord/watchers/lifecycle/claims.rs
@@ -193,10 +193,8 @@ pub(crate) fn claim_watcher(
     if let Some((existing_channel_id, existing_cancelled, existing_paused, existing_output_path)) =
         find_watcher_by_tmux_session(watchers, &requested_tmux)
     {
-        let turn_start_uses_provisional_output_path = matches!(
-            source,
-            "turn_start_message" | "turn_start_headless"
-        );
+        let turn_start_uses_provisional_output_path =
+            matches!(source, "turn_start_message" | "turn_start_headless");
         let output_path_changed = existing_output_path != requested_output_path;
         let replace_paused_incumbent = existing_paused && !turn_start_uses_provisional_output_path;
         // Turn admission resolves the canonical pre-handoff wrapper path. Once a

--- a/src/services/discord/watchers/lifecycle/claims.rs
+++ b/src/services/discord/watchers/lifecycle/claims.rs
@@ -193,12 +193,21 @@ pub(crate) fn claim_watcher(
     if let Some((existing_channel_id, existing_cancelled, existing_paused, existing_output_path)) =
         find_watcher_by_tmux_session(watchers, &requested_tmux)
     {
-        let replace_paused_incumbent =
-            existing_paused && !matches!(source, "turn_start_message" | "turn_start_headless");
+        let turn_start_uses_provisional_output_path = matches!(
+            source,
+            "turn_start_message" | "turn_start_headless"
+        );
+        let output_path_changed = existing_output_path != requested_output_path;
+        let replace_paused_incumbent = existing_paused && !turn_start_uses_provisional_output_path;
+        // Turn admission resolves the canonical pre-handoff wrapper path. Once a
+        // healthy watcher has adopted the provider-native runtime transcript,
+        // that provisional path must not downgrade the live registry binding.
+        let replace_for_output_path =
+            output_path_changed && !turn_start_uses_provisional_output_path;
         if force_replace_live_same_tmux
             || existing_cancelled
             || replace_paused_incumbent
-            || existing_output_path != requested_output_path
+            || replace_for_output_path
         {
             if let Some((_, existing_handle)) =
                 watchers.remove_tmux_session_locked(&guard, &requested_tmux)
@@ -216,7 +225,7 @@ pub(crate) fn claim_watcher(
                     existing_cancelled,
                     force_replace_live_same_tmux,
                     replace_paused_incumbent,
-                    output_path_changed = existing_output_path != requested_output_path,
+                    output_path_changed,
                     "watcher claim cancelled same-tmux incumbent before spawning replacement"
                 );
             }

--- a/src/services/discord/watchers/lifecycle/tests.rs
+++ b/src/services/discord/watchers/lifecycle/tests.rs
@@ -115,6 +115,48 @@ mod tests {
         assert!(!watchers.contains_key(&channel_a));
     }
 
+    #[test]
+    fn turn_starts_reuse_healthy_runtime_path_incumbent_after_handoff() {
+        let watchers = TmuxWatcherRegistry::new();
+        let owner = ChannelId::new(1_485_506_232_256_168_134);
+        let tmux_name = "AgentDesk-claude-adk-cc-respawn";
+        let runtime_path = "/tmp/claude-runtime-after-respawn.jsonl";
+        let provisional_path = "/tmp/agentdesk-wrapper-before-handoff.jsonl";
+        let incumbent = test_watcher_handle(tmux_name, runtime_path);
+        let incumbent_cancel = incumbent.cancel.clone();
+        assert!(try_claim_watcher(&watchers, owner, incumbent));
+        let mut spawn_count = 1;
+
+        for source in [
+            "turn_start_message",
+            "turn_start_headless",
+            "turn_start_message",
+        ] {
+            let outcome = claim_or_reuse_watcher(
+                &watchers,
+                owner,
+                test_watcher_handle(tmux_name, provisional_path),
+                &ProviderKind::Claude,
+                source,
+            );
+            spawn_count += usize::from(outcome.should_spawn());
+            assert_eq!(outcome.action, WatcherClaimAction::ReuseExisting);
+            assert_eq!(outcome.owner_channel_id(), owner);
+            assert!(!incumbent_cancel.load(Ordering::Relaxed));
+            assert_eq!(
+                watchers.get(&owner).expect("healthy incumbent").output_path,
+                runtime_path
+            );
+        }
+
+        assert_eq!(spawn_count, 1, "turn starts must not respawn the watcher");
+        assert_eq!(
+            watchers.len(),
+            1,
+            "the incumbent remains the only registry slot"
+        );
+    }
+
     /// #4455: a crossed-provider-turn Codex rebind must replace even a live
     /// same-session/same-output incumbent. Reuse would leave its stale
     /// `current_msg_id` render seed and converter generation in authority.

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -23,6 +23,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --lib server::routes::e2e_control::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib formatting -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib delivery_record -- --skip _pg --skip pg_ --skip postgres",
+    "env -u AGENTDESK_ROOT_DIR cargo test --lib watchers::lifecycle -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib server::claude_oauth_usage_tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib tui_task_card::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib server::routes::message_outbox::tests -- --skip _pg --skip pg_ --skip postgres",

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -23,7 +23,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --lib server::routes::e2e_control::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib formatting -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib delivery_record -- --skip _pg --skip pg_ --skip postgres",
-    "env -u AGENTDESK_ROOT_DIR cargo test --lib watchers::lifecycle -- --skip _pg --skip pg_ --skip postgres",
+    "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tmux::watcher_lifecycle::tests::tests::turn_starts_reuse_healthy_runtime_path_incumbent_after_handoff -- --exact",
     "cargo test --lib server::claude_oauth_usage_tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib tui_task_card::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib server::routes::message_outbox::tests -- --skip _pg --skip pg_ --skip postgres",


### PR DESCRIPTION
## Summary

Preserve a healthy same-tmux watcher when a new turn-start claim presents the provisional pre-handoff wrapper path after the watcher has already adopted the provider-native transcript path.

Closes #4759

## Root cause

The churn was not a registry update failure. Two paths from different lifecycle stages were treated as having equal replacement authority:

- `router/message_handler/intake_turn.rs:1841-1859` recomputes the pre-handoff wrapper path with `tmux_runtime_paths(tmux_name)` on every turn admission.
- `intake_turn.rs:2322-2331` submits that path in a watcher claim with `source="turn_start_message"`.
- `turn_bridge/runtime_handoff_loop.rs:691-720` updates inflight `output_path` to the actual provider-native transcript path when runtime handoff arrives.
- `runtime_handoff_loop.rs:747-765` claims the watcher with that actual path and `source="turn_bridge_runtime_ready"`.
- `watchers/lifecycle/claims.rs:60-71` returns the path string stored on the handle; there is no canonical-path or generation cache.
- The former `claims.rs:193-201` replacement condition treated `existing_output_path != requested_output_path` as authoritative regardless of source.

After handoff, the registry therefore retained the transcript path, the next turn-start presented the wrapper path, and runtime-ready then presented the transcript path again. Each alternating comparison set `output_path_changed=true`, cancelling and respawning an otherwise healthy watcher.

Observed instances 16→19 (03:14–03:21) and 33→38 (06:57–07:02) showed offsets jumping `19360310 → 0 → 19490407 → 0`; the backstop also observed `Done before delivery confirmation` mismatches.

## Fix

`claims.rs:196-210` now applies source-aware path authority:

- `turn_start_message` and `turn_start_headless` paths are provisional.
- A healthy same-tmux incumbent is not replaced solely because a provisional turn-start path differs, and its provider-native runtime path is not overwritten.
- Existing replacement behavior remains for cancelled or heartbeat-stale incumbents, explicit forced replacement, an actual path change confirmed by a non-turn-start source, and replacement of a paused incumbent by a non-turn-start source.

No pane-identity field was introduced. The observed churn is exactly the wrapper↔transcript path alternation, so the minimal invariant is sufficient: preserve a healthy incumbent against a provisional turn-start mismatch without introducing a new pane-generation system.

## Offset reset semantics

- Legitimate `→0`: fresh watcher; cancelled/stale replacement; explicit forced rebind; or a real output-path change confirmed by a non-turn-start source.
- Illegitimate `→0`: a turn-start claim re-presenting its provisional wrapper path to a healthy same-tmux runtime watcher. This now converges on `ReuseExisting`, retaining both offset and transcript binding.

## Mutation proof

With `&& !turn_start_uses_provisional_output_path` removed, the focused regression failed directly at its `ReuseExisting` assertion rather than at compilation:

```text
test ...turn_starts_reuse_healthy_runtime_path_incumbent_after_handoff ... FAILED
panicked at src/services/discord/watchers/lifecycle/tests.rs:143:13:
assertion `left == right` failed
test result: FAILED. 0 passed; 1 failed; 0 ignored
```

After restoring the guard:

```text
test ...turn_starts_reuse_healthy_runtime_path_incumbent_after_handoff ... ok
test result: ok. 1 passed; 0 failed; 0 ignored
```

## CI wiring

The regression lives under `#[cfg(test)]` in the watcher lifecycle module. PR CI's fast lane is intentionally compile-only, while `main` executes `just check` and nightly executes broad non-PG tests. To guarantee the new regression is retained in the explicit main recipe, this PR adds its exact command to `justfile::test-non-pg` and updates the exact mirror in `tests/test_fast_check_ci_wiring.py`.

## Verification

All heavy commands ran serially while holding `/tmp/adk-build-token.lock`. Return codes were captured without pipelines.

```text
cargo fmt --all --check                                            rc=0
cargo check --lib                                                  rc=0
env -u AGENTDESK_ROOT_DIR cargo test --lib watchers::lifecycle     rc=0
env -u AGENTDESK_ROOT_DIR cargo test --lib watcher                 rc=0
python3 scripts/generate_inventory_docs.py                          rc=0
python3 scripts/check_agent_maintenance_docs.py                     rc=0
python3 -m unittest tests.test_fast_check_ci_wiring                  rc=0
env -u AGENTDESK_ROOT_DIR cargo test --lib <exact regression> -- --exact  rc=0
```

The broad `watcher` filter ran 582 tests with 0 failures and included `turn_starts_reuse_healthy_runtime_path_incumbent_after_handoff ... ok`. Generated documentation produced no tracked diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
