### PR TITLE
fix(#4910): make test-lane baseline ratchet semantic

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -252,8 +252,8 @@ jobs:
       - name: Run script checks
         run: ./scripts/ci-script-checks.sh
         env:
-          # Compare the checked-out main snapshot with the immutable state
-          # before this push, including every commit in a multi-commit push.
+          # The non-cancelling test-lane-baseline-main workflow is authoritative
+          # across adjacent pushes; this aggregate lane keeps equivalent coverage.
           TEST_LANE_BASELINE_REF: ${{ github.event.before }}
 
       - name: Upload maintainability audit artifact

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -251,6 +251,10 @@ jobs:
 
       - name: Run script checks
         run: ./scripts/ci-script-checks.sh
+        env:
+          # Compare the checked-out main snapshot with the immutable state
+          # before this push, including every commit in a multi-commit push.
+          TEST_LANE_BASELINE_REF: ${{ github.event.before }}
 
       - name: Upload maintainability audit artifact
         if: always()

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -12,6 +12,11 @@ on:
   # covered by ci-main.yml.
   pull_request:
   workflow_dispatch:
+    inputs:
+      test_lane_baseline_ref:
+        description: Immutable commit SHA used by the test-lane baseline ratchet
+        required: true
+        type: string
 
 concurrency:
   # A PR number is unique inside the base repository, unlike `head_ref`: two
@@ -784,9 +789,9 @@ jobs:
       - name: Run script checks
         run: ./scripts/ci-script-checks.sh
         env:
-          # pull_request checkouts are candidate merge commits. Their first
-          # parent is the exact base snapshot used to build this candidate.
-          TEST_LANE_BASELINE_REF: ${{ github.event_name == 'pull_request' && 'HEAD^1' || 'HEAD' }}
+          # PR checkouts use the candidate merge's exact first parent. Manual
+          # runs must supply an immutable comparison SHA; omission fails closed.
+          TEST_LANE_BASELINE_REF: ${{ github.event_name == 'pull_request' && 'HEAD^1' || inputs.test_lane_baseline_ref }}
 
       # Keep high-value relay ratchets as explicit named steps as well as in the
       # aggregate script suite so their failure surface is immediately visible.

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -783,6 +783,10 @@ jobs:
 
       - name: Run script checks
         run: ./scripts/ci-script-checks.sh
+        env:
+          # pull_request checkouts are candidate merge commits. Their first
+          # parent is the exact base snapshot used to build this candidate.
+          TEST_LANE_BASELINE_REF: ${{ github.event_name == 'pull_request' && 'HEAD^1' || 'HEAD' }}
 
       # Keep high-value relay ratchets as explicit named steps as well as in the
       # aggregate script suite so their failure surface is immediately visible.

--- a/.github/workflows/test-lane-baseline-main.yml
+++ b/.github/workflows/test-lane-baseline-main.yml
@@ -1,0 +1,30 @@
+name: Test-lane baseline main guard
+
+on:
+  push:
+    branches:
+      - main
+
+# This guard must inspect every main push. If P1 introduced debt and its run were
+# cancelled by P2, comparing P2 only with P1 would make that debt authoritative.
+concurrency:
+  group: test-lane-baseline-main-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test-lane-baseline:
+    name: Test-lane baseline monotonicity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compare with the immutable pre-push snapshot
+        env:
+          TEST_LANE_BASELINE_REF: ${{ github.event.before }}
+        run: python3 scripts/check_test_lane_coverage.py --baseline-ref "$TEST_LANE_BASELINE_REF"

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -60,6 +60,14 @@ unless document["concurrency"] == expected_concurrency
   exit 1
 end
 
+manual_inputs = document.dig(true, "workflow_dispatch", "inputs")
+manual_inputs ||= document.dig("on", "workflow_dispatch", "inputs")
+baseline_input = manual_inputs.is_a?(Hash) ? manual_inputs["test_lane_baseline_ref"] : nil
+unless baseline_input.is_a?(Hash) && baseline_input["required"] == true && baseline_input["type"] == "string"
+  warn "#{path}: workflow_dispatch must require an immutable test-lane baseline ref"
+  exit 1
+end
+
 targets = {
   "check_fast_cross_os" => {
     "label" => "cross-OS job",

--- a/scripts/check_test_lane_coverage.py
+++ b/scripts/check_test_lane_coverage.py
@@ -26,7 +26,6 @@ from typing import Iterable
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BASELINE_REL = Path("scripts/test_lane_coverage_baseline.txt")
-DEFAULT_BASELINE_REF = "HEAD"
 
 # Attributes do not contain a closing square bracket in the forms used by this
 # repository. Strings and comments are blanked without changing offsets, so the
@@ -664,7 +663,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
     parser.add_argument("--baseline", type=Path, default=None)
-    parser.add_argument("--baseline-ref", default=DEFAULT_BASELINE_REF)
+    parser.add_argument("--baseline-ref", required=True)
     args = parser.parse_args(argv)
     repo_root = args.repo_root.resolve()
     baseline = args.baseline.resolve() if args.baseline else repo_root / BASELINE_REL

--- a/scripts/check_test_lane_coverage.py
+++ b/scripts/check_test_lane_coverage.py
@@ -7,10 +7,10 @@ filters instead of running every library test. This source-only guard finds
 (including ``#[path = "..."]`` aliases), and compares them with each curated
 ``cargo test`` command's positive and ``--skip`` filters.
 
-The existing uncovered set is locked twice: its sorted names live in the
-baseline file and its entry count lives in this script. Any new module, stale
-entry, or baseline growth fails. Reducing debt therefore requires an explicit,
-reviewable edit to both locks.
+The existing uncovered set is recorded as sorted names in the baseline file.
+The checked-out candidate baseline must be a subset of an immutable reference
+snapshot, and any newly uncovered module or stale entry also fails. Baseline
+debt can therefore only shrink without a redundant scalar lock.
 """
 
 from __future__ import annotations
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import re
 import shlex
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -25,7 +26,7 @@ from typing import Iterable
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BASELINE_REL = Path("scripts/test_lane_coverage_baseline.txt")
-BASELINE_ENTRY_COUNT = 686
+DEFAULT_BASELINE_REF = "HEAD"
 
 # Attributes do not contain a closing square bracket in the forms used by this
 # repository. Strings and comments are blanked without changing offsets, so the
@@ -528,25 +529,81 @@ def uncovered_modules(
     }
 
 
-def load_baseline(path: Path) -> set[str]:
-    """Read the sorted one-module-per-line debt baseline."""
+def parse_baseline(text: str, source: str) -> set[str]:
+    """Parse a sorted one-module-per-line debt baseline."""
     entries = [
         line.strip()
-        for line in path.read_text(encoding="utf-8").splitlines()
+        for line in text.splitlines()
         if line.strip() and not line.lstrip().startswith("#")
     ]
     if entries != sorted(entries):
-        raise ValueError(f"baseline entries must be sorted: {path}")
+        raise ValueError(f"baseline entries must be sorted: {source}")
     if len(entries) != len(set(entries)):
-        raise ValueError(f"baseline contains duplicate entries: {path}")
+        raise ValueError(f"baseline contains duplicate entries: {source}")
     return set(entries)
+
+
+def load_baseline(path: Path) -> set[str]:
+    """Read the working-tree debt baseline."""
+    return parse_baseline(path.read_text(encoding="utf-8"), str(path))
+
+
+def resolve_commit(repo_root: Path, ref: str) -> str:
+    """Resolve a baseline reference once to an immutable commit object."""
+    if not ref or set(ref) == {"0"}:
+        raise ValueError(f"invalid baseline reference: {ref or '<empty>'}")
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        raise ValueError(
+            f"cannot resolve baseline reference {ref!r}: {detail.strip()}"
+        ) from exc
+    sha = result.stdout.strip()
+    if not re.fullmatch(r"[0-9a-fA-F]{40,64}", sha):
+        raise ValueError(f"git returned an invalid commit id for {ref!r}: {sha!r}")
+    return sha
+
+
+def load_baseline_from_git(repo_root: Path, ref: str) -> tuple[str, set[str]]:
+    """Read the baseline blob from one immutable commit snapshot."""
+    sha = resolve_commit(repo_root, ref)
+    source = f"{sha}:{BASELINE_REL.as_posix()}"
+    try:
+        result = subprocess.run(
+            ["git", "show", source],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        raise ValueError(
+            f"cannot read reference baseline {source}: {detail.strip()}"
+        ) from exc
+    return sha, parse_baseline(result.stdout, source)
+
+
+def baseline_growth(
+    baseline: set[str], reference_baseline: set[str]
+) -> list[str]:
+    """Return candidate entries absent from the immutable reference."""
+    return sorted(baseline - reference_baseline)
 
 
 def check(
     repo_root: Path,
     baseline_path: Path,
-    expected_baseline_count: int = BASELINE_ENTRY_COUNT,
+    reference_baseline: set[str],
     *,
+    reference_label: str = "reference snapshot",
     emit_success: bool = True,
 ) -> int:
     inventory = discover_test_inventory(repo_root)
@@ -554,16 +611,18 @@ def check(
     current = uncovered_modules(inventory, lanes)
     baseline = load_baseline(baseline_path)
 
-    if len(baseline) != expected_baseline_count:
-        direction = "growth" if len(baseline) > expected_baseline_count else "shrinkage"
+    growth = baseline_growth(baseline, reference_baseline)
+    if growth:
         print(
-            f"FAIL: baseline {direction}: {len(baseline)} entries, but the locked "
-            f"count is {expected_baseline_count}.",
+            f"FAIL: baseline growth forbidden: {len(growth)} entr"
+            f"{'y' if len(growth) == 1 else 'ies'} absent from {reference_label}.",
             file=sys.stderr,
         )
+        for module in growth:
+            print(f"  + {module}", file=sys.stderr)
         print(
-            "Update BASELINE_ENTRY_COUNT only when review intentionally accepts a "
-            "smaller corrected debt set; baseline growth is forbidden.",
+            "Remove '+' entries; the candidate baseline may only preserve or "
+            "remove debt from its immutable reference snapshot.",
             file=sys.stderr,
         )
         return 1
@@ -574,7 +633,7 @@ def check(
         print(
             f"FAIL: coverage baseline drift: {len(new)} newly uncovered, "
             f"{len(stale)} stale/covered, {len(current)} currently uncovered "
-            f"(locked baseline {len(baseline)}).",
+            f"(candidate baseline {len(baseline)}).",
             file=sys.stderr,
         )
         for module in new:
@@ -582,17 +641,20 @@ def check(
         for module in stale:
             print(f"  - {module}", file=sys.stderr)
         print(
-            "Add broad module coverage for '+' entries. Remove '-' entries and "
-            "lower BASELINE_ENTRY_COUNT to lock in debt reduction.",
+            "Add broad module coverage for '+' entries. Remove '-' entries to "
+            "lock in debt reduction.",
             file=sys.stderr,
         )
         return 1
 
     if emit_success:
+        removed = len(reference_baseline - baseline)
         print(
             f"OK: {len(inventory)} logical Rust cfg(test) modules and "
             f"{sum(map(len, inventory.values()))} test function(s) inventoried; "
-            f"{len(current)} uncovered module(s) exactly match the locked baseline; "
+            f"{len(current)} uncovered module(s) exactly match the candidate "
+            f"baseline, which removed {removed} debt entr"
+            f"{'y' if removed == 1 else 'ies'} from {reference_label}; "
             f"{len(lanes)} curated cargo-test invocation(s)."
         )
     return 0
@@ -602,11 +664,20 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
     parser.add_argument("--baseline", type=Path, default=None)
+    parser.add_argument("--baseline-ref", default=DEFAULT_BASELINE_REF)
     args = parser.parse_args(argv)
     repo_root = args.repo_root.resolve()
     baseline = args.baseline.resolve() if args.baseline else repo_root / BASELINE_REL
     try:
-        return check(repo_root, baseline)
+        reference_sha, reference_baseline = load_baseline_from_git(
+            repo_root, args.baseline_ref
+        )
+        return check(
+            repo_root,
+            baseline,
+            reference_baseline,
+            reference_label=f"commit {reference_sha}",
+        )
     except (OSError, ValueError) as exc:
         print(f"FAIL: {exc}", file=sys.stderr)
         return 2

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -115,7 +115,11 @@ echo "=== Fast compile check PR/main/nightly split contract (#4747) ==="
 "$PYTHON" -m unittest tests.test_fast_check_ci_wiring
 
 echo "=== Rust test-lane coverage ratchet (#4846/#4910) ==="
-"$PYTHON" scripts/check_test_lane_coverage.py --baseline-ref "${TEST_LANE_BASELINE_REF:-HEAD}"
+if [[ -z "${TEST_LANE_BASELINE_REF:-}" ]]; then
+  echo "ERROR: TEST_LANE_BASELINE_REF must name an immutable comparison snapshot" >&2
+  exit 1
+fi
+"$PYTHON" scripts/check_test_lane_coverage.py --baseline-ref "$TEST_LANE_BASELINE_REF"
 "$PYTHON" -m unittest tests.test_test_lane_coverage
 
 echo "=== Scheduled-message PG path-filter wiring contract ==="

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -114,8 +114,8 @@ echo "=== Relay recovery targeted-lane wiring contract (#4423) ==="
 echo "=== Fast compile check PR/main/nightly split contract (#4747) ==="
 "$PYTHON" -m unittest tests.test_fast_check_ci_wiring
 
-echo "=== Rust test-lane coverage ratchet (#4846) ==="
-"$PYTHON" scripts/check_test_lane_coverage.py
+echo "=== Rust test-lane coverage ratchet (#4846/#4910) ==="
+"$PYTHON" scripts/check_test_lane_coverage.py --baseline-ref "${TEST_LANE_BASELINE_REF:-HEAD}"
 "$PYTHON" -m unittest tests.test_test_lane_coverage
 
 echo "=== Scheduled-message PG path-filter wiring contract ==="

--- a/scripts/test_lane_coverage_baseline.txt
+++ b/scripts/test_lane_coverage_baseline.txt
@@ -1,6 +1,6 @@
 # Existing logical Rust cfg(test) modules not fully selected by test-non-pg or
-# PR-targeted cargo-test invocations. Keep sorted and exactly synchronized with
-# BASELINE_ENTRY_COUNT in check_test_lane_coverage.py. Entries may only shrink.
+# PR-targeted cargo-test invocations. Keep sorted. A candidate baseline must be
+# a subset of its immutable comparison snapshot, so entries may only shrink.
 api_caller_observability::tests
 cli::args::tests
 cli::client::activity_tests

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -196,6 +196,23 @@ class FastCheckCiWiringTests(unittest.TestCase):
             job_block(nightly, "full_windows"),
         )
 
+    def test_test_lane_baseline_uses_candidate_snapshot_refs(self) -> None:
+        pr_job = job_block(PR_WORKFLOW.read_text(encoding="utf-8"), "scripts")
+        main_job = job_block(MAIN_WORKFLOW.read_text(encoding="utf-8"), "scripts")
+
+        for job in (pr_job, main_job):
+            self.assertIn("fetch-depth: 0", job)
+            self.assertNotIn("origin/main", job)
+            self.assertNotIn("github.event.pull_request.base.sha", job)
+        self.assertIn(
+            "TEST_LANE_BASELINE_REF: ${{ github.event_name == 'pull_request' "
+            "&& 'HEAD^1' || 'HEAD' }}",
+            pr_job,
+        )
+        self.assertIn(
+            "TEST_LANE_BASELINE_REF: ${{ github.event.before }}", main_job
+        )
+
     def test_ci_script_checks_runs_this_contract(self) -> None:
         script = (REPO_ROOT / "scripts/ci-script-checks.sh").read_text(
             encoding="utf-8"
@@ -203,7 +220,10 @@ class FastCheckCiWiringTests(unittest.TestCase):
         self.assertIn(
             '"$PYTHON" -m unittest tests.test_fast_check_ci_wiring', script
         )
-        self.assertIn('"$PYTHON" scripts/check_test_lane_coverage.py', script)
+        self.assertIn(
+            'scripts/check_test_lane_coverage.py --baseline-ref "${TEST_LANE_BASELINE_REF:-HEAD}"',
+            script,
+        )
         self.assertIn(
             '"$PYTHON" -m unittest tests.test_test_lane_coverage', script
         )

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -12,6 +12,9 @@ PR_WORKFLOW = REPO_ROOT / ".github/workflows/ci-pr.yml"
 MAIN_WORKFLOW = REPO_ROOT / ".github/workflows/ci-main.yml"
 NIGHTLY_WORKFLOW = REPO_ROOT / ".github/workflows/ci-nightly.yml"
 MACOS_TRUSTED_WORKFLOW = REPO_ROOT / ".github/workflows/ci-macos-trusted.yml"
+TEST_LANE_MAIN_WORKFLOW = (
+    REPO_ROOT / ".github/workflows/test-lane-baseline-main.yml"
+)
 
 # This manifest is intentionally exact: changing the retained test recipe must also
 # update this test deliberately. The duplication is a drift-prevention gate, not an
@@ -197,20 +200,41 @@ class FastCheckCiWiringTests(unittest.TestCase):
         )
 
     def test_test_lane_baseline_uses_candidate_snapshot_refs(self) -> None:
-        pr_job = job_block(PR_WORKFLOW.read_text(encoding="utf-8"), "scripts")
-        main_job = job_block(MAIN_WORKFLOW.read_text(encoding="utf-8"), "scripts")
+        pr_workflow = PR_WORKFLOW.read_text(encoding="utf-8")
+        main_workflow = MAIN_WORKFLOW.read_text(encoding="utf-8")
+        pr_job = job_block(pr_workflow, "scripts")
+        main_job = job_block(main_workflow, "scripts")
 
         for job in (pr_job, main_job):
             self.assertIn("fetch-depth: 0", job)
             self.assertNotIn("origin/main", job)
             self.assertNotIn("github.event.pull_request.base.sha", job)
+        self.assertIn("workflow_dispatch:", pr_workflow)
+        self.assertIn("test_lane_baseline_ref:", pr_workflow)
+        self.assertIn("required: true", pr_workflow)
         self.assertIn(
             "TEST_LANE_BASELINE_REF: ${{ github.event_name == 'pull_request' "
-            "&& 'HEAD^1' || 'HEAD' }}",
+            "&& 'HEAD^1' || inputs.test_lane_baseline_ref }}",
             pr_job,
         )
+        self.assertNotIn("|| 'HEAD'", pr_job)
         self.assertIn(
             "TEST_LANE_BASELINE_REF: ${{ github.event.before }}", main_job
+        )
+
+    def test_cancelled_adjacent_main_pushes_cannot_skip_baseline_guard(self) -> None:
+        workflow = TEST_LANE_MAIN_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("name: Test-lane baseline main guard", workflow)
+        self.assertIn("group: test-lane-baseline-main-${{ github.ref }}", workflow)
+        self.assertIn("cancel-in-progress: false", workflow)
+        self.assertNotIn("cancel-in-progress: true", workflow)
+        self.assertIn("fetch-depth: 0", workflow)
+        self.assertIn(
+            "TEST_LANE_BASELINE_REF: ${{ github.event.before }}", workflow
+        )
+        self.assertIn(
+            'scripts/check_test_lane_coverage.py --baseline-ref "$TEST_LANE_BASELINE_REF"',
+            workflow,
         )
 
     def test_ci_script_checks_runs_this_contract(self) -> None:
@@ -221,9 +245,10 @@ class FastCheckCiWiringTests(unittest.TestCase):
             '"$PYTHON" -m unittest tests.test_fast_check_ci_wiring', script
         )
         self.assertIn(
-            'scripts/check_test_lane_coverage.py --baseline-ref "${TEST_LANE_BASELINE_REF:-HEAD}"',
+            'scripts/check_test_lane_coverage.py --baseline-ref "$TEST_LANE_BASELINE_REF"',
             script,
         )
+        self.assertNotIn("TEST_LANE_BASELINE_REF:-HEAD", script)
         self.assertIn(
             '"$PYTHON" -m unittest tests.test_test_lane_coverage', script
         )

--- a/tests/test_test_lane_coverage.py
+++ b/tests/test_test_lane_coverage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import io
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -231,14 +232,21 @@ class RatchetTests(unittest.TestCase):
         )
 
     def run_check(
-        self, root: Path, baseline_entries: str, expected_count: int
+        self,
+        root: Path,
+        baseline_entries: str,
+        reference_entries: set[str],
     ) -> tuple[int, str]:
         baseline = root / "scripts/test_lane_coverage_baseline.txt"
         baseline.write_text(baseline_entries, encoding="utf-8")
         stderr = io.StringIO()
         with contextlib.redirect_stderr(stderr):
             result = coverage.check(
-                root, baseline, expected_count, emit_success=False
+                root,
+                baseline,
+                reference_entries,
+                reference_label="fixture base",
+                emit_success=False,
             )
         return result, stderr.getvalue()
 
@@ -246,7 +254,7 @@ class RatchetTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             self.make_repo(root, "new_tests")
-            result, stderr = self.run_check(root, "", 0)
+            result, stderr = self.run_check(root, "", set())
             self.assertEqual(result, 1)
             self.assertIn("+ new_tests", stderr)
 
@@ -254,15 +262,30 @@ class RatchetTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             self.make_repo(root, "new_tests")
-            result, stderr = self.run_check(root, "new_tests\n", 0)
+            result, stderr = self.run_check(root, "new_tests\n", set())
             self.assertEqual(result, 1)
-            self.assertIn("baseline growth", stderr)
+            self.assertIn("baseline growth forbidden", stderr)
+            self.assertIn("+ new_tests", stderr)
+
+    def test_parallel_disjoint_removals_compose_without_conflict(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            self.make_repo(root, "legacy_c")
+            result, stderr = self.run_check(
+                root,
+                "legacy_c\n",
+                {"legacy_a", "legacy_c"},
+            )
+            self.assertEqual(result, 0)
+            self.assertEqual(stderr, "")
 
     def test_stale_baseline_entry_fails(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             self.make_repo(root, "covered_tests")
-            result, stderr = self.run_check(root, "covered_tests\n", 1)
+            result, stderr = self.run_check(
+                root, "covered_tests\n", {"covered_tests"}
+            )
             self.assertEqual(result, 1)
             self.assertIn("1 stale/covered", stderr)
             self.assertIn("- covered_tests", stderr)
@@ -271,7 +294,9 @@ class RatchetTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             self.make_repo(root, "legacy_tests")
-            result, stderr = self.run_check(root, "legacy_tests\n", 1)
+            result, stderr = self.run_check(
+                root, "legacy_tests\n", {"legacy_tests"}
+            )
             self.assertEqual(result, 0)
             self.assertEqual(stderr, "")
 
@@ -286,15 +311,235 @@ class RatchetTests(unittest.TestCase):
             baseline,
         )
 
-    def test_repository_baseline_count_matches_locked_constant(self) -> None:
-        baseline = coverage.load_baseline(REPO_ROOT / coverage.BASELINE_REL)
-        self.assertEqual(len(baseline), coverage.BASELINE_ENTRY_COUNT)
+    def test_candidate_merge_first_parent_composes_parallel_removals(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            self.make_repo(root, "legacy_01")
+            baseline = root / coverage.BASELINE_REL
+            (root / "src/lib.rs").write_text(
+                "#[cfg(test)] mod legacy_09 {}\n",
+                encoding="utf-8",
+            )
+            subprocess.run(
+                ["git", "init", "-q", "-b", "main", root], check=True
+            )
+            subprocess.run(
+                ["git", "-C", root, "config", "user.email", "tests@example.com"],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", root, "config", "user.name", "Tests"], check=True
+            )
+
+            baseline.write_text(
+                "".join(f"legacy_{index:02d}\n" for index in range(1, 10)),
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "-C", root, "add", "."], check=True)
+            subprocess.run(
+                ["git", "-C", root, "commit", "-q", "-m", "common base"],
+                check=True,
+            )
+            common_sha = subprocess.check_output(
+                ["git", "-C", root, "rev-parse", "HEAD"], text=True
+            ).strip()
+
+            subprocess.run(["git", "-C", root, "switch", "-q", "-c", "pr"], check=True)
+            baseline.write_text(
+                "".join(
+                    f"legacy_{index:02d}\n"
+                    for index in range(1, 10)
+                    if index != 8
+                ),
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "-C", root, "commit", "-qam", "remove b"], check=True)
+            pr_sha = subprocess.check_output(
+                ["git", "-C", root, "rev-parse", "HEAD"], text=True
+            ).strip()
+
+            subprocess.run(
+                ["git", "-C", root, "switch", "-q", "--detach", common_sha], check=True
+            )
+            baseline.write_text(
+                "".join(
+                    f"legacy_{index:02d}\n"
+                    for index in range(1, 10)
+                    if index != 2
+                ),
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "-C", root, "commit", "-qam", "remove a"], check=True)
+            main_sha = subprocess.check_output(
+                ["git", "-C", root, "rev-parse", "HEAD"], text=True
+            ).strip()
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    root,
+                    "merge",
+                    "-q",
+                    "--no-ff",
+                    pr_sha,
+                    "-m",
+                    "candidate",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            candidate_sha = subprocess.check_output(
+                ["git", "-C", root, "rev-parse", "HEAD"], text=True
+            ).strip()
+
+            resolved, reference = coverage.load_baseline_from_git(root, "HEAD^1")
+            self.assertEqual(resolved, main_sha)
+            self.assertEqual(
+                reference,
+                {f"legacy_{index:02d}" for index in range(1, 10) if index != 2},
+            )
+            self.assertEqual(
+                coverage.load_baseline(baseline),
+                {
+                    f"legacy_{index:02d}"
+                    for index in range(1, 10)
+                    if index not in {2, 8}
+                },
+            )
+            candidate = coverage.load_baseline(baseline)
+            self.assertEqual(coverage.baseline_growth(candidate, reference), [])
+            self.assertEqual(reference - candidate, {"legacy_08"})
+
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    root,
+                    "update-ref",
+                    "refs/remotes/origin/main",
+                    pr_sha,
+                ],
+                check=True,
+            )
+            self.assertEqual(
+                coverage.load_baseline_from_git(root, "HEAD^1"),
+                (
+                    main_sha,
+                    {
+                        f"legacy_{index:02d}"
+                        for index in range(1, 10)
+                        if index != 2
+                    },
+                ),
+            )
+            self.assertEqual(
+                subprocess.check_output(
+                    ["git", "-C", root, "rev-parse", "HEAD"], text=True
+                ).strip(),
+                candidate_sha,
+            )
+
+    def test_main_push_before_sha_reads_pre_push_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            baseline = root / coverage.BASELINE_REL
+            baseline.parent.mkdir(parents=True)
+            subprocess.run(
+                ["git", "init", "-q", "-b", "main", root], check=True
+            )
+            subprocess.run(
+                ["git", "-C", root, "config", "user.email", "tests@example.com"],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", root, "config", "user.name", "Tests"], check=True
+            )
+            baseline.write_text("legacy_a\n", encoding="utf-8")
+            subprocess.run(["git", "-C", root, "add", "."], check=True)
+            subprocess.run(
+                ["git", "-C", root, "commit", "-q", "-m", "before"], check=True
+            )
+            before = subprocess.check_output(
+                ["git", "-C", root, "rev-parse", "HEAD"], text=True
+            ).strip()
+
+            baseline.write_text("legacy_a\nlegacy_b\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", root, "commit", "-qam", "intermediate growth"],
+                check=True,
+            )
+            baseline.write_text("legacy_b\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", root, "commit", "-qam", "tip changes growth"],
+                check=True,
+            )
+
+            _, reference = coverage.load_baseline_from_git(root, before)
+            _, previous_commit = coverage.load_baseline_from_git(root, "HEAD^1")
+            self.assertEqual(reference, {"legacy_a"})
+            self.assertEqual(previous_commit, {"legacy_a", "legacy_b"})
+            self.assertEqual(
+                coverage.baseline_growth(coverage.load_baseline(baseline), reference),
+                ["legacy_b"],
+            )
+            self.assertEqual(
+                coverage.baseline_growth(
+                    coverage.load_baseline(baseline), previous_commit
+                ),
+                [],
+            )
+
+    def test_missing_zero_or_shallow_reference_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            subprocess.run(
+                ["git", "init", "-q", "-b", "main", root], check=True
+            )
+            for ref in ("0" * 40, "missing-parent"):
+                with self.subTest(ref=ref), self.assertRaises(ValueError):
+                    coverage.load_baseline_from_git(root, ref)
+
+    def test_reference_without_baseline_blob_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            subprocess.run(
+                ["git", "init", "-q", "-b", "main", root], check=True
+            )
+            subprocess.run(
+                ["git", "-C", root, "config", "user.email", "tests@example.com"],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", root, "config", "user.name", "Tests"], check=True
+            )
+            (root / "placeholder").write_text("x", encoding="utf-8")
+            subprocess.run(["git", "-C", root, "add", "."], check=True)
+            subprocess.run(
+                ["git", "-C", root, "commit", "-q", "-m", "no baseline"],
+                check=True,
+            )
+            with self.assertRaises(ValueError):
+                coverage.load_baseline_from_git(root, "HEAD")
+
+    def test_repository_uses_semantic_baseline_without_scalar(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        baseline_text = (REPO_ROOT / coverage.BASELINE_REL).read_text(encoding="utf-8")
+        self.assertNotIn("BASELINE_ENTRY_COUNT", source)
+        self.assertNotIn("BASELINE_ENTRY_COUNT", baseline_text)
+        self.assertEqual(
+            coverage.load_baseline(REPO_ROOT / coverage.BASELINE_REL),
+            coverage.parse_baseline(baseline_text, "repository baseline"),
+        )
 
     def test_ci_script_checks_wires_guard_and_tests(self) -> None:
         script = (REPO_ROOT / "scripts/ci-script-checks.sh").read_text(
             encoding="utf-8"
         )
-        self.assertIn('"$PYTHON" scripts/check_test_lane_coverage.py', script)
+        self.assertIn(
+            'scripts/check_test_lane_coverage.py --baseline-ref "${TEST_LANE_BASELINE_REF:-HEAD}"',
+            script,
+        )
         self.assertIn(
             '"$PYTHON" -m unittest tests.test_test_lane_coverage', script
         )

--- a/tests/test_test_lane_coverage.py
+++ b/tests/test_test_lane_coverage.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -490,13 +491,147 @@ class RatchetTests(unittest.TestCase):
                 [],
             )
 
+    def test_cancelled_adjacent_push_cannot_make_debt_authoritative(self) -> None:
+        trusted = {"legacy_a"}
+        cancelled_push = {"legacy_a", "legacy_b"}
+        adjacent_push = {"legacy_b"}
+
+        self.assertEqual(
+            coverage.baseline_growth(cancelled_push, trusted), ["legacy_b"]
+        )
+        self.assertEqual(
+            coverage.baseline_growth(adjacent_push, cancelled_push), []
+        )
+        self.assertEqual(
+            coverage.baseline_growth(adjacent_push, trusted), ["legacy_b"]
+        )
+        workflow = (
+            REPO_ROOT / ".github/workflows/test-lane-baseline-main.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("cancel-in-progress: false", workflow)
+
+    def test_main_forwards_explicit_baseline_ref_to_git_loader(self) -> None:
+        reference = {"legacy_a"}
+        with mock.patch.object(
+            coverage,
+            "load_baseline_from_git",
+            return_value=("a" * 40, reference),
+        ) as load_reference, mock.patch.object(
+            coverage, "check", return_value=0
+        ) as check:
+            result = coverage.main(
+                [
+                    "--repo-root",
+                    str(REPO_ROOT),
+                    "--baseline-ref",
+                    "immutable-before",
+                ]
+            )
+
+        self.assertEqual(result, 0)
+        load_reference.assert_called_once_with(REPO_ROOT.resolve(), "immutable-before")
+        check.assert_called_once()
+        self.assertEqual(check.call_args.args[2], reference)
+        self.assertEqual(check.call_args.kwargs["reference_label"], f"commit {'a' * 40}")
+
+    def test_cli_explicit_reference_catches_growth_that_self_compare_misses(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            self.make_repo(root, "legacy_b")
+            baseline = root / coverage.BASELINE_REL
+            subprocess.run(["git", "init", "-q", "-b", "main", root], check=True)
+            subprocess.run(
+                ["git", "-C", root, "config", "user.email", "tests@example.com"],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", root, "config", "user.name", "Tests"], check=True
+            )
+            baseline.write_text("legacy_a\n", encoding="utf-8")
+            subprocess.run(["git", "-C", root, "add", "."], check=True)
+            subprocess.run(
+                ["git", "-C", root, "commit", "-q", "-m", "trusted"], check=True
+            )
+            trusted = subprocess.check_output(
+                ["git", "-C", root, "rev-parse", "HEAD"], text=True
+            ).strip()
+            baseline.write_text("legacy_b\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", root, "commit", "-qam", "candidate growth"],
+                check=True,
+            )
+
+            explicit = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--repo-root",
+                    str(root),
+                    "--baseline-ref",
+                    trusted,
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self_compare = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--repo-root",
+                    str(root),
+                    "--baseline-ref",
+                    "HEAD",
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+        self.assertEqual(explicit.returncode, 1)
+        self.assertIn("baseline growth forbidden", explicit.stderr)
+        self.assertEqual(self_compare.returncode, 0)
+        self.assertNotIn("baseline growth forbidden", self_compare.stderr)
+
+    def test_cli_requires_explicit_baseline_ref(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--repo-root",
+                str(REPO_ROOT),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("--baseline-ref", result.stderr)
+
+    def test_cli_missing_reference_exits_two(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--repo-root",
+                str(REPO_ROOT),
+                "--baseline-ref",
+                "0" * 40,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("invalid baseline reference", result.stderr)
+
     def test_missing_zero_or_shallow_reference_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             subprocess.run(
                 ["git", "init", "-q", "-b", "main", root], check=True
             )
-            for ref in ("0" * 40, "missing-parent"):
+            for ref in ("", "0" * 40, "missing-parent"):
                 with self.subTest(ref=ref), self.assertRaises(ValueError):
                     coverage.load_baseline_from_git(root, ref)
 
@@ -537,9 +672,10 @@ class RatchetTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn(
-            'scripts/check_test_lane_coverage.py --baseline-ref "${TEST_LANE_BASELINE_REF:-HEAD}"',
+            'scripts/check_test_lane_coverage.py --baseline-ref "$TEST_LANE_BASELINE_REF"',
             script,
         )
+        self.assertNotIn("TEST_LANE_BASELINE_REF:-HEAD", script)
         self.assertIn(
             '"$PYTHON" -m unittest tests.test_test_lane_coverage', script
         )


### PR DESCRIPTION
## Summary
- replace the shared `BASELINE_ENTRY_COUNT` lock with semantic candidate-baseline subset validation against an immutable Git commit snapshot
- bind PR checks to the synthetic merge commit's first parent and main-push checks to `github.event.before`, preserving existing newly-uncovered and stale-entry failures
- add mutation-sensitive fixtures for disjoint removals, candidate-parent selection, multi-commit push baselines, growth rejection, stale debt, and unavailable reference snapshots

Closes #4910

## Test plan
- [x] `python3 -m unittest tests.test_test_lane_coverage tests.test_fast_check_ci_wiring`
- [x] `python3 scripts/check_test_lane_coverage.py --baseline-ref HEAD`
- [x] `TEST_LANE_BASELINE_REF=HEAD bash scripts/ci-script-checks.sh`
- [x] `python3 scripts/generate_inventory_docs.py`
- [x] `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate`
- [x] `git diff --check`
- [x] mutation proof: replacing `baseline_growth()` with an empty result makes the growth regression fail; restoring it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)