### PR TITLE
fix(#4892): show last tool in active status panel

### DIFF
--- a/.github/workflows/ci-macos-trusted.yml
+++ b/.github/workflows/ci-macos-trusted.yml
@@ -139,6 +139,7 @@ jobs:
           cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+          env -u AGENTDESK_ROOT_DIR cargo test --lib placeholder_live_events -- --skip _pg --skip pg_ --skip postgres
           env -u AGENTDESK_ROOT_DIR cargo test --lib single_message_panel::tests -- --skip _pg --skip pg_ --skip postgres
           # Health must precede relay_recovery so fail-fast reports both surfaces.
           python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
@@ -259,6 +260,7 @@ jobs:
           nice -n 10 cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+          nice -n 10 env -u AGENTDESK_ROOT_DIR cargo test --lib placeholder_live_events -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 env -u AGENTDESK_ROOT_DIR cargo test --lib single_message_panel::tests -- --skip _pg --skip pg_ --skip postgres
           # Health must precede relay_recovery so fail-fast reports both surfaces.
           nice -n 10 python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres

--- a/.github/workflows/ci-macos-trusted.yml
+++ b/.github/workflows/ci-macos-trusted.yml
@@ -139,6 +139,7 @@ jobs:
           cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+          env -u AGENTDESK_ROOT_DIR cargo test --lib single_message_panel::tests -- --skip _pg --skip pg_ --skip postgres
           # Health must precede relay_recovery so fail-fast reports both surfaces.
           python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
           env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres
@@ -258,6 +259,7 @@ jobs:
           nice -n 10 cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+          nice -n 10 env -u AGENTDESK_ROOT_DIR cargo test --lib single_message_panel::tests -- --skip _pg --skip pg_ --skip postgres
           # Health must precede relay_recovery so fail-fast reports both surfaces.
           nice -n 10 python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -599,6 +599,7 @@ src/
 │   │   │   └── turn_output_controller.rs
 │   │   ├── placeholder_live_events/
 │   │   │   ├── status_panel/
+│   │   │   │   ├── completed_kind.rs
 │   │   │   │   └── derived_status.rs
 │   │   │   ├── background_task_events.rs
 │   │   │   ├── common.rs

--- a/justfile
+++ b/justfile
@@ -50,6 +50,8 @@ test-non-pg:
     cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib status_panel_singleton_store -- --skip _pg --skip pg_ --skip postgres
+    # #4892: keep the live panel's latest-tool rendering contract in the retained lane.
+    env -u AGENTDESK_ROOT_DIR cargo test --lib placeholder_live_events -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib services::discord::outbound::serenity_reference::tests::lifecycle_notice_nonce_is_stable_and_semantic_event_scoped -- --exact
     cargo test --lib services::discord::outbound::delivery::tests::v3_referenced_send_preserves_reference_and_dedupes -- --exact
     cargo test --lib cli::args::tests::legacy_queue_help_directs_users_to_query_without_changing_compatibility_contract

--- a/justfile
+++ b/justfile
@@ -50,8 +50,9 @@ test-non-pg:
     cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib status_panel_singleton_store -- --skip _pg --skip pg_ --skip postgres
-    # #4892: keep the live panel's latest-tool rendering contract in the retained lane.
+    # #4892: keep the live panel and spinner-merged latest-tool contracts in the retained lane.
     env -u AGENTDESK_ROOT_DIR cargo test --lib placeholder_live_events -- --skip _pg --skip pg_ --skip postgres
+    env -u AGENTDESK_ROOT_DIR cargo test --lib single_message_panel::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib services::discord::outbound::serenity_reference::tests::lifecycle_notice_nonce_is_stable_and_semantic_event_scoped -- --exact
     cargo test --lib services::discord::outbound::delivery::tests::v3_referenced_send_preserves_reference_and_dedupes -- --exact
     cargo test --lib cli::args::tests::legacy_queue_help_directs_users_to_query_without_changing_compatibility_contract

--- a/scripts/check_test_lane_coverage.py
+++ b/scripts/check_test_lane_coverage.py
@@ -25,7 +25,7 @@ from typing import Iterable
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BASELINE_REL = Path("scripts/test_lane_coverage_baseline.txt")
-BASELINE_ENTRY_COUNT = 693
+BASELINE_ENTRY_COUNT = 687
 
 # Attributes do not contain a closing square bracket in the forms used by this
 # repository. Strings and comments are blanked without changing offsets, so the

--- a/scripts/check_test_lane_coverage.py
+++ b/scripts/check_test_lane_coverage.py
@@ -25,7 +25,7 @@ from typing import Iterable
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BASELINE_REL = Path("scripts/test_lane_coverage_baseline.txt")
-BASELINE_ENTRY_COUNT = 687
+BASELINE_ENTRY_COUNT = 686
 
 # Attributes do not contain a closing square bracket in the forms used by this
 # repository. Strings and comments are blanked without changing offsets, so the

--- a/scripts/test_lane_coverage_baseline.txt
+++ b/scripts/test_lane_coverage_baseline.txt
@@ -280,12 +280,6 @@ services::discord::placeholder_cleanup::permanent_failure_tests
 services::discord::placeholder_cleanup::terminal_anchor_guard_tests
 services::discord::placeholder_controller::edit_retry_tests
 services::discord::placeholder_controller::live_events_tests
-services::discord::placeholder_live_events::freshness::tests
-services::discord::placeholder_live_events::slot_rehydration::tests
-services::discord::placeholder_live_events::subagent_panel::tests
-services::discord::placeholder_live_events::subagent_rollout::tests
-services::discord::placeholder_live_events::tests
-services::discord::placeholder_live_events::turn_anchor::tests
 services::discord::placeholder_sweeper::abandon_guard::tests
 services::discord::placeholder_sweeper::is_message_still_placeholder_tests
 services::discord::placeholder_sweeper::panel_shape::tests

--- a/scripts/test_lane_coverage_baseline.txt
+++ b/scripts/test_lane_coverage_baseline.txt
@@ -393,7 +393,6 @@ services::discord::settings::content::shared_prompt_profile_tests
 services::discord::settings::memory::tests
 services::discord::settings::validation::voice_channel_guard_tests
 services::discord::shared_state::restart_lifecycle_tests
-services::discord::single_message_panel::tests
 services::discord::standby_relay::tests
 services::discord::startup_reclaim::tests
 services::discord::status_panel_orphan_store::tests

--- a/src/services/discord/placeholder_live_events/common.rs
+++ b/src/services/discord/placeholder_live_events/common.rs
@@ -93,7 +93,8 @@ pub(super) fn is_harness_task_tool_name(name: &str) -> bool {
 }
 
 pub(super) fn tool_prefix(name: &str) -> String {
-    let lower = name.trim().to_ascii_lowercase();
+    let trimmed = name.trim();
+    let lower = trimmed.to_ascii_lowercase();
     let prefix = match lower.as_str() {
         "bash" | "bashoutput" | "killbash" | "command_execution" => Some("Bash"),
         "edit" | "multiedit" | "write" | "notebookedit" => Some("Edit"),
@@ -107,14 +108,23 @@ pub(super) fn tool_prefix(name: &str) -> String {
         | "taskstop" => Some("Task"),
         "webfetch" => Some("WebFetch"),
         "websearch" => Some("WebSearch"),
-        _ => canonical_tool_name(name),
+        _ => canonical_tool_name(trimmed),
     };
     if let Some(prefix) = prefix {
         return format!("[{prefix}]");
     }
-    sanitized_tool_name(name)
-        .map(|name| format!("[{name}]"))
-        .unwrap_or_else(|| "[Tool]".to_string())
+
+    // MCP server namespaces can identify private infrastructure. Keep only the
+    // operation class after the final `__`; every other unknown name fails closed.
+    if lower.starts_with("mcp__") {
+        return trimmed
+            .rsplit("__")
+            .next()
+            .and_then(sanitized_tool_name)
+            .map(|operation| format!("[{operation}]"))
+            .unwrap_or_else(|| "[Tool]".to_string());
+    }
+    "[Tool]".to_string()
 }
 
 pub(super) fn sanitized_tool_name(name: &str) -> Option<String> {

--- a/src/services/discord/placeholder_live_events/common.rs
+++ b/src/services/discord/placeholder_live_events/common.rs
@@ -92,39 +92,39 @@ pub(super) fn is_harness_task_tool_name(name: &str) -> bool {
     )
 }
 
-pub(super) fn tool_prefix(name: &str) -> String {
+/// Classifies an untrusted tool name into a closed set of static display labels.
+/// No caller-controlled bytes can enter the returned value.
+pub(super) fn tool_prefix(name: &str) -> &'static str {
     let trimmed = name.trim();
     let lower = trimmed.to_ascii_lowercase();
-    let prefix = match lower.as_str() {
-        "bash" | "bashoutput" | "killbash" | "command_execution" => Some("Bash"),
-        "edit" | "multiedit" | "write" | "notebookedit" => Some("Edit"),
-        "read" => Some("Read"),
-        "grep" => Some("Grep"),
-        "glob" => Some("Glob"),
-        "monitor" => Some("Monitor"),
-        "schedulewakeup" | "schedule_wakeup" => Some("ScheduleWakeup"),
-        "toolsearch" | "tool_search" | "tool_search_tool" => Some("ToolSearch"),
-        "task" | "agent" | "taskcreate" | "taskget" | "taskupdate" | "tasklist" | "taskoutput"
-        | "taskstop" => Some("Task"),
-        "webfetch" => Some("WebFetch"),
-        "websearch" => Some("WebSearch"),
-        _ => canonical_tool_name(trimmed),
-    };
-    if let Some(prefix) = prefix {
-        return format!("[{prefix}]");
+
+    if lower.starts_with("mcp__") {
+        return "[MCP]";
     }
 
-    // MCP server namespaces can identify private infrastructure. Keep only the
-    // operation class after the final `__`; every other unknown name fails closed.
-    if lower.starts_with("mcp__") {
-        return trimmed
-            .rsplit("__")
-            .next()
-            .and_then(sanitized_tool_name)
-            .map(|operation| format!("[{operation}]"))
-            .unwrap_or_else(|| "[Tool]".to_string());
+    match lower.as_str() {
+        "bash" | "bashoutput" | "killbash" | "command_execution" | "exec" | "exec_command"
+        | "run_cmd" => "[Bash]",
+        "edit" | "multiedit" | "write" | "notebookedit" => "[Edit]",
+        "read" => "[Read]",
+        "grep" => "[Grep]",
+        "glob" => "[Glob]",
+        "monitor" => "[Monitor]",
+        "schedulewakeup" | "schedule_wakeup" => "[ScheduleWakeup]",
+        "toolsearch" | "tool_search" | "tool_search_tool" => "[ToolSearch]",
+        "task" | "agent" | "taskcreate" | "taskget" | "taskupdate" | "tasklist" | "taskoutput"
+        | "taskstop" => "[Task]",
+        "webfetch" => "[WebFetch]",
+        "websearch" => "[WebSearch]",
+        _ => match canonical_tool_name(trimmed) {
+            Some("Skill") => "[Skill]",
+            Some("SlashCommand") => "[SlashCommand]",
+            Some("AskUserQuestion") => "[AskUserQuestion]",
+            Some("EnterPlanMode") => "[EnterPlanMode]",
+            Some("ExitPlanMode") => "[ExitPlanMode]",
+            _ => "[Tool]",
+        },
     }
-    "[Tool]".to_string()
 }
 
 pub(super) fn sanitized_tool_name(name: &str) -> Option<String> {

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -117,9 +117,10 @@ fn render_last_tool(last_tool: Option<&LastToolCall>) -> String {
 /// #4892: tool inputs are untrusted and may contain credentials, signed URLs,
 /// private paths, or arbitrary payloads. This channel-visible surface therefore
 /// renders only the allowlisted tool class produced by `tool_prefix`; new tools
-/// fail closed to a sanitized class name and never render their arguments.
+/// fail closed and never render their arguments.
 fn render_tool_activity(name: &str) -> String {
-    format!("🔧 마지막 도구 ({})", tool_prefix(name))
+    let class = escape_status_panel_markdown(&tool_prefix(name));
+    format!("🔧 마지막 도구 ({})", truncate_chars(&class, 140))
 }
 
 #[cfg(test)]
@@ -208,6 +209,57 @@ mod tests {
     #[test]
     fn last_tool_hides_non_json_payload() {
         assert_raw_tool_input_hidden("Monitor", "non-json payload hvs.CAES... secret/prod/db");
+    }
+
+    #[test]
+    fn unknown_tool_names_fail_closed_without_namespace_disclosure() {
+        let rendered = render_activity_line_with_last_tool(
+            &DerivedStatus::ToolRunning {
+                name: "internal_prod_deploy_secret".to_string(),
+                summary: None,
+            },
+            None,
+        );
+
+        assert_eq!(rendered, "🔧 마지막 도구 ([Tool])");
+        assert!(
+            !rendered.contains("internal_prod"),
+            "unknown tool identity must fail closed: {rendered}"
+        );
+    }
+
+    #[test]
+    fn mcp_tool_hides_server_namespace_and_escapes_operation_markdown() {
+        let rendered = render_activity_line_with_last_tool(
+            &DerivedStatus::ToolRunning {
+                name: "mcp__vault_prod__read_secret".to_string(),
+                summary: None,
+            },
+            None,
+        );
+
+        assert_eq!(rendered, r"🔧 마지막 도구 ([read\_secret])");
+        assert!(
+            !rendered.contains("vault_prod") && !rendered.contains("mcp__"),
+            "MCP server namespace must not reach the status panel: {rendered}"
+        );
+    }
+
+    #[test]
+    fn tool_activity_restores_defensive_class_clamp() {
+        let rendered = render_activity_line_with_last_tool(
+            &DerivedStatus::ToolRunning {
+                name: format!("mcp__private_server__{}", "a".repeat(300)),
+                summary: None,
+            },
+            None,
+        );
+
+        assert!(
+            rendered.chars().count() <= "🔧 마지막 도구 ()".chars().count() + 140,
+            "tool class must remain defensively clamped: {rendered}"
+        );
+        assert!(!rendered.contains("private_server"));
     }
 
     #[test]

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -5,9 +5,11 @@
 //! derived-status activity label and the store-facing time-line builder live here
 //! with their tests.
 //!
-//! While a turn is active, the footer header shows the latest observed tool call
-//! (`🔧 마지막 도구 (…)`) or a non-progress fallback when no tool has run yet.
-//! Completed turns retain their existing completion label. The spinner merge
+//! While a turn is actively processing, the footer header shows the latest
+//! observed tool call (`🔧 마지막 도구 (…)`) or a non-progress fallback when no
+//! tool has run yet. Distinct wait states retain their specific labels because
+//! those details are not represented by the spinner. Completed turns retain
+//! their existing completion label. The spinner merge
 //! (`single_message_panel::merged_footer_header_line`) swaps the leading status
 //! emoji for the animated spinner, so the marker set there must stay in sync with
 //! the emojis this label can start with. The request anchor follows the activity
@@ -66,10 +68,11 @@ pub(super) fn render_time_line(last_activity_unix: Option<i64>, started_at_unix:
     )
 }
 
-/// #3983/#4892: the panel's first (activity) line. Active and waiting turns
+/// #3983/#4892: the panel's first (activity) line. Generic running/tool states
 /// render the latest observed tool instead of duplicating the answer message's
-/// spinner/progress state. Completed turns deliberately retain the pre-#4892
-/// labels so the completion-only follow-up can replace that path independently.
+/// spinner/progress state. Wait states retain their specific labels because the
+/// spinner does not communicate monitor, wakeup, subagent, or workflow details.
+/// Completed turns retain the pre-#4892 labels.
 pub(super) fn render_activity_line(status: &DerivedStatus) -> String {
     render_activity_line_with_last_tool(status, None)
 }
@@ -85,13 +88,22 @@ pub(super) fn render_activity_line_with_last_tool(
         DerivedStatus::Completed {
             kind: CompletedKind::Foreground,
         } => "✅ 완료".to_string(),
-        DerivedStatus::Running
-        | DerivedStatus::MonitorWait
-        | DerivedStatus::ScheduleWakeup(_)
-        | DerivedStatus::SubagentRunning { .. }
-        | DerivedStatus::WorkflowRunning { .. } => render_last_tool(last_tool),
+        DerivedStatus::Running => render_last_tool(last_tool),
+        DerivedStatus::MonitorWait => "💤 monitor 대기".to_string(),
+        DerivedStatus::ScheduleWakeup(Some(eta_secs)) => {
+            format!("⏰ scheduled wakeup ({eta_secs}s 후)")
+        }
+        DerivedStatus::ScheduleWakeup(None) => "⏰ scheduled wakeup".to_string(),
         DerivedStatus::ToolRunning { name, summary } => {
             render_tool_activity(name, summary.as_deref())
+        }
+        DerivedStatus::SubagentRunning { desc } => {
+            let desc = escape_status_panel_markdown(desc);
+            format!("🧵 subagent 실행 중 ({})", truncate_chars(&desc, 120))
+        }
+        DerivedStatus::WorkflowRunning { label } => {
+            let label = escape_status_panel_markdown(label);
+            format!("🧬 workflow 실행 중 ({})", truncate_chars(&label, 120))
         }
     }
 }
@@ -165,26 +177,75 @@ mod tests {
     }
 
     #[test]
-    fn waiting_states_keep_the_last_tool_instead_of_progress_copy() {
+    fn monitor_wait_keeps_specific_label_instead_of_last_tool() {
         let last_tool = LastToolCall {
             name: "Monitor".to_string(),
             summary: Some("wait for build".to_string()),
         };
 
-        for status in [
-            DerivedStatus::MonitorWait,
-            DerivedStatus::ScheduleWakeup(Some(30)),
-            DerivedStatus::SubagentRunning {
-                desc: "review".to_string(),
-            },
-            DerivedStatus::WorkflowRunning {
-                label: "CI".to_string(),
-            },
-        ] {
-            let rendered = render_activity_line_with_last_tool(&status, Some(&last_tool));
-            assert_eq!(rendered, "🔧 마지막 도구 ([Monitor] · wait for build)");
-            assert!(!rendered.contains("진행 중"));
-        }
+        assert_eq!(
+            render_activity_line_with_last_tool(&DerivedStatus::MonitorWait, Some(&last_tool),),
+            "💤 monitor 대기"
+        );
+    }
+
+    #[test]
+    fn schedule_wakeup_keeps_eta_label_instead_of_last_tool() {
+        let last_tool = LastToolCall {
+            name: "ScheduleWakeup".to_string(),
+            summary: Some("30 seconds".to_string()),
+        };
+
+        assert_eq!(
+            render_activity_line_with_last_tool(
+                &DerivedStatus::ScheduleWakeup(Some(30)),
+                Some(&last_tool),
+            ),
+            "⏰ scheduled wakeup (30s 후)"
+        );
+        assert_eq!(
+            render_activity_line_with_last_tool(
+                &DerivedStatus::ScheduleWakeup(None),
+                Some(&last_tool),
+            ),
+            "⏰ scheduled wakeup"
+        );
+    }
+
+    #[test]
+    fn subagent_running_keeps_description_label_instead_of_last_tool() {
+        let last_tool = LastToolCall {
+            name: "Task".to_string(),
+            summary: Some("review".to_string()),
+        };
+
+        assert_eq!(
+            render_activity_line_with_last_tool(
+                &DerivedStatus::SubagentRunning {
+                    desc: "review_status".to_string(),
+                },
+                Some(&last_tool),
+            ),
+            r"🧵 subagent 실행 중 (review\_status)"
+        );
+    }
+
+    #[test]
+    fn workflow_running_keeps_label_instead_of_last_tool() {
+        let last_tool = LastToolCall {
+            name: "Workflow".to_string(),
+            summary: Some("CI".to_string()),
+        };
+
+        assert_eq!(
+            render_activity_line_with_last_tool(
+                &DerivedStatus::WorkflowRunning {
+                    label: "CI_review".to_string(),
+                },
+                Some(&last_tool),
+            ),
+            r"🧬 workflow 실행 중 (CI\_review)"
+        );
     }
 
     #[test]
@@ -220,11 +281,11 @@ mod tests {
         };
         for (status, last_tool, expected_prefix) in [
             (DerivedStatus::Running, None, "🔧"),
-            (DerivedStatus::MonitorWait, Some(&last_tool), "🔧"),
+            (DerivedStatus::MonitorWait, Some(&last_tool), "💤"),
             (
                 DerivedStatus::ScheduleWakeup(Some(30)),
                 Some(&last_tool),
-                "🔧",
+                "⏰",
             ),
             (
                 DerivedStatus::ToolRunning {
@@ -239,14 +300,14 @@ mod tests {
                     desc: "explore".to_string(),
                 },
                 Some(&last_tool),
-                "🔧",
+                "🧵",
             ),
             (
                 DerivedStatus::WorkflowRunning {
                     label: "review".to_string(),
                 },
                 Some(&last_tool),
-                "🔧",
+                "🧬",
             ),
             (
                 DerivedStatus::Completed {

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -114,13 +114,12 @@ fn render_last_tool(last_tool: Option<&LastToolCall>) -> String {
     )
 }
 
-/// #4892: tool inputs are untrusted and may contain credentials, signed URLs,
-/// private paths, or arbitrary payloads. This channel-visible surface therefore
-/// renders only the allowlisted tool class produced by `tool_prefix`; new tools
-/// fail closed and never render their arguments.
+/// #4892: tool inputs and names are untrusted and may contain credentials,
+/// tenant identifiers, signed URLs, private paths, or arbitrary payloads. The
+/// classifier returns only static labels, so no caller-controlled bytes reach
+/// this channel-visible surface.
 fn render_tool_activity(name: &str) -> String {
-    let class = escape_status_panel_markdown(&tool_prefix(name));
-    format!("🔧 마지막 도구 ({})", truncate_chars(&class, 140))
+    format!("🔧 마지막 도구 ({})", tool_prefix(name))
 }
 
 #[cfg(test)]
@@ -229,24 +228,32 @@ mod tests {
     }
 
     #[test]
-    fn mcp_tool_hides_server_namespace_and_escapes_operation_markdown() {
-        let rendered = render_activity_line_with_last_tool(
-            &DerivedStatus::ToolRunning {
-                name: "mcp__vault_prod__read_secret".to_string(),
-                summary: None,
-            },
-            None,
-        );
+    fn mcp_tool_names_collapse_to_one_static_label() {
+        for name in [
+            "mcp__vault-prod",
+            "mcp__a__b__c",
+            "mcp__hr__lookup_employee_alice",
+        ] {
+            let rendered = render_activity_line_with_last_tool(
+                &DerivedStatus::ToolRunning {
+                    name: name.to_string(),
+                    summary: None,
+                },
+                None,
+            );
 
-        assert_eq!(rendered, r"🔧 마지막 도구 ([read\_secret])");
-        assert!(
-            !rendered.contains("vault_prod") && !rendered.contains("mcp__"),
-            "MCP server namespace must not reach the status panel: {rendered}"
-        );
+            assert_eq!(rendered, "🔧 마지막 도구 ([MCP])", "input: {name}");
+            for private_fragment in ["vault-prod", "a__b__c", "hr", "lookup_employee_alice"] {
+                assert!(
+                    !rendered.contains(private_fragment),
+                    "MCP names and operations must never reach the status panel: {rendered}"
+                );
+            }
+        }
     }
 
     #[test]
-    fn tool_activity_restores_defensive_class_clamp() {
+    fn tool_activity_output_is_bounded_by_the_static_label_set() {
         let rendered = render_activity_line_with_last_tool(
             &DerivedStatus::ToolRunning {
                 name: format!("mcp__private_server__{}", "a".repeat(300)),
@@ -255,11 +262,23 @@ mod tests {
             None,
         );
 
-        assert!(
-            rendered.chars().count() <= "🔧 마지막 도구 ()".chars().count() + 140,
-            "tool class must remain defensively clamped: {rendered}"
-        );
+        assert_eq!(rendered, "🔧 마지막 도구 ([MCP])");
         assert!(!rendered.contains("private_server"));
+    }
+
+    #[test]
+    fn codex_execution_function_names_map_to_bash() {
+        for name in ["command_execution", "exec", "exec_command", "run_cmd"] {
+            let rendered = render_activity_line_with_last_tool(
+                &DerivedStatus::ToolRunning {
+                    name: name.to_string(),
+                    summary: None,
+                },
+                None,
+            );
+
+            assert_eq!(rendered, "🔧 마지막 도구 ([Bash])", "input: {name}");
+        }
     }
 
     #[test]

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -140,7 +140,8 @@ mod tests {
             name: "Read".to_string(),
             summary: Some("src/services/discord/status_panel.rs".to_string()),
         };
-        let rendered = render_activity_line_with_last_tool(&DerivedStatus::Running, Some(&last_tool));
+        let rendered =
+            render_activity_line_with_last_tool(&DerivedStatus::Running, Some(&last_tool));
 
         assert_eq!(
             rendered,
@@ -181,10 +182,7 @@ mod tests {
             },
         ] {
             let rendered = render_activity_line_with_last_tool(&status, Some(&last_tool));
-            assert_eq!(
-                rendered,
-                "🔧 마지막 도구 ([Monitor] · wait for build)"
-            );
+            assert_eq!(rendered, "🔧 마지막 도구 ([Monitor] · wait for build)");
             assert!(!rendered.contains("진행 중"));
         }
     }
@@ -221,7 +219,7 @@ mod tests {
             summary: None,
         };
         for (status, last_tool, expected_prefix) in [
-            (DerivedStatus::Running, None, "🛠️"),
+            (DerivedStatus::Running, None, "🔧"),
             (DerivedStatus::MonitorWait, Some(&last_tool), "🔧"),
             (
                 DerivedStatus::ScheduleWakeup(Some(30)),

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -216,29 +216,52 @@ mod tests {
     fn activity_labels_lead_with_a_spinner_swap_marker() {
         // Every actively-rendered label must lead with a status emoji so the
         // spinner-merge swaps it for the animation cleanly (spinner-prefix parity).
-        for status in [
-            DerivedStatus::Running,
-            DerivedStatus::MonitorWait,
-            DerivedStatus::ScheduleWakeup(Some(30)),
-            DerivedStatus::ToolRunning {
-                name: "Bash".to_string(),
-                summary: None,
-            },
-            DerivedStatus::SubagentRunning {
-                desc: "explore".to_string(),
-            },
-            DerivedStatus::WorkflowRunning {
-                label: "review".to_string(),
-            },
-            DerivedStatus::Completed {
-                kind: CompletedKind::Foreground,
-            },
+        let last_tool = LastToolCall {
+            name: "Read".to_string(),
+            summary: None,
+        };
+        for (status, last_tool, expected_prefix) in [
+            (DerivedStatus::Running, None, "🛠️"),
+            (DerivedStatus::MonitorWait, Some(&last_tool), "🔧"),
+            (
+                DerivedStatus::ScheduleWakeup(Some(30)),
+                Some(&last_tool),
+                "🔧",
+            ),
+            (
+                DerivedStatus::ToolRunning {
+                    name: "Bash".to_string(),
+                    summary: None,
+                },
+                None,
+                "🔧",
+            ),
+            (
+                DerivedStatus::SubagentRunning {
+                    desc: "explore".to_string(),
+                },
+                Some(&last_tool),
+                "🔧",
+            ),
+            (
+                DerivedStatus::WorkflowRunning {
+                    label: "review".to_string(),
+                },
+                Some(&last_tool),
+                "🔧",
+            ),
+            (
+                DerivedStatus::Completed {
+                    kind: CompletedKind::Foreground,
+                },
+                None,
+                "✅",
+            ),
         ] {
-            let line = render_activity_line_with_last_tool(&status, None);
-            let first = line.chars().next().expect("non-empty label");
+            let line = render_activity_line_with_last_tool(&status, last_tool);
             assert!(
-                ['🛠', '🔧', '✅'].contains(&first),
-                "label {line:?} must lead with a spinner-swap marker"
+                line.starts_with(expected_prefix),
+                "label {line:?} must lead with spinner-swap marker {expected_prefix:?}"
             );
         }
     }

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -5,8 +5,9 @@
 //! derived-status activity label and the store-facing time-line builder live here
 //! with their tests.
 //!
-//! The footer header starts with the derived-status ACTIVITY label (`🛠️ 도구 호출 전` /
-//! `🔧 마지막 도구 (…)` / `✅ 완료`). The spinner merge
+//! While a turn is active, the footer header shows the latest observed tool call
+//! (`🔧 마지막 도구 (…)`) or a non-progress fallback when no tool has run yet.
+//! Completed turns retain their existing completion label. The spinner merge
 //! (`single_message_panel::merged_footer_header_line`) swaps the leading status
 //! emoji for the animated spinner, so the marker set there must stay in sync with
 //! the emojis this label can start with. The request anchor follows the activity
@@ -65,46 +66,44 @@ pub(super) fn render_time_line(last_activity_unix: Option<i64>, started_at_unix:
     )
 }
 
-/// #3983/#4892: the panel's first (activity) line — the derived-status label
-/// alone (no provider, no timestamp; those moved to the time line). A generic
-/// running state renders the latest observed tool call instead of duplicating the
-/// answer message's spinner. The final confidence class is absorbed into the emoji
-/// here (item B): a clean completion reads `✅ 완료`.
-pub(super) fn render_activity_line(
+/// #3983/#4892: the panel's first (activity) line. Active and waiting turns
+/// render the latest observed tool instead of duplicating the answer message's
+/// spinner/progress state. Completed turns deliberately retain the pre-#4892
+/// labels so the completion-only follow-up can replace that path independently.
+pub(super) fn render_activity_line(status: &DerivedStatus) -> String {
+    render_activity_line_with_last_tool(status, None)
+}
+
+pub(super) fn render_activity_line_with_last_tool(
     status: &DerivedStatus,
     last_tool: Option<&LastToolCall>,
 ) -> String {
     match status {
-        DerivedStatus::Running => last_tool.map_or_else(
-            || "🛠️ 도구 호출 전".to_string(),
-            |tool| render_tool_activity("마지막 도구", &tool.name, tool.summary.as_deref()),
-        ),
-        DerivedStatus::MonitorWait => "💤 monitor 대기".to_string(),
-        DerivedStatus::ScheduleWakeup(Some(eta_secs)) => {
-            format!("⏰ scheduled wakeup ({eta_secs}s 후)")
-        }
-        DerivedStatus::ScheduleWakeup(None) => "⏰ scheduled wakeup".to_string(),
         DerivedStatus::Completed {
             kind: CompletedKind::Background,
         } => "✅ 백그라운드 완료".to_string(),
         DerivedStatus::Completed {
             kind: CompletedKind::Foreground,
         } => "✅ 완료".to_string(),
+        DerivedStatus::Running
+        | DerivedStatus::MonitorWait
+        | DerivedStatus::ScheduleWakeup(_)
+        | DerivedStatus::SubagentRunning { .. }
+        | DerivedStatus::WorkflowRunning { .. } => render_last_tool(last_tool),
         DerivedStatus::ToolRunning { name, summary } => {
-            render_tool_activity("마지막 도구", name, summary.as_deref())
-        }
-        DerivedStatus::SubagentRunning { desc } => {
-            let desc = escape_status_panel_markdown(desc);
-            format!("🧵 subagent 실행 중 ({})", truncate_chars(&desc, 120))
-        }
-        DerivedStatus::WorkflowRunning { label } => {
-            let label = escape_status_panel_markdown(label);
-            format!("🧬 workflow 실행 중 ({})", truncate_chars(&label, 120))
+            render_tool_activity(name, summary.as_deref())
         }
     }
 }
 
-fn render_tool_activity(label: &str, name: &str, summary: Option<&str>) -> String {
+fn render_last_tool(last_tool: Option<&LastToolCall>) -> String {
+    last_tool.map_or_else(
+        || "🛠️ 도구 호출 대기".to_string(),
+        |tool| render_tool_activity(&tool.name, tool.summary.as_deref()),
+    )
+}
+
+fn render_tool_activity(name: &str, summary: Option<&str>) -> String {
     let name = tool_prefix(name);
     let detail = summary
         .map(str::trim)
@@ -115,7 +114,7 @@ fn render_tool_activity(label: &str, name: &str, summary: Option<&str>) -> Strin
         Some(detail) => format!("{name} · {detail}"),
         None => name,
     };
-    format!("🔧 {label} ({})", truncate_chars(&rendered, 140))
+    format!("🔧 마지막 도구 ({})", truncate_chars(&rendered, 140))
 }
 
 #[cfg(test)]
@@ -129,9 +128,9 @@ mod tests {
 
     #[test]
     fn running_turn_without_tool_uses_non_duplicate_fallback() {
-        let rendered = render_activity_line(&DerivedStatus::Running, None);
+        let rendered = render_activity_line_with_last_tool(&DerivedStatus::Running, None);
 
-        assert_eq!(rendered, "🛠️ 도구 호출 전");
+        assert_eq!(rendered, "🛠️ 도구 호출 대기");
         assert!(!rendered.contains("진행 중"));
     }
 
@@ -139,13 +138,13 @@ mod tests {
     fn running_turn_renders_last_tool_name_and_short_target() {
         let last_tool = LastToolCall {
             name: "Read".to_string(),
-            summary: Some("/workspace/src/services/discord/status_panel.rs".to_string()),
+            summary: Some("src/services/discord/status_panel.rs".to_string()),
         };
-        let rendered = render_activity_line(&DerivedStatus::Running, Some(&last_tool));
+        let rendered = render_activity_line_with_last_tool(&DerivedStatus::Running, Some(&last_tool));
 
         assert_eq!(
             rendered,
-            "🔧 마지막 도구 ([Read] · /workspace/src/services/discord/status\_panel.rs)"
+            "🔧 마지막 도구 ([Read] · src/services/discord/status\_panel.rs)"
         );
         assert!(!rendered.contains("진행 중"));
     }
@@ -153,7 +152,7 @@ mod tests {
     #[test]
     fn tool_running_uses_same_last_tool_format() {
         assert_eq!(
-            render_activity_line(
+            render_activity_line_with_last_tool(
                 &DerivedStatus::ToolRunning {
                     name: "Bash".to_string(),
                     summary: Some("check status".to_string()),
@@ -165,18 +164,50 @@ mod tests {
     }
 
     #[test]
+    fn waiting_states_keep_the_last_tool_instead_of_progress_copy() {
+        let last_tool = LastToolCall {
+            name: "Monitor".to_string(),
+            summary: Some("wait for build".to_string()),
+        };
+
+        for status in [
+            DerivedStatus::MonitorWait,
+            DerivedStatus::ScheduleWakeup(Some(30)),
+            DerivedStatus::SubagentRunning {
+                desc: "review".to_string(),
+            },
+            DerivedStatus::WorkflowRunning {
+                label: "CI".to_string(),
+            },
+        ] {
+            let rendered = render_activity_line_with_last_tool(&status, Some(&last_tool));
+            assert_eq!(
+                rendered,
+                "🔧 마지막 도구 ([Monitor] · wait for build)"
+            );
+            assert!(!rendered.contains("진행 중"));
+        }
+    }
+
+    #[test]
     fn completed_turn_renders_final_check_label() {
         // #3983 item B: `final` is absorbed into the ✅ activity emoji.
         assert_eq!(
-            render_activity_line(&DerivedStatus::Completed {
-                kind: CompletedKind::Foreground
-            }),
+            render_activity_line_with_last_tool(
+                &DerivedStatus::Completed {
+                    kind: CompletedKind::Foreground
+                },
+                None,
+            ),
             "✅ 완료"
         );
         assert_eq!(
-            render_activity_line(&DerivedStatus::Completed {
-                kind: CompletedKind::Background
-            }),
+            render_activity_line_with_last_tool(
+                &DerivedStatus::Completed {
+                    kind: CompletedKind::Background
+                },
+                None,
+            ),
             "✅ 백그라운드 완료"
         );
     }
@@ -203,10 +234,10 @@ mod tests {
                 kind: CompletedKind::Foreground,
             },
         ] {
-            let line = render_activity_line(&status, None);
+            let line = render_activity_line_with_last_tool(&status, None);
             let first = line.chars().next().expect("non-empty label");
             assert!(
-                ['🟢', '💤', '⏰', '🔧', '🧵', '🧬', '✅'].contains(&first),
+                ['🛠', '🔧', '✅'].contains(&first),
                 "label {line:?} must lead with a spinner-swap marker"
             );
         }

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -98,7 +98,7 @@ pub(super) fn render_activity_line_with_last_tool(
 
 fn render_last_tool(last_tool: Option<&LastToolCall>) -> String {
     last_tool.map_or_else(
-        || "🛠️ 도구 호출 대기".to_string(),
+        || "🔧 마지막 도구 (아직 없음)".to_string(),
         |tool| render_tool_activity(&tool.name, tool.summary.as_deref()),
     )
 }
@@ -130,7 +130,7 @@ mod tests {
     fn running_turn_without_tool_uses_non_duplicate_fallback() {
         let rendered = render_activity_line_with_last_tool(&DerivedStatus::Running, None);
 
-        assert_eq!(rendered, "🛠️ 도구 호출 대기");
+        assert_eq!(rendered, "🔧 마지막 도구 (아직 없음)");
         assert!(!rendered.contains("진행 중"));
     }
 

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -5,11 +5,12 @@
 //! derived-status activity label and the store-facing time-line builder live here
 //! with their tests.
 //!
-//! While a turn is actively processing, the footer header shows the latest
-//! observed tool call (`🔧 마지막 도구 (…)`) or a non-progress fallback when no
-//! tool has run yet. Distinct wait states retain their specific labels because
-//! those details are not represented by the spinner. Completed turns retain
-//! their existing completion label. The spinner merge
+//! While a turn is actively processing, the footer header shows only the latest
+//! observed tool class (`🔧 마지막 도구 ([Read])`) or a non-progress fallback when
+//! no tool has run yet. Raw tool arguments are intentionally excluded from this
+//! channel-visible surface. Distinct wait states retain their specific labels
+//! because those details are not represented by the spinner. Completed turns
+//! retain their existing completion label. The spinner merge
 //! (`single_message_panel::merged_footer_header_line`) swaps the leading status
 //! emoji for the animated spinner, so the marker set there must stay in sync with
 //! the emojis this label can start with. The request anchor follows the activity
@@ -94,9 +95,7 @@ pub(super) fn render_activity_line_with_last_tool(
             format!("⏰ scheduled wakeup ({eta_secs}s 후)")
         }
         DerivedStatus::ScheduleWakeup(None) => "⏰ scheduled wakeup".to_string(),
-        DerivedStatus::ToolRunning { name, summary } => {
-            render_tool_activity(name, summary.as_deref())
-        }
+        DerivedStatus::ToolRunning { name, summary: _ } => render_tool_activity(name),
         DerivedStatus::SubagentRunning { desc } => {
             let desc = escape_status_panel_markdown(desc);
             format!("🧵 subagent 실행 중 ({})", truncate_chars(&desc, 120))
@@ -111,22 +110,16 @@ pub(super) fn render_activity_line_with_last_tool(
 fn render_last_tool(last_tool: Option<&LastToolCall>) -> String {
     last_tool.map_or_else(
         || "🔧 마지막 도구 (아직 없음)".to_string(),
-        |tool| render_tool_activity(&tool.name, tool.summary.as_deref()),
+        |tool| render_tool_activity(&tool.name),
     )
 }
 
-fn render_tool_activity(name: &str, summary: Option<&str>) -> String {
-    let name = tool_prefix(name);
-    let detail = summary
-        .map(str::trim)
-        .filter(|summary| !summary.is_empty())
-        .map(escape_status_panel_markdown)
-        .map(|summary| truncate_chars(&summary, 100));
-    let rendered = match detail {
-        Some(detail) => format!("{name} · {detail}"),
-        None => name,
-    };
-    format!("🔧 마지막 도구 ({})", truncate_chars(&rendered, 140))
+/// #4892: tool inputs are untrusted and may contain credentials, signed URLs,
+/// private paths, or arbitrary payloads. This channel-visible surface therefore
+/// renders only the allowlisted tool class produced by `tool_prefix`; new tools
+/// fail closed to a sanitized class name and never render their arguments.
+fn render_tool_activity(name: &str) -> String {
+    format!("🔧 마지막 도구 ({})", tool_prefix(name))
 }
 
 #[cfg(test)]
@@ -147,33 +140,74 @@ mod tests {
     }
 
     #[test]
-    fn running_turn_renders_last_tool_name_and_short_target() {
+    fn running_turn_renders_only_last_tool_class() {
+        let raw_path = "src/services/discord/status_panel.rs";
         let last_tool = LastToolCall {
             name: "Read".to_string(),
-            summary: Some("src/services/discord/status_panel.rs".to_string()),
+            summary: Some(raw_path.to_string()),
         };
         let rendered =
             render_activity_line_with_last_tool(&DerivedStatus::Running, Some(&last_tool));
 
-        assert_eq!(
-            rendered,
-            r"🔧 마지막 도구 ([Read] · src/services/discord/status\_panel.rs)"
-        );
+        assert_eq!(rendered, "🔧 마지막 도구 ([Read])");
+        assert!(!rendered.contains(raw_path));
         assert!(!rendered.contains("진행 중"));
     }
 
     #[test]
-    fn tool_running_uses_same_last_tool_format() {
-        assert_eq!(
-            render_activity_line_with_last_tool(
-                &DerivedStatus::ToolRunning {
-                    name: "Bash".to_string(),
-                    summary: Some("check status".to_string()),
-                },
-                None,
-            ),
-            "🔧 마지막 도구 ([Bash] · check status)"
+    fn tool_running_uses_same_class_only_format() {
+        let raw_summary = "check status";
+        let rendered = render_activity_line_with_last_tool(
+            &DerivedStatus::ToolRunning {
+                name: "Bash".to_string(),
+                summary: Some(raw_summary.to_string()),
+            },
+            None,
         );
+
+        assert_eq!(rendered, "🔧 마지막 도구 ([Bash])");
+        assert!(!rendered.contains(raw_summary));
+    }
+
+    fn assert_raw_tool_input_hidden(name: &str, raw: &str) {
+        let last_tool = LastToolCall {
+            name: name.to_string(),
+            summary: Some(raw.to_string()),
+        };
+        let rendered =
+            render_activity_line_with_last_tool(&DerivedStatus::Running, Some(&last_tool));
+
+        assert!(
+            !rendered.contains(raw),
+            "raw tool input must not reach the status panel: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Hunter2")
+                && !rendered.contains("hvs.CAES")
+                && !rendered.contains("secret/prod/db"),
+            "sensitive tool detail must not reach the status panel: {rendered}"
+        );
+    }
+
+    #[test]
+    fn last_tool_hides_bash_database_url() {
+        assert_raw_tool_input_hidden(
+            "Bash",
+            "psql postgresql://svc:Hunter2@db.prod:5432/main -c SELECT",
+        );
+    }
+
+    #[test]
+    fn last_tool_hides_vault_json() {
+        assert_raw_tool_input_hidden(
+            "mcp__vault__read",
+            r#"read: {"path":"secret/prod/db","token":"hvs.CAES..."}"#,
+        );
+    }
+
+    #[test]
+    fn last_tool_hides_non_json_payload() {
+        assert_raw_tool_input_hidden("Monitor", "non-json payload hvs.CAES... secret/prod/db");
     }
 
     #[test]

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -5,8 +5,8 @@
 //! derived-status activity label and the store-facing time-line builder live here
 //! with their tests.
 //!
-//! The footer header starts with the derived-status ACTIVITY label (`🟢 진행 중` /
-//! `🔧 도구 실행 중 (…)` / `✅ 완료`). The spinner merge
+//! The footer header starts with the derived-status ACTIVITY label (`🛠️ 도구 호출 전` /
+//! `🔧 마지막 도구 (…)` / `✅ 완료`). The spinner merge
 //! (`single_message_panel::merged_footer_header_line`) swaps the leading status
 //! emoji for the animated spinner, so the marker set there must stay in sync with
 //! the emojis this label can start with. The request anchor follows the activity
@@ -24,7 +24,7 @@
 use poise::serenity_prelude::ChannelId;
 
 use super::common::{escape_status_panel_markdown, tool_prefix, truncate_chars};
-use super::status_panel::{CompletedKind, DerivedStatus};
+use super::status_panel::{CompletedKind, DerivedStatus, LastToolCall};
 
 impl super::PlaceholderLiveEvents {
     /// #3983: builds the panel's time line from the channel's STABLE last-activity
@@ -65,13 +65,20 @@ pub(super) fn render_time_line(last_activity_unix: Option<i64>, started_at_unix:
     )
 }
 
-/// #3983: the panel's first (activity) line — the derived-status label alone (no
-/// provider, no timestamp; those moved to the time line). The final confidence
-/// class is absorbed into the emoji here (item B): a clean completion reads
-/// `✅ 완료`.
-pub(super) fn render_activity_line(status: &DerivedStatus) -> String {
+/// #3983/#4892: the panel's first (activity) line — the derived-status label
+/// alone (no provider, no timestamp; those moved to the time line). A generic
+/// running state renders the latest observed tool call instead of duplicating the
+/// answer message's spinner. The final confidence class is absorbed into the emoji
+/// here (item B): a clean completion reads `✅ 완료`.
+pub(super) fn render_activity_line(
+    status: &DerivedStatus,
+    last_tool: Option<&LastToolCall>,
+) -> String {
     match status {
-        DerivedStatus::Running => "🟢 진행 중".to_string(),
+        DerivedStatus::Running => last_tool.map_or_else(
+            || "🛠️ 도구 호출 전".to_string(),
+            |tool| render_tool_activity("마지막 도구", &tool.name, tool.summary.as_deref()),
+        ),
         DerivedStatus::MonitorWait => "💤 monitor 대기".to_string(),
         DerivedStatus::ScheduleWakeup(Some(eta_secs)) => {
             format!("⏰ scheduled wakeup ({eta_secs}s 후)")
@@ -83,9 +90,8 @@ pub(super) fn render_activity_line(status: &DerivedStatus) -> String {
         DerivedStatus::Completed {
             kind: CompletedKind::Foreground,
         } => "✅ 완료".to_string(),
-        DerivedStatus::ToolRunning { name, summary: _ } => {
-            let rendered = tool_prefix(name);
-            format!("🔧 도구 실행 중 ({})", truncate_chars(&rendered, 140))
+        DerivedStatus::ToolRunning { name, summary } => {
+            render_tool_activity("마지막 도구", name, summary.as_deref())
         }
         DerivedStatus::SubagentRunning { desc } => {
             let desc = escape_status_panel_markdown(desc);
@@ -98,6 +104,20 @@ pub(super) fn render_activity_line(status: &DerivedStatus) -> String {
     }
 }
 
+fn render_tool_activity(label: &str, name: &str, summary: Option<&str>) -> String {
+    let name = tool_prefix(name);
+    let detail = summary
+        .map(str::trim)
+        .filter(|summary| !summary.is_empty())
+        .map(escape_status_panel_markdown)
+        .map(|summary| truncate_chars(&summary, 100));
+    let rendered = match detail {
+        Some(detail) => format!("{name} · {detail}"),
+        None => name,
+    };
+    format!("🔧 {label} ({})", truncate_chars(&rendered, 140))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -108,18 +128,39 @@ mod tests {
     // ---- render_activity_line: the derived-status labels ------------------
 
     #[test]
-    fn running_turn_renders_green_activity_label() {
-        assert_eq!(render_activity_line(&DerivedStatus::Running), "🟢 진행 중");
+    fn running_turn_without_tool_uses_non_duplicate_fallback() {
+        let rendered = render_activity_line(&DerivedStatus::Running, None);
+
+        assert_eq!(rendered, "🛠️ 도구 호출 전");
+        assert!(!rendered.contains("진행 중"));
     }
 
     #[test]
-    fn tool_running_renders_wrench_activity_label() {
+    fn running_turn_renders_last_tool_name_and_short_target() {
+        let last_tool = LastToolCall {
+            name: "Read".to_string(),
+            summary: Some("/workspace/src/services/discord/status_panel.rs".to_string()),
+        };
+        let rendered = render_activity_line(&DerivedStatus::Running, Some(&last_tool));
+
         assert_eq!(
-            render_activity_line(&DerivedStatus::ToolRunning {
-                name: "Bash".to_string(),
-                summary: None,
-            }),
-            "🔧 도구 실행 중 ([Bash])"
+            rendered,
+            "🔧 마지막 도구 ([Read] · /workspace/src/services/discord/status\_panel.rs)"
+        );
+        assert!(!rendered.contains("진행 중"));
+    }
+
+    #[test]
+    fn tool_running_uses_same_last_tool_format() {
+        assert_eq!(
+            render_activity_line(
+                &DerivedStatus::ToolRunning {
+                    name: "Bash".to_string(),
+                    summary: Some("check status".to_string()),
+                },
+                None,
+            ),
+            "🔧 마지막 도구 ([Bash] · check status)"
         );
     }
 
@@ -162,7 +203,7 @@ mod tests {
                 kind: CompletedKind::Foreground,
             },
         ] {
-            let line = render_activity_line(&status);
+            let line = render_activity_line(&status, None);
             let first = line.chars().next().expect("non-empty label");
             assert!(
                 ['🟢', '💤', '⏰', '🔧', '🧵', '🧬', '✅'].contains(&first),

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -144,7 +144,7 @@ mod tests {
 
         assert_eq!(
             rendered,
-            "🔧 마지막 도구 ([Read] · src/services/discord/status\_panel.rs)"
+            r"🔧 마지막 도구 ([Read] · src/services/discord/status\_panel.rs)"
         );
         assert!(!rendered.contains("진행 중"));
     }

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -41,16 +41,23 @@ pub(in crate::services::discord) fn status_events_from_tool_use_with_id_for_foot
     tool_use_id: Option<&str>,
     footer_mode_enabled: bool,
 ) -> Vec<StatusEvent> {
-    let args_summary = format_tool_input(name, input)
-        .trim()
-        .is_empty()
-        .then(|| first_content_line(input))
-        .filter(|value| !value.trim().is_empty())
-        .or_else(|| {
-            let summary = format_tool_input(name, input);
-            (!summary.trim().is_empty()).then_some(summary)
+    // Subagent inputs are arbitrary prompts and may contain credentials or
+    // private endpoints. Keep them out of status state entirely; the lifecycle
+    // is represented only by explicitly allowlisted description fields instead.
+    let args_summary = (!is_task_tool(name))
+        .then(|| {
+            format_tool_input(name, input)
+                .trim()
+                .is_empty()
+                .then(|| first_content_line(input))
+                .filter(|value| !value.trim().is_empty())
+                .or_else(|| {
+                    let summary = format_tool_input(name, input);
+                    (!summary.trim().is_empty()).then_some(summary)
+                })
+                .map(|summary| truncate_chars(&summary, EVENT_LINE_MAX_CHARS))
         })
-        .map(|summary| truncate_chars(&summary, EVENT_LINE_MAX_CHARS));
+        .flatten();
 
     let mut events = vec![StatusEvent::ToolStart {
         name: name.to_string(),
@@ -97,7 +104,7 @@ pub(in crate::services::discord) fn status_events_from_tool_use_with_id_for_foot
                 .and_then(Value::as_str)
                 .map(str::to_string)
                 .or_else(|| Some(name.to_string())),
-            desc: subagent_description(&value).or(args_summary.clone()),
+            desc: subagent_description(&value),
             agent_id: subagent_agent_id(&value),
             tool_use_id: tool_use_id.map(str::to_string),
             background,
@@ -418,18 +425,11 @@ pub(super) fn is_schedule_wakeup_tool(name: &str) -> bool {
 }
 
 fn subagent_description(value: &Value) -> Option<String> {
-    [
-        "description",
-        "desc",
-        "prompt",
-        "task",
-        "message",
-        "request",
-    ]
-    .into_iter()
-    .find_map(|key| value.get(key).and_then(Value::as_str))
-    .map(normalize_summary)
-    .filter(|summary| !summary.is_empty())
+    ["description", "desc"]
+        .into_iter()
+        .find_map(|key| value.get(key).and_then(Value::as_str))
+        .map(normalize_summary)
+        .filter(|summary| !summary.is_empty())
 }
 
 fn subagent_agent_id(value: &Value) -> Option<String> {

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -611,8 +611,10 @@ pub(super) fn render_status_panel(
     // the request anchor when present, then the start/update TIME fields. Keep the
     // entire header in one section so each field occupies the immediately following
     // physical line and section-wise truncation preserves the header atomically.
-    let activity_line =
-        super::freshness::render_activity_line(&header_status, snapshot.last_tool.as_ref());
+    let activity_line = super::freshness::render_activity_line_with_last_tool(
+        &header_status,
+        snapshot.last_tool.as_ref(),
+    );
     let time_lines = time_line.lines().collect::<Vec<_>>();
     let mut header_lines = std::iter::once(activity_line.as_str())
         .chain(time_lines)

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -586,9 +586,9 @@ pub(super) fn render_status_panel(
     // activity line (or `None` for headless/synthetic/id-0 turns).
     turn_trigger_line: Option<String>,
 ) -> String {
-    let header_status = if matches!(provider, ProviderKind::Codex)
-        && matches!(snapshot.status, DerivedStatus::SubagentRunning { .. })
-    {
+    let codex_subagent_projection = matches!(provider, ProviderKind::Codex)
+        && matches!(snapshot.status, DerivedStatus::SubagentRunning { .. });
+    let header_status = if codex_subagent_projection {
         DerivedStatus::Running
     } else {
         snapshot.status.clone()
@@ -597,10 +597,14 @@ pub(super) fn render_status_panel(
     // the request anchor when present, then the start/update TIME fields. Keep the
     // entire header in one section so each field occupies the immediately following
     // physical line and section-wise truncation preserves the header atomically.
-    let activity_line = super::freshness::render_activity_line_with_last_tool(
-        &header_status,
-        snapshot.last_tool.as_ref(),
-    );
+    // #4367: projecting Codex subagent activity to generic Running must also
+    // suppress the Task-derived last tool; otherwise the hidden description is
+    // reintroduced through a sibling header field.
+    let visible_last_tool = (!codex_subagent_projection)
+        .then_some(snapshot.last_tool.as_ref())
+        .flatten();
+    let activity_line =
+        super::freshness::render_activity_line_with_last_tool(&header_status, visible_last_tool);
     let time_lines = time_line.lines().collect::<Vec<_>>();
     let mut header_lines = std::iter::once(activity_line.as_str())
         .chain(time_lines)

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -73,9 +73,16 @@ impl CompletedKind {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LastToolCall {
+    pub(super) name: String,
+    pub(super) summary: Option<String>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(super) struct StatusPanelState {
     pub(super) status: DerivedStatus,
+    pub(super) last_tool: Option<LastToolCall>,
     pub(super) session: Option<SessionPanelSnapshot>,
     pub(super) task: Option<TaskPanelSnapshot>,
     pub(super) context: Option<ContextPanelSnapshot>,
@@ -106,6 +113,7 @@ impl StatusPanelState {
     /// context/token usage + session snapshots and the ordinal counter.
     pub(super) fn reset_session_content(&mut self) {
         self.status = DerivedStatus::Running;
+        self.last_tool = None;
         self.todos.clear();
         self.tasks.clear();
         // #4396 r3: the cleared subagents leave the state — tombstone their keys
@@ -224,6 +232,10 @@ impl StatusPanelState {
     pub(super) fn apply(&mut self, event: StatusEvent) {
         match event {
             StatusEvent::ToolStart { name, args_summary } => {
+                self.last_tool = Some(LastToolCall {
+                    name: name.clone(),
+                    summary: args_summary.clone(),
+                });
                 if is_schedule_wakeup_tool(&name) {
                     self.status =
                         DerivedStatus::ScheduleWakeup(parse_eta_secs(args_summary.as_deref()));
@@ -599,7 +611,8 @@ pub(super) fn render_status_panel(
     // the request anchor when present, then the start/update TIME fields. Keep the
     // entire header in one section so each field occupies the immediately following
     // physical line and section-wise truncation preserves the header atomically.
-    let activity_line = super::freshness::render_activity_line(&header_status);
+    let activity_line =
+        super::freshness::render_activity_line(&header_status, snapshot.last_tool.as_ref());
     let time_lines = time_line.lines().collect::<Vec<_>>();
     let mut header_lines = std::iter::once(activity_line.as_str())
         .chain(time_lines)

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -54,24 +54,10 @@ pub(super) struct SubagentSlot {
     /// silent longer than `STUCK_BACKGROUND_TASK_TTL`.
     pub(super) started_at: std::time::Instant,
 }
+mod completed_kind;
 mod derived_status;
+pub(super) use completed_kind::CompletedKind;
 pub(super) use derived_status::DerivedStatus;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum CompletedKind {
-    Foreground,
-    Background,
-}
-
-impl CompletedKind {
-    fn from_background(background: bool) -> Self {
-        if background {
-            Self::Background
-        } else {
-            Self::Foreground
-        }
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct LastToolCall {

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -588,7 +588,12 @@ pub(super) fn render_status_panel(
 ) -> String {
     let codex_subagent_projection = matches!(provider, ProviderKind::Codex)
         && matches!(snapshot.status, DerivedStatus::SubagentRunning { .. });
-    let header_status = if codex_subagent_projection {
+    let codex_task_projection = matches!(provider, ProviderKind::Codex)
+        && snapshot
+            .last_tool
+            .as_ref()
+            .is_some_and(|tool| super::status_events::is_task_tool(&tool.name));
+    let header_status = if codex_subagent_projection || codex_task_projection {
         DerivedStatus::Running
     } else {
         snapshot.status.clone()
@@ -597,10 +602,10 @@ pub(super) fn render_status_panel(
     // the request anchor when present, then the start/update TIME fields. Keep the
     // entire header in one section so each field occupies the immediately following
     // physical line and section-wise truncation preserves the header atomically.
-    // #4367: projecting Codex subagent activity to generic Running must also
-    // suppress the Task-derived last tool; otherwise the hidden description is
-    // reintroduced through a sibling header field.
-    let visible_last_tool = (!codex_subagent_projection)
+    // #4367: Codex subagent evidence stays hidden after launch acknowledgement,
+    // terminal completion, and later turns. Status alone cannot provide the gate
+    // because `last_tool` persists for the provider session.
+    let visible_last_tool = (!codex_task_projection)
         .then_some(snapshot.last_tool.as_ref())
         .flatten();
     let activity_line =

--- a/src/services/discord/placeholder_live_events/status_panel/completed_kind.rs
+++ b/src/services/discord/placeholder_live_events/status_panel/completed_kind.rs
@@ -1,0 +1,15 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord::placeholder_live_events) enum CompletedKind {
+    Foreground,
+    Background,
+}
+
+impl CompletedKind {
+    pub(super) fn from_background(background: bool) -> Self {
+        if background {
+            Self::Background
+        } else {
+            Self::Foreground
+        }
+    }
+}

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -5,6 +5,7 @@ use super::super::formatting::{
 };
 use super::common::{
     EVENT_BLOCK_MAX_CHARS, EVENT_LINE_MAX_CHARS, STATUS_PANEL_MAX_CHARS, STATUS_PANEL_TASK_LIMIT,
+    tool_prefix,
 };
 use super::*;
 use serde_json::json;
@@ -30,6 +31,63 @@ fn render_block_compacts_newest_events_under_limit() {
     assert_eq!(live_lines.len(), 1);
     assert!(block.contains("5회"));
     assert!(!block.contains("echo 24"));
+}
+
+#[test]
+fn tool_prefix_is_a_closed_static_label_set() {
+    let cases = [
+        ("Bash", "[Bash]"),
+        ("command_execution", "[Bash]"),
+        ("exec", "[Bash]"),
+        ("exec_command", "[Bash]"),
+        ("run_cmd", "[Bash]"),
+        ("update_plan", "[Tool]"),
+        ("Read", "[Read]"),
+        ("Edit", "[Edit]"),
+        ("mcp__vault-prod", "[MCP]"),
+        ("mcp__a__b__c", "[MCP]"),
+        ("mcp__hr__lookup_employee_alice", "[MCP]"),
+        ("tenant_secret_custom_tool", "[Tool]"),
+    ];
+
+    for (name, expected) in cases {
+        let label: &'static str = tool_prefix(name);
+        assert_eq!(label, expected, "input: {name}");
+    }
+}
+
+#[test]
+fn compact_events_render_only_closed_labels_for_untrusted_tool_names() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_892_400);
+    for name in [
+        "mcp__vault-prod",
+        "mcp__a__b__c",
+        "mcp__hr__lookup_employee_alice",
+        "tenant_secret_custom_tool",
+    ] {
+        events.push_event(
+            channel_id,
+            RecentPlaceholderEvent::tool_use(name, r#"{"value":"safe summary"}"#).unwrap(),
+        );
+    }
+
+    let block = events
+        .render_block(channel_id)
+        .expect("compact event block");
+    assert!(block.contains("[MCP]") && block.contains("[Tool]"));
+    for private_fragment in [
+        "vault-prod",
+        "a__b__c",
+        "hr",
+        "lookup_employee_alice",
+        "tenant_secret_custom_tool",
+    ] {
+        assert!(
+            !block.contains(private_fragment),
+            "untrusted tool names must not reach compact rendering: {block}"
+        );
+    }
 }
 
 #[test]

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -57,6 +57,61 @@ fn tool_prefix_is_a_closed_static_label_set() {
 }
 
 #[test]
+fn raw_codex_exec_command_reaches_single_message_footer_as_bash() {
+    use std::sync::mpsc;
+
+    use crate::services::agent_protocol::StreamMessage;
+    use crate::services::codex_tui::rollout_tail::replay_rollout_file;
+
+    let raw_command = "printf parser-bridge-secret";
+    let rollout = tempfile::NamedTempFile::new().expect("raw Codex rollout fixture");
+    std::fs::write(
+        rollout.path(),
+        format!(
+            r#"{{"type":"response_item","payload":{{"type":"function_call","name":"exec_command","arguments":"{{\"cmd\":\"{raw_command}\"}}","call_id":"call-footer"}}}}
+"#,
+        ),
+    )
+    .expect("write raw Codex rollout fixture");
+    let (tx, rx) = mpsc::channel();
+    replay_rollout_file(rollout.path(), 0, &tx).expect("parse raw Codex rollout");
+    drop(tx);
+
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_892_401);
+    let mut bridged_tool_uses = 0;
+    for message in rx {
+        if let StreamMessage::ToolUse {
+            name,
+            input,
+            tool_use_id,
+        } = message
+        {
+            bridged_tool_uses += 1;
+            events.push_status_events(
+                channel_id,
+                status_events_from_tool_use_with_id(&name, &input, tool_use_id.as_deref()),
+            );
+        }
+    }
+    assert_eq!(
+        bridged_tool_uses, 1,
+        "raw rollout must produce exactly one bridgeable ToolUse"
+    );
+
+    let panel = events.render_status_panel(channel_id, &ProviderKind::Codex, 1_700_000_000);
+    let footer = super::super::single_message_panel::compose_footer_status_block("⠸", &panel);
+    assert!(
+        footer.contains("마지막 도구 ([Bash])"),
+        "raw Codex exec_command must survive parser and status handoff: {footer}"
+    );
+    assert!(
+        !footer.contains(raw_command) && !footer.contains("parser-bridge-secret"),
+        "single-message footer must not expose raw Codex command input: {footer}"
+    );
+}
+
+#[test]
 fn compact_events_render_only_closed_labels_for_untrusted_tool_names() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(4_892_400);

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -88,6 +88,19 @@ fn raw_codex_exec_command_reaches_single_message_footer_as_bash() {
         } = message
         {
             bridged_tool_uses += 1;
+            assert_eq!(
+                name, "exec_command",
+                "parser must preserve the function name"
+            );
+            assert_eq!(
+                tool_use_id.as_deref(),
+                Some("call-footer"),
+                "parser must preserve the function call id"
+            );
+            assert!(
+                input.contains(raw_command) && input.contains("parser-bridge-secret"),
+                "parser must preserve the raw function arguments before display redaction: {input}"
+            );
             events.push_status_events(
                 channel_id,
                 status_events_from_tool_use_with_id(&name, &input, tool_use_id.as_deref()),

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -258,12 +258,13 @@ fn status_panel_renders_derived_tool_state_under_limit() {
     );
 
     let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    assert!(rendered.contains("도구 실행 중"));
+    assert!(rendered.contains("마지막 도구"));
     assert!(rendered.contains("[Bash]"));
     assert!(
-        !rendered.contains("cargo test"),
-        "status header should show the tool class, not raw command text: {rendered}"
+        rendered.contains("cargo test"),
+        "status header should show the latest tool's short target: {rendered}"
     );
+    assert!(!rendered.contains("진행 중"));
     assert!(rendered.chars().count() <= STATUS_PANEL_MAX_CHARS);
 }
 
@@ -280,14 +281,14 @@ fn status_panel_recent_compacts_raw_command_details() {
     );
 
     let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    // #3983 item 5a: the footer no longer echoes the compact 🖥️ Recent block; the
-    // activity label shows the tool class, never the raw command detail.
-    assert!(rendered.contains("🔧 도구 실행 중"));
+    // #3983 item 5a: the footer no longer echoes the compact 🖥️ Recent block;
+    // #4892 instead exposes the formatter's bounded target as the latest tool.
+    assert!(rendered.contains("🔧 마지막 도구"));
     assert!(!rendered.contains("🖥️ Recent"));
     assert!(!rendered.contains("```text"));
     assert!(
-        !rendered.contains(raw_command),
-        "normal status panel must not render raw command detail: {rendered}"
+        rendered.contains(raw_command),
+        "normal status panel must render the latest tool's short target: {rendered}"
     );
 
     let raw_debug_block = events.render_raw_block_for_tests(channel_id).unwrap();
@@ -309,9 +310,9 @@ fn characterize_rollover_seed_has_no_status_panel_content_s0() {
     );
 
     let panel = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    assert!(panel.contains("도구 실행 중"));
+    assert!(panel.contains("마지막 도구"));
     assert!(panel.contains("[Bash]"));
-    assert!(!panel.contains("cargo test --lib placeholder_live_events"));
+    assert!(panel.contains("cargo test --lib placeholder\_live\_events"));
 
     let status_block = build_processing_status_block("⠸");
     let current_portion = "relay body ".repeat(250);
@@ -325,7 +326,7 @@ fn characterize_rollover_seed_has_no_status_panel_content_s0() {
             .ends_with(&format!("\n\n{status_block}"))
     );
     for status_panel_fragment in [
-        "도구 실행 중",
+        "마지막 도구",
         "[Bash]",
         "cargo test --lib placeholder_live_events",
     ] {
@@ -387,7 +388,7 @@ fn status_panel_absorbs_stale_and_final_into_the_activity_emoji() {
     );
     let live = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
     assert!(
-        live.contains("🔧 도구 실행 중"),
+        live.contains("🔧 마지막 도구"),
         "running activity: {live:?}"
     );
     assert!(
@@ -441,7 +442,7 @@ fn status_panel_codex_active_omits_processing_tail_after_recent_block() {
         1_700_000_005,
     );
 
-    assert!(rendered.contains("🔧 도구 실행 중"));
+    assert!(rendered.contains("🔧 마지막 도구"));
     assert!(rendered.contains("[Bash]"));
     // #3983 item 5a: the 🖥️ Recent echo is retired from the footer.
     assert!(!rendered.contains("🖥️ Recent"));
@@ -4141,10 +4142,11 @@ fn status_panel_shows_live_subagent_activity_by_parent_id() {
         !rendered.contains("grep ERROR app.log"),
         "subagent activity must not leak raw command args, got: {rendered}"
     );
-    // Nested activity must NOT turn the panel header into a foreground tool run.
+    // Nested activity must not replace the top-level Agent launch remembered by
+    // the panel header; the nested Bash step belongs only to the subagent slot.
     assert!(
-        !rendered.contains("🔧 도구 실행 중"),
-        "nested subagent step must not clobber the panel header, got: {rendered}"
+        rendered.contains("🔧 마지막 도구 ([Agent]"),
+        "top-level Agent launch must remain the panel's latest tool, got: {rendered}"
     );
 }
 
@@ -9305,7 +9307,7 @@ fn status_panel_free_renderer_orders_header_fields_on_separate_lines() {
     assert_eq!(
         out.lines().take(4).collect::<Vec<_>>(),
         vec![
-            "-# 🟢 진행 중",
+            "-# 🛠️ 도구 호출 대기",
             "-# 턴 트리거: https://discord.com/channels/1/2/3",
             "-# 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)",
             "-# 마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)",

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -9307,7 +9307,7 @@ fn status_panel_free_renderer_orders_header_fields_on_separate_lines() {
     assert_eq!(
         out.lines().take(4).collect::<Vec<_>>(),
         vec![
-            "-# 🛠️ 도구 호출 대기",
+            "-# 🔧 마지막 도구 (아직 없음)",
             "-# 턴 트리거: https://discord.com/channels/1/2/3",
             "-# 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)",
             "-# 마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)",

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -287,8 +287,8 @@ fn status_panel_recent_compacts_raw_command_details() {
     assert!(!rendered.contains("🖥️ Recent"));
     assert!(!rendered.contains("```text"));
     assert!(
-        rendered.contains(raw_command),
-        "normal status panel must render the latest tool's short target: {rendered}"
+        rendered.contains(r"cargo test --lib placeholder\_live\_events -- --nocapture"),
+        "normal status panel must render the escaped latest-tool target: {rendered}"
     );
 
     let raw_debug_block = events.render_raw_block_for_tests(channel_id).unwrap();
@@ -3812,8 +3812,12 @@ fn background_bash_command_only_slot_hides_raw_command_3806() {
         "background Bash class should remain visible: {rendered}"
     );
     assert!(
-        !rendered.contains(raw_command),
-        "background Bash slot must not leak raw command detail: {rendered}"
+        rendered.contains("🔧 마지막 도구 ([Bash]"),
+        "background Bash launch must remain visible as the latest tool: {rendered}"
+    );
+    assert!(
+        rendered.contains("codex exec --skip-git-repo-check -m gpt-5.5"),
+        "the latest-tool header must reuse the bounded formatter summary: {rendered}"
     );
 }
 
@@ -4142,11 +4146,11 @@ fn status_panel_shows_live_subagent_activity_by_parent_id() {
         !rendered.contains("grep ERROR app.log"),
         "subagent activity must not leak raw command args, got: {rendered}"
     );
-    // Nested activity must not replace the top-level Agent launch remembered by
+    // Nested activity must not replace the top-level Task launch remembered by
     // the panel header; the nested Bash step belongs only to the subagent slot.
     assert!(
-        rendered.contains("🔧 마지막 도구 ([Agent]"),
-        "top-level Agent launch must remain the panel's latest tool, got: {rendered}"
+        rendered.contains("🔧 마지막 도구 ([Task] · [general-purpose] Audit logs)"),
+        "top-level Task launch must remain the panel's latest tool, got: {rendered}"
     );
 }
 
@@ -6308,7 +6312,10 @@ fn status_panel_renders_plan_but_hides_subagents_for_codex() {
     assert!(rendered.contains("Plan"));
     assert!(rendered.contains("Hidden for Codex"));
     assert!(!rendered.contains("Subagents"));
-    assert!(!rendered.contains("Hidden subagent"));
+    assert!(
+        rendered.contains("🔧 마지막 도구 ([Task] · Hidden subagent)"),
+        "Codex must omit the subagent section while retaining the latest tool header: {rendered}"
+    );
 }
 
 #[test]

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -6327,6 +6327,133 @@ fn status_panel_renders_plan_but_hides_subagents_for_codex() {
 }
 
 #[test]
+fn codex_task_class_stays_hidden_after_subagent_terminal_result() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_892_301);
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use(
+            "Task",
+            &json!({"description": "Private deployment review"}).to_string(),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result(Some("Task"), true),
+    );
+
+    assert_eq!(status_for(&events, channel_id), DerivedStatus::Running);
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Codex, 1_700_000_000);
+    assert!(
+        !rendered.contains("[Task]"),
+        "Codex must not reveal the Task class after subagent termination: {rendered}"
+    );
+    assert!(
+        !rendered.contains("Private deployment review"),
+        "Codex must not reveal terminated subagent input: {rendered}"
+    );
+}
+
+#[test]
+fn codex_task_class_stays_hidden_after_background_launch_ack() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_892_302);
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use(
+            "Task",
+            &json!({
+                "description": "Private background review",
+                "run_in_background": true
+            })
+            .to_string(),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result(Some("Task"), false),
+    );
+
+    assert_eq!(status_for(&events, channel_id), DerivedStatus::Running);
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Codex, 1_700_000_000);
+    assert!(
+        !rendered.contains("[Task]"),
+        "Codex must not reveal the Task class while a background subagent remains active: {rendered}"
+    );
+    assert!(
+        !rendered.contains("Private background review"),
+        "Codex must not reveal acknowledged background subagent input: {rendered}"
+    );
+}
+
+#[test]
+fn subagent_tool_inputs_never_become_channel_visible_descriptions() {
+    let secret = "hvs.CAES.private-token";
+    let endpoint = "https://vault-prod.internal.example";
+
+    for (index, name, input) in [
+        (
+            0_u64,
+            "Task",
+            json!({"prompt": format!("inspect {secret} at {endpoint}")}),
+        ),
+        (
+            1,
+            "Agent",
+            json!({"request": format!("inspect {secret} at {endpoint}")}),
+        ),
+        (
+            2,
+            "SpawnAgent",
+            json!({
+                "credentials": {"token": secret},
+                "endpoint": endpoint
+            }),
+        ),
+    ] {
+        let events = PlaceholderLiveEvents::default();
+        let channel_id = ChannelId::new(4_892_310 + index);
+        events.push_status_events(
+            channel_id,
+            status_events_from_tool_use(name, &input.to_string()),
+        );
+
+        let status_entry = events
+            .status_by_channel
+            .get(&channel_id)
+            .expect("status panel state");
+        let guard = status_entry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(
+            guard
+                .last_tool
+                .as_ref()
+                .and_then(|tool| tool.summary.as_deref()),
+            None,
+            "subagent tool input must not be retained as args_summary for {name}"
+        );
+        assert_eq!(
+            guard.subagents.first().map(|slot| slot.desc.as_str()),
+            Some("subagent"),
+            "non-allowlisted subagent input must not become a slot description for {name}"
+        );
+        drop(guard);
+        drop(status_entry);
+
+        let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+        assert!(
+            !rendered.contains(secret) && !rendered.contains(endpoint),
+            "subagent tool input must not reach status descriptions for {name}: {rendered}"
+        );
+        assert!(
+            !rendered.contains("credentials") && !rendered.contains("private-token"),
+            "subagent input structure must not reach status descriptions for {name}: {rendered}"
+        );
+    }
+}
+
+#[test]
 fn status_events_from_json_keeps_tool_result_visibility() {
     let events = status_events_from_json(&json!({
         "type": "user",

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -4146,11 +4146,13 @@ fn status_panel_shows_live_subagent_activity_by_parent_id() {
         !rendered.contains("grep ERROR app.log"),
         "subagent activity must not leak raw command args, got: {rendered}"
     );
-    // Nested activity must not replace the top-level Task launch remembered by
-    // the panel header; the nested Bash step belongs only to the subagent slot.
     assert!(
-        rendered.contains("🔧 마지막 도구 ([Task] · [general-purpose] Audit logs)"),
-        "top-level Task launch must remain the panel's latest tool, got: {rendered}"
+        rendered.contains("🧵 subagent 실행 중 (Audit logs)"),
+        "subagent wait state must retain its specific header, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("🔧 마지막 도구"),
+        "subagent wait state must not collapse into the latest-tool header: {rendered}"
     );
 }
 
@@ -6314,7 +6316,7 @@ fn status_panel_renders_plan_but_hides_subagents_for_codex() {
     assert!(!rendered.contains("Subagents"));
     assert!(
         rendered.contains("🔧 마지막 도구 ([Task] · Hidden subagent)"),
-        "Codex must omit the subagent section while retaining the latest tool header: {rendered}"
+        "Codex's hidden-subagent header projection must retain the latest tool: {rendered}"
     );
 }
 

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -261,8 +261,8 @@ fn status_panel_renders_derived_tool_state_under_limit() {
     assert!(rendered.contains("마지막 도구"));
     assert!(rendered.contains("[Bash]"));
     assert!(
-        rendered.contains("cargo test"),
-        "status header should show the latest tool's short target: {rendered}"
+        !rendered.contains("cargo test"),
+        "status header should show the tool class, not raw command text: {rendered}"
     );
     assert!(!rendered.contains("진행 중"));
     assert!(rendered.chars().count() <= STATUS_PANEL_MAX_CHARS);
@@ -282,13 +282,14 @@ fn status_panel_recent_compacts_raw_command_details() {
 
     let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
     // #3983 item 5a: the footer no longer echoes the compact 🖥️ Recent block;
-    // #4892 instead exposes the formatter's bounded target as the latest tool.
+    // #4892 shows only the tool class and keeps arguments on explicit debug surfaces.
     assert!(rendered.contains("🔧 마지막 도구"));
     assert!(!rendered.contains("🖥️ Recent"));
     assert!(!rendered.contains("```text"));
     assert!(
-        rendered.contains(r"cargo test --lib placeholder\_live\_events -- --nocapture"),
-        "normal status panel must render the escaped latest-tool target: {rendered}"
+        !rendered.contains(raw_command)
+            && !rendered.contains(r"cargo test --lib placeholder\_live\_events -- --nocapture"),
+        "normal status panel must not render raw command detail: {rendered}"
     );
 
     let raw_debug_block = events.render_raw_block_for_tests(channel_id).unwrap();
@@ -312,7 +313,8 @@ fn characterize_rollover_seed_has_no_status_panel_content_s0() {
     let panel = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
     assert!(panel.contains("마지막 도구"));
     assert!(panel.contains("[Bash]"));
-    assert!(panel.contains(r"cargo test --lib placeholder\_live\_events"));
+    assert!(!panel.contains("cargo test --lib placeholder_live_events"));
+    assert!(!panel.contains(r"cargo test --lib placeholder\_live\_events"));
 
     let status_block = build_processing_status_block("⠸");
     let current_portion = "relay body ".repeat(250);
@@ -3813,11 +3815,11 @@ fn background_bash_command_only_slot_hides_raw_command_3806() {
     );
     assert!(
         rendered.contains("🔧 마지막 도구 ([Bash]"),
-        "background Bash launch must remain visible as the latest tool: {rendered}"
+        "background Bash class must remain visible as the latest tool: {rendered}"
     );
     assert!(
-        rendered.contains("codex exec --skip-git-repo-check -m gpt-5.5"),
-        "the latest-tool header must reuse the bounded formatter summary: {rendered}"
+        !rendered.contains(raw_command),
+        "background Bash slot must not leak raw command detail: {rendered}"
     );
 }
 
@@ -6315,8 +6317,12 @@ fn status_panel_renders_plan_but_hides_subagents_for_codex() {
     assert!(rendered.contains("Hidden for Codex"));
     assert!(!rendered.contains("Subagents"));
     assert!(
-        rendered.contains("🔧 마지막 도구 ([Task] · Hidden subagent)"),
-        "Codex's hidden-subagent header projection must retain the latest tool: {rendered}"
+        !rendered.contains("Hidden subagent"),
+        "Codex's hidden-subagent projection must suppress header detail too: {rendered}"
+    );
+    assert!(
+        !rendered.contains("[Task]"),
+        "Codex's hidden-subagent projection must not reintroduce the Task class: {rendered}"
     );
 }
 

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -312,7 +312,7 @@ fn characterize_rollover_seed_has_no_status_panel_content_s0() {
     let panel = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
     assert!(panel.contains("마지막 도구"));
     assert!(panel.contains("[Bash]"));
-    assert!(panel.contains("cargo test --lib placeholder\_live\_events"));
+    assert!(panel.contains(r"cargo test --lib placeholder\_live\_events"));
 
     let status_block = build_processing_status_block("⠸");
     let current_portion = "relay body ".repeat(250);

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -845,6 +845,7 @@ fn is_panel_activity_status_label(status: &str) -> bool {
         "진행 중" | "monitor 대기" | "완료" | "백그라운드 완료" | "scheduled wakeup"
     ) || status.starts_with("응답 지연")
         || parenthesized_status_label(status, "scheduled wakeup")
+        || parenthesized_status_label(status, "마지막 도구")
         || parenthesized_status_label(status, "도구 실행 중")
         || parenthesized_status_label(status, "subagent 실행 중")
         || parenthesized_status_label(status, "workflow 실행 중")
@@ -1009,6 +1010,18 @@ mod tests {
         assert!(!footer_header(&block).contains('🟢'));
         assert!(!block.contains("계속 처리 중"));
         assert!(block.contains("\n\n-# Subagents\n-# └ review inspect"));
+    }
+
+    #[test]
+    fn latest_tool_footer_header_is_recognized_after_spinner_merge() {
+        let panel = "🔧 마지막 도구 ([Read] · src/lib.rs)\n턴 시작 : 07-25 09:00:00";
+        let block = super::compose_footer_status_block("⠸", panel);
+
+        assert_eq!(
+            footer_header(&block),
+            "-# ⠸ 마지막 도구 ([Read] · src/lib.rs)"
+        );
+        assert!(super::is_merged_footer_status_line(footer_header(&block)));
     }
 
     #[test]

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -162,6 +162,14 @@ class FastCheckCiWiringTests(unittest.TestCase):
         )
         self.assertEqual(workflow.count(command), 2)
 
+    def test_macos_pr_lane_runs_placeholder_live_events_tests(self) -> None:
+        workflow = MACOS_TRUSTED_WORKFLOW.read_text(encoding="utf-8")
+        command = (
+            "env -u AGENTDESK_ROOT_DIR cargo test --lib "
+            "placeholder_live_events -- --skip _pg --skip pg_ --skip postgres"
+        )
+        self.assertEqual(workflow.count(command), 2)
+
     def test_main_and_nightly_retain_non_pg_test_coverage(self) -> None:
         justfile = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
         self.assertIn("check: fmt-check lint cargo-check test", justfile)

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -36,6 +36,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib status_panel_singleton_store -- --skip _pg --skip pg_ --skip postgres",
+    "env -u AGENTDESK_ROOT_DIR cargo test --lib placeholder_live_events -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib services::discord::outbound::serenity_reference::tests::lifecycle_notice_nonce_is_stable_and_semantic_event_scoped -- --exact",
     "cargo test --lib services::discord::outbound::delivery::tests::v3_referenced_send_preserves_reference_and_dedupes -- --exact",
     "cargo test --lib cli::args::tests::legacy_queue_help_directs_users_to_query_without_changing_compatibility_contract",

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -11,6 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PR_WORKFLOW = REPO_ROOT / ".github/workflows/ci-pr.yml"
 MAIN_WORKFLOW = REPO_ROOT / ".github/workflows/ci-main.yml"
 NIGHTLY_WORKFLOW = REPO_ROOT / ".github/workflows/ci-nightly.yml"
+MACOS_TRUSTED_WORKFLOW = REPO_ROOT / ".github/workflows/ci-macos-trusted.yml"
 
 # This manifest is intentionally exact: changing the retained test recipe must also
 # update this test deliberately. The duplication is a drift-prevention gate, not an
@@ -37,6 +38,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib status_panel_singleton_store -- --skip _pg --skip pg_ --skip postgres",
     "env -u AGENTDESK_ROOT_DIR cargo test --lib placeholder_live_events -- --skip _pg --skip pg_ --skip postgres",
+    "env -u AGENTDESK_ROOT_DIR cargo test --lib single_message_panel::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib services::discord::outbound::serenity_reference::tests::lifecycle_notice_nonce_is_stable_and_semantic_event_scoped -- --exact",
     "cargo test --lib services::discord::outbound::delivery::tests::v3_referenced_send_preserves_reference_and_dedupes -- --exact",
     "cargo test --lib cli::args::tests::legacy_queue_help_directs_users_to_query_without_changing_compatibility_contract",
@@ -151,6 +153,14 @@ class FastCheckCiWiringTests(unittest.TestCase):
         self.assertNotRegex(job, r"(?m)^\s*cargo test\b")
         self.assertNotIn("- name: cargo test", job)
         self.assertNotIn("Discord thread-create cross-process lock", job)
+
+    def test_macos_pr_lane_runs_single_message_panel_tests(self) -> None:
+        workflow = MACOS_TRUSTED_WORKFLOW.read_text(encoding="utf-8")
+        command = (
+            "env -u AGENTDESK_ROOT_DIR cargo test --lib "
+            "single_message_panel::tests -- --skip _pg --skip pg_ --skip postgres"
+        )
+        self.assertEqual(workflow.count(command), 2)
 
     def test_main_and_nightly_retain_non_pg_test_coverage(self) -> None:
         justfile = (REPO_ROOT / "justfile").read_text(encoding="utf-8")


### PR DESCRIPTION
## 요약

- 상단 edit-in-place 스피너와 하단 상태 패널의 중복된 `진행 중` 라벨을 제거했습니다.
- `Running` / `ToolRunning`은 `🔧 마지막 도구 ([도구 클래스])`만 렌더하고, 아직 관측된 도구가 없으면 `🔧 마지막 도구 (아직 없음)`을 표시합니다.
- 프라이버시 후속 수정에서 Bash 명령, URL, MCP JSON, 비-JSON payload 등 모든 원시 도구 입력을 이 채널 표면에서 제거했습니다. 상세는 기본 숨김이며 새 도구도 class-only로 fail closed 합니다.
- `MonitorWait`, `ScheduleWakeup`, `SubagentRunning`, `WorkflowRunning`은 기존 고유 라벨을 유지합니다.
- 완료 렌더 경로의 `✅ 완료` / `✅ 백그라운드 완료`도 그대로 유지했습니다.

## 데이터 소스

추측 데이터를 새로 만들지 않고 기존 관측 경로를 재사용합니다.

- `placeholder_live_events/status_events.rs`: `format_tool_input(name, input)` 결과로 `StatusEvent::ToolStart { name, args_summary }`를 생성합니다.
- `placeholder_live_events/status_panel.rs`: `StatusPanelState.last_tool`에 최근 도구를 추적하지만, 렌더 시 raw `args_summary`는 전달하지 않습니다.
- `placeholder_live_events/freshness.rs`: `Running`/`ToolRunning`에서 allowlisted/sanitized 도구 클래스만 렌더합니다.

## 설계 판정

대기 상태 4종은 최근 도구 표시로 붕괴시키지 않고 기존 라벨을 보존하기로 결정했습니다.

- 상단 스피너는 단지 작업 중임을 나타내며 대기 종류를 구분하지 않습니다.
- 하단의 `monitor 대기`, scheduled wakeup ETA, subagent 설명, workflow 라벨은 상단에 없는 고유 정보입니다.
- 따라서 중복 제거 대상은 `Running`/`ToolRunning`의 일반 진행 표현뿐이며, 대기 라벨까지 제거하면 순수 정보 손실입니다.


## 프라이버시 후속 판정

- 선택지 (a): 상세를 렌더하지 않고 도구 클래스만 표시합니다.
- 근거: 기존 계약을 가장 작게 복원하면서 중복 `진행 중` 제거와 최근 도구 종류 표시는 유지합니다. 부분 redaction은 DB URL, signed internal URL, vault JSON, 비-JSON payload를 완전하게 보장하지 못합니다.
- Codex의 #4367 subagent projection에서는 `last_tool`도 함께 억제해 `Task` 클래스나 설명이 우회 재주입되지 않게 했습니다.
- `마지막 도구`는 병렬 실행 완료 순서가 아니라 가장 최근 도착한 `ToolStart`를 의미하는 last-write-wins 특성화입니다.

## 테스트와 CI 배선

- 대기 상태 4종이 각각 고유 라벨을 유지하는 회귀 테스트를 추가했습니다.
- `Running`/`ToolRunning` 최근 도구 렌더와 도구 미관측 fallback을 고정했습니다.
- 대기 분기를 제거해 전부 최근 도구로 붕괴시키는 mutation에서 테스트 자체 assert 5건이 실패함을 확인했습니다.
- `justfile`의 retained non-PG `placeholder_live_events` 필터가 위 신규 테스트를 이름 단위로 실제 선택함을 확인했습니다(237 tests, 프라이버시 신규 3개 포함).
- 해당 필터로 커버된 기존 baseline 6개를 제거하고 잠금 수를 693에서 686으로 낮췄습니다. 신규 uncovered 항목은 없습니다.

## 게이트

build token을 블로킹 획득해 Cargo 게이트를 직렬 실행했습니다.

- `cargo fmt --all` / `cargo fmt --all --check`: rc=0
- `cargo check --lib`: rc=0
- `env -u AGENTDESK_ROOT_DIR cargo test --lib placeholder_live_events`: rc=0 (237 passed)
- `env -u AGENTDESK_ROOT_DIR cargo test --lib status_panel`: rc=0 (226 passed)
- `env -u AGENTDESK_ROOT_DIR cargo test --lib placeholder_live_events::freshness::tests`: rc=0 (13 passed)
- `env -u AGENTDESK_ROOT_DIR cargo test --lib single_message_panel::tests`: rc=0 (72 passed)
- `env -u AGENTDESK_ROOT_DIR cargo test --lib formatting::status_panel_v2_formatter_tests`: rc=0 (56 passed)
- `python3 scripts/generate_inventory_docs.py`: rc=0
- `python3 scripts/check_agent_maintenance_docs.py`: rc=0
- `python3 -m unittest tests.test_fast_check_ci_wiring`: rc=0
- `python3 scripts/check_test_lane_coverage.py`: rc=0 (686 baseline exact match)

Closes #4892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

