### PR TITLE
feat(#4875): auto-refresh Claude model catalog

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -575,6 +575,7 @@ src/
 │   │   │   ├── selection.rs
 │   │   │   └── selection_runtime.rs
 │   │   ├── model_catalog/
+│   │   │   ├── bounded_cache_file.rs
 │   │   │   └── claude.rs
 │   │   ├── outbound/
 │   │   │   ├── turn_output_controller/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -574,6 +574,8 @@ src/
 │   │   │   ├── rounds.rs
 │   │   │   ├── selection.rs
 │   │   │   └── selection_runtime.rs
+│   │   ├── model_catalog/
+│   │   │   └── claude.rs
 │   │   ├── outbound/
 │   │   │   ├── turn_output_controller/
 │   │   │   │   ├── fresh_send.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ blake3 = "1"
 dashmap = "6"
 
 # From RCC — HTTP client
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 
 # From RCC — crypto
 sha2 = "0.10"

--- a/justfile
+++ b/justfile
@@ -66,6 +66,9 @@ test-non-pg:
     # Run health first so a fail-fast relay_recovery failure cannot hide it.
     python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
     env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres
+    # #4875: keep the Claude catalog and picker test modules fully selected.
+    cargo test --lib services::discord::model_catalog -- --skip _pg --skip pg_ --skip postgres
+    cargo test --lib services::discord::commands::model_ui::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
     # `ClaudeBinary` capability invariants are compile-fail doctests in src/lib.rs.
     # Filter the real rustdoc harness to this public capability contract.

--- a/justfile
+++ b/justfile
@@ -69,6 +69,7 @@ test-non-pg:
     # #4875: keep the Claude catalog and picker test modules fully selected.
     cargo test --lib services::discord::model_catalog -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib services::discord::commands::model_ui::tests -- --skip _pg --skip pg_ --skip postgres
+    cargo test --lib services::discord::runtime_bootstrap::shutdown::lifecycle_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
     # `ClaudeBinary` capability invariants are compile-fail doctests in src/lib.rs.
     # Filter the real rustdoc harness to this public capability contract.

--- a/src/services/discord/commands/model_ui.rs
+++ b/src/services/discord/commands/model_ui.rs
@@ -2,7 +2,7 @@ use poise::serenity_prelude as serenity;
 
 use crate::services::discord::model_catalog::{
     DEFAULT_PICKER_VALUE, ModelCatalogEntry, SOURCE_PROVIDER_DEFAULT, is_default_picker_value,
-    resolved_default_model, resolved_models,
+    is_valid_discord_select_option_value, resolved_default_model, resolved_models,
 };
 use crate::services::provider::ProviderKind;
 
@@ -150,14 +150,15 @@ fn capped_model_picker_explicit_entries<'a>(
 ) -> Vec<&'a ModelCatalogEntry> {
     let mut entries: Vec<&ModelCatalogEntry> = resolved_models
         .iter()
+        .filter(|entry| is_valid_discord_select_option_value(entry.value.as_ref()))
         .take(EXPLICIT_MODEL_OPTION_LIMIT)
         .collect();
 
     if let Some(selected_value) = selected_explicit_model {
-        if let Some(selected_entry) = resolved_models
-            .iter()
-            .find(|entry| selected_value.eq_ignore_ascii_case(entry.value.as_ref()))
-        {
+        if let Some(selected_entry) = resolved_models.iter().find(|entry| {
+            is_valid_discord_select_option_value(entry.value.as_ref())
+                && selected_value.eq_ignore_ascii_case(entry.value.as_ref())
+        }) {
             if !entries.iter().any(|entry| {
                 entry
                     .value
@@ -178,7 +179,9 @@ fn append_unavailable_selected_option(
     options: &mut Vec<ModelPickerOptionSpec>,
     selected_explicit_model: Option<&str>,
 ) {
-    let Some(selected_value) = selected_explicit_model else {
+    let Some(selected_value) =
+        selected_explicit_model.filter(|value| is_valid_discord_select_option_value(value))
+    else {
         return;
     };
 
@@ -211,8 +214,9 @@ pub(super) fn build_model_picker_option_specs(
 ) -> Vec<ModelPickerOptionSpec> {
     let selected_explicit_model = match pending_model {
         Some(value) if is_default_picker_value(value) => None,
-        Some(value) => Some(value),
-        None => override_model,
+        Some(value) if is_valid_discord_select_option_value(value) => Some(value),
+        Some(_) => override_model.filter(|value| is_valid_discord_select_option_value(value)),
+        None => override_model.filter(|value| is_valid_discord_select_option_value(value)),
     };
     let resolved_models = resolved_models(provider, working_dir);
     let mut options = Vec::with_capacity(resolved_models.len());
@@ -227,6 +231,7 @@ pub(super) fn build_model_picker_option_specs(
                     .is_some_and(|active| active.eq_ignore_ascii_case(entry.value.as_ref())),
             }),
     );
+    append_unavailable_selected_option(&mut options, selected_explicit_model);
     if options.is_empty() {
         options.push(ModelPickerOptionSpec {
             value: DEFAULT_PICKER_VALUE.to_string(),
@@ -240,7 +245,6 @@ pub(super) fn build_model_picker_option_specs(
             selected: false,
         });
     }
-    append_unavailable_selected_option(&mut options, selected_explicit_model);
     options
 }
 
@@ -297,8 +301,8 @@ mod tests {
     }
 
     #[test]
-    fn invariant_model_picker_keeps_unavailable_selection_with_bounded_text() {
-        let selected = "claude-".to_string() + &"x".repeat(120);
+    fn invariant_model_picker_keeps_valid_unavailable_selection_with_bounded_text() {
+        let selected = "가".repeat(DISCORD_SELECT_MENU_TEXT_LIMIT);
         let mut options = (0..DISCORD_SELECT_MENU_OPTION_LIMIT)
             .map(|index| ModelPickerOptionSpec {
                 value: format!("value-{index}"),
@@ -322,6 +326,31 @@ mod tests {
             option.label.chars().count() <= DISCORD_SELECT_MENU_TEXT_LIMIT
                 && option.description.chars().count() <= DISCORD_SELECT_MENU_TEXT_LIMIT
         }));
+    }
+
+    #[test]
+    fn invariant_model_picker_skips_oversize_catalog_and_persisted_values_without_truncating() {
+        let invalid = "x".repeat(DISCORD_SELECT_MENU_TEXT_LIMIT + 1);
+        let entries = vec![ModelCatalogEntry::owned(
+            invalid.clone(),
+            "Invalid catalog value".to_string(),
+            "Test catalog entry".to_string(),
+            "Model picker invariant".to_string(),
+        )];
+        assert!(capped_model_picker_explicit_entries(&entries, Some(&invalid)).is_empty());
+
+        let options = build_model_picker_option_specs(
+            &ProviderKind::OpenCode,
+            None,
+            Some(&invalid),
+            "default",
+            SOURCE_PROVIDER_DEFAULT,
+            None,
+        );
+
+        assert_eq!(options.len(), 1);
+        assert_eq!(options[0].value, DEFAULT_PICKER_VALUE);
+        assert!(options.iter().all(|option| option.value != invalid));
     }
 
     #[test]

--- a/src/services/discord/commands/model_ui.rs
+++ b/src/services/discord/commands/model_ui.rs
@@ -8,6 +8,11 @@ use crate::services::provider::ProviderKind;
 
 const DISCORD_SELECT_MENU_OPTION_LIMIT: usize = 25;
 const EXPLICIT_MODEL_OPTION_LIMIT: usize = DISCORD_SELECT_MENU_OPTION_LIMIT - 1;
+const DISCORD_SELECT_MENU_TEXT_LIMIT: usize = 100;
+
+fn truncate_picker_text(raw: &str) -> String {
+    raw.chars().take(DISCORD_SELECT_MENU_TEXT_LIMIT).collect()
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct ModelPickerOptionSpec {
@@ -151,12 +156,13 @@ fn capped_model_picker_explicit_entries<'a>(
     if let Some(selected_value) = selected_explicit_model {
         if let Some(selected_entry) = resolved_models
             .iter()
-            .find(|entry| selected_value.eq_ignore_ascii_case(entry.value))
+            .find(|entry| selected_value.eq_ignore_ascii_case(entry.value.as_ref()))
         {
-            if !entries
-                .iter()
-                .any(|entry| entry.value.eq_ignore_ascii_case(selected_entry.value))
-            {
+            if !entries.iter().any(|entry| {
+                entry
+                    .value
+                    .eq_ignore_ascii_case(selected_entry.value.as_ref())
+            }) {
                 if entries.len() == EXPLICIT_MODEL_OPTION_LIMIT {
                     entries.pop();
                 }
@@ -189,8 +195,8 @@ fn append_unavailable_selected_option(
 
     options.push(ModelPickerOptionSpec {
         value: selected_value.to_string(),
-        label: selected_value.to_string(),
-        description: "Current override | Not in current catalog".to_string(),
+        label: truncate_picker_text(selected_value),
+        description: truncate_picker_text("Current override | Not in current catalog"),
         selected: true,
     });
 }
@@ -215,22 +221,22 @@ pub(super) fn build_model_picker_option_specs(
             .iter()
             .map(|entry| ModelPickerOptionSpec {
                 value: entry.value.to_string(),
-                label: entry.label.to_string(),
-                description: entry.picker_description(),
+                label: truncate_picker_text(&entry.label),
+                description: truncate_picker_text(&entry.picker_description()),
                 selected: selected_explicit_model
-                    .is_some_and(|active| active.eq_ignore_ascii_case(entry.value)),
+                    .is_some_and(|active| active.eq_ignore_ascii_case(entry.value.as_ref())),
             }),
     );
     if options.is_empty() {
         options.push(ModelPickerOptionSpec {
             value: DEFAULT_PICKER_VALUE.to_string(),
-            label: default_picker_option_label(),
-            description: default_picker_option_description(
+            label: truncate_picker_text(&default_picker_option_label()),
+            description: truncate_picker_text(&default_picker_option_description(
                 provider,
                 default_model,
                 default_source,
                 working_dir,
-            ),
+            )),
             selected: false,
         });
     }
@@ -261,4 +267,69 @@ pub(super) fn build_model_picker_options(
             .default_selection(entry.selected)
     })
     .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(index: usize) -> ModelCatalogEntry {
+        ModelCatalogEntry::owned(
+            format!("claude-test-{index}"),
+            format!("Claude test {index}"),
+            "Test catalog entry".to_string(),
+            "Model picker invariant".to_string(),
+        )
+    }
+
+    #[test]
+    fn invariant_model_picker_caps_explicit_entries_and_keeps_selected_catalog_entry() {
+        let entries = (0..40).map(entry).collect::<Vec<_>>();
+        let selected = "claude-test-39";
+        let capped = capped_model_picker_explicit_entries(&entries, Some(selected));
+
+        assert_eq!(capped.len(), EXPLICIT_MODEL_OPTION_LIMIT);
+        assert!(
+            capped
+                .iter()
+                .any(|entry| entry.value.eq_ignore_ascii_case(selected))
+        );
+    }
+
+    #[test]
+    fn invariant_model_picker_keeps_unavailable_selection_with_bounded_text() {
+        let selected = "claude-".to_string() + &"x".repeat(120);
+        let mut options = (0..DISCORD_SELECT_MENU_OPTION_LIMIT)
+            .map(|index| ModelPickerOptionSpec {
+                value: format!("value-{index}"),
+                label: format!("label-{index}"),
+                description: format!("description-{index}"),
+                selected: false,
+            })
+            .collect::<Vec<_>>();
+
+        append_unavailable_selected_option(&mut options, Some(&selected));
+
+        assert_eq!(options.len(), DISCORD_SELECT_MENU_OPTION_LIMIT);
+        let retained = options.last().expect("selected option retained");
+        assert_eq!(retained.value, selected);
+        assert!(retained.selected);
+        assert_eq!(
+            retained.label.chars().count(),
+            DISCORD_SELECT_MENU_TEXT_LIMIT
+        );
+        assert!(options.iter().all(|option| {
+            option.label.chars().count() <= DISCORD_SELECT_MENU_TEXT_LIMIT
+                && option.description.chars().count() <= DISCORD_SELECT_MENU_TEXT_LIMIT
+        }));
+    }
+
+    #[test]
+    fn invariant_model_picker_truncation_is_unicode_character_safe() {
+        let raw = "가".repeat(DISCORD_SELECT_MENU_TEXT_LIMIT + 5);
+        let truncated = truncate_picker_text(&raw);
+
+        assert_eq!(truncated.chars().count(), DISCORD_SELECT_MENU_TEXT_LIMIT);
+        assert!(truncated.is_char_boundary(truncated.len()));
+    }
 }

--- a/src/services/discord/commands/model_ui.rs
+++ b/src/services/discord/commands/model_ui.rs
@@ -231,7 +231,6 @@ pub(super) fn build_model_picker_option_specs(
                     .is_some_and(|active| active.eq_ignore_ascii_case(entry.value.as_ref())),
             }),
     );
-    append_unavailable_selected_option(&mut options, selected_explicit_model);
     if options.is_empty() {
         options.push(ModelPickerOptionSpec {
             value: DEFAULT_PICKER_VALUE.to_string(),
@@ -245,6 +244,7 @@ pub(super) fn build_model_picker_option_specs(
             selected: false,
         });
     }
+    append_unavailable_selected_option(&mut options, selected_explicit_model);
     options
 }
 
@@ -326,6 +326,25 @@ mod tests {
             option.label.chars().count() <= DISCORD_SELECT_MENU_TEXT_LIMIT
                 && option.description.chars().count() <= DISCORD_SELECT_MENU_TEXT_LIMIT
         }));
+    }
+
+    #[test]
+    fn invariant_model_picker_empty_catalog_keeps_default_before_valid_unavailable_override() {
+        let selected = "custom-provider/custom-model";
+        let options = build_model_picker_option_specs(
+            &ProviderKind::OpenCode,
+            None,
+            Some(selected),
+            "default",
+            SOURCE_PROVIDER_DEFAULT,
+            None,
+        );
+
+        assert_eq!(options.len(), 2);
+        assert_eq!(options[0].value, DEFAULT_PICKER_VALUE);
+        assert!(!options[0].selected);
+        assert_eq!(options[1].value, selected);
+        assert!(options[1].selected);
     }
 
     #[test]

--- a/src/services/discord/model_catalog.rs
+++ b/src/services/discord/model_catalog.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
@@ -8,6 +9,8 @@ use regex::Regex;
 use serde::Deserialize;
 
 use crate::services::provider::ProviderKind;
+
+mod claude;
 
 /// Sentinel value stored in the picker's pending state when the user selects "Default".
 /// Callers use `is_default_picker_value()` rather than comparing this directly.
@@ -23,15 +26,43 @@ pub(in crate::services::discord) const SOURCE_DISPATCH_ROLE: &str = "dispatch ro
 pub(in crate::services::discord) const SOURCE_ROLE_MAP: &str = "role-map";
 pub(in crate::services::discord) const SOURCE_PROVIDER_DEFAULT: &str = "provider default";
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ModelCatalogEntry {
-    pub value: &'static str,
-    pub label: &'static str,
-    pub primary_summary: &'static str,
-    pub secondary_summary: &'static str,
+    pub value: Cow<'static, str>,
+    pub label: Cow<'static, str>,
+    pub primary_summary: Cow<'static, str>,
+    pub secondary_summary: Cow<'static, str>,
 }
 
 impl ModelCatalogEntry {
+    const fn borrowed(
+        value: &'static str,
+        label: &'static str,
+        primary_summary: &'static str,
+        secondary_summary: &'static str,
+    ) -> Self {
+        Self {
+            value: Cow::Borrowed(value),
+            label: Cow::Borrowed(label),
+            primary_summary: Cow::Borrowed(primary_summary),
+            secondary_summary: Cow::Borrowed(secondary_summary),
+        }
+    }
+
+    pub(super) fn owned(
+        value: String,
+        label: String,
+        primary_summary: String,
+        secondary_summary: String,
+    ) -> Self {
+        Self {
+            value: Cow::Owned(value),
+            label: Cow::Owned(label),
+            primary_summary: Cow::Owned(primary_summary),
+            secondary_summary: Cow::Owned(secondary_summary),
+        }
+    }
+
     pub(crate) fn picker_description(&self) -> String {
         format!("{} | {}", self.primary_summary, self.secondary_summary)
     }
@@ -43,96 +74,75 @@ struct CatalogSummary {
     secondary: &'static str,
 }
 
-// Curated from installed provider CLIs and Anthropic Claude Code docs as of 2026-03-30.
-const CLAUDE_MODEL_CATALOG: &[ModelCatalogEntry] = &[
-    ModelCatalogEntry {
-        value: "sonnet",
-        label: "Sonnet 4.6",
-        primary_summary: "Latest Sonnet 4.6 alias",
-        secondary_summary: "Claude Code plan",
-    },
-    ModelCatalogEntry {
-        value: "opus",
-        label: "Opus 4.8",
-        primary_summary: "Highest quality 4.8 alias",
-        secondary_summary: "Claude Code plan",
-    },
-    ModelCatalogEntry {
-        value: "haiku",
-        label: "Haiku 4.5",
-        primary_summary: "Fast simple-task 4.5 alias",
-        secondary_summary: "Claude Code plan",
-    },
-    ModelCatalogEntry {
-        value: "sonnet[1m]",
-        label: "Sonnet 4.6 1M",
-        primary_summary: "1M context window",
-        secondary_summary: "Sonnet 4.6 alias",
-    },
-    ModelCatalogEntry {
-        value: "opus[1m]",
-        label: "Opus 4.8 1M",
-        primary_summary: "1M context window",
-        secondary_summary: "Opus 4.8 alias",
-    },
-    ModelCatalogEntry {
-        value: "opusplan",
-        label: "Opus Plan 4.8",
-        primary_summary: "Opus 4.8 planning",
-        secondary_summary: "Sonnet 4.6 executes",
-    },
-];
+#[derive(Clone, Copy)]
+struct StaticModelCatalogEntry {
+    value: &'static str,
+    label: &'static str,
+    primary_summary: &'static str,
+    secondary_summary: &'static str,
+}
 
-const CODEX_MODEL_CATALOG: &[ModelCatalogEntry] = &[
-    ModelCatalogEntry {
+impl From<&StaticModelCatalogEntry> for ModelCatalogEntry {
+    fn from(entry: &StaticModelCatalogEntry) -> Self {
+        Self::borrowed(
+            entry.value,
+            entry.label,
+            entry.primary_summary,
+            entry.secondary_summary,
+        )
+    }
+}
+
+const CODEX_MODEL_CATALOG: &[StaticModelCatalogEntry] = &[
+    StaticModelCatalogEntry {
         value: "gpt-5.5",
         label: "GPT-5.5",
         primary_summary: "Frontier complex work",
         secondary_summary: "Local CLI catalog",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gpt-5.4",
         label: "gpt-5.4",
         primary_summary: "Frontier coding baseline",
         secondary_summary: "API $2.5/$15",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gpt-5.4-mini",
         label: "GPT-5.4-Mini",
         primary_summary: "Fast strong mini",
         secondary_summary: "API $0.75/$4.5",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gpt-5.3-codex",
         label: "gpt-5.3-codex",
         primary_summary: "Fast Codex line",
         secondary_summary: "API $1.75/$14",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gpt-5.3-codex-spark",
         label: "GPT-5.3-Codex-Spark",
         primary_summary: "Text-only preview",
         secondary_summary: "No API",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gpt-5.2-codex",
         label: "gpt-5.2-codex",
         primary_summary: "Long-horizon coding",
         secondary_summary: "API $1.75/$14",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gpt-5.2",
         label: "gpt-5.2",
         primary_summary: "Long-running pro work",
         secondary_summary: "Local CLI catalog",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gpt-5.1-codex-max",
         label: "gpt-5.1-codex-max",
         primary_summary: "Legacy max agent model",
         secondary_summary: "API $1.25/$10",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gpt-5.1-codex-mini",
         label: "gpt-5.1-codex-mini",
         primary_summary: "Cheap fast codex mini",
@@ -140,56 +150,56 @@ const CODEX_MODEL_CATALOG: &[ModelCatalogEntry] = &[
     },
 ];
 
-const GEMINI_MODEL_CATALOG: &[ModelCatalogEntry] = &[
-    ModelCatalogEntry {
+const GEMINI_MODEL_CATALOG: &[StaticModelCatalogEntry] = &[
+    StaticModelCatalogEntry {
         value: "auto-gemini-3",
         label: "Auto (Gemini 3)",
         primary_summary: "Preview auto routing",
         secondary_summary: "Pro/Flash preview",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "auto-gemini-2.5",
         label: "Auto (Gemini 2.5)",
         primary_summary: "Stable auto routing",
         secondary_summary: "Pro/Flash stable",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gemini-3.1-pro-preview",
         label: "gemini-3.1-pro-preview",
         primary_summary: "Gemini 3.1 Pro preview",
         secondary_summary: "Local CLI catalog",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gemini-3-pro-preview",
         label: "gemini-3-pro-preview",
         primary_summary: "Frontier reasoning and coding",
         secondary_summary: "$2/$12",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gemini-3-flash-preview",
         label: "gemini-3-flash-preview",
         primary_summary: "Low-latency frontier work",
         secondary_summary: "$0.5/$3",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gemini-2.5-pro",
         label: "gemini-2.5-pro",
         primary_summary: "Stable advanced reasoning",
         secondary_summary: "$1.25/$10",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gemini-2.5-flash",
         label: "gemini-2.5-flash",
         primary_summary: "Stable fast fallback",
         secondary_summary: "$0.3/$2.5",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gemini-2.5-flash-lite",
         label: "gemini-2.5-flash-lite",
         primary_summary: "Low-cost flash-lite",
         secondary_summary: "Local CLI catalog",
     },
-    ModelCatalogEntry {
+    StaticModelCatalogEntry {
         value: "gemini-3.1-flash-lite-preview",
         label: "gemini-3.1-flash-lite-preview",
         primary_summary: "Preview flash-lite variant",
@@ -256,11 +266,7 @@ struct QwenModelProviderEntry {
 #[derive(Clone, Debug, Default)]
 struct QwenResolvedCatalog {
     entries: Vec<ModelCatalogEntry>,
-    default_model: Option<&'static str>,
-}
-
-fn intern_owned(value: String) -> &'static str {
-    Box::leak(value.into_boxed_str())
+    default_model: Option<String>,
 }
 
 fn codex_model_cache_path() -> Option<PathBuf> {
@@ -402,14 +408,14 @@ fn file_backed_catalog_cache_key(path: PathBuf) -> Option<FileBackedCatalogCache
 fn build_file_backed_catalog(
     cache: &'static OnceLock<Mutex<FileBackedCatalogCache>>,
     path: Option<PathBuf>,
-    fallback: &[ModelCatalogEntry],
+    fallback: &[StaticModelCatalogEntry],
     parse: fn(&str) -> Option<Vec<ModelCatalogEntry>>,
 ) -> Vec<ModelCatalogEntry> {
     let Some(path) = path else {
-        return fallback.to_vec();
+        return fallback.iter().map(ModelCatalogEntry::from).collect();
     };
     let Some(cache_key) = file_backed_catalog_cache_key(path) else {
-        return fallback.to_vec();
+        return fallback.iter().map(ModelCatalogEntry::from).collect();
     };
 
     let cache_cell = cache.get_or_init(|| Mutex::new(FileBackedCatalogCache::default()));
@@ -422,7 +428,7 @@ fn build_file_backed_catalog(
     let entries = fs::read_to_string(&cache_key.path)
         .ok()
         .and_then(|raw| parse(&raw))
-        .unwrap_or_else(|| fallback.to_vec());
+        .unwrap_or_else(|| fallback.iter().map(ModelCatalogEntry::from).collect());
 
     if let Ok(mut cached) = cache_cell.lock() {
         cached.key = Some(cache_key);
@@ -462,12 +468,12 @@ fn build_codex_model_catalog_from_cache(raw: &str) -> Option<Vec<ModelCatalogEnt
         } else {
             model.display_name
         };
-        entries.push(ModelCatalogEntry {
-            value: intern_owned(model.slug),
-            label: intern_owned(label),
-            primary_summary: summary.primary,
-            secondary_summary: summary.secondary,
-        });
+        entries.push(ModelCatalogEntry::owned(
+            model.slug,
+            label,
+            summary.primary.to_string(),
+            summary.secondary.to_string(),
+        ));
     }
 
     (!entries.is_empty()).then_some(entries)
@@ -558,21 +564,22 @@ fn build_gemini_model_catalog_from_models_js(raw: &str) -> Option<Vec<ModelCatal
             continue;
         }
         let summary = gemini_catalog_summary(model);
-        entries.push(ModelCatalogEntry {
-            value: intern_owned(model.clone()),
-            label: intern_owned(gemini_display_label(model)),
-            primary_summary: summary.primary,
-            secondary_summary: summary.secondary,
-        });
+        entries.push(ModelCatalogEntry::owned(
+            model.clone(),
+            gemini_display_label(model),
+            summary.primary.to_string(),
+            summary.secondary.to_string(),
+        ));
     }
 
     (!entries.is_empty()).then_some(entries)
 }
 
 const CLAUDE_MODEL_ALIASES: &[(&str, &str)] = &[
-    ("opus", "claude-opus-4-8"),
-    ("sonnet", "claude-sonnet-4-6"),
-    ("haiku", "claude-haiku-4-5-20251001"),
+    ("fable", "fable"),
+    ("opus", "opus"),
+    ("sonnet", "sonnet"),
+    ("haiku", "haiku"),
 ];
 
 const CODEX_MODEL_ALIASES: &[(&str, &str)] = &[
@@ -687,7 +694,7 @@ fn resolve_qwen_model_catalog(working_dir: Option<&str>) -> QwenResolvedCatalog 
 
     let mut merged_entries: HashMap<String, (usize, ModelCatalogEntry)> = HashMap::new();
     let mut next_order = 0usize;
-    let mut default_model: Option<&'static str> = None;
+    let mut default_model: Option<String> = None;
 
     for settings in layers.iter().flatten().filter_map(load_qwen_settings_file) {
         if let Some(default_name) = settings
@@ -697,7 +704,7 @@ fn resolve_qwen_model_catalog(working_dir: Option<&str>) -> QwenResolvedCatalog 
             .map(str::trim)
             .filter(|value| !value.is_empty())
         {
-            default_model = Some(intern_owned(default_name.to_string()));
+            default_model = Some(default_name.to_string());
         }
 
         for (auth_type, models) in settings.model_providers {
@@ -728,12 +735,12 @@ fn resolve_qwen_model_catalog(working_dir: Option<&str>) -> QwenResolvedCatalog 
                     dedupe_key,
                     (
                         next_order,
-                        ModelCatalogEntry {
-                            value: intern_owned(model_id.to_string()),
-                            label: intern_owned(label.to_string()),
-                            primary_summary: intern_owned(primary_summary),
-                            secondary_summary: intern_owned(secondary_summary),
-                        },
+                        ModelCatalogEntry::owned(
+                            model_id.to_string(),
+                            label.to_string(),
+                            primary_summary,
+                            secondary_summary,
+                        ),
                     ),
                 );
             }
@@ -744,19 +751,19 @@ fn resolve_qwen_model_catalog(working_dir: Option<&str>) -> QwenResolvedCatalog 
     entries.sort_by_key(|(order, _)| *order);
     let mut entries: Vec<ModelCatalogEntry> = entries.into_iter().map(|(_, entry)| entry).collect();
 
-    if let Some(default_model) = default_model {
+    if let Some(default_model) = default_model.as_deref() {
         let exists = entries
             .iter()
             .any(|entry| entry.value.eq_ignore_ascii_case(default_model));
         if !exists {
             entries.insert(
                 0,
-                ModelCatalogEntry {
-                    value: default_model,
-                    label: default_model,
-                    primary_summary: "Configured default model",
-                    secondary_summary: "Qwen settings.model.name",
-                },
+                ModelCatalogEntry::owned(
+                    default_model.to_string(),
+                    default_model.to_string(),
+                    "Configured default model".to_string(),
+                    "Qwen settings.model.name".to_string(),
+                ),
             );
         }
     }
@@ -781,9 +788,7 @@ pub(crate) fn resolved_default_model(
     working_dir: Option<&str>,
 ) -> Option<String> {
     match provider {
-        ProviderKind::Qwen => resolve_qwen_model_catalog(working_dir)
-            .default_model
-            .map(str::to_string),
+        ProviderKind::Qwen => resolve_qwen_model_catalog(working_dir).default_model,
         _ => None,
     }
 }
@@ -838,12 +843,18 @@ pub(in crate::services::discord) fn model_hint(
 
 pub(crate) fn known_models(provider: &ProviderKind) -> Vec<ModelCatalogEntry> {
     match provider {
-        ProviderKind::Claude => CLAUDE_MODEL_CATALOG.to_vec(),
+        ProviderKind::Claude => claude::resolved_models(),
         ProviderKind::Codex => build_codex_model_catalog(),
         ProviderKind::Gemini => build_gemini_model_catalog(),
         ProviderKind::OpenCode | ProviderKind::Qwen => Vec::new(),
         ProviderKind::Unsupported(_) => Vec::new(),
     }
+}
+
+pub(in crate::services::discord) fn spawn_claude_model_catalog_refresh(
+    provider: &ProviderKind,
+) -> Option<tokio::task::JoinHandle<()>> {
+    claude::spawn_background_refresh(provider)
 }
 
 fn model_aliases(provider: &ProviderKind) -> &'static [(&'static str, &'static str)] {
@@ -856,27 +867,32 @@ fn model_aliases(provider: &ProviderKind) -> &'static [(&'static str, &'static s
     }
 }
 
-fn canonical_known_model(provider: &ProviderKind, raw: &str) -> Option<&'static str> {
+fn canonical_known_model(provider: &ProviderKind, raw: &str) -> Option<String> {
     let trimmed = raw.trim();
     for entry in known_models(provider) {
         if entry.value.eq_ignore_ascii_case(trimmed) {
-            return Some(entry.value);
+            return Some(entry.value.into_owned());
         }
     }
 
     model_aliases(provider)
         .iter()
         .find(|(alias, _)| alias.eq_ignore_ascii_case(trimmed))
-        .map(|(_, canonical)| *canonical)
+        .map(|(_, canonical)| (*canonical).to_string())
 }
 
-fn looks_like_model_identifier(raw: &str) -> bool {
+fn is_safe_model_selector(raw: &str) -> bool {
     let trimmed = raw.trim();
     !trimmed.is_empty()
         && trimmed.len() <= 64
+        && trimmed.is_ascii()
         && trimmed
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | ':' | '[' | ']'))
+}
+
+fn looks_like_model_identifier(raw: &str) -> bool {
+    is_safe_model_selector(raw)
 }
 
 pub(in crate::services::discord) fn validate_model_input(
@@ -918,7 +934,7 @@ pub(in crate::services::discord) fn validate_model_input(
     }
 
     if let Some(canonical) = canonical_known_model(provider, trimmed) {
-        return Ok(canonical.to_string());
+        return Ok(canonical);
     }
 
     if looks_like_model_identifier(trimmed) {
@@ -943,4 +959,27 @@ fn is_valid_opencode_model_override(raw: &str) -> bool {
         && raw.chars().all(|c| {
             c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | ':' | '/' | '[' | ']')
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invariant_claude_model_alias_validation_preserves_runtime_selector() {
+        for selector in ["fable", "opus", "sonnet", "haiku"] {
+            assert_eq!(
+                validate_model_input(&ProviderKind::Claude, selector, None).unwrap(),
+                selector
+            );
+        }
+    }
+
+    #[test]
+    fn invariant_claude_model_selector_validation_is_ascii_and_bounded() {
+        assert!(validate_model_input(&ProviderKind::Claude, &"a".repeat(64), None).is_ok());
+        assert!(validate_model_input(&ProviderKind::Claude, &"a".repeat(65), None).is_err());
+        assert!(validate_model_input(&ProviderKind::Claude, "claude/unsafe", None).is_err());
+        assert!(validate_model_input(&ProviderKind::Claude, "클로드", None).is_err());
+    }
 }

--- a/src/services/discord/model_catalog.rs
+++ b/src/services/discord/model_catalog.rs
@@ -12,6 +12,8 @@ use crate::services::provider::ProviderKind;
 
 mod claude;
 
+pub(crate) const DISCORD_SELECT_OPTION_VALUE_LIMIT: usize = 100;
+
 /// Sentinel value stored in the picker's pending state when the user selects "Default".
 /// Callers use `is_default_picker_value()` rather than comparing this directly.
 pub(in crate::services::discord) const DEFAULT_PICKER_VALUE: &str = "__agentdesk_default__";
@@ -575,13 +577,6 @@ fn build_gemini_model_catalog_from_models_js(raw: &str) -> Option<Vec<ModelCatal
     (!entries.is_empty()).then_some(entries)
 }
 
-const CLAUDE_MODEL_ALIASES: &[(&str, &str)] = &[
-    ("fable", "fable"),
-    ("opus", "opus"),
-    ("sonnet", "sonnet"),
-    ("haiku", "haiku"),
-];
-
 const CODEX_MODEL_ALIASES: &[(&str, &str)] = &[
     ("gpt-5-codex", "gpt-5-codex"),
     ("o3", "o3"),
@@ -859,10 +854,9 @@ pub(in crate::services::discord) fn spawn_claude_model_catalog_refresh(
 
 fn model_aliases(provider: &ProviderKind) -> &'static [(&'static str, &'static str)] {
     match provider {
-        ProviderKind::Claude => CLAUDE_MODEL_ALIASES,
         ProviderKind::Codex => CODEX_MODEL_ALIASES,
         ProviderKind::Gemini => GEMINI_MODEL_ALIASES,
-        ProviderKind::OpenCode | ProviderKind::Qwen => &[],
+        ProviderKind::Claude | ProviderKind::OpenCode | ProviderKind::Qwen => &[],
         ProviderKind::Unsupported(_) => &[],
     }
 }
@@ -891,8 +885,8 @@ fn is_safe_model_selector(raw: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | ':' | '[' | ']'))
 }
 
-fn looks_like_model_identifier(raw: &str) -> bool {
-    is_safe_model_selector(raw)
+pub(crate) fn is_valid_discord_select_option_value(raw: &str) -> bool {
+    !raw.is_empty() && raw.chars().count() <= DISCORD_SELECT_OPTION_VALUE_LIMIT
 }
 
 pub(in crate::services::discord) fn validate_model_input(
@@ -903,6 +897,11 @@ pub(in crate::services::discord) fn validate_model_input(
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return Err("Model name cannot be empty.".to_string());
+    }
+    if !is_valid_discord_select_option_value(trimmed) {
+        return Err(format!(
+            "Model name cannot exceed {DISCORD_SELECT_OPTION_VALUE_LIMIT} characters."
+        ));
     }
 
     if matches!(provider, ProviderKind::Qwen) {
@@ -937,7 +936,7 @@ pub(in crate::services::discord) fn validate_model_input(
         return Ok(canonical);
     }
 
-    if looks_like_model_identifier(trimmed) {
+    if is_safe_model_selector(trimmed) {
         return Ok(trimmed.to_string());
     }
 
@@ -955,7 +954,7 @@ fn is_valid_opencode_model_override(raw: &str) -> bool {
     };
     !provider_id.trim().is_empty()
         && !model_id.trim().is_empty()
-        && raw.len() <= 128
+        && is_valid_discord_select_option_value(raw)
         && raw.chars().all(|c| {
             c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | ':' | '/' | '[' | ']')
         })
@@ -981,5 +980,18 @@ mod tests {
         assert!(validate_model_input(&ProviderKind::Claude, &"a".repeat(65), None).is_err());
         assert!(validate_model_input(&ProviderKind::Claude, "claude/unsafe", None).is_err());
         assert!(validate_model_input(&ProviderKind::Claude, "클로드", None).is_err());
+    }
+
+    #[test]
+    fn invariant_model_input_rejects_values_over_discord_option_limit_without_truncating() {
+        let valid = format!("provider/{}", "x".repeat(91));
+        let invalid = format!("provider/{}", "x".repeat(92));
+
+        assert_eq!(valid.chars().count(), DISCORD_SELECT_OPTION_VALUE_LIMIT);
+        assert_eq!(
+            validate_model_input(&ProviderKind::OpenCode, &valid, None).unwrap(),
+            valid
+        );
+        assert!(validate_model_input(&ProviderKind::OpenCode, &invalid, None).is_err());
     }
 }

--- a/src/services/discord/model_catalog.rs
+++ b/src/services/discord/model_catalog.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 
 use crate::services::provider::ProviderKind;
 
+mod bounded_cache_file;
 mod claude;
 
 pub(crate) const DISCORD_SELECT_OPTION_VALUE_LIMIT: usize = 100;
@@ -850,6 +851,33 @@ pub(in crate::services::discord) fn spawn_claude_model_catalog_refresh(
     provider: &ProviderKind,
 ) -> Option<tokio::task::JoinHandle<()>> {
     claude::spawn_background_refresh(provider)
+}
+
+#[cfg(test)]
+pub(in crate::services::discord) fn spawn_test_claude_model_catalog_refresh(
+    refreshes: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+) -> tokio::task::JoinHandle<()> {
+    claude::spawn_test_background_refresh(refreshes)
+}
+
+#[cfg(test)]
+pub(in crate::services::discord) fn spawn_test_claude_model_catalog_refresh_after_claim(
+    refreshes: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    after_claim: impl Fn() + Send + Sync + 'static,
+) -> tokio::task::JoinHandle<()> {
+    claude::spawn_test_background_refresh_after_claim(refreshes, after_claim)
+}
+
+#[cfg(test)]
+pub(in crate::services::discord) fn with_test_claude_model_catalog_refresh_state<T>(
+    operation: impl FnOnce() -> T,
+) -> T {
+    claude::with_test_refresh_task_state(operation)
+}
+
+#[cfg(test)]
+pub(in crate::services::discord) fn test_claude_model_catalog_refresh_running() -> bool {
+    claude::test_refresh_task_running()
 }
 
 fn model_aliases(provider: &ProviderKind) -> &'static [(&'static str, &'static str)] {

--- a/src/services/discord/model_catalog/bounded_cache_file.rs
+++ b/src/services/discord/model_catalog/bounded_cache_file.rs
@@ -1,0 +1,154 @@
+use std::fs::OpenOptions;
+use std::io::Read;
+use std::path::Path;
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt as _;
+#[cfg(windows)]
+use std::os::windows::fs::OpenOptionsExt as _;
+
+#[cfg(unix)]
+const SAFE_OPEN_FLAGS: i32 = libc::O_NONBLOCK | libc::O_NOFOLLOW;
+#[cfg(windows)]
+const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+
+pub(super) fn read_regular_file_bounded(path: &Path, max_bytes: usize) -> Option<Vec<u8>> {
+    read_regular_file_bounded_after_open(path, max_bytes, || {})
+}
+
+fn read_regular_file_bounded_after_open(
+    path: &Path,
+    max_bytes: usize,
+    after_open: impl FnOnce(),
+) -> Option<Vec<u8>> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(SAFE_OPEN_FLAGS);
+    #[cfg(windows)]
+    options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+
+    let mut file = options.open(path).ok()?;
+    after_open();
+    let metadata = file.metadata().ok()?;
+    if !metadata.file_type().is_file() || metadata.is_symlink() || metadata.len() > max_bytes as u64
+    {
+        return None;
+    }
+
+    let mut body = Vec::with_capacity(metadata.len() as usize);
+    file.by_ref()
+        .take(max_bytes.saturating_add(1) as u64)
+        .read_to_end(&mut body)
+        .ok()?;
+    (body.len() <= max_bytes && body.len() as u64 == metadata.len()).then_some(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn invariant_bounded_cache_file_accepts_regular_file_within_limit() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("cache.json");
+        std::fs::write(&path, b"bounded-cache").unwrap();
+
+        assert_eq!(
+            read_regular_file_bounded(&path, 64).as_deref(),
+            Some(b"bounded-cache".as_slice())
+        );
+        assert!(read_regular_file_bounded(&path, 4).is_none());
+    }
+
+    #[test]
+    fn invariant_bounded_cache_file_reads_the_opened_descriptor_after_path_replacement() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("cache.json");
+        let replacement = directory.path().join("replacement.json");
+        std::fs::write(&path, b"opened-descriptor").unwrap();
+        std::fs::write(&replacement, b"replacement-path").unwrap();
+
+        let body = read_regular_file_bounded_after_open(&path, 64, || {
+            std::fs::rename(&replacement, &path).unwrap();
+        });
+
+        assert_eq!(body.as_deref(), Some(b"opened-descriptor".as_slice()));
+        assert_eq!(std::fs::read(&path).unwrap(), b"replacement-path");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invariant_bounded_cache_file_rejects_symlink_and_fifo_without_blocking() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempdir().unwrap();
+        let target = directory.path().join("target.json");
+        let link = directory.path().join("link.json");
+        let fifo = directory.path().join("cache.fifo");
+        std::fs::write(&target, b"cache").unwrap();
+        symlink(&target, &link).unwrap();
+        let status = std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .expect("spawn mkfifo");
+        assert!(status.success(), "mkfifo should succeed");
+
+        let started = std::time::Instant::now();
+        assert!(read_regular_file_bounded(&link, 64).is_none());
+        assert!(read_regular_file_bounded(&fifo, 64).is_none());
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "unsafe cache paths must be rejected without a blocking open"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invariant_bounded_cache_file_replacement_race_never_opens_fifo_blocking() {
+        use std::os::unix::fs::symlink;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("cache.json");
+        let regular = directory.path().join("regular.json");
+        let fifo = directory.path().join("cache.fifo");
+        std::fs::write(&regular, b"cache").unwrap();
+        let status = std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .expect("spawn mkfifo");
+        assert!(status.success(), "mkfifo should succeed");
+        symlink(&regular, &path).unwrap();
+
+        let stop = std::sync::Arc::new(AtomicBool::new(false));
+        let writer_stop = std::sync::Arc::clone(&stop);
+        let writer_path = path.clone();
+        let writer_regular = regular.clone();
+        let writer_fifo = fifo.clone();
+        let writer = std::thread::spawn(move || {
+            while !writer_stop.load(Ordering::Acquire) {
+                let _ = std::fs::remove_file(&writer_path);
+                let _ = symlink(&writer_regular, &writer_path);
+                let _ = std::fs::remove_file(&writer_path);
+                let _ = symlink(&writer_fifo, &writer_path);
+            }
+            let _ = std::fs::remove_file(&writer_path);
+        });
+
+        let started = std::time::Instant::now();
+        for _ in 0..2_000 {
+            let _ = read_regular_file_bounded(&path, 64);
+        }
+        stop.store(true, Ordering::Release);
+        writer.join().unwrap();
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "regular-file replacement must not leave a blocked reader"
+        );
+    }
+}

--- a/src/services/discord/model_catalog/claude.rs
+++ b/src/services/discord/model_catalog/claude.rs
@@ -235,7 +235,7 @@ fn truncate_catalog_text(raw: &str, fallback: &str) -> String {
 
 fn file_cache_key(path: &Path) -> Option<FileCacheKey> {
     let metadata = std::fs::metadata(path).ok()?;
-    if metadata.len() > MAX_CACHE_BODY_BYTES as u64 {
+    if !metadata.file_type().is_file() || metadata.len() > MAX_CACHE_BODY_BYTES as u64 {
         return None;
     }
     let modified_ms = metadata
@@ -694,6 +694,20 @@ mod tests {
             assert_eq!(entry.secondary_summary, alias.metadata_fallback_id);
             assert_ne!(entry.value, alias.metadata_fallback_id);
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invariant_claude_model_catalog_rejects_fifo_before_bounded_read() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("cache.fifo");
+        let status = std::process::Command::new("mkfifo")
+            .arg(&path)
+            .status()
+            .expect("spawn mkfifo");
+        assert!(status.success(), "mkfifo should succeed");
+
+        assert!(file_cache_key(&path).is_none());
     }
 
     #[test]

--- a/src/services/discord/model_catalog/claude.rs
+++ b/src/services/discord/model_catalog/claude.rs
@@ -67,6 +67,21 @@ const CURATED_ALIASES: &[CuratedAlias] = &[
         label: "Haiku 4.5",
         metadata_fallback_id: "claude-haiku-4-5-20251001",
     },
+    CuratedAlias {
+        selector: "sonnet[1m]",
+        label: "Sonnet 1M",
+        metadata_fallback_id: "claude-sonnet-5",
+    },
+    CuratedAlias {
+        selector: "opus[1m]",
+        label: "Opus 1M",
+        metadata_fallback_id: "claude-opus-5",
+    },
+    CuratedAlias {
+        selector: "opusplan",
+        label: "Opus Plan",
+        metadata_fallback_id: "claude-sonnet-5",
+    },
 ];
 
 const STATIC_FALLBACK_IDS: &[&str] = &[
@@ -451,7 +466,7 @@ where
         after_id = Some(next);
     }
 
-    Err(FetchFailure::PaginationLimit)
+    unreachable!("bounded page loop returns from every terminal page state")
 }
 
 async fn fetch_network_page(
@@ -503,12 +518,18 @@ async fn fetch_network_page(
     Ok(body)
 }
 
-async fn fetch_api_models(api_key: &str) -> Result<Vec<ApiModel>, FetchFailure> {
-    let client = reqwest::Client::builder()
+fn build_anthropic_client() -> Result<reqwest::Client, FetchFailure> {
+    reqwest::Client::builder()
         .connect_timeout(HTTP_CONNECT_TIMEOUT)
         .timeout(HTTP_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
+        .no_proxy()
         .build()
-        .map_err(|_| FetchFailure::Transport)?;
+        .map_err(|_| FetchFailure::Transport)
+}
+
+async fn fetch_api_models(api_key: &str) -> Result<Vec<ApiModel>, FetchFailure> {
+    let client = build_anthropic_client()?;
     let api_key = api_key.to_string();
     fetch_api_models_with(move |after_id| {
         let client = client.clone();
@@ -539,7 +560,11 @@ where
     F: FnOnce(String) -> Fut,
     Fut: Future<Output = Result<Vec<ApiModel>, FetchFailure>>,
 {
-    if cache_is_fresh(path, current_ms) {
+    let freshness_path = path.to_path_buf();
+    if tokio::task::spawn_blocking(move || cache_is_fresh(&freshness_path, current_ms))
+        .await
+        .unwrap_or(false)
+    {
         return RefreshOutcome::Fresh;
     }
     let Some(api_key) = api_key.map(str::trim).filter(|key| !key.is_empty()) else {
@@ -561,9 +586,12 @@ where
     let Ok(serialized) = serde_json::to_string(&cache) else {
         return RefreshOutcome::CacheWriteFailed;
     };
-    match runtime_store::atomic_write(path, &serialized) {
-        Ok(()) => RefreshOutcome::Updated,
-        Err(_) => RefreshOutcome::CacheWriteFailed,
+    let write_path = path.to_path_buf();
+    match tokio::task::spawn_blocking(move || runtime_store::atomic_write(&write_path, &serialized))
+        .await
+    {
+        Ok(Ok(())) => RefreshOutcome::Updated,
+        Ok(Err(_)) | Err(_) => RefreshOutcome::CacheWriteFailed,
     }
 }
 
@@ -652,6 +680,12 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(&values[..4], ["fable", "opus", "sonnet", "haiku"]);
+        for selector in ["sonnet[1m]", "opus[1m]", "opusplan"] {
+            assert!(
+                values.contains(&selector),
+                "runtime-only selector {selector} must survive without caches"
+            );
+        }
         for alias in CURATED_ALIASES {
             let entry = entries
                 .iter()
@@ -765,6 +799,101 @@ mod tests {
         assert!(rendered.contains("claude-safe"));
         assert!(!rendered.contains(secret));
         assert!(!rendered.contains("credential-secret"));
+    }
+
+    #[tokio::test]
+    async fn invariant_claude_model_catalog_http_client_does_not_follow_redirects() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = vec![0_u8; 1_024];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:9/credential-leak\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+        });
+
+        let client = build_anthropic_client().unwrap();
+        let response = client
+            .get(format!("http://{address}/models"))
+            .header("x-api-key", "test-only-secret")
+            .send()
+            .await
+            .unwrap();
+
+        server.await.unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+    }
+
+    #[tokio::test]
+    async fn invariant_claude_model_catalog_http_client_ignores_environment_proxy() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        struct EnvRestore {
+            values: Vec<(&'static str, Option<std::ffi::OsString>)>,
+        }
+
+        impl Drop for EnvRestore {
+            fn drop(&mut self) {
+                for (name, value) in self.values.drain(..) {
+                    match value {
+                        Some(value) => unsafe { std::env::set_var(name, value) },
+                        None => unsafe { std::env::remove_var(name) },
+                    }
+                }
+            }
+        }
+
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let variables = ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"];
+        let _restore = EnvRestore {
+            values: variables
+                .iter()
+                .map(|name| (*name, std::env::var_os(name)))
+                .collect(),
+        };
+        let proxy = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_address = proxy.local_addr().unwrap();
+        for name in ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"] {
+            unsafe { std::env::set_var(name, format!("http://{proxy_address}")) };
+        }
+        unsafe { std::env::remove_var("NO_PROXY") };
+
+        let origin = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let origin_address = origin.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = origin.accept().await.unwrap();
+            let mut request = vec![0_u8; 1_024];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+                .await
+                .unwrap();
+        });
+
+        let response = build_anthropic_client()
+            .unwrap()
+            .get(format!("http://{origin_address}/models"))
+            .send()
+            .await
+            .unwrap();
+
+        server.await.unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), proxy.accept())
+                .await
+                .is_err(),
+            "environment proxy must not receive the request"
+        );
     }
 
     #[tokio::test]

--- a/src/services/discord/model_catalog/claude.rs
+++ b/src/services/discord/model_catalog/claude.rs
@@ -864,9 +864,7 @@ mod tests {
             }
         }
 
-        let _env_lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
+        let _env_lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let variables = ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"];
         let _restore = EnvRestore {
             values: variables

--- a/src/services/discord/model_catalog/claude.rs
+++ b/src/services/discord/model_catalog/claude.rs
@@ -14,6 +14,7 @@ use crate::services::provider::ProviderKind;
 
 const GATEWAY_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 const REFRESH_CHECK_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+const REFRESH_STANDBY_INTERVAL: Duration = Duration::from_secs(1);
 const CLOCK_SKEW_ALLOWANCE: Duration = Duration::from_secs(5 * 60);
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
@@ -189,15 +190,11 @@ impl RefreshOutcome {
 struct RefreshTaskGuard;
 
 impl RefreshTaskGuard {
-    fn claim(provider: &ProviderKind) -> Option<Self> {
-        if !matches!(provider, ProviderKind::Claude)
-            || REFRESH_TASK_RUNNING
-                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-                .is_err()
-        {
-            return None;
-        }
-        Some(Self)
+    fn claim() -> Option<Self> {
+        REFRESH_TASK_RUNNING
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+            .then_some(Self)
     }
 }
 
@@ -419,16 +416,6 @@ fn catalog_candidate_from_disk_paths(
     }
 }
 
-fn publish_initial_catalog_if_empty(cache: &RwLock<CatalogCache>, candidate: DiskCatalogCandidate) {
-    if let Ok(mut cached) = cache.write()
-        && cached.entries.is_empty()
-    {
-        cached.gateway_entries = candidate.gateway_entries;
-        cached.api_entries = candidate.api_entries;
-        cached.entries = merge_entries(cached.gateway_entries.clone(), cached.api_entries.clone());
-    }
-}
-
 fn publish_fresh_catalog_candidate(cache: &RwLock<CatalogCache>, candidate: &DiskCatalogCandidate) {
     if let Ok(mut cached) = cache.write() {
         if !candidate.gateway_entries.is_empty() {
@@ -437,6 +424,16 @@ fn publish_fresh_catalog_candidate(cache: &RwLock<CatalogCache>, candidate: &Dis
         if candidate.api_cache_fresh {
             cached.api_entries = candidate.api_entries.clone();
         }
+        cached.entries = merge_entries(cached.gateway_entries.clone(), cached.api_entries.clone());
+    }
+}
+
+fn publish_api_models(cache: &RwLock<CatalogCache>, models: Vec<ApiModel>) {
+    if let Ok(mut cached) = cache.write() {
+        cached.api_entries = usable_api_models(models)
+            .into_iter()
+            .map(|model| model_entry(model.id, model.display_name, "Anthropic Models API"))
+            .collect();
         cached.entries = merge_entries(cached.gateway_entries.clone(), cached.api_entries.clone());
     }
 }
@@ -585,14 +582,32 @@ async fn fetch_api_models(api_key: &str) -> Result<Vec<ApiModel>, FetchFailure> 
     .await
 }
 
+fn usable_api_models(models: Vec<ApiModel>) -> Vec<ApiModel> {
+    let mut seen = HashSet::new();
+    models
+        .into_iter()
+        .take(MAX_MODELS_PER_SOURCE)
+        .filter_map(|model| {
+            let id = model.id.trim().to_string();
+            if !is_safe_model_selector(&id) || !seen.insert(id.to_ascii_lowercase()) {
+                return None;
+            }
+            Some(ApiModel {
+                display_name: truncate_catalog_text(&model.display_name, &id),
+                id,
+            })
+        })
+        .collect()
+}
+
 fn cache_is_fresh(path: &Path, current_ms: u64) -> bool {
     file_cache_key(path)
         .and_then(|key| bounded_read(path, &key))
         .and_then(|raw| serde_json::from_slice::<ApiCache>(&raw).ok())
         .is_some_and(|cache| {
             cache.version == API_CACHE_VERSION
-                && !cache.models.is_empty()
                 && is_fresh(cache.fetched_at_ms, current_ms)
+                && !usable_api_models(cache.models).is_empty()
         })
 }
 
@@ -601,7 +616,7 @@ async fn refresh_cache_with<F, Fut>(
     current_ms: u64,
     api_key: Option<&str>,
     fetch: F,
-) -> RefreshOutcome
+) -> (RefreshOutcome, Option<Vec<ApiModel>>)
 where
     F: FnOnce(String) -> Fut,
     Fut: Future<Output = Result<Vec<ApiModel>, FetchFailure>>,
@@ -611,33 +626,33 @@ where
         .await
         .unwrap_or(false)
     {
-        return RefreshOutcome::Fresh;
+        return (RefreshOutcome::Fresh, None);
     }
     let Some(api_key) = api_key.map(str::trim).filter(|key| !key.is_empty()) else {
-        return RefreshOutcome::MissingApiKey;
+        return (RefreshOutcome::MissingApiKey, None);
     };
     let models = match fetch(api_key.to_string()).await {
-        Ok(models) => models,
-        Err(error) => return RefreshOutcome::FetchFailed(error),
+        Ok(models) => usable_api_models(models),
+        Err(error) => return (RefreshOutcome::FetchFailed(error), None),
     };
     if models.is_empty() {
-        return RefreshOutcome::Empty;
+        return (RefreshOutcome::Empty, None);
     }
 
     let cache = ApiCache {
         version: API_CACHE_VERSION,
         fetched_at_ms: current_ms,
-        models: models.into_iter().take(MAX_MODELS_PER_SOURCE).collect(),
+        models: models.clone(),
     };
     let Ok(serialized) = serde_json::to_string(&cache) else {
-        return RefreshOutcome::CacheWriteFailed;
+        return (RefreshOutcome::CacheWriteFailed, None);
     };
     let write_path = path.to_path_buf();
     match tokio::task::spawn_blocking(move || runtime_store::atomic_write(&write_path, &serialized))
         .await
     {
-        Ok(Ok(())) => RefreshOutcome::Updated,
-        Ok(Err(_)) | Err(_) => RefreshOutcome::CacheWriteFailed,
+        Ok(Ok(())) => (RefreshOutcome::Updated, Some(models)),
+        Ok(Err(_)) | Err(_) => (RefreshOutcome::CacheWriteFailed, None),
     }
 }
 
@@ -652,21 +667,17 @@ where
     F: FnOnce(String) -> Fut,
     Fut: Future<Output = Result<Vec<ApiModel>, FetchFailure>>,
 {
-    let candidate =
-        load_catalog_candidate(gateway_path.clone(), api_path.clone(), current_ms).await;
+    let candidate = load_catalog_candidate(gateway_path, api_path.clone(), current_ms).await;
     let cache = CATALOG_CACHE.get_or_init(|| RwLock::new(CatalogCache::default()));
-    publish_initial_catalog_if_empty(cache, candidate.clone());
+    publish_fresh_catalog_candidate(cache, &candidate);
 
     let Some(path) = api_path else {
-        publish_fresh_catalog_candidate(cache, &candidate);
         return RefreshOutcome::CachePathUnavailable;
     };
-    let outcome = refresh_cache_with(&path, current_ms, api_key, fetch).await;
-    if matches!(outcome, RefreshOutcome::Updated) {
-        let refreshed = load_catalog_candidate(gateway_path, Some(path), current_ms).await;
-        publish_fresh_catalog_candidate(cache, &refreshed);
-    } else {
-        publish_fresh_catalog_candidate(cache, &candidate);
+    let (outcome, refreshed_api_models) =
+        refresh_cache_with(&path, current_ms, api_key, fetch).await;
+    if let Some(models) = refreshed_api_models {
+        publish_api_models(cache, models);
     }
     outcome
 }
@@ -688,21 +699,47 @@ async fn refresh_and_log() {
     );
 }
 
+async fn run_refresh_owner<F, Fut>(refresh_interval: Duration, refresh: &mut F)
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    refresh().await;
+    let start = tokio::time::Instant::now() + refresh_interval;
+    let mut interval = tokio::time::interval_at(start, refresh_interval);
+    loop {
+        interval.tick().await;
+        refresh().await;
+    }
+}
+
+async fn supervise_background_refresh<F, Fut>(
+    standby_interval: Duration,
+    refresh_interval: Duration,
+    mut refresh: F,
+) where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    loop {
+        if let Some(_guard) = RefreshTaskGuard::claim() {
+            run_refresh_owner(refresh_interval, &mut refresh).await;
+            unreachable!("refresh owner runs until its supervisor is cancelled")
+        }
+        tokio::time::sleep(standby_interval).await;
+    }
+}
+
 pub(super) fn spawn_background_refresh(
     provider: &ProviderKind,
 ) -> Option<tokio::task::JoinHandle<()>> {
-    let guard = RefreshTaskGuard::claim(provider)?;
-
-    Some(tokio::spawn(async move {
-        let _guard = guard;
-        refresh_and_log().await;
-        let start = tokio::time::Instant::now() + REFRESH_CHECK_INTERVAL;
-        let mut interval = tokio::time::interval_at(start, REFRESH_CHECK_INTERVAL);
-        loop {
-            interval.tick().await;
-            refresh_and_log().await;
-        }
-    }))
+    matches!(provider, ProviderKind::Claude).then(|| {
+        tokio::spawn(supervise_background_refresh(
+            REFRESH_STANDBY_INTERVAL,
+            REFRESH_CHECK_INTERVAL,
+            refresh_and_log,
+        ))
+    })
 }
 
 #[cfg(test)]
@@ -725,19 +762,75 @@ mod tests {
     }
 
     #[test]
-    fn invariant_claude_model_catalog_refresh_claim_is_claude_only_singleflight() {
+    fn invariant_claude_model_catalog_refresh_claim_is_singleflight() {
         REFRESH_TASK_RUNNING.store(false, Ordering::Release);
-        assert!(RefreshTaskGuard::claim(&ProviderKind::Codex).is_none());
-        assert!(!REFRESH_TASK_RUNNING.load(Ordering::Acquire));
-
-        let guard =
-            RefreshTaskGuard::claim(&ProviderKind::Claude).expect("first Claude task claim");
-        assert!(RefreshTaskGuard::claim(&ProviderKind::Claude).is_none());
+        let guard = RefreshTaskGuard::claim().expect("first Claude task claim");
+        assert!(RefreshTaskGuard::claim().is_none());
         drop(guard);
-        let reclaimed =
-            RefreshTaskGuard::claim(&ProviderKind::Claude).expect("claim reset after drop");
+        let reclaimed = RefreshTaskGuard::claim().expect("claim reset after drop");
         drop(reclaimed);
         assert!(!REFRESH_TASK_RUNNING.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn invariant_claude_model_catalog_non_claude_provider_has_no_supervisor() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            assert!(spawn_background_refresh(&ProviderKind::Codex).is_none());
+            let handle = spawn_background_refresh(&ProviderKind::Claude)
+                .expect("Claude gateway must keep a refresh supervisor");
+            handle.abort();
+            let _ = handle.await;
+        });
+    }
+
+    #[test]
+    fn invariant_claude_model_catalog_owner_exit_hands_off_to_live_supervisor() {
+        let _env_lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
+        REFRESH_TASK_RUNNING.store(false, Ordering::Release);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            tokio::time::pause();
+            let refreshes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let spawn_supervisor = |refreshes: Arc<std::sync::atomic::AtomicUsize>| {
+                tokio::spawn(supervise_background_refresh(
+                    Duration::from_secs(1),
+                    Duration::from_secs(60),
+                    move || {
+                        let refreshes = Arc::clone(&refreshes);
+                        async move {
+                            refreshes.fetch_add(1, Ordering::AcqRel);
+                            std::future::pending::<()>().await;
+                        }
+                    },
+                ))
+            };
+
+            let first = spawn_supervisor(Arc::clone(&refreshes));
+            let second = spawn_supervisor(Arc::clone(&refreshes));
+            tokio::task::yield_now().await;
+            assert_eq!(refreshes.load(Ordering::Acquire), 1);
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+
+            first.abort();
+            let _ = first.await;
+            assert!(!REFRESH_TASK_RUNNING.load(Ordering::Acquire));
+            tokio::time::advance(Duration::from_secs(1)).await;
+            tokio::task::yield_now().await;
+            assert_eq!(refreshes.load(Ordering::Acquire), 2);
+            assert!(REFRESH_TASK_RUNNING.load(Ordering::Acquire));
+
+            second.abort();
+            let _ = second.await;
+            assert!(!REFRESH_TASK_RUNNING.load(Ordering::Acquire));
+        });
     }
 
     #[test]
@@ -1206,6 +1299,86 @@ mod tests {
         });
     }
 
+    #[test]
+    fn invariant_claude_model_catalog_successful_api_refresh_preserves_gateway_memory_source() {
+        let _env_lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let directory = tempdir().unwrap();
+            let gateway_path = directory.path().join("gateway.json");
+            let api_path = directory.path().join("api.json");
+            let current_ms = 55_000;
+            let stale_ms = current_ms + GATEWAY_CACHE_TTL.as_millis() as u64 + 1;
+            std::fs::write(
+                &gateway_path,
+                serde_json::json!({
+                    "fetchedAt": current_ms,
+                    "models": [{"id": "gateway-memory", "display_name": "Memory gateway"}],
+                })
+                .to_string(),
+            )
+            .unwrap();
+            std::fs::write(
+                &api_path,
+                api_cache_json(
+                    current_ms,
+                    serde_json::json!([{"id": "claude-old-api", "display_name": "Old API"}]),
+                ),
+            )
+            .unwrap();
+            let cache = CATALOG_CACHE.get_or_init(|| RwLock::new(CatalogCache::default()));
+            if let Ok(mut cached) = cache.write() {
+                *cached = CatalogCache::default();
+            }
+            let initial = refresh_and_log_with(
+                Some(gateway_path.clone()),
+                Some(api_path.clone()),
+                current_ms,
+                None,
+                |_| async { unreachable!("fresh cache must not fetch") },
+            )
+            .await;
+            assert_eq!(initial, RefreshOutcome::Fresh);
+
+            let updated = refresh_and_log_with(
+                Some(gateway_path.clone()),
+                Some(api_path),
+                stale_ms,
+                Some("key"),
+                move |_| async move {
+                    std::fs::write(
+                        &gateway_path,
+                        serde_json::json!({
+                            "fetchedAt": stale_ms,
+                            "models": [{"id": "gateway-disk-race", "display_name": "Disk race"}],
+                        })
+                        .to_string(),
+                    )
+                    .unwrap();
+                    Ok(vec![ApiModel {
+                        id: "claude-new-api".to_string(),
+                        display_name: "New API".to_string(),
+                    }])
+                },
+            )
+            .await;
+
+            assert_eq!(updated, RefreshOutcome::Updated);
+            let resolved = resolved_models();
+            assert!(resolved.iter().any(|entry| entry.value == "gateway-memory"));
+            assert!(
+                !resolved
+                    .iter()
+                    .any(|entry| entry.value == "gateway-disk-race")
+            );
+            assert!(resolved.iter().any(|entry| entry.value == "claude-new-api"));
+            assert!(!resolved.iter().any(|entry| entry.value == "claude-old-api"));
+        });
+    }
+
     #[tokio::test]
     async fn invariant_claude_model_catalog_fresh_cache_skips_refresh_fetch() {
         let directory = tempdir().unwrap();
@@ -1221,7 +1394,7 @@ mod tests {
         .unwrap();
         let fetch_called = Arc::new(AtomicBool::new(false));
 
-        let outcome = refresh_cache_with(&path, current_ms, Some("key"), {
+        let (outcome, published) = refresh_cache_with(&path, current_ms, Some("key"), {
             let fetch_called = Arc::clone(&fetch_called);
             move |_| {
                 fetch_called.store(true, Ordering::Release);
@@ -1231,7 +1404,45 @@ mod tests {
         .await;
 
         assert_eq!(outcome, RefreshOutcome::Fresh);
+        assert!(published.is_none());
         assert!(!fetch_called.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn invariant_claude_model_catalog_invalid_only_fresh_cache_triggers_fetch() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("cache.json");
+        let current_ms = 55_000;
+        std::fs::write(
+            &path,
+            api_cache_json(
+                current_ms,
+                serde_json::json!([
+                    {"id": "bad selector!", "display_name": "Invalid"},
+                    {"id": "x".repeat(65), "display_name": "Oversize"}
+                ]),
+            ),
+        )
+        .unwrap();
+        let fetch_called = Arc::new(AtomicBool::new(false));
+
+        let (outcome, published) = refresh_cache_with(&path, current_ms, Some("key"), {
+            let fetch_called = Arc::clone(&fetch_called);
+            move |_| {
+                fetch_called.store(true, Ordering::Release);
+                async {
+                    Ok(vec![ApiModel {
+                        id: "claude-valid-refresh".to_string(),
+                        display_name: "Valid refresh".to_string(),
+                    }])
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(outcome, RefreshOutcome::Updated);
+        assert!(fetch_called.load(Ordering::Acquire));
+        assert_eq!(published.unwrap()[0].id, "claude-valid-refresh");
     }
 
     #[tokio::test]
@@ -1244,7 +1455,7 @@ mod tests {
         );
         std::fs::write(&path, &original).unwrap();
 
-        let outcome = refresh_cache_with(
+        let (outcome, published) = refresh_cache_with(
             &path,
             GATEWAY_CACHE_TTL.as_millis() as u64 + 2,
             Some("key"),
@@ -1256,6 +1467,7 @@ mod tests {
             outcome,
             RefreshOutcome::FetchFailed(FetchFailure::Transport)
         );
+        assert!(published.is_none());
         assert_eq!(std::fs::read(&path).unwrap(), original);
     }
 
@@ -1269,7 +1481,7 @@ mod tests {
         );
         std::fs::write(&path, &original).unwrap();
 
-        let outcome = refresh_cache_with(
+        let (outcome, published) = refresh_cache_with(
             &path,
             GATEWAY_CACHE_TTL.as_millis() as u64 + 2,
             Some("key"),
@@ -1278,6 +1490,7 @@ mod tests {
         .await;
 
         assert_eq!(outcome, RefreshOutcome::Empty);
+        assert!(published.is_none());
         assert_eq!(std::fs::read(&path).unwrap(), original);
     }
 
@@ -1286,7 +1499,7 @@ mod tests {
         let directory = tempdir().unwrap();
         let path = directory.path().join("nested").join("cache.json");
         let current_ms = 55_000;
-        let outcome = refresh_cache_with(&path, current_ms, Some("key"), |_| async {
+        let (outcome, published) = refresh_cache_with(&path, current_ms, Some("key"), |_| async {
             Ok(vec![ApiModel {
                 id: "claude-new".to_string(),
                 display_name: "New model".to_string(),
@@ -1295,6 +1508,7 @@ mod tests {
         .await;
 
         assert_eq!(outcome, RefreshOutcome::Updated);
+        assert_eq!(published.unwrap()[0].id, "claude-new");
         let cache: ApiCache = serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
         assert_eq!(cache.fetched_at_ms, current_ms);
         assert_eq!(cache.models[0].id, "claude-new");

--- a/src/services/discord/model_catalog/claude.rs
+++ b/src/services/discord/model_catalog/claude.rs
@@ -1,0 +1,985 @@
+use std::collections::HashSet;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{OnceLock, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+
+use super::{ModelCatalogEntry, is_safe_model_selector};
+use crate::services::discord::runtime_store;
+use crate::services::provider::ProviderKind;
+
+const GATEWAY_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+const REFRESH_CHECK_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+const CLOCK_SKEW_ALLOWANCE: Duration = Duration::from_secs(5 * 60);
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const MAX_CACHE_BODY_BYTES: usize = 256 * 1024;
+const MAX_API_PAGES: usize = 4;
+const MAX_MODELS_PER_SOURCE: usize = 100;
+const MAX_CATALOG_TEXT_CHARS: usize = 100;
+const ANTHROPIC_MODELS_URL: &str = "https://api.anthropic.com/v1/models";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const API_CACHE_VERSION: u8 = 1;
+
+static REFRESH_TASK_RUNNING: AtomicBool = AtomicBool::new(false);
+static CATALOG_CACHE: OnceLock<RwLock<CatalogCache>> = OnceLock::new();
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FileCacheKey {
+    modified_ms: u128,
+    len: u64,
+}
+
+#[derive(Clone, Debug, Default)]
+struct CatalogCache {
+    entries: Vec<ModelCatalogEntry>,
+}
+
+#[derive(Clone, Copy)]
+struct CuratedAlias {
+    selector: &'static str,
+    label: &'static str,
+    metadata_fallback_id: &'static str,
+}
+
+const CURATED_ALIASES: &[CuratedAlias] = &[
+    CuratedAlias {
+        selector: "fable",
+        label: "Fable 5",
+        metadata_fallback_id: "claude-fable-5",
+    },
+    CuratedAlias {
+        selector: "opus",
+        label: "Opus 5",
+        metadata_fallback_id: "claude-opus-5",
+    },
+    CuratedAlias {
+        selector: "sonnet",
+        label: "Sonnet 5",
+        metadata_fallback_id: "claude-sonnet-5",
+    },
+    CuratedAlias {
+        selector: "haiku",
+        label: "Haiku 4.5",
+        metadata_fallback_id: "claude-haiku-4-5-20251001",
+    },
+];
+
+const STATIC_FALLBACK_IDS: &[&str] = &[
+    "claude-fable-5",
+    "claude-opus-5",
+    "claude-sonnet-5",
+    "claude-haiku-4-5-20251001",
+];
+
+#[derive(Debug, Deserialize)]
+struct GatewayCache {
+    #[serde(rename = "fetchedAt")]
+    fetched_at_ms: u64,
+    #[serde(default)]
+    models: Vec<GatewayModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GatewayModel {
+    #[serde(alias = "value")]
+    id: String,
+    #[serde(default, alias = "displayName")]
+    display_name: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ApiCache {
+    version: u8,
+    fetched_at_ms: u64,
+    models: Vec<ApiModel>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ApiModel {
+    id: String,
+    display_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiPage {
+    #[serde(default)]
+    data: Vec<ApiModelWire>,
+    #[serde(default)]
+    has_more: bool,
+    #[serde(default)]
+    last_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiModelWire {
+    id: String,
+    #[serde(default)]
+    display_name: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FetchFailure {
+    Timeout,
+    Transport,
+    HttpStatus,
+    BodyLimit,
+    InvalidResponse,
+    PaginationLimit,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RefreshOutcome {
+    Fresh,
+    MissingApiKey,
+    Updated,
+    Empty,
+    FetchFailed(FetchFailure),
+    CacheWriteFailed,
+    CachePathUnavailable,
+}
+
+impl RefreshOutcome {
+    fn category(self) -> &'static str {
+        match self {
+            Self::Fresh => "fresh",
+            Self::MissingApiKey => "missing_api_key",
+            Self::Updated => "updated",
+            Self::Empty => "empty",
+            Self::FetchFailed(FetchFailure::Timeout) => "timeout",
+            Self::FetchFailed(FetchFailure::Transport) => "transport_failure",
+            Self::FetchFailed(FetchFailure::HttpStatus) => "http_status_failure",
+            Self::FetchFailed(FetchFailure::BodyLimit) => "body_limit",
+            Self::FetchFailed(FetchFailure::InvalidResponse) => "invalid_response",
+            Self::FetchFailed(FetchFailure::PaginationLimit) => "pagination_limit",
+            Self::CacheWriteFailed => "cache_write_failure",
+            Self::CachePathUnavailable => "cache_path_unavailable",
+        }
+    }
+}
+
+struct RefreshTaskGuard;
+
+impl RefreshTaskGuard {
+    fn claim(provider: &ProviderKind) -> Option<Self> {
+        if !matches!(provider, ProviderKind::Claude)
+            || REFRESH_TASK_RUNNING
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+        {
+            return None;
+        }
+        Some(Self)
+    }
+}
+
+impl Drop for RefreshTaskGuard {
+    fn drop(&mut self) {
+        REFRESH_TASK_RUNNING.store(false, Ordering::Release);
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+fn is_fresh(fetched_at_ms: u64, current_ms: u64) -> bool {
+    let ttl_ms: u64 = GATEWAY_CACHE_TTL.as_millis().try_into().unwrap_or(u64::MAX);
+    let skew_ms: u64 = CLOCK_SKEW_ALLOWANCE
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX);
+    fetched_at_ms <= current_ms.saturating_add(skew_ms)
+        && current_ms.saturating_sub(fetched_at_ms) <= ttl_ms
+}
+
+fn truncate_catalog_text(raw: &str, fallback: &str) -> String {
+    let mut text = raw
+        .trim()
+        .chars()
+        .filter(|character| !character.is_control())
+        .take(MAX_CATALOG_TEXT_CHARS)
+        .collect::<String>();
+    if text.is_empty() {
+        text = fallback
+            .chars()
+            .take(MAX_CATALOG_TEXT_CHARS)
+            .collect::<String>();
+    }
+    text
+}
+
+fn file_cache_key(path: &Path) -> Option<FileCacheKey> {
+    let metadata = std::fs::metadata(path).ok()?;
+    if metadata.len() > MAX_CACHE_BODY_BYTES as u64 {
+        return None;
+    }
+    let modified_ms = metadata
+        .modified()
+        .ok()?
+        .duration_since(UNIX_EPOCH)
+        .ok()?
+        .as_millis();
+    Some(FileCacheKey {
+        modified_ms,
+        len: metadata.len(),
+    })
+}
+
+fn bounded_read(path: &Path, expected: &FileCacheKey) -> Option<Vec<u8>> {
+    let body = std::fs::read(path).ok()?;
+    (body.len() <= MAX_CACHE_BODY_BYTES && body.len() as u64 == expected.len).then_some(body)
+}
+
+fn gateway_cache_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| {
+        home.join(".claude")
+            .join("cache")
+            .join("gateway-models.json")
+    })
+}
+
+fn api_cache_path() -> Option<PathBuf> {
+    runtime_store::runtime_root().map(|root| root.join("claude_model_catalog.json"))
+}
+
+fn model_entry(id: String, label: String, source: &'static str) -> ModelCatalogEntry {
+    ModelCatalogEntry::owned(
+        id,
+        truncate_catalog_text(&label, "Claude model"),
+        source.to_string(),
+        "Local bounded cache".to_string(),
+    )
+}
+
+fn curated_entries() -> Vec<ModelCatalogEntry> {
+    CURATED_ALIASES
+        .iter()
+        .map(|alias| {
+            ModelCatalogEntry::borrowed(
+                alias.selector,
+                alias.label,
+                "Evergreen Claude Code selector",
+                alias.metadata_fallback_id,
+            )
+        })
+        .collect()
+}
+
+fn static_fallback_entries() -> Vec<ModelCatalogEntry> {
+    STATIC_FALLBACK_IDS
+        .iter()
+        .map(|id| {
+            ModelCatalogEntry::borrowed(
+                id,
+                id,
+                "Static Claude metadata fallback",
+                "AgentDesk fallback",
+            )
+        })
+        .collect()
+}
+
+fn gateway_entries_from_raw(raw: &[u8], current_ms: u64) -> Vec<ModelCatalogEntry> {
+    if raw.len() > MAX_CACHE_BODY_BYTES {
+        return Vec::new();
+    }
+    let Ok(cache) = serde_json::from_slice::<GatewayCache>(raw) else {
+        return Vec::new();
+    };
+    if !is_fresh(cache.fetched_at_ms, current_ms) {
+        return Vec::new();
+    }
+
+    cache
+        .models
+        .into_iter()
+        .take(MAX_MODELS_PER_SOURCE)
+        .filter_map(|model| {
+            let id = model.id.trim().to_string();
+            is_safe_model_selector(&id).then(|| {
+                let label = truncate_catalog_text(&model.display_name, &id);
+                model_entry(id, label, "Claude gateway selector")
+            })
+        })
+        .collect()
+}
+
+fn api_entries_from_raw(raw: &[u8], current_ms: u64) -> Vec<ModelCatalogEntry> {
+    if raw.len() > MAX_CACHE_BODY_BYTES {
+        return Vec::new();
+    }
+    let Ok(cache) = serde_json::from_slice::<ApiCache>(raw) else {
+        return Vec::new();
+    };
+    if cache.version != API_CACHE_VERSION || !is_fresh(cache.fetched_at_ms, current_ms) {
+        return Vec::new();
+    }
+
+    cache
+        .models
+        .into_iter()
+        .take(MAX_MODELS_PER_SOURCE)
+        .filter_map(|model| {
+            let id = model.id.trim().to_string();
+            is_safe_model_selector(&id).then(|| {
+                let label = truncate_catalog_text(&model.display_name, &id);
+                model_entry(id, label, "Anthropic Models API")
+            })
+        })
+        .collect()
+}
+
+fn merge_entries(
+    gateway_entries: Vec<ModelCatalogEntry>,
+    api_entries: Vec<ModelCatalogEntry>,
+) -> Vec<ModelCatalogEntry> {
+    let mut seen = HashSet::new();
+    curated_entries()
+        .into_iter()
+        .chain(gateway_entries)
+        .chain(api_entries)
+        .chain(static_fallback_entries())
+        .filter(|entry| seen.insert(entry.value.to_ascii_lowercase()))
+        .collect()
+}
+
+fn catalog_from_raw_sources(
+    gateway_raw: Option<&[u8]>,
+    api_raw: Option<&[u8]>,
+    current_ms: u64,
+) -> Vec<ModelCatalogEntry> {
+    merge_entries(
+        gateway_raw
+            .map(|raw| gateway_entries_from_raw(raw, current_ms))
+            .unwrap_or_default(),
+        api_raw
+            .map(|raw| api_entries_from_raw(raw, current_ms))
+            .unwrap_or_default(),
+    )
+}
+
+fn reload_catalog_cache_from_disk() {
+    let gateway_path = gateway_cache_path();
+    let api_path = api_cache_path();
+    let gateway_key = gateway_path.as_deref().and_then(file_cache_key);
+    let api_key = api_path.as_deref().and_then(file_cache_key);
+    let cache = CATALOG_CACHE.get_or_init(|| RwLock::new(CatalogCache::default()));
+    let gateway_raw = gateway_path
+        .as_deref()
+        .zip(gateway_key.as_ref())
+        .and_then(|(path, expected)| bounded_read(path, expected));
+    let api_raw = api_path
+        .as_deref()
+        .zip(api_key.as_ref())
+        .and_then(|(path, expected)| bounded_read(path, expected));
+    let entries = catalog_from_raw_sources(gateway_raw.as_deref(), api_raw.as_deref(), now_ms());
+    if let Ok(mut cached) = cache.write() {
+        cached.entries = entries;
+    }
+}
+
+async fn reload_catalog_cache() {
+    let _ = tokio::task::spawn_blocking(reload_catalog_cache_from_disk).await;
+}
+
+pub(super) fn resolved_models() -> Vec<ModelCatalogEntry> {
+    CATALOG_CACHE
+        .get_or_init(|| RwLock::new(CatalogCache::default()))
+        .read()
+        .ok()
+        .filter(|cached| !cached.entries.is_empty())
+        .map(|cached| cached.entries.clone())
+        .unwrap_or_else(|| merge_entries(Vec::new(), Vec::new()))
+}
+
+fn parse_api_page(raw: &[u8]) -> Result<ApiPage, FetchFailure> {
+    if raw.len() > MAX_CACHE_BODY_BYTES {
+        return Err(FetchFailure::BodyLimit);
+    }
+    serde_json::from_slice(raw).map_err(|_| FetchFailure::InvalidResponse)
+}
+
+async fn fetch_api_models_with<F, Fut>(mut fetch: F) -> Result<Vec<ApiModel>, FetchFailure>
+where
+    F: FnMut(Option<String>) -> Fut,
+    Fut: Future<Output = Result<Vec<u8>, FetchFailure>>,
+{
+    let mut models = Vec::new();
+    let mut seen = HashSet::new();
+    let mut after_id = None;
+
+    for page_index in 0..MAX_API_PAGES {
+        let page = parse_api_page(&fetch(after_id.clone()).await?)?;
+        for model in page.data {
+            let id = model.id.trim().to_string();
+            if !is_safe_model_selector(&id) || !seen.insert(id.to_ascii_lowercase()) {
+                continue;
+            }
+            models.push(ApiModel {
+                display_name: truncate_catalog_text(&model.display_name, &id),
+                id,
+            });
+            if models.len() == MAX_MODELS_PER_SOURCE {
+                return Ok(models);
+            }
+        }
+
+        if !page.has_more {
+            return Ok(models);
+        }
+        if page_index + 1 == MAX_API_PAGES {
+            return Err(FetchFailure::PaginationLimit);
+        }
+        let next = page
+            .last_id
+            .map(|value| value.trim().to_string())
+            .filter(|value| is_safe_model_selector(value))
+            .ok_or(FetchFailure::InvalidResponse)?;
+        if after_id.as_ref() == Some(&next) {
+            return Err(FetchFailure::InvalidResponse);
+        }
+        after_id = Some(next);
+    }
+
+    Err(FetchFailure::PaginationLimit)
+}
+
+async fn fetch_network_page(
+    client: reqwest::Client,
+    api_key: String,
+    after_id: Option<String>,
+) -> Result<Vec<u8>, FetchFailure> {
+    let mut request = client
+        .get(ANTHROPIC_MODELS_URL)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", ANTHROPIC_VERSION)
+        .query(&[("limit", MAX_MODELS_PER_SOURCE.to_string())]);
+    if let Some(after_id) = after_id {
+        request = request.query(&[("after_id", after_id)]);
+    }
+
+    let response = request.send().await.map_err(|error| {
+        if error.is_timeout() {
+            FetchFailure::Timeout
+        } else {
+            FetchFailure::Transport
+        }
+    })?;
+    if !response.status().is_success() {
+        return Err(FetchFailure::HttpStatus);
+    }
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_CACHE_BODY_BYTES as u64)
+    {
+        return Err(FetchFailure::BodyLimit);
+    }
+
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| {
+            if error.is_timeout() {
+                FetchFailure::Timeout
+            } else {
+                FetchFailure::Transport
+            }
+        })?;
+        if body.len().saturating_add(chunk.len()) > MAX_CACHE_BODY_BYTES {
+            return Err(FetchFailure::BodyLimit);
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+async fn fetch_api_models(api_key: &str) -> Result<Vec<ApiModel>, FetchFailure> {
+    let client = reqwest::Client::builder()
+        .connect_timeout(HTTP_CONNECT_TIMEOUT)
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .map_err(|_| FetchFailure::Transport)?;
+    let api_key = api_key.to_string();
+    fetch_api_models_with(move |after_id| {
+        let client = client.clone();
+        let api_key = api_key.clone();
+        async move { fetch_network_page(client, api_key, after_id).await }
+    })
+    .await
+}
+
+fn cache_is_fresh(path: &Path, current_ms: u64) -> bool {
+    file_cache_key(path)
+        .and_then(|key| bounded_read(path, &key))
+        .and_then(|raw| serde_json::from_slice::<ApiCache>(&raw).ok())
+        .is_some_and(|cache| {
+            cache.version == API_CACHE_VERSION
+                && !cache.models.is_empty()
+                && is_fresh(cache.fetched_at_ms, current_ms)
+        })
+}
+
+async fn refresh_cache_with<F, Fut>(
+    path: &Path,
+    current_ms: u64,
+    api_key: Option<&str>,
+    fetch: F,
+) -> RefreshOutcome
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = Result<Vec<ApiModel>, FetchFailure>>,
+{
+    if cache_is_fresh(path, current_ms) {
+        return RefreshOutcome::Fresh;
+    }
+    let Some(api_key) = api_key.map(str::trim).filter(|key| !key.is_empty()) else {
+        return RefreshOutcome::MissingApiKey;
+    };
+    let models = match fetch(api_key.to_string()).await {
+        Ok(models) => models,
+        Err(error) => return RefreshOutcome::FetchFailed(error),
+    };
+    if models.is_empty() {
+        return RefreshOutcome::Empty;
+    }
+
+    let cache = ApiCache {
+        version: API_CACHE_VERSION,
+        fetched_at_ms: current_ms,
+        models: models.into_iter().take(MAX_MODELS_PER_SOURCE).collect(),
+    };
+    let Ok(serialized) = serde_json::to_string(&cache) else {
+        return RefreshOutcome::CacheWriteFailed;
+    };
+    match runtime_store::atomic_write(path, &serialized) {
+        Ok(()) => RefreshOutcome::Updated,
+        Err(_) => RefreshOutcome::CacheWriteFailed,
+    }
+}
+
+async fn refresh_once() -> RefreshOutcome {
+    let Some(path) = api_cache_path() else {
+        return RefreshOutcome::CachePathUnavailable;
+    };
+    let api_key = std::env::var("ANTHROPIC_API_KEY").ok();
+    refresh_cache_with(&path, now_ms(), api_key.as_deref(), |api_key| async move {
+        fetch_api_models(&api_key).await
+    })
+    .await
+}
+
+async fn refresh_and_log() {
+    reload_catalog_cache().await;
+    let outcome = refresh_once().await;
+    if matches!(outcome, RefreshOutcome::Updated) {
+        reload_catalog_cache().await;
+    }
+    tracing::info!(
+        target: "agentdesk::claude_model_catalog",
+        status = outcome.category(),
+        "Claude model catalog refresh check"
+    );
+}
+
+pub(super) fn spawn_background_refresh(
+    provider: &ProviderKind,
+) -> Option<tokio::task::JoinHandle<()>> {
+    let guard = RefreshTaskGuard::claim(provider)?;
+
+    Some(tokio::spawn(async move {
+        let _guard = guard;
+        refresh_and_log().await;
+        let start = tokio::time::Instant::now() + REFRESH_CHECK_INTERVAL;
+        let mut interval = tokio::time::interval_at(start, REFRESH_CHECK_INTERVAL);
+        loop {
+            interval.tick().await;
+            refresh_and_log().await;
+        }
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn api_cache_json(fetched_at_ms: u64, models: serde_json::Value) -> Vec<u8> {
+        serde_json::json!({
+            "version": API_CACHE_VERSION,
+            "fetched_at_ms": fetched_at_ms,
+            "models": models,
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    #[test]
+    fn invariant_claude_model_catalog_refresh_claim_is_claude_only_singleflight() {
+        REFRESH_TASK_RUNNING.store(false, Ordering::Release);
+        assert!(RefreshTaskGuard::claim(&ProviderKind::Codex).is_none());
+        assert!(!REFRESH_TASK_RUNNING.load(Ordering::Acquire));
+
+        let guard =
+            RefreshTaskGuard::claim(&ProviderKind::Claude).expect("first Claude task claim");
+        assert!(RefreshTaskGuard::claim(&ProviderKind::Claude).is_none());
+        drop(guard);
+        let reclaimed =
+            RefreshTaskGuard::claim(&ProviderKind::Claude).expect("claim reset after drop");
+        drop(reclaimed);
+        assert!(!REFRESH_TASK_RUNNING.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn invariant_claude_model_catalog_curated_aliases_remain_evergreen_runtime_selectors() {
+        let entries = catalog_from_raw_sources(None, None, 1_000_000);
+        let values = entries
+            .iter()
+            .map(|entry| entry.value.as_ref())
+            .collect::<Vec<_>>();
+
+        assert_eq!(&values[..4], ["fable", "opus", "sonnet", "haiku"]);
+        for alias in CURATED_ALIASES {
+            let entry = entries
+                .iter()
+                .find(|entry| entry.value == alias.selector)
+                .expect("curated alias");
+            assert_eq!(entry.secondary_summary, alias.metadata_fallback_id);
+            assert_ne!(entry.value, alias.metadata_fallback_id);
+        }
+    }
+
+    #[test]
+    fn invariant_claude_model_catalog_invalid_and_stale_caches_fall_back_safely() {
+        let stale = serde_json::json!({
+            "fetchedAt": 1,
+            "models": [{"id": "gateway-only", "display_name": "Gateway"}],
+        })
+        .to_string();
+        let invalid_api = br#"{"version":1,"fetched_at_ms":"secret"}"#;
+        let entries = catalog_from_raw_sources(
+            Some(stale.as_bytes()),
+            Some(invalid_api),
+            GATEWAY_CACHE_TTL.as_millis() as u64 + 10_000,
+        );
+
+        assert!(!entries.iter().any(|entry| entry.value == "gateway-only"));
+        assert!(entries.iter().any(|entry| entry.value == "fable"));
+        assert!(entries.iter().any(|entry| entry.value == "claude-fable-5"));
+    }
+
+    #[test]
+    fn invariant_claude_model_catalog_merge_priority_and_dedupe_are_stable() {
+        let current_ms = 9_000_000;
+        let gateway = serde_json::json!({
+            "fetchedAt": current_ms,
+            "models": [
+                {"id": "claude-shared", "display_name": "Gateway winner"},
+                {"id": "CLAUDE-SHARED", "display_name": "Duplicate"}
+            ],
+        })
+        .to_string();
+        let api = api_cache_json(
+            current_ms,
+            serde_json::json!([
+                {"id": "claude-shared", "display_name": "API loser"},
+                {"id": "claude-api-only", "display_name": "API only"},
+                {"id": "claude-fable-5", "display_name": "API fallback winner"}
+            ]),
+        );
+        let entries = catalog_from_raw_sources(Some(gateway.as_bytes()), Some(&api), current_ms);
+
+        assert_eq!(entries[0].value, "fable");
+        let shared = entries
+            .iter()
+            .find(|entry| entry.value.eq_ignore_ascii_case("claude-shared"))
+            .expect("shared model");
+        assert_eq!(shared.label, "Gateway winner");
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|entry| entry.value.eq_ignore_ascii_case("claude-shared"))
+                .count(),
+            1
+        );
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|entry| entry.value == "claude-fable-5")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn invariant_claude_model_catalog_gateway_value_selector_is_supported() {
+        let raw = serde_json::json!({
+            "fetchedAt": 10_000,
+            "models": [{"value": "fable[1m]", "displayName": "Fable 1M"}],
+        })
+        .to_string();
+        let entries = catalog_from_raw_sources(Some(raw.as_bytes()), None, 10_000);
+
+        let discovered = entries
+            .iter()
+            .find(|entry| entry.value == "fable[1m]")
+            .expect("gateway selector");
+        assert_eq!(discovered.label, "Fable 1M");
+    }
+
+    #[test]
+    fn invariant_claude_model_catalog_gateway_base_url_and_unknown_fields_never_surface() {
+        let secret = "https://user:password@example.invalid/private?token=secret";
+        let raw = serde_json::json!({
+            "baseUrl": secret,
+            "credentials": {"token": "credential-secret"},
+            "fetchedAt": 10_000,
+            "models": [{"id": "claude-safe", "display_name": "Safe label"}],
+        })
+        .to_string();
+        let entries = catalog_from_raw_sources(Some(raw.as_bytes()), None, 10_000);
+        let rendered = entries
+            .iter()
+            .map(|entry| {
+                format!(
+                    "{} {} {} {}",
+                    entry.value, entry.label, entry.primary_summary, entry.secondary_summary
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("claude-safe"));
+        assert!(!rendered.contains(secret));
+        assert!(!rendered.contains("credential-secret"));
+    }
+
+    #[tokio::test]
+    async fn invariant_claude_model_catalog_api_pagination_uses_bounded_cursor_sequence() {
+        let pages = Arc::new(Mutex::new(VecDeque::from([
+            Ok(serde_json::json!({
+                "data": [{"id": "claude-page-1", "display_name": "Page one"}],
+                "has_more": true,
+                "last_id": "claude-page-1"
+            })
+            .to_string()
+            .into_bytes()),
+            Ok(serde_json::json!({
+                "data": [{"id": "claude-page-2", "display_name": "Page two"}],
+                "has_more": false,
+                "last_id": "claude-page-2"
+            })
+            .to_string()
+            .into_bytes()),
+        ])));
+        let cursors = Arc::new(Mutex::new(Vec::new()));
+        let models = fetch_api_models_with({
+            let pages = Arc::clone(&pages);
+            let cursors = Arc::clone(&cursors);
+            move |cursor| {
+                cursors.lock().unwrap().push(cursor);
+                let response = pages.lock().unwrap().pop_front().unwrap();
+                async move { response }
+            }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            models
+                .iter()
+                .map(|model| model.id.as_str())
+                .collect::<Vec<_>>(),
+            ["claude-page-1", "claude-page-2"]
+        );
+        assert_eq!(
+            *cursors.lock().unwrap(),
+            [None, Some("claude-page-1".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn invariant_claude_model_catalog_api_rejects_body_and_pagination_bounds() {
+        let body = vec![b'x'; MAX_CACHE_BODY_BYTES + 1];
+        let error = fetch_api_models_with(move |_| {
+            let body = body.clone();
+            async move { Ok(body) }
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(error, FetchFailure::BodyLimit);
+
+        let error = fetch_api_models_with(|_| async {
+            Ok(serde_json::json!({
+                "data": [],
+                "has_more": true,
+                "last_id": "same-cursor"
+            })
+            .to_string()
+            .into_bytes())
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(error, FetchFailure::InvalidResponse);
+
+        let cursor_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let error = fetch_api_models_with({
+            let cursor_count = Arc::clone(&cursor_count);
+            move |_| {
+                let page = cursor_count.fetch_add(1, Ordering::Relaxed);
+                async move {
+                    Ok(serde_json::json!({
+                        "data": [],
+                        "has_more": true,
+                        "last_id": format!("cursor-{page}")
+                    })
+                    .to_string()
+                    .into_bytes())
+                }
+            }
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(error, FetchFailure::PaginationLimit);
+        assert_eq!(cursor_count.load(Ordering::Relaxed), MAX_API_PAGES);
+    }
+
+    #[tokio::test]
+    async fn invariant_claude_model_catalog_api_caps_count_and_sanitizes_text() {
+        let models = (0..MAX_MODELS_PER_SOURCE + 10)
+            .map(|index| {
+                serde_json::json!({
+                    "id": format!("claude-{index}"),
+                    "display_name": format!("{}\nsecret", "가".repeat(120)),
+                })
+            })
+            .collect::<Vec<_>>();
+        let fetched = fetch_api_models_with(move |_| {
+            let models = models.clone();
+            async move {
+                Ok(serde_json::json!({
+                    "data": models,
+                    "has_more": false,
+                    "last_id": null
+                })
+                .to_string()
+                .into_bytes())
+            }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(fetched.len(), MAX_MODELS_PER_SOURCE);
+        assert!(fetched.iter().all(|model| {
+            model.display_name.chars().count() <= MAX_CATALOG_TEXT_CHARS
+                && !model.display_name.chars().any(char::is_control)
+        }));
+    }
+
+    #[tokio::test]
+    async fn invariant_claude_model_catalog_fresh_cache_skips_refresh_fetch() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("cache.json");
+        let current_ms = 55_000;
+        std::fs::write(
+            &path,
+            api_cache_json(
+                current_ms,
+                serde_json::json!([{"id": "claude-lkg", "display_name": "LKG"}]),
+            ),
+        )
+        .unwrap();
+        let fetch_called = Arc::new(AtomicBool::new(false));
+
+        let outcome = refresh_cache_with(&path, current_ms, Some("key"), {
+            let fetch_called = Arc::clone(&fetch_called);
+            move |_| {
+                fetch_called.store(true, Ordering::Release);
+                async { Ok(Vec::new()) }
+            }
+        })
+        .await;
+
+        assert_eq!(outcome, RefreshOutcome::Fresh);
+        assert!(!fetch_called.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn invariant_claude_model_catalog_refresh_failure_preserves_last_known_good_cache() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("cache.json");
+        let original = api_cache_json(
+            1,
+            serde_json::json!([{"id": "claude-lkg", "display_name": "LKG"}]),
+        );
+        std::fs::write(&path, &original).unwrap();
+
+        let outcome = refresh_cache_with(
+            &path,
+            GATEWAY_CACHE_TTL.as_millis() as u64 + 2,
+            Some("key"),
+            |_| async { Err(FetchFailure::Transport) },
+        )
+        .await;
+
+        assert_eq!(
+            outcome,
+            RefreshOutcome::FetchFailed(FetchFailure::Transport)
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn invariant_claude_model_catalog_empty_refresh_does_not_replace_cache() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("cache.json");
+        let original = api_cache_json(
+            1,
+            serde_json::json!([{"id": "claude-lkg", "display_name": "LKG"}]),
+        );
+        std::fs::write(&path, &original).unwrap();
+
+        let outcome = refresh_cache_with(
+            &path,
+            GATEWAY_CACHE_TTL.as_millis() as u64 + 2,
+            Some("key"),
+            |_| async { Ok(Vec::new()) },
+        )
+        .await;
+
+        assert_eq!(outcome, RefreshOutcome::Empty);
+        assert_eq!(std::fs::read(&path).unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn invariant_claude_model_catalog_successful_refresh_atomically_updates_cache() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("nested").join("cache.json");
+        let current_ms = 55_000;
+        let outcome = refresh_cache_with(&path, current_ms, Some("key"), |_| async {
+            Ok(vec![ApiModel {
+                id: "claude-new".to_string(),
+                display_name: "New model".to_string(),
+            }])
+        })
+        .await;
+
+        assert_eq!(outcome, RefreshOutcome::Updated);
+        let cache: ApiCache = serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+        assert_eq!(cache.fetched_at_ms, current_ms);
+        assert_eq!(cache.models[0].id, "claude-new");
+    }
+}

--- a/src/services/discord/model_catalog/claude.rs
+++ b/src/services/discord/model_catalog/claude.rs
@@ -36,7 +36,16 @@ struct FileCacheKey {
 
 #[derive(Clone, Debug, Default)]
 struct CatalogCache {
+    gateway_entries: Vec<ModelCatalogEntry>,
+    api_entries: Vec<ModelCatalogEntry>,
     entries: Vec<ModelCatalogEntry>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct DiskCatalogCandidate {
+    gateway_entries: Vec<ModelCatalogEntry>,
+    api_entries: Vec<ModelCatalogEntry>,
+    api_cache_fresh: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -383,28 +392,65 @@ fn catalog_from_raw_sources(
     )
 }
 
-fn reload_catalog_cache_from_disk() {
-    let gateway_path = gateway_cache_path();
-    let api_path = api_cache_path();
-    let gateway_key = gateway_path.as_deref().and_then(file_cache_key);
-    let api_key = api_path.as_deref().and_then(file_cache_key);
-    let cache = CATALOG_CACHE.get_or_init(|| RwLock::new(CatalogCache::default()));
+fn catalog_candidate_from_disk_paths(
+    gateway_path: Option<&Path>,
+    api_path: Option<&Path>,
+    current_ms: u64,
+) -> DiskCatalogCandidate {
+    let gateway_key = gateway_path.and_then(file_cache_key);
+    let api_key = api_path.and_then(file_cache_key);
     let gateway_raw = gateway_path
-        .as_deref()
         .zip(gateway_key.as_ref())
         .and_then(|(path, expected)| bounded_read(path, expected));
     let api_raw = api_path
-        .as_deref()
         .zip(api_key.as_ref())
         .and_then(|(path, expected)| bounded_read(path, expected));
-    let entries = catalog_from_raw_sources(gateway_raw.as_deref(), api_raw.as_deref(), now_ms());
-    if let Ok(mut cached) = cache.write() {
-        cached.entries = entries;
+    let api_entries = api_raw
+        .as_deref()
+        .map(|raw| api_entries_from_raw(raw, current_ms))
+        .unwrap_or_default();
+    DiskCatalogCandidate {
+        gateway_entries: gateway_raw
+            .as_deref()
+            .map(|raw| gateway_entries_from_raw(raw, current_ms))
+            .unwrap_or_default(),
+        api_cache_fresh: !api_entries.is_empty(),
+        api_entries,
     }
 }
 
-async fn reload_catalog_cache() {
-    let _ = tokio::task::spawn_blocking(reload_catalog_cache_from_disk).await;
+fn publish_initial_catalog_if_empty(cache: &RwLock<CatalogCache>, candidate: DiskCatalogCandidate) {
+    if let Ok(mut cached) = cache.write()
+        && cached.entries.is_empty()
+    {
+        cached.gateway_entries = candidate.gateway_entries;
+        cached.api_entries = candidate.api_entries;
+        cached.entries = merge_entries(cached.gateway_entries.clone(), cached.api_entries.clone());
+    }
+}
+
+fn publish_fresh_catalog_candidate(cache: &RwLock<CatalogCache>, candidate: &DiskCatalogCandidate) {
+    if let Ok(mut cached) = cache.write() {
+        if !candidate.gateway_entries.is_empty() {
+            cached.gateway_entries = candidate.gateway_entries.clone();
+        }
+        if candidate.api_cache_fresh {
+            cached.api_entries = candidate.api_entries.clone();
+        }
+        cached.entries = merge_entries(cached.gateway_entries.clone(), cached.api_entries.clone());
+    }
+}
+
+async fn load_catalog_candidate(
+    gateway_path: Option<PathBuf>,
+    api_path: Option<PathBuf>,
+    current_ms: u64,
+) -> DiskCatalogCandidate {
+    tokio::task::spawn_blocking(move || {
+        catalog_candidate_from_disk_paths(gateway_path.as_deref(), api_path.as_deref(), current_ms)
+    })
+    .await
+    .unwrap_or_default()
 }
 
 pub(super) fn resolved_models() -> Vec<ModelCatalogEntry> {
@@ -595,23 +641,46 @@ where
     }
 }
 
-async fn refresh_once() -> RefreshOutcome {
-    let Some(path) = api_cache_path() else {
+async fn refresh_and_log_with<F, Fut>(
+    gateway_path: Option<PathBuf>,
+    api_path: Option<PathBuf>,
+    current_ms: u64,
+    api_key: Option<&str>,
+    fetch: F,
+) -> RefreshOutcome
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = Result<Vec<ApiModel>, FetchFailure>>,
+{
+    let candidate =
+        load_catalog_candidate(gateway_path.clone(), api_path.clone(), current_ms).await;
+    let cache = CATALOG_CACHE.get_or_init(|| RwLock::new(CatalogCache::default()));
+    publish_initial_catalog_if_empty(cache, candidate.clone());
+
+    let Some(path) = api_path else {
+        publish_fresh_catalog_candidate(cache, &candidate);
         return RefreshOutcome::CachePathUnavailable;
     };
-    let api_key = std::env::var("ANTHROPIC_API_KEY").ok();
-    refresh_cache_with(&path, now_ms(), api_key.as_deref(), |api_key| async move {
-        fetch_api_models(&api_key).await
-    })
-    .await
+    let outcome = refresh_cache_with(&path, current_ms, api_key, fetch).await;
+    if matches!(outcome, RefreshOutcome::Updated) {
+        let refreshed = load_catalog_candidate(gateway_path, Some(path), current_ms).await;
+        publish_fresh_catalog_candidate(cache, &refreshed);
+    } else {
+        publish_fresh_catalog_candidate(cache, &candidate);
+    }
+    outcome
 }
 
 async fn refresh_and_log() {
-    reload_catalog_cache().await;
-    let outcome = refresh_once().await;
-    if matches!(outcome, RefreshOutcome::Updated) {
-        reload_catalog_cache().await;
-    }
+    let api_key = std::env::var("ANTHROPIC_API_KEY").ok();
+    let outcome = refresh_and_log_with(
+        gateway_cache_path(),
+        api_cache_path(),
+        now_ms(),
+        api_key.as_deref(),
+        |api_key| async move { fetch_api_models(&api_key).await },
+    )
+    .await;
     tracing::info!(
         target: "agentdesk::claude_model_catalog",
         status = outcome.category(),
@@ -1028,6 +1097,113 @@ mod tests {
             model.display_name.chars().count() <= MAX_CATALOG_TEXT_CHARS
                 && !model.display_name.chars().any(char::is_control)
         }));
+    }
+
+    #[test]
+    fn invariant_claude_model_catalog_failed_and_empty_refreshes_preserve_memory_lkg() {
+        let _env_lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let directory = tempdir().unwrap();
+            let api_path = directory.path().join("cache.json");
+            let fresh_ms = 55_000;
+            let stale_ms = fresh_ms + GATEWAY_CACHE_TTL.as_millis() as u64 + 1;
+            let original = api_cache_json(
+                fresh_ms,
+                serde_json::json!([{"id": "claude-memory-lkg", "display_name": "Memory LKG"}]),
+            );
+            std::fs::write(&api_path, &original).unwrap();
+            let cache = CATALOG_CACHE.get_or_init(|| RwLock::new(CatalogCache::default()));
+            if let Ok(mut cached) = cache.write() {
+                *cached = CatalogCache::default();
+            }
+
+            let initial =
+                refresh_and_log_with(None, Some(api_path.clone()), fresh_ms, None, |_| async {
+                    unreachable!("fresh cache must not fetch")
+                })
+                .await;
+            assert_eq!(initial, RefreshOutcome::Fresh);
+            assert!(
+                resolved_models()
+                    .iter()
+                    .any(|entry| entry.value == "claude-memory-lkg")
+            );
+
+            let missing_key =
+                refresh_and_log_with(None, Some(api_path.clone()), stale_ms, None, |_| async {
+                    unreachable!("missing key must not fetch")
+                })
+                .await;
+            assert_eq!(missing_key, RefreshOutcome::MissingApiKey);
+            assert!(
+                resolved_models()
+                    .iter()
+                    .any(|entry| entry.value == "claude-memory-lkg")
+            );
+            assert_eq!(std::fs::read(&api_path).unwrap(), original);
+
+            let failed = refresh_and_log_with(
+                None,
+                Some(api_path.clone()),
+                stale_ms,
+                Some("key"),
+                |_| async { Err(FetchFailure::Transport) },
+            )
+            .await;
+            assert_eq!(failed, RefreshOutcome::FetchFailed(FetchFailure::Transport));
+            assert!(
+                resolved_models()
+                    .iter()
+                    .any(|entry| entry.value == "claude-memory-lkg")
+            );
+            assert_eq!(std::fs::read(&api_path).unwrap(), original);
+
+            let empty = refresh_and_log_with(
+                None,
+                Some(api_path.clone()),
+                stale_ms,
+                Some("key"),
+                |_| async { Ok(Vec::new()) },
+            )
+            .await;
+            assert_eq!(empty, RefreshOutcome::Empty);
+            assert_eq!(std::fs::read(&api_path).unwrap(), original);
+            assert!(
+                resolved_models()
+                    .iter()
+                    .any(|entry| entry.value == "claude-memory-lkg")
+            );
+
+            let updated = refresh_and_log_with(
+                None,
+                Some(api_path.clone()),
+                stale_ms,
+                Some("key"),
+                |_| async {
+                    Ok(vec![ApiModel {
+                        id: "claude-replacement".to_string(),
+                        display_name: "Replacement".to_string(),
+                    }])
+                },
+            )
+            .await;
+            assert_eq!(updated, RefreshOutcome::Updated);
+            let resolved = resolved_models();
+            assert!(
+                resolved
+                    .iter()
+                    .any(|entry| entry.value == "claude-replacement")
+            );
+            assert!(
+                !resolved
+                    .iter()
+                    .any(|entry| entry.value == "claude-memory-lkg")
+            );
+        });
     }
 
     #[tokio::test]

--- a/src/services/discord/model_catalog/claude.rs
+++ b/src/services/discord/model_catalog/claude.rs
@@ -29,12 +29,6 @@ const API_CACHE_VERSION: u8 = 1;
 static REFRESH_TASK_RUNNING: AtomicBool = AtomicBool::new(false);
 static CATALOG_CACHE: OnceLock<RwLock<CatalogCache>> = OnceLock::new();
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct FileCacheKey {
-    modified_ms: u128,
-    len: u64,
-}
-
 #[derive(Clone, Debug, Default)]
 struct CatalogCache {
     gateway_entries: Vec<ModelCatalogEntry>,
@@ -239,26 +233,8 @@ fn truncate_catalog_text(raw: &str, fallback: &str) -> String {
     text
 }
 
-fn file_cache_key(path: &Path) -> Option<FileCacheKey> {
-    let metadata = std::fs::metadata(path).ok()?;
-    if !metadata.file_type().is_file() || metadata.len() > MAX_CACHE_BODY_BYTES as u64 {
-        return None;
-    }
-    let modified_ms = metadata
-        .modified()
-        .ok()?
-        .duration_since(UNIX_EPOCH)
-        .ok()?
-        .as_millis();
-    Some(FileCacheKey {
-        modified_ms,
-        len: metadata.len(),
-    })
-}
-
-fn bounded_read(path: &Path, expected: &FileCacheKey) -> Option<Vec<u8>> {
-    let body = std::fs::read(path).ok()?;
-    (body.len() <= MAX_CACHE_BODY_BYTES && body.len() as u64 == expected.len).then_some(body)
+fn read_cache_file(path: &Path) -> Option<Vec<u8>> {
+    super::bounded_cache_file::read_regular_file_bounded(path, MAX_CACHE_BODY_BYTES)
 }
 
 fn gateway_cache_path() -> Option<PathBuf> {
@@ -394,14 +370,8 @@ fn catalog_candidate_from_disk_paths(
     api_path: Option<&Path>,
     current_ms: u64,
 ) -> DiskCatalogCandidate {
-    let gateway_key = gateway_path.and_then(file_cache_key);
-    let api_key = api_path.and_then(file_cache_key);
-    let gateway_raw = gateway_path
-        .zip(gateway_key.as_ref())
-        .and_then(|(path, expected)| bounded_read(path, expected));
-    let api_raw = api_path
-        .zip(api_key.as_ref())
-        .and_then(|(path, expected)| bounded_read(path, expected));
+    let gateway_raw = gateway_path.and_then(read_cache_file);
+    let api_raw = api_path.and_then(read_cache_file);
     let api_entries = api_raw
         .as_deref()
         .map(|raw| api_entries_from_raw(raw, current_ms))
@@ -601,8 +571,7 @@ fn usable_api_models(models: Vec<ApiModel>) -> Vec<ApiModel> {
 }
 
 fn cache_is_fresh(path: &Path, current_ms: u64) -> bool {
-    file_cache_key(path)
-        .and_then(|key| bounded_read(path, &key))
+    read_cache_file(path)
         .and_then(|raw| serde_json::from_slice::<ApiCache>(&raw).ok())
         .is_some_and(|cache| {
             cache.version == API_CACHE_VERSION
@@ -743,6 +712,44 @@ pub(super) fn spawn_background_refresh(
 }
 
 #[cfg(test)]
+pub(super) fn spawn_test_background_refresh(
+    refreshes: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+) -> tokio::task::JoinHandle<()> {
+    spawn_test_background_refresh_after_claim(refreshes, || {})
+}
+
+#[cfg(test)]
+pub(super) fn spawn_test_background_refresh_after_claim(
+    refreshes: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    after_claim: impl Fn() + Send + Sync + 'static,
+) -> tokio::task::JoinHandle<()> {
+    let after_claim = std::sync::Arc::new(after_claim);
+    tokio::spawn(async move {
+        let mut attempts = tokio::time::interval(REFRESH_STANDBY_INTERVAL);
+        loop {
+            attempts.tick().await;
+            if let Some(_guard) = RefreshTaskGuard::claim() {
+                after_claim();
+                refreshes.fetch_add(1, Ordering::AcqRel);
+                std::future::pending::<()>().await;
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+pub(super) fn with_test_refresh_task_state<T>(operation: impl FnOnce() -> T) -> T {
+    let _env_lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
+    REFRESH_TASK_RUNNING.store(false, Ordering::Release);
+    operation()
+}
+
+#[cfg(test)]
+pub(super) fn test_refresh_task_running() -> bool {
+    REFRESH_TASK_RUNNING.load(Ordering::Acquire)
+}
+
+#[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
@@ -762,74 +769,105 @@ mod tests {
     }
 
     #[test]
+    fn invariant_claude_model_catalog_global_test_state_uses_canonical_lock_scope() {
+        const REFRESH_STATE_STORE: &str = concat!("REFRESH_TASK_RUNNING", ".store");
+
+        let source = include_str!("claude.rs");
+        let scope = source
+            .split("pub(super) fn with_test_refresh_task_state")
+            .nth(1)
+            .and_then(|suffix| suffix.split("\n}\n").next())
+            .expect("test refresh state scope");
+        let lock = scope
+            .find("acquire_shared_test_env_lock")
+            .expect("canonical shared test lock");
+        let reset = scope
+            .find(REFRESH_STATE_STORE)
+            .expect("scoped refresh state reset");
+        assert!(lock < reset, "the canonical lock must precede the reset");
+
+        let test_module = source
+            .split("#[cfg(test)]\nmod tests")
+            .nth(1)
+            .expect("Claude catalog test module");
+        assert!(
+            !test_module.contains(REFRESH_STATE_STORE),
+            "tests must mutate refresh state only through the locked scope"
+        );
+    }
+
+    #[test]
     fn invariant_claude_model_catalog_refresh_claim_is_singleflight() {
-        REFRESH_TASK_RUNNING.store(false, Ordering::Release);
-        let guard = RefreshTaskGuard::claim().expect("first Claude task claim");
-        assert!(RefreshTaskGuard::claim().is_none());
-        drop(guard);
-        let reclaimed = RefreshTaskGuard::claim().expect("claim reset after drop");
-        drop(reclaimed);
-        assert!(!REFRESH_TASK_RUNNING.load(Ordering::Acquire));
+        with_test_refresh_task_state(|| {
+            let guard = RefreshTaskGuard::claim().expect("first Claude task claim");
+            assert!(RefreshTaskGuard::claim().is_none());
+            drop(guard);
+            let reclaimed = RefreshTaskGuard::claim().expect("claim reset after drop");
+            drop(reclaimed);
+            assert!(!REFRESH_TASK_RUNNING.load(Ordering::Acquire));
+        });
     }
 
     #[test]
     fn invariant_claude_model_catalog_non_claude_provider_has_no_supervisor() {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        runtime.block_on(async {
-            assert!(spawn_background_refresh(&ProviderKind::Codex).is_none());
-            let handle = spawn_background_refresh(&ProviderKind::Claude)
-                .expect("Claude gateway must keep a refresh supervisor");
-            handle.abort();
-            let _ = handle.await;
+        with_test_refresh_task_state(|| {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            runtime.block_on(async {
+                assert!(spawn_background_refresh(&ProviderKind::Codex).is_none());
+                let handle = spawn_background_refresh(&ProviderKind::Claude)
+                    .expect("Claude gateway must keep a refresh supervisor");
+                handle.abort();
+                let _ = handle.await;
+            });
         });
     }
 
     #[test]
     fn invariant_claude_model_catalog_owner_exit_hands_off_to_live_supervisor() {
-        let _env_lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
-        REFRESH_TASK_RUNNING.store(false, Ordering::Release);
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        runtime.block_on(async {
-            tokio::time::pause();
-            let refreshes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-            let spawn_supervisor = |refreshes: Arc<std::sync::atomic::AtomicUsize>| {
-                tokio::spawn(supervise_background_refresh(
-                    Duration::from_secs(1),
-                    Duration::from_secs(60),
-                    move || {
-                        let refreshes = Arc::clone(&refreshes);
-                        async move {
-                            refreshes.fetch_add(1, Ordering::AcqRel);
-                            std::future::pending::<()>().await;
-                        }
-                    },
-                ))
-            };
+        with_test_refresh_task_state(|| {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            runtime.block_on(async {
+                tokio::time::pause();
+                let refreshes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+                let spawn_supervisor = |refreshes: Arc<std::sync::atomic::AtomicUsize>| {
+                    tokio::spawn(supervise_background_refresh(
+                        Duration::from_secs(1),
+                        Duration::from_secs(60),
+                        move || {
+                            let refreshes = Arc::clone(&refreshes);
+                            async move {
+                                refreshes.fetch_add(1, Ordering::AcqRel);
+                                std::future::pending::<()>().await;
+                            }
+                        },
+                    ))
+                };
 
-            let first = spawn_supervisor(Arc::clone(&refreshes));
-            let second = spawn_supervisor(Arc::clone(&refreshes));
-            tokio::task::yield_now().await;
-            assert_eq!(refreshes.load(Ordering::Acquire), 1);
-            tokio::time::advance(Duration::from_millis(500)).await;
-            tokio::task::yield_now().await;
+                let first = spawn_supervisor(Arc::clone(&refreshes));
+                let second = spawn_supervisor(Arc::clone(&refreshes));
+                tokio::task::yield_now().await;
+                assert_eq!(refreshes.load(Ordering::Acquire), 1);
+                tokio::time::advance(Duration::from_millis(500)).await;
+                tokio::task::yield_now().await;
 
-            first.abort();
-            let _ = first.await;
-            assert!(!REFRESH_TASK_RUNNING.load(Ordering::Acquire));
-            tokio::time::advance(Duration::from_secs(1)).await;
-            tokio::task::yield_now().await;
-            assert_eq!(refreshes.load(Ordering::Acquire), 2);
-            assert!(REFRESH_TASK_RUNNING.load(Ordering::Acquire));
+                first.abort();
+                let _ = first.await;
+                assert!(!REFRESH_TASK_RUNNING.load(Ordering::Acquire));
+                tokio::time::advance(Duration::from_secs(1)).await;
+                tokio::task::yield_now().await;
+                assert_eq!(refreshes.load(Ordering::Acquire), 2);
+                assert!(REFRESH_TASK_RUNNING.load(Ordering::Acquire));
 
-            second.abort();
-            let _ = second.await;
-            assert!(!REFRESH_TASK_RUNNING.load(Ordering::Acquire));
+                second.abort();
+                let _ = second.await;
+                assert!(!REFRESH_TASK_RUNNING.load(Ordering::Acquire));
+            });
         });
     }
 
@@ -856,20 +894,6 @@ mod tests {
             assert_eq!(entry.secondary_summary, alias.metadata_fallback_id);
             assert_ne!(entry.value, alias.metadata_fallback_id);
         }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn invariant_claude_model_catalog_rejects_fifo_before_bounded_read() {
-        let directory = tempdir().unwrap();
-        let path = directory.path().join("cache.fifo");
-        let status = std::process::Command::new("mkfifo")
-            .arg(&path)
-            .status()
-            .expect("spawn mkfifo");
-        assert!(status.success(), "mkfifo should succeed");
-
-        assert!(file_cache_key(&path).is_none());
     }
 
     #[test]

--- a/src/services/discord/runtime_bootstrap/gateway_runtime.rs
+++ b/src/services/discord/runtime_bootstrap/gateway_runtime.rs
@@ -113,6 +113,10 @@ pub(super) async fn run_bot_start_gateway_runtime(
         .await
         .expect("Failed to create Discord client");
 
+    // This path is reached only after gateway-role resolution. Standby and
+    // indeterminate runtimes return before framework construction, so the
+    // refresh task remains owned by the active gateway lifecycle.
+    let model_catalog_refresh_task = model_catalog::spawn_claude_model_catalog_refresh(&provider);
     let gateway_lease_task = gateway_lease.map(|lease| {
         run_bot_spawn_gateway_lease_keepalive(
             lease,
@@ -134,6 +138,7 @@ pub(super) async fn run_bot_start_gateway_runtime(
         client,
         &provider_for_error,
         gateway_lease_task,
+        model_catalog_refresh_task,
         startup_reconcile_remaining_for_client_start,
         startup_doctor_started_for_client_start,
         health_registry_for_client_start,

--- a/src/services/discord/runtime_bootstrap/shutdown.rs
+++ b/src/services/discord/runtime_bootstrap/shutdown.rs
@@ -147,10 +147,27 @@ pub(super) fn run_bot_spawn_sigterm_handler(
     });
 }
 
+async fn abort_and_join_task(handle: Option<tokio::task::JoinHandle<()>>) {
+    if let Some(handle) = handle {
+        handle.abort();
+        let _ = handle.await;
+    }
+}
+
+async fn release_catalog_before_diagnostic<F>(
+    model_catalog_refresh_task: Option<tokio::task::JoinHandle<()>>,
+    diagnostic: F,
+) where
+    F: std::future::Future<Output = ()>,
+{
+    abort_and_join_task(model_catalog_refresh_task).await;
+    diagnostic.await;
+}
+
 /// Run the Discord gateway backend (`client.start()`) to completion, classify
-/// the exit, run the post-reconcile startup diagnostic on failure, then abort
-/// and join gateway-owned background tasks. This is the final event-loop entry
-/// of run_bot. Consumes `client`.
+/// the exit, release gateway-owned background work, then run the post-reconcile
+/// startup diagnostic on failure. This is the final event-loop entry of run_bot.
+/// Consumes `client`.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn run_bot_run_gateway_backend(
     mut client: serenity::Client,
@@ -193,21 +210,93 @@ pub(super) async fn run_bot_run_gateway_backend(
             true
         }
     };
-    if gateway_backend_failed {
-        run_startup_diagnostic_after_reconcile_barrier(
-            startup_reconcile_remaining_for_client_start,
-            startup_doctor_started_for_client_start,
-            health_registry_for_client_start,
-            api_port,
-        )
-        .await;
-    }
+    release_catalog_before_diagnostic(model_catalog_refresh_task, async {
+        if gateway_backend_failed {
+            run_startup_diagnostic_after_reconcile_barrier(
+                startup_reconcile_remaining_for_client_start,
+                startup_doctor_started_for_client_start,
+                health_registry_for_client_start,
+                api_port,
+            )
+            .await;
+        }
+    })
+    .await;
 
-    for handle in [gateway_lease_task, model_catalog_refresh_task]
-        .into_iter()
-        .flatten()
-    {
-        handle.abort();
-        let _ = handle.await;
+    abort_and_join_task(gateway_lease_task).await;
+}
+
+#[cfg(test)]
+mod lifecycle_tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use super::{abort_and_join_task, release_catalog_before_diagnostic};
+
+    #[test]
+    fn invariant_gateway_exit_releases_catalog_owner_before_diagnostics_and_takeover() {
+        crate::services::discord::model_catalog::with_test_claude_model_catalog_refresh_state(
+            || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                runtime.block_on(async {
+                    let refreshes = Arc::new(AtomicUsize::new(0));
+                    let (owner_tx, owner_rx) = tokio::sync::oneshot::channel();
+                    let owner_tx = std::sync::Mutex::new(Some(owner_tx));
+                    let owner = crate::services::discord::model_catalog::spawn_test_claude_model_catalog_refresh_after_claim(
+                        Arc::clone(&refreshes),
+                        move || {
+                            if let Some(owner_tx) = owner_tx.lock().unwrap().take() {
+                                let _ = owner_tx.send(());
+                            }
+                        },
+                    );
+                    tokio::time::timeout(Duration::from_millis(100), owner_rx)
+                        .await
+                        .expect("the initial supervisor must claim refresh ownership")
+                        .expect("initial supervisor ended before claiming");
+                    assert_eq!(refreshes.load(Ordering::Acquire), 1);
+
+                    let (takeover_tx, takeover_rx) = tokio::sync::oneshot::channel();
+                    let takeover_tx = std::sync::Mutex::new(Some(takeover_tx));
+                    let survivor = crate::services::discord::model_catalog::spawn_test_claude_model_catalog_refresh_after_claim(
+                        Arc::clone(&refreshes),
+                        move || {
+                            if let Some(takeover_tx) = takeover_tx.lock().unwrap().take() {
+                                let _ = takeover_tx.send(());
+                            }
+                        },
+                    );
+                    tokio::task::yield_now().await;
+                    assert_eq!(refreshes.load(Ordering::Acquire), 1);
+
+                    release_catalog_before_diagnostic(Some(owner), async {
+                        assert_eq!(
+                            refreshes.load(Ordering::Acquire),
+                            1,
+                            "the original owner must be released before diagnostics"
+                        );
+                        tokio::time::timeout(Duration::from_millis(1_100), takeover_rx)
+                            .await
+                            .expect("a live supervisor must claim before diagnostics continue")
+                            .expect("takeover supervisor ended before claiming");
+                    })
+                    .await;
+                    assert_eq!(
+                        refreshes.load(Ordering::Acquire),
+                        2,
+                        "a live supervisor must take over within the one-second standby interval"
+                    );
+
+                    abort_and_join_task(Some(survivor)).await;
+                    assert!(
+                        !crate::services::discord::model_catalog::test_claude_model_catalog_refresh_running()
+                    );
+                });
+            },
+        );
     }
 }

--- a/src/services/discord/runtime_bootstrap/shutdown.rs
+++ b/src/services/discord/runtime_bootstrap/shutdown.rs
@@ -149,13 +149,14 @@ pub(super) fn run_bot_spawn_sigterm_handler(
 
 /// Run the Discord gateway backend (`client.start()`) to completion, classify
 /// the exit, run the post-reconcile startup diagnostic on failure, then abort
-/// and join the gateway-lease keepalive task. This is the final event-loop
-/// entry of run_bot. Consumes `client`.
+/// and join gateway-owned background tasks. This is the final event-loop entry
+/// of run_bot. Consumes `client`.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn run_bot_run_gateway_backend(
     mut client: serenity::Client,
     provider_for_error: &ProviderKind,
     gateway_lease_task: Option<tokio::task::JoinHandle<()>>,
+    model_catalog_refresh_task: Option<tokio::task::JoinHandle<()>>,
     startup_reconcile_remaining_for_client_start: Arc<std::sync::atomic::AtomicUsize>,
     startup_doctor_started_for_client_start: Arc<std::sync::atomic::AtomicBool>,
     health_registry_for_client_start: Arc<health::HealthRegistry>,
@@ -202,7 +203,10 @@ pub(super) async fn run_bot_run_gateway_backend(
         .await;
     }
 
-    if let Some(handle) = gateway_lease_task {
+    for handle in [gateway_lease_task, model_catalog_refresh_task]
+        .into_iter()
+        .flatten()
+    {
         handle.abort();
         let _ = handle.await;
     }

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -55,6 +55,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib services::discord::model_catalog -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib services::discord::commands::model_ui::tests -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib services::discord::runtime_bootstrap::shutdown::lifecycle_tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --doc ClaudeBinary",
 )

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -53,6 +53,8 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres",
     "python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres",
     "env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib services::discord::model_catalog -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib services::discord::commands::model_ui::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --doc ClaudeBinary",
 )


### PR DESCRIPTION
## Summary
- keep evergreen Claude Code selectors (`fable`, `opus`, `sonnet`, `haiku`) at the top of `/model`, with current metadata/static fallback IDs
- build the picker from a nonblocking in-memory snapshot merged from bounded Claude gateway/API caches and static fallbacks
- run a gateway-owned, singleflight Anthropic Models API refresh with fixed endpoint, strict timeout/body/page/model/text limits, and last-known-good preservation
- replace leaked dynamic catalog strings with borrowed/owned `Cow` values and enforce Discord's 25-option and 100-character bounds while retaining the selected model

## Security and lifecycle
- reads only `ANTHROPIC_API_KEY` for API refresh and always targets `https://api.anthropic.com/v1/models`
- ignores gateway `baseUrl`, credentials, and other unknown fields; logs categorical outcomes only
- starts only on the active Claude gateway path and is aborted/joined with gateway-owned tasks

## Verification
- [x] `cargo fmt --all --check`
- [x] `cargo check --lib`
- [x] `cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres` (55 passed)
- [x] `python3 scripts/generate_inventory_docs.py`
- [x] `python3 scripts/check_agent_maintenance_docs.py`
- [x] `python3 scripts/audit_maintainability.py --check`
- [x] 18 new invariant tests run through the existing trusted `invariant` test filter
- [x] selector-bound mutation is detected by its invariant test; restored HEAD passes

The shared #4915/#4906 test-lane checker and baseline are unchanged.

Closes #4875