### PR TITLE
feat(#4860): add pure completed-turn footer formatter

### DIFF
--- a/src/services/discord/completion_footer_metadata.rs
+++ b/src/services/discord/completion_footer_metadata.rs
@@ -111,10 +111,7 @@ fn context_percent_floor(used: u128, window: u128) -> Option<u8> {
 
 fn sanitize_model_label(value: &str) -> Option<String> {
     let value = sanitize_bounded_label(value, MAX_MODEL_LABEL_CHARS, true)?;
-    !value
-        .chars()
-        .all(|character| character.is_ascii_digit())
-        .then_some(value)
+    (!value.chars().all(|character| character.is_ascii_digit())).then_some(value)
 }
 
 fn sanitize_host_label(value: &str) -> Option<String> {

--- a/src/services/discord/completion_footer_metadata.rs
+++ b/src/services/discord/completion_footer_metadata.rs
@@ -196,6 +196,41 @@ fn looks_like_credential(value: &str) -> bool {
         ]
         .iter()
         .any(|marker| compact.contains(marker))
+        || value.split('/').any(looks_like_secret_token)
+}
+
+fn looks_like_secret_token(value: &str) -> bool {
+    let looks_like_aws_access_key = value.len() == 20
+        && [
+            "AKIA", "ASIA", "AIDA", "AROA", "AIPA", "ANPA", "ANVA", "A3T",
+        ]
+        .iter()
+        .any(|prefix| value.starts_with(prefix))
+        && value
+            .chars()
+            .all(|character| character.is_ascii_uppercase() || character.is_ascii_digit());
+
+    let mut jwt_segments = value.split('.');
+    let header = jwt_segments.next().unwrap_or_default();
+    let payload = jwt_segments.next();
+    let signature = jwt_segments.next();
+    let looks_like_jwt = payload.is_some_and(|segment| segment.starts_with("eyJ"))
+        && signature.is_some_and(|segment| !segment.is_empty())
+        && jwt_segments.next().is_none()
+        && header.starts_with("eyJ")
+        && [
+            header,
+            payload.unwrap_or_default(),
+            signature.unwrap_or_default(),
+        ]
+        .iter()
+        .all(|segment| {
+            segment.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '-' | '_')
+            })
+        });
+
+    looks_like_aws_access_key || looks_like_jwt
 }
 
 fn is_filesystem_path_component(value: &str) -> bool {
@@ -256,11 +291,7 @@ fn looks_like_fqdn(value: &str) -> bool {
     let Some((prefix, suffix)) = value.rsplit_once('.') else {
         return false;
     };
-    !prefix.is_empty()
-        && suffix.len() >= 2
-        && suffix
-            .chars()
-            .all(|character| character.is_ascii_alphabetic())
+    !prefix.is_empty() && suffix.len() >= 2 && suffix.chars().all(char::is_alphabetic)
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -610,6 +641,7 @@ pub(in crate::services::discord) mod tests {
         }
         for malicious_model in [
             "host.example.com",
+            "例子.公司",
             "12345",
             "anthropic/12345",
             "anthropic/claude/sonnet",
@@ -633,6 +665,8 @@ pub(in crate::services::discord) mod tests {
             "anthropic/session-deadbeef",
             "anthropic/api-key-secret",
             "openai/sk-proj-secret",
+            "openai/AKIAIOSFODNN7EXAMPLE",
+            "openai/eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjF9.sig",
             "github/ghp_secret",
         ] {
             let snapshot = CompletedTurnFooterSnapshot {

--- a/src/services/discord/completion_footer_metadata.rs
+++ b/src/services/discord/completion_footer_metadata.rs
@@ -110,7 +110,11 @@ fn context_percent_floor(used: u128, window: u128) -> Option<u8> {
 }
 
 fn sanitize_model_label(value: &str) -> Option<String> {
-    sanitize_bounded_label(value, MAX_MODEL_LABEL_CHARS, true)
+    let value = sanitize_bounded_label(value, MAX_MODEL_LABEL_CHARS, true)?;
+    !value
+        .chars()
+        .all(|character| character.is_ascii_digit())
+        .then_some(value)
 }
 
 fn sanitize_host_label(value: &str) -> Option<String> {

--- a/src/services/discord/completion_footer_metadata.rs
+++ b/src/services/discord/completion_footer_metadata.rs
@@ -20,6 +20,7 @@ const MAX_HOST_LABEL_CHARS: usize = 63;
 pub(in crate::services::discord) struct CompletedTurnFooterSnapshot {
     pub(in crate::services::discord) elapsed_secs: Option<u64>,
     pub(in crate::services::discord) model: Option<String>,
+    pub(in crate::services::discord) approved_model_ids: Vec<String>,
     pub(in crate::services::discord) host: Option<String>,
     pub(in crate::services::discord) context_used_tokens: Option<u128>,
     pub(in crate::services::discord) context_window_tokens: Option<u128>,
@@ -35,7 +36,11 @@ pub(in crate::services::discord) fn render_completed_turn_footer(
             format_compact_elapsed(elapsed_secs)
         ));
     }
-    if let Some(model) = snapshot.model.as_deref().and_then(sanitize_model_label) {
+    if let Some(model) = snapshot
+        .model
+        .as_deref()
+        .and_then(|model| approved_model_label(model, &snapshot.approved_model_ids))
+    {
         segments.push(model);
     }
     if let Some(host) = snapshot.host.as_deref().and_then(sanitize_host_label) {
@@ -109,102 +114,21 @@ fn context_percent_floor(used: u128, window: u128) -> Option<u8> {
     })
 }
 
-fn sanitize_model_label(value: &str) -> Option<String> {
-    if value.is_empty() || value.trim() != value || value.chars().any(char::is_control) {
+fn approved_model_label(value: &str, approved_model_ids: &[String]) -> Option<String> {
+    if !is_valid_approved_model_id(value) {
         return None;
     }
-
-    let (core, effort_suffix) = match value.strip_suffix("[1m]") {
-        Some(core) => (core, Some("[1m]")),
-        None => (value, None),
-    };
-    if core.is_empty() || core.contains(['[', ']']) {
-        return None;
-    }
-
-    let mut components = core.split('/');
-    let first = components.next()?;
-    let second = components.next();
-    if components.next().is_some()
-        || !is_safe_model_component(first, second.is_some(), false)
-        || second.is_some_and(|model| !is_safe_model_component(model, true, true))
-        || core.split('/').any(looks_like_fqdn)
-        || core.split('/').any(looks_like_uuid)
-        || contains_private_identity_label(core)
-        || looks_like_credential(core)
-        || second.is_some() && core.split('/').any(is_filesystem_path_component)
-        || core.split('/').any(|component| {
-            component
-                .chars()
-                .all(|character| character.is_ascii_digit())
-        })
-    {
-        return None;
-    }
-
-    Some(truncate_model_label(core, effort_suffix))
+    approved_model_ids
+        .iter()
+        .any(|approved| approved == value && is_valid_approved_model_id(approved))
+        .then(|| value.to_string())
 }
 
-fn is_safe_model_component(value: &str, ascii_only: bool, allow_colon: bool) -> bool {
+fn is_valid_approved_model_id(value: &str) -> bool {
     !value.is_empty()
-        && value.chars().next().is_some_and(char::is_alphanumeric)
-        && value.chars().last().is_some_and(char::is_alphanumeric)
-        && value.chars().all(|character| {
-            (!ascii_only && character.is_alphanumeric())
-                || character.is_ascii_alphanumeric()
-                || matches!(character, '-' | '_' | '.')
-                || (allow_colon && character == ':')
-        })
-        && !value.contains("..")
-        && !value.contains("::")
-}
-
-fn truncate_model_label(core: &str, effort_suffix: Option<&str>) -> String {
-    let suffix_chars = effort_suffix.map_or(0, |suffix| suffix.chars().count());
-    let core_limit = MAX_MODEL_LABEL_CHARS.saturating_sub(suffix_chars);
-    let mut rendered = core.chars().take(core_limit).collect::<String>();
-    while rendered
-        .chars()
-        .last()
-        .is_some_and(|character| !character.is_alphanumeric())
-    {
-        rendered.pop();
-    }
-    if let Some(suffix) = effort_suffix {
-        rendered.push_str(suffix);
-    }
-    rendered
-}
-
-fn looks_like_credential(value: &str) -> bool {
-    let lowercase = value.to_ascii_lowercase();
-    let compact = lowercase
-        .chars()
-        .filter(|character| character.is_ascii_alphanumeric())
-        .collect::<String>();
-    ["sk-", "sk_", "ghp_", "github_pat_", "xoxb-", "xoxp-"]
-        .iter()
-        .any(|prefix| lowercase.starts_with(prefix) || lowercase.contains(&format!("/{prefix}")))
-        || [
-            "apikey",
-            "accesstoken",
-            "refreshtoken",
-            "password",
-            "passwd",
-            "credential",
-            "bearertoken",
-        ]
-        .iter()
-        .any(|marker| compact.contains(marker))
-}
-
-fn is_filesystem_path_component(value: &str) -> bool {
-    [
-        "bin", "boot", "dev", "etc", "home", "lib", "lib64", "opt", "private", "proc", "root",
-        "run", "sbin", "srv", "sys", "tmp", "usr", "users", "var", "windows",
-    ]
-    .iter()
-    .any(|component| value.eq_ignore_ascii_case(component))
+        && value.trim() == value
+        && !value.chars().any(char::is_control)
+        && value.chars().count() <= MAX_MODEL_LABEL_CHARS
 }
 
 fn sanitize_host_label(value: &str) -> Option<String> {
@@ -452,6 +376,7 @@ pub(in crate::services::discord) mod tests {
         CompletedTurnFooterSnapshot {
             elapsed_secs: Some(92),
             model: Some("fable-5".to_string()),
+            approved_model_ids: vec!["fable-5".to_string()],
             host: Some("mac-book".to_string()),
             context_used_tokens: Some(261_000),
             context_window_tokens: Some(1_000_000),
@@ -554,6 +479,7 @@ pub(in crate::services::discord) mod tests {
         assert_eq!(
             render_completed_turn_footer(&CompletedTurnFooterSnapshot {
                 model: Some("fable-5".to_string()),
+                approved_model_ids: vec!["fable-5".to_string()],
                 context_used_tokens: Some(42),
                 ..Default::default()
             })
@@ -563,7 +489,7 @@ pub(in crate::services::discord) mod tests {
     }
 
     #[test]
-    fn completed_footer_renders_supported_runtime_model_labels_4860() {
+    fn completed_footer_renders_only_exact_approved_model_ids_4860() {
         for model in [
             "sonnet[1m]",
             "opus[1m]",
@@ -575,6 +501,7 @@ pub(in crate::services::discord) mod tests {
         ] {
             let snapshot = CompletedTurnFooterSnapshot {
                 model: Some(model.to_string()),
+                approved_model_ids: vec![model.to_string()],
                 ..Default::default()
             };
             assert_eq!(
@@ -586,10 +513,74 @@ pub(in crate::services::discord) mod tests {
     }
 
     #[test]
-    fn completed_footer_sanitizes_injection_paths_and_private_identity_4860() {
-        for malicious in [
+    fn completed_footer_model_membership_is_exact_and_fail_closed_4860() {
+        let approved = "anthropic/claude-sonnet-4-5";
+        for rejected in [
+            "Anthropic/claude-sonnet-4-5",
+            "anthropic/CLAUDE-sonnet-4-5",
+            " anthropic/claude-sonnet-4-5",
+            "anthropic/claude-sonnet-4-5 ",
+            "anthropic/claude-sonnet-4-5\n",
+            "host.example.com",
+            "例子.公司",
+            "../claude-sonnet-4-5",
+            "/opt/models/claude-sonnet-4-5",
+            "pid-1234",
+            "session-deadbeef",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "openai/AKIAIOSFODNN7EXAMPLE",
+            "openai/eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjF9.sig",
+            "<@123456789>",
+            "**fable-5**",
+        ] {
+            let snapshot = CompletedTurnFooterSnapshot {
+                model: Some(rejected.to_string()),
+                approved_model_ids: vec![approved.to_string()],
+                ..Default::default()
+            };
+            assert_eq!(render_completed_turn_footer(&snapshot), None, "{rejected}");
+        }
+    }
+
+    #[test]
+    fn completed_footer_rejects_invalid_approved_entries_and_overlength_models_4860() {
+        for invalid in [
+            " approved",
+            "approved ",
+            "approved\nmodel",
+            "approved\tmodel",
+            &"a".repeat(MAX_MODEL_LABEL_CHARS + 1),
+        ] {
+            let snapshot = CompletedTurnFooterSnapshot {
+                model: Some(invalid.to_string()),
+                approved_model_ids: vec![invalid.to_string()],
+                ..Default::default()
+            };
+            assert_eq!(render_completed_turn_footer(&snapshot), None, "{invalid:?}");
+        }
+    }
+
+    #[test]
+    fn completed_footer_accepted_model_is_exact_deterministic_and_bounded_4860() {
+        let model = "anthropic/claude-sonnet-4-6[1m]";
+        let snapshot = CompletedTurnFooterSnapshot {
+            model: Some(model.to_string()),
+            approved_model_ids: vec![model.to_string(), model.to_string()],
+            ..Default::default()
+        };
+        let once = render_completed_turn_footer(&snapshot).expect("approved model");
+        let twice = render_completed_turn_footer(&snapshot).expect("approved model");
+
+        assert_eq!(once, twice);
+        assert_eq!(once, format!("-# {model}"));
+        assert_eq!(once.strip_prefix(COMPLETED_FOOTER_PREFIX), Some(model));
+        assert!(model.chars().count() <= MAX_MODEL_LABEL_CHARS);
+    }
+
+    #[test]
+    fn completed_footer_sanitizes_host_injection_paths_and_private_identity_4860() {
+        for malicious_host in [
             "fable-5\n@everyone",
-            "fable\n5",
             "<@123456789>",
             "**fable-5**",
             "../fable-5",
@@ -598,54 +589,13 @@ pub(in crate::services::discord) mod tests {
             "session-deadbeef",
             "channel-1234",
             "550e8400-e29b-41d4-a716-446655440000",
+            "host.example.com",
+            "12345",
+            "mac-1234",
+            "맥북",
             " fable-5",
             "fable-5 ",
         ] {
-            let snapshot = CompletedTurnFooterSnapshot {
-                model: Some(malicious.to_string()),
-                host: Some(malicious.to_string()),
-                ..Default::default()
-            };
-            assert_eq!(render_completed_turn_footer(&snapshot), None, "{malicious}");
-        }
-        for malicious_model in [
-            "host.example.com",
-            "12345",
-            "anthropic/12345",
-            "anthropic/claude/sonnet",
-            "../claude-sonnet-4-5",
-            "opt/models",
-            "Users/alice",
-            "C:/Windows",
-            "anthropic/.env",
-            "anthropic/../secret",
-            "anthropic/claude-sonnet-4-5]",
-            "anthropic-/claude-sonnet-4-5",
-            "anthropic/claude-sonnet-4-5-",
-            "anthropic/claude[sonnet]",
-            "anthropic/claude-sonnet-4-5[2m]",
-            "anthropic/claude-sonnet-4-5[1m][1m]",
-            "anthropic/@everyone",
-            "anthropic/**claude**",
-            "anthropic/claude\nsonnet",
-            "anthropic/claude\tsonnet",
-            "anthropic/host.example.com",
-            "anthropic/session-deadbeef",
-            "anthropic/api-key-secret",
-            "openai/sk-proj-secret",
-            "github/ghp_secret",
-        ] {
-            let snapshot = CompletedTurnFooterSnapshot {
-                model: Some(malicious_model.to_string()),
-                ..Default::default()
-            };
-            assert_eq!(
-                render_completed_turn_footer(&snapshot),
-                None,
-                "{malicious_model}"
-            );
-        }
-        for malicious_host in ["host.example.com", "12345", "mac-1234", "맥북"] {
             let snapshot = CompletedTurnFooterSnapshot {
                 host: Some(malicious_host.to_string()),
                 ..Default::default()
@@ -659,21 +609,15 @@ pub(in crate::services::discord) mod tests {
     }
 
     #[test]
-    fn completed_footer_truncates_model_on_utf8_character_boundary_4860() {
-        let model = "가".repeat(MAX_MODEL_LABEL_CHARS + 2);
+    fn completed_footer_truncates_host_on_utf8_character_boundary_4860() {
         let rendered = render_completed_turn_footer(&CompletedTurnFooterSnapshot {
-            model: Some(model),
             host: Some(format!("{}zz", "a".repeat(MAX_HOST_LABEL_CHARS))),
             ..Default::default()
         })
-        .expect("safe labels");
-        let expected_model = "가".repeat(MAX_MODEL_LABEL_CHARS);
-        let expected_host = format!("{}", "a".repeat(MAX_HOST_LABEL_CHARS));
+        .expect("safe host");
+        let expected_host = "a".repeat(MAX_HOST_LABEL_CHARS);
 
-        assert_eq!(
-            rendered,
-            format!("-# {expected_model} · 🖥️ {expected_host}")
-        );
+        assert_eq!(rendered, format!("-# 🖥️ {expected_host}"));
         assert_eq!(rendered.lines().count(), 1);
     }
 

--- a/src/services/discord/completion_footer_metadata.rs
+++ b/src/services/discord/completion_footer_metadata.rs
@@ -110,8 +110,101 @@ fn context_percent_floor(used: u128, window: u128) -> Option<u8> {
 }
 
 fn sanitize_model_label(value: &str) -> Option<String> {
-    let value = sanitize_bounded_label(value, MAX_MODEL_LABEL_CHARS, true)?;
-    (!value.chars().all(|character| character.is_ascii_digit())).then_some(value)
+    if value.is_empty() || value.trim() != value || value.chars().any(char::is_control) {
+        return None;
+    }
+
+    let (core, effort_suffix) = match value.strip_suffix("[1m]") {
+        Some(core) => (core, Some("[1m]")),
+        None => (value, None),
+    };
+    if core.is_empty() || core.contains(['[', ']']) {
+        return None;
+    }
+
+    let mut components = core.split('/');
+    let first = components.next()?;
+    let second = components.next();
+    if components.next().is_some()
+        || !is_safe_model_component(first, second.is_some(), false)
+        || second.is_some_and(|model| !is_safe_model_component(model, true, true))
+        || core.split('/').any(looks_like_fqdn)
+        || core.split('/').any(looks_like_uuid)
+        || contains_private_identity_label(core)
+        || looks_like_credential(core)
+        || second.is_some() && core.split('/').any(is_filesystem_path_component)
+        || core.split('/').any(|component| {
+            component
+                .chars()
+                .all(|character| character.is_ascii_digit())
+        })
+    {
+        return None;
+    }
+
+    Some(truncate_model_label(core, effort_suffix))
+}
+
+fn is_safe_model_component(value: &str, ascii_only: bool, allow_colon: bool) -> bool {
+    !value.is_empty()
+        && value.chars().next().is_some_and(char::is_alphanumeric)
+        && value.chars().last().is_some_and(char::is_alphanumeric)
+        && value.chars().all(|character| {
+            (!ascii_only && character.is_alphanumeric())
+                || character.is_ascii_alphanumeric()
+                || matches!(character, '-' | '_' | '.')
+                || (allow_colon && character == ':')
+        })
+        && !value.contains("..")
+        && !value.contains("::")
+}
+
+fn truncate_model_label(core: &str, effort_suffix: Option<&str>) -> String {
+    let suffix_chars = effort_suffix.map_or(0, |suffix| suffix.chars().count());
+    let core_limit = MAX_MODEL_LABEL_CHARS.saturating_sub(suffix_chars);
+    let mut rendered = core.chars().take(core_limit).collect::<String>();
+    while rendered
+        .chars()
+        .last()
+        .is_some_and(|character| !character.is_alphanumeric())
+    {
+        rendered.pop();
+    }
+    if let Some(suffix) = effort_suffix {
+        rendered.push_str(suffix);
+    }
+    rendered
+}
+
+fn looks_like_credential(value: &str) -> bool {
+    let lowercase = value.to_ascii_lowercase();
+    let compact = lowercase
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .collect::<String>();
+    ["sk-", "sk_", "ghp_", "github_pat_", "xoxb-", "xoxp-"]
+        .iter()
+        .any(|prefix| lowercase.starts_with(prefix) || lowercase.contains(&format!("/{prefix}")))
+        || [
+            "apikey",
+            "accesstoken",
+            "refreshtoken",
+            "password",
+            "passwd",
+            "credential",
+            "bearertoken",
+        ]
+        .iter()
+        .any(|marker| compact.contains(marker))
+}
+
+fn is_filesystem_path_component(value: &str) -> bool {
+    [
+        "bin", "boot", "dev", "etc", "home", "lib", "lib64", "opt", "private", "proc", "root",
+        "run", "sbin", "srv", "sys", "tmp", "usr", "users", "var", "windows",
+    ]
+    .iter()
+    .any(|component| value.eq_ignore_ascii_case(component))
 }
 
 fn sanitize_host_label(value: &str) -> Option<String> {
@@ -145,7 +238,7 @@ fn sanitize_bounded_label(value: &str, max_chars: usize, allow_model_dots: bool)
 }
 
 fn contains_private_identity_label(value: &str) -> bool {
-    value.split(['-', '.']).any(|component| {
+    value.split(['-', '.', '_', ':', '/']).any(|component| {
         ["pid", "session", "channel", "thread", "dispatch"]
             .iter()
             .any(|reserved| component.eq_ignore_ascii_case(reserved))
@@ -470,6 +563,29 @@ pub(in crate::services::discord) mod tests {
     }
 
     #[test]
+    fn completed_footer_renders_supported_runtime_model_labels_4860() {
+        for model in [
+            "sonnet[1m]",
+            "opus[1m]",
+            "routed-sonnet[1m]",
+            "anthropic/claude-sonnet-4-5",
+            "anthropic/claude-sonnet-4-6[1m]",
+            "openai/gpt-5.1",
+            "openrouter/google-gemini-2.5-pro:free",
+        ] {
+            let snapshot = CompletedTurnFooterSnapshot {
+                model: Some(model.to_string()),
+                ..Default::default()
+            };
+            assert_eq!(
+                render_completed_turn_footer(&snapshot).as_deref(),
+                Some(format!("-# {model}").as_str()),
+                "{model}"
+            );
+        }
+    }
+
+    #[test]
     fn completed_footer_sanitizes_injection_paths_and_private_identity_4860() {
         for malicious in [
             "fable-5\n@everyone",
@@ -492,7 +608,33 @@ pub(in crate::services::discord) mod tests {
             };
             assert_eq!(render_completed_turn_footer(&snapshot), None, "{malicious}");
         }
-        for malicious_model in ["host.example.com", "12345"] {
+        for malicious_model in [
+            "host.example.com",
+            "12345",
+            "anthropic/12345",
+            "anthropic/claude/sonnet",
+            "../claude-sonnet-4-5",
+            "opt/models",
+            "Users/alice",
+            "C:/Windows",
+            "anthropic/.env",
+            "anthropic/../secret",
+            "anthropic/claude-sonnet-4-5]",
+            "anthropic-/claude-sonnet-4-5",
+            "anthropic/claude-sonnet-4-5-",
+            "anthropic/claude[sonnet]",
+            "anthropic/claude-sonnet-4-5[2m]",
+            "anthropic/claude-sonnet-4-5[1m][1m]",
+            "anthropic/@everyone",
+            "anthropic/**claude**",
+            "anthropic/claude\nsonnet",
+            "anthropic/claude\tsonnet",
+            "anthropic/host.example.com",
+            "anthropic/session-deadbeef",
+            "anthropic/api-key-secret",
+            "openai/sk-proj-secret",
+            "github/ghp_secret",
+        ] {
             let snapshot = CompletedTurnFooterSnapshot {
                 model: Some(malicious_model.to_string()),
                 ..Default::default()

--- a/src/services/discord/completion_footer_metadata.rs
+++ b/src/services/discord/completion_footer_metadata.rs
@@ -11,6 +11,163 @@ const ELAPSED_PREFIX: &str = "⏱ ";
 const RATE_LIMIT_PREFIX: &str = "⏳ ";
 const HOST_PREFIX: &str = "🖥️ ";
 const METADATA_SUFFIX_SEPARATOR: &str = "\u{2063}";
+const COMPLETED_FOOTER_PREFIX: &str = "-# ";
+const COMPLETED_FOOTER_SEPARATOR: &str = " · ";
+const MAX_MODEL_LABEL_CHARS: usize = 48;
+const MAX_HOST_LABEL_CHARS: usize = 63;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(in crate::services::discord) struct CompletedTurnFooterSnapshot {
+    pub(in crate::services::discord) elapsed_secs: Option<u64>,
+    pub(in crate::services::discord) model: Option<String>,
+    pub(in crate::services::discord) host: Option<String>,
+    pub(in crate::services::discord) context_used_tokens: Option<u128>,
+    pub(in crate::services::discord) context_window_tokens: Option<u128>,
+}
+
+pub(in crate::services::discord) fn render_completed_turn_footer(
+    snapshot: &CompletedTurnFooterSnapshot,
+) -> Option<String> {
+    let mut segments = Vec::with_capacity(4);
+    if let Some(elapsed_secs) = snapshot.elapsed_secs {
+        segments.push(format!(
+            "{ELAPSED_PREFIX}{}",
+            format_compact_elapsed(elapsed_secs)
+        ));
+    }
+    if let Some(model) = snapshot.model.as_deref().and_then(sanitize_model_label) {
+        segments.push(model);
+    }
+    if let Some(host) = snapshot.host.as_deref().and_then(sanitize_host_label) {
+        segments.push(format!("{HOST_PREFIX}{host}"));
+    }
+    if let (Some(used), Some(window)) =
+        (snapshot.context_used_tokens, snapshot.context_window_tokens)
+    {
+        if let Some(percent) = context_percent_floor(used, window) {
+            segments.push(format!("📦 {} ({percent}%)", format_compact_tokens(used)));
+        }
+    }
+    (!segments.is_empty()).then(|| {
+        format!(
+            "{COMPLETED_FOOTER_PREFIX}{}",
+            segments.join(COMPLETED_FOOTER_SEPARATOR)
+        )
+    })
+}
+
+fn format_compact_elapsed(total_secs: u64) -> String {
+    if total_secs == 0 {
+        return "0s".to_string();
+    }
+    let units = [(86_400, "d"), (3_600, "h"), (60, "m"), (1, "s")];
+    let mut remaining = total_secs;
+    let mut rendered = String::new();
+    for (unit_secs, suffix) in units {
+        let value = remaining / unit_secs;
+        remaining %= unit_secs;
+        if value > 0 {
+            rendered.push_str(&format!("{value}{suffix}"));
+        }
+    }
+    rendered
+}
+
+fn format_compact_tokens(tokens: u128) -> String {
+    const UNITS: [(u128, &str); 4] = [
+        (1_000_000_000_000, "t"),
+        (1_000_000_000, "b"),
+        (1_000_000, "m"),
+        (1_000, "k"),
+    ];
+    for (scale, suffix) in UNITS {
+        if tokens >= scale {
+            let whole = tokens / scale;
+            let decimal = (tokens % scale) / (scale / 10);
+            return if decimal == 0 {
+                format!("{whole}{suffix}")
+            } else {
+                format!("{whole}.{decimal}{suffix}")
+            };
+        }
+    }
+    tokens.to_string()
+}
+
+fn context_percent_floor(used: u128, window: u128) -> Option<u8> {
+    if window == 0 {
+        return None;
+    }
+    let used = used.min(window);
+    let window_hundredths = window / 100;
+    let window_remainder = window % 100;
+    (0..=100).rev().find(|percent| {
+        let percent = u128::from(*percent);
+        let fractional = window_remainder * percent;
+        let threshold = window_hundredths * percent + fractional.div_ceil(100);
+        used >= threshold
+    })
+}
+
+fn sanitize_model_label(value: &str) -> Option<String> {
+    sanitize_bounded_label(value, MAX_MODEL_LABEL_CHARS, true)
+}
+
+fn sanitize_host_label(value: &str) -> Option<String> {
+    let value = sanitize_bounded_label(value, MAX_HOST_LABEL_CHARS, false)?;
+    let has_long_digit_run = value
+        .split(|character: char| !character.is_ascii_digit())
+        .any(|digits| digits.len() >= 4);
+    (value.is_ascii() && !has_long_digit_run).then_some(value)
+}
+
+fn sanitize_bounded_label(value: &str, max_chars: usize, allow_model_dots: bool) -> Option<String> {
+    if value.is_empty() || value.trim() != value || value.chars().any(char::is_control) {
+        return None;
+    }
+    let allowed = |character: char| {
+        character.is_alphanumeric() || character == '-' || (allow_model_dots && character == '.')
+    };
+    if !value.chars().all(allowed)
+        || !value.chars().next().is_some_and(char::is_alphanumeric)
+        || !value.chars().last().is_some_and(char::is_alphanumeric)
+        || value.contains("..")
+        || contains_private_identity_label(value)
+        || looks_like_uuid(value)
+        || (allow_model_dots && looks_like_fqdn(value))
+    {
+        return None;
+    }
+    let truncated = value.chars().take(max_chars).collect::<String>();
+    let truncated = truncated.trim_end_matches(['-', '.']);
+    (!truncated.is_empty()).then(|| truncated.to_string())
+}
+
+fn contains_private_identity_label(value: &str) -> bool {
+    value.split(['-', '.']).any(|component| {
+        ["pid", "session", "channel", "thread", "dispatch"]
+            .iter()
+            .any(|reserved| component.eq_ignore_ascii_case(reserved))
+    })
+}
+
+fn looks_like_uuid(value: &str) -> bool {
+    value.matches('-').count() >= 4
+        && value
+            .chars()
+            .all(|character| character == '-' || character.is_ascii_hexdigit())
+}
+
+fn looks_like_fqdn(value: &str) -> bool {
+    let Some((prefix, suffix)) = value.rsplit_once('.') else {
+        return false;
+    };
+    !prefix.is_empty()
+        && suffix.len() >= 2
+        && suffix
+            .chars()
+            .all(|character| character.is_ascii_alphabetic())
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(in crate::services::discord) struct CompletionFooterMetadata {
@@ -196,6 +353,218 @@ async fn terminal_rate_limit_summary(
 pub(in crate::services::discord) mod tests {
     use super::*;
     use chrono::TimeZone;
+
+    fn completed_snapshot() -> CompletedTurnFooterSnapshot {
+        CompletedTurnFooterSnapshot {
+            elapsed_secs: Some(92),
+            model: Some("fable-5".to_string()),
+            host: Some("mac-book".to_string()),
+            context_used_tokens: Some(261_000),
+            context_window_tokens: Some(1_000_000),
+        }
+    }
+
+    #[test]
+    fn completed_footer_renders_owner_format_and_fixed_order_4860() {
+        assert_eq!(
+            render_completed_turn_footer(&completed_snapshot()).as_deref(),
+            Some("-# ⏱ 1m32s · fable-5 · 🖥️ mac-book · 📦 261k (26%)")
+        );
+    }
+
+    #[test]
+    fn completed_footer_elapsed_boundaries_are_compact_4860() {
+        for (seconds, expected) in [
+            (0, "0s"),
+            (1, "1s"),
+            (59, "59s"),
+            (60, "1m"),
+            (61, "1m1s"),
+            (3_599, "59m59s"),
+            (3_600, "1h"),
+            (3_661, "1h1m1s"),
+            (86_400, "1d"),
+            (90_061, "1d1h1m1s"),
+        ] {
+            let snapshot = CompletedTurnFooterSnapshot {
+                elapsed_secs: Some(seconds),
+                ..Default::default()
+            };
+            assert_eq!(
+                render_completed_turn_footer(&snapshot).as_deref(),
+                Some(format!("-# ⏱ {expected}").as_str())
+            );
+        }
+    }
+
+    #[test]
+    fn completed_footer_token_boundaries_are_decimal_and_lowercase_4860() {
+        for (tokens, expected) in [
+            (0, "0"),
+            (999, "999"),
+            (1_000, "1k"),
+            (1_099, "1k"),
+            (1_100, "1.1k"),
+            (261_999, "261.9k"),
+            (1_000_000, "1m"),
+            (1_500_000, "1.5m"),
+            (1_000_000_000, "1b"),
+            (1_000_000_000_000, "1t"),
+            (u128::MAX, "340282366920938463463374607.4t"),
+        ] {
+            let snapshot = CompletedTurnFooterSnapshot {
+                context_used_tokens: Some(tokens),
+                context_window_tokens: Some(u128::MAX),
+                ..Default::default()
+            };
+            let rendered = render_completed_turn_footer(&snapshot).expect("context segment");
+            let expected_percent = if tokens == u128::MAX { 100 } else { 0 };
+            assert_eq!(rendered, format!("-# 📦 {expected} ({expected_percent}%)"));
+        }
+    }
+
+    #[test]
+    fn completed_footer_percent_is_floor_clamped_and_overflow_safe_4860() {
+        for (used, window, expected) in [
+            (1, 3, 33),
+            (2, 3, 66),
+            (999, 1_000, 99),
+            (1_001, 1_000, 100),
+            (u128::MAX, u128::MAX, 100),
+            (u128::MAX - 1, u128::MAX, 99),
+        ] {
+            let snapshot = CompletedTurnFooterSnapshot {
+                context_used_tokens: Some(used),
+                context_window_tokens: Some(window),
+                ..Default::default()
+            };
+            let rendered = render_completed_turn_footer(&snapshot).expect("context segment");
+            assert!(rendered.ends_with(&format!("({expected}%)")), "{rendered}");
+        }
+    }
+
+    #[test]
+    fn completed_footer_omits_missing_and_zero_window_context_4860() {
+        assert_eq!(
+            render_completed_turn_footer(&CompletedTurnFooterSnapshot::default()),
+            None
+        );
+        assert_eq!(
+            render_completed_turn_footer(&CompletedTurnFooterSnapshot {
+                context_used_tokens: Some(42),
+                context_window_tokens: Some(0),
+                ..Default::default()
+            }),
+            None
+        );
+        assert_eq!(
+            render_completed_turn_footer(&CompletedTurnFooterSnapshot {
+                model: Some("fable-5".to_string()),
+                context_used_tokens: Some(42),
+                ..Default::default()
+            })
+            .as_deref(),
+            Some("-# fable-5")
+        );
+    }
+
+    #[test]
+    fn completed_footer_sanitizes_injection_paths_and_private_identity_4860() {
+        for malicious in [
+            "fable-5\n@everyone",
+            "<@123456789>",
+            "**fable-5**",
+            "../fable-5",
+            "/opt/models/fable-5",
+            "pid-1234",
+            "session-deadbeef",
+            "channel-1234",
+            "550e8400-e29b-41d4-a716-446655440000",
+            " fable-5",
+            "fable-5 ",
+        ] {
+            let snapshot = CompletedTurnFooterSnapshot {
+                model: Some(malicious.to_string()),
+                host: Some(malicious.to_string()),
+                ..Default::default()
+            };
+            assert_eq!(render_completed_turn_footer(&snapshot), None, "{malicious}");
+        }
+        for malicious_host in ["host.example.com", "12345", "mac-1234", "맥북"] {
+            let snapshot = CompletedTurnFooterSnapshot {
+                host: Some(malicious_host.to_string()),
+                ..Default::default()
+            };
+            assert_eq!(
+                render_completed_turn_footer(&snapshot),
+                None,
+                "{malicious_host}"
+            );
+        }
+    }
+
+    #[test]
+    fn completed_footer_truncates_model_on_utf8_character_boundary_4860() {
+        let model = "가".repeat(MAX_MODEL_LABEL_CHARS + 2);
+        let rendered = render_completed_turn_footer(&CompletedTurnFooterSnapshot {
+            model: Some(model),
+            host: Some(format!("{}zz", "a".repeat(MAX_HOST_LABEL_CHARS))),
+            ..Default::default()
+        })
+        .expect("safe labels");
+        let expected_model = "가".repeat(MAX_MODEL_LABEL_CHARS);
+        let expected_host = format!("{}", "a".repeat(MAX_HOST_LABEL_CHARS));
+
+        assert_eq!(
+            rendered,
+            format!("-# {expected_model} · 🖥️ {expected_host}")
+        );
+        assert_eq!(rendered.lines().count(), 1);
+    }
+
+    #[test]
+    fn completed_footer_is_single_line_deterministic_and_privacy_bounded_4860() {
+        let snapshot = completed_snapshot();
+        let once = render_completed_turn_footer(&snapshot).expect("footer");
+        let twice = render_completed_turn_footer(&snapshot).expect("footer");
+
+        assert_eq!(once, twice);
+        assert_eq!(once.lines().count(), 1);
+        for forbidden in [
+            "quota",
+            "threshold",
+            "payload",
+            "channel",
+            "session",
+            "dispatch",
+            "5h:",
+            "7d:",
+            METADATA_SUFFIX_SEPARATOR,
+        ] {
+            assert!(!once.contains(forbidden), "{once}");
+        }
+    }
+
+    #[test]
+    fn visible_completed_footer_never_becomes_internal_metadata_4860() {
+        let visible = "-# ⏱ 1m32s · fable-5 · 🖥️ mac-book · 📦 261k (26%)";
+        assert_eq!(
+            completion_footer_metadata_from_block(Some(visible)),
+            CompletionFooterMetadata::default()
+        );
+        let metadata = completion_footer_metadata_at(
+            1_800_000_154,
+            1_800_000_000,
+            None,
+            None,
+            Some("node-a".to_string()),
+        );
+        let appended = append_completion_footer_metadata(visible.to_string(), &metadata);
+
+        assert!(appended.starts_with(visible));
+        assert_eq!(appended.matches("-# ⏱ 1m32s").count(), 1);
+        assert_eq!(appended.matches(METADATA_SUFFIX_SEPARATOR).count(), 1);
+    }
 
     #[test]
     fn ownerless_metadata_uses_inflight_started_at_fallback_4806() {

--- a/src/services/discord/completion_footer_metadata.rs
+++ b/src/services/discord/completion_footer_metadata.rs
@@ -473,6 +473,7 @@ pub(in crate::services::discord) mod tests {
     fn completed_footer_sanitizes_injection_paths_and_private_identity_4860() {
         for malicious in [
             "fable-5\n@everyone",
+            "fable\n5",
             "<@123456789>",
             "**fable-5**",
             "../fable-5",

--- a/src/services/discord/completion_footer_metadata.rs
+++ b/src/services/discord/completion_footer_metadata.rs
@@ -196,41 +196,6 @@ fn looks_like_credential(value: &str) -> bool {
         ]
         .iter()
         .any(|marker| compact.contains(marker))
-        || value.split('/').any(looks_like_secret_token)
-}
-
-fn looks_like_secret_token(value: &str) -> bool {
-    let looks_like_aws_access_key = value.len() == 20
-        && [
-            "AKIA", "ASIA", "AIDA", "AROA", "AIPA", "ANPA", "ANVA", "A3T",
-        ]
-        .iter()
-        .any(|prefix| value.starts_with(prefix))
-        && value
-            .chars()
-            .all(|character| character.is_ascii_uppercase() || character.is_ascii_digit());
-
-    let mut jwt_segments = value.split('.');
-    let header = jwt_segments.next().unwrap_or_default();
-    let payload = jwt_segments.next();
-    let signature = jwt_segments.next();
-    let looks_like_jwt = payload.is_some_and(|segment| segment.starts_with("eyJ"))
-        && signature.is_some_and(|segment| !segment.is_empty())
-        && jwt_segments.next().is_none()
-        && header.starts_with("eyJ")
-        && [
-            header,
-            payload.unwrap_or_default(),
-            signature.unwrap_or_default(),
-        ]
-        .iter()
-        .all(|segment| {
-            segment.chars().all(|character| {
-                character.is_ascii_alphanumeric() || matches!(character, '-' | '_')
-            })
-        });
-
-    looks_like_aws_access_key || looks_like_jwt
 }
 
 fn is_filesystem_path_component(value: &str) -> bool {
@@ -291,7 +256,11 @@ fn looks_like_fqdn(value: &str) -> bool {
     let Some((prefix, suffix)) = value.rsplit_once('.') else {
         return false;
     };
-    !prefix.is_empty() && suffix.len() >= 2 && suffix.chars().all(char::is_alphabetic)
+    !prefix.is_empty()
+        && suffix.len() >= 2
+        && suffix
+            .chars()
+            .all(|character| character.is_ascii_alphabetic())
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -641,7 +610,6 @@ pub(in crate::services::discord) mod tests {
         }
         for malicious_model in [
             "host.example.com",
-            "例子.公司",
             "12345",
             "anthropic/12345",
             "anthropic/claude/sonnet",
@@ -665,8 +633,6 @@ pub(in crate::services::discord) mod tests {
             "anthropic/session-deadbeef",
             "anthropic/api-key-secret",
             "openai/sk-proj-secret",
-            "openai/AKIAIOSFODNN7EXAMPLE",
-            "openai/eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjF9.sig",
             "github/ghp_secret",
         ] {
             let snapshot = CompletedTurnFooterSnapshot {

--- a/src/services/discord/completion_footer_metadata.rs
+++ b/src/services/discord/completion_footer_metadata.rs
@@ -492,6 +492,17 @@ pub(in crate::services::discord) mod tests {
             };
             assert_eq!(render_completed_turn_footer(&snapshot), None, "{malicious}");
         }
+        for malicious_model in ["host.example.com", "12345"] {
+            let snapshot = CompletedTurnFooterSnapshot {
+                model: Some(malicious_model.to_string()),
+                ..Default::default()
+            };
+            assert_eq!(
+                render_completed_turn_footer(&snapshot),
+                None,
+                "{malicious_model}"
+            );
+        }
         for malicious_host in ["host.example.com", "12345", "mac-1234", "맥북"] {
             let snapshot = CompletedTurnFooterSnapshot {
                 host: Some(malicious_host.to_string()),


### PR DESCRIPTION
## Summary
- add a mode-neutral completed-turn footer snapshot and pure one-line renderer
- keep elapsed/model/host/context ordering fixed with overflow-safe percentages and strict label sanitization
- preserve the existing U+2063 metadata parser boundary; visible footer-like answer text is never parsed or removed

## Scope
- pure formatter and direct unit tests only
- no production Discord answer-path wiring
- no hotfile changes
- not user-visible yet

## Dependencies
Production wiring remains blocked on #4893 and #4901. This draft must not be wired or merged as the user-visible completion path until those authority/panel dependencies are satisfied.

## Test plan
- [x] `cargo test --lib completion_footer_metadata::tests` (18 passed)
- [x] `cargo check --lib`
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `python3 scripts/generate_inventory_docs.py`
- [x] `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate`
- [x] `python3 scripts/audit_maintainability.py --check`
- [x] newline-acceptance mutant fails sanitizer assertion
- [x] unsafe `used * 100` mutant fails at `u128::MAX` overflow

Refs #4860

🤖 Generated with [Claude Code](https://claude.com/claude-code)