### PR TITLE
fix(#4874): wake queued work after local slash controls

### DIFF
--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -455,7 +455,8 @@ mod last_message_checkpoint_tests {
 
 pub(in crate::services::discord) use queue_io::{
     arm_slow_idle_queue_backstop_if_queue_nonempty, schedule_deferred_idle_queue_kickoff,
-    schedule_deferred_idle_queue_kickoff_immediate, spawn_turn_completion_idle_queue_listener,
+    schedule_deferred_idle_queue_kickoff_immediate, schedule_local_only_slash_idle_queue_kickoff,
+    spawn_turn_completion_idle_queue_listener,
 };
 pub(super) fn single_message_panel_enabled() -> bool {
     single_message_panel::enabled()

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -509,13 +509,27 @@ async fn idle_queue_backstop_backlog_units_all(
         .sum()
 }
 
+/// Wait for either the normal delay or a coalesced immediate queue signal.
+/// The signal belongs to the per-channel task guard, so waking it cannot create
+/// a second concurrent dequeue or bypass the normal kickoff admission gates.
+async fn wait_for_deferred_idle_queue_delay(
+    delay: std::time::Duration,
+    immediate_signal: &tokio::sync::Notify,
+) {
+    tokio::select! {
+        _ = tokio::time::sleep(delay) => {}
+        _ = immediate_signal.notified() => {}
+    }
+}
+
 async fn run_single_slow_idle_queue_backstop(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: ChannelId,
     reason: &'static str,
+    immediate_signal: &tokio::sync::Notify,
 ) -> Option<IdleQueueBackstopRearm> {
-    tokio::time::sleep(DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY).await;
+    wait_for_deferred_idle_queue_delay(DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY, immediate_signal).await;
     let snapshot = super::mailbox_snapshot(shared.as_ref(), channel_id).await;
     let backlog_units =
         idle_queue_backstop_backlog_units(shared.as_ref(), provider, channel_id, &snapshot);
@@ -577,6 +591,12 @@ fn schedule_single_slow_idle_queue_backstop(
             entry.insert(Arc::new(tokio::sync::Notify::new()));
         }
     };
+    let immediate_signal = shared
+        .restart
+        .deferred_hook_channels
+        .get(&channel_id)
+        .expect("new slow backstop must retain its per-channel signal")
+        .clone();
     shared
         .restart
         .deferred_hook_backlog
@@ -587,8 +607,14 @@ fn schedule_single_slow_idle_queue_backstop(
             channel_id,
             active: true,
         };
-        let rearm =
-            run_single_slow_idle_queue_backstop(&shared, &provider, channel_id, reason).await;
+        let rearm = run_single_slow_idle_queue_backstop(
+            &shared,
+            &provider,
+            channel_id,
+            reason,
+            immediate_signal.as_ref(),
+        )
+        .await;
         backlog_guard.release();
         if let Some(rearm) = rearm {
             schedule_single_slow_idle_queue_backstop(
@@ -758,6 +784,12 @@ fn schedule_deferred_idle_queue_kickoff_inner(
             entry.insert(Arc::new(tokio::sync::Notify::new()));
         }
     };
+    let immediate_signal = shared
+        .restart
+        .deferred_hook_channels
+        .get(&channel_id)
+        .expect("new deferred kickoff must retain its per-channel signal")
+        .clone();
     shared
         .restart
         .deferred_hook_backlog
@@ -773,15 +805,21 @@ fn schedule_deferred_idle_queue_kickoff_inner(
 
         let initial_presleep = profile.initial_presleep();
         if !initial_presleep.is_zero() {
-            tokio::time::sleep(initial_presleep).await;
+            wait_for_deferred_idle_queue_delay(initial_presleep, immediate_signal.as_ref()).await;
         }
 
         let _ =
             kick_idle_queue_channel_if_context_available(&shared, &provider, channel_id, reason)
                 .await;
 
-        let rearm =
-            run_single_slow_idle_queue_backstop(&shared, &provider, channel_id, reason).await;
+        let rearm = run_single_slow_idle_queue_backstop(
+            &shared,
+            &provider,
+            channel_id,
+            reason,
+            immediate_signal.as_ref(),
+        )
+        .await;
         backlog_guard.release();
         if let Some(rearm) = rearm {
             schedule_single_slow_idle_queue_backstop(
@@ -1026,26 +1064,126 @@ mod presleep_tests {
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn coalesced_immediate_kick_notifies_existing_slow_task() {
+    async fn coalesced_immediate_kick_interrupts_existing_initial_delay_once() {
         let shared = make_shared_data_for_tests();
         let provider = ProviderKind::Claude;
         let channel_id = ChannelId::new(4_024_281);
-        let notify = Arc::new(tokio::sync::Notify::new());
-        shared
-            .restart
-            .deferred_hook_channels
-            .insert(channel_id, notify.clone());
+        let kicks = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hook_kicks = kicks.clone();
+        let _hook = set_idle_queue_kick_hook_for_tests(Arc::new(
+            move |_shared, _provider, channel, reason| {
+                let hook_kicks = hook_kicks.clone();
+                Box::pin(async move {
+                    if channel != channel_id {
+                        return None;
+                    }
+                    assert_eq!(reason, "slow-initial-delay");
+                    hook_kicks.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Some(IdleQueueKickoffChannelOutcome::default())
+                })
+            },
+        ));
 
-        schedule_deferred_idle_queue_kickoff_immediate(
-            shared,
-            provider,
+        let before_immediate_signal = tokio::time::Instant::now();
+        schedule_deferred_idle_queue_kickoff(
+            shared.clone(),
+            provider.clone(),
             channel_id,
-            "coalesced-immediate-test",
+            "slow-initial-delay",
         );
+        tokio::task::yield_now().await;
+        schedule_local_only_slash_idle_queue_kickoff(shared, provider, channel_id);
+        tokio::task::yield_now().await;
 
-        tokio::time::timeout(std::time::Duration::from_millis(1), notify.notified())
-            .await
-            .expect("immediate coalesce should wake the existing task");
+        assert_eq!(
+            tokio::time::Instant::now(),
+            before_immediate_signal,
+            "the existing 2s timer must not elapse before the coalesced immediate signal kicks"
+        );
+        assert_eq!(
+            kicks.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "immediate coalescing must interrupt the existing 2s initial sleep and perform one kickoff"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn coalesced_immediate_kick_interrupts_existing_backstop_once() {
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_024_282);
+        let queued_message_id = MessageId::new(4_024_283);
+        shared
+            .mailbox(channel_id)
+            .replace_queue(
+                vec![user_intervention(
+                    queued_message_id.get(),
+                    "backstop wakeup",
+                )],
+                queue_persistence_context(&shared, &provider, channel_id),
+            )
+            .await;
+
+        let kicks = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hook_kicks = kicks.clone();
+        let _hook = set_idle_queue_kick_hook_for_tests(Arc::new(
+            move |shared, provider, channel, reason| {
+                let hook_kicks = hook_kicks.clone();
+                Box::pin(async move {
+                    if channel != channel_id {
+                        return None;
+                    }
+                    assert_eq!(reason, "slow-backstop");
+                    hook_kicks.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let taken = super::super::mailbox_take_next_automatic_intervention(
+                        &shared, &provider, channel,
+                    )
+                    .await;
+                    let intervention = taken
+                        .intervention
+                        .expect("backstop wakeup promotes queued work");
+                    let started = mailbox_try_start_turn(
+                        &shared,
+                        channel,
+                        Arc::new(CancelToken::new()),
+                        intervention.author_id,
+                        intervention.message_id,
+                    )
+                    .await;
+                    Some(IdleQueueKickoffChannelOutcome { started })
+                })
+            },
+        ));
+
+        let before_immediate_signal = tokio::time::Instant::now();
+        assert!(schedule_single_slow_idle_queue_backstop(
+            shared.clone(),
+            provider.clone(),
+            channel_id,
+            "slow-backstop",
+            1,
+        ));
+        tokio::task::yield_now().await;
+        schedule_local_only_slash_idle_queue_kickoff(shared.clone(), provider, channel_id);
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            tokio::time::Instant::now(),
+            before_immediate_signal,
+            "the existing 60s timer must not elapse before the coalesced immediate signal kicks"
+        );
+        assert_eq!(
+            kicks.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "immediate coalescing must interrupt the existing 60s backstop and perform one kickoff"
+        );
+        assert_eq!(
+            mailbox_snapshot(&shared, channel_id)
+                .await
+                .active_user_message_id,
+            Some(queued_message_id),
+            "the existing queue authority, not the local-only branch, promotes the queued message"
+        );
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -24,6 +24,35 @@ const DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY: std::time::Duration =
 const DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY: std::time::Duration = std::time::Duration::from_secs(60);
 const IDLE_QUEUE_BACKSTOP_WARN_TARGET: &str = "agentdesk::discord::idle_queue_backstop";
 
+/// Per-channel coalesced wake state for the one live deferred queue task.
+/// `requested_generation` advances once per immediate request; the task owns its
+/// consumed generation so it can acknowledge signals received during a kickoff
+/// before entering the slow backstop wait.
+pub(in crate::services) struct DeferredIdleQueueWake {
+    notify: tokio::sync::Notify,
+    requested_generation: std::sync::atomic::AtomicU64,
+}
+
+impl DeferredIdleQueueWake {
+    pub(in crate::services) fn new() -> Self {
+        Self {
+            notify: tokio::sync::Notify::new(),
+            requested_generation: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    fn request_immediate(&self) {
+        self.requested_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
+        self.notify.notify_one();
+    }
+
+    fn requested_generation(&self) -> u64 {
+        self.requested_generation
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+}
+
 #[cfg(test)]
 static IDLE_QUEUE_BACKSTOP_FIRES_FOR_TESTS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
@@ -514,11 +543,35 @@ async fn idle_queue_backstop_backlog_units_all(
 /// a second concurrent dequeue or bypass the normal kickoff admission gates.
 async fn wait_for_deferred_idle_queue_delay(
     delay: std::time::Duration,
-    immediate_signal: &tokio::sync::Notify,
+    immediate_signal: &DeferredIdleQueueWake,
+    consumed_generation: &mut u64,
 ) {
-    tokio::select! {
-        _ = tokio::time::sleep(delay) => {}
-        _ = immediate_signal.notified() => {}
+    let deadline = tokio::time::Instant::now() + delay;
+    loop {
+        let requested_generation = immediate_signal.requested_generation();
+        if requested_generation > *consumed_generation {
+            *consumed_generation = requested_generation;
+            return;
+        }
+
+        let notified = immediate_signal.notify.notified();
+        // `Notify` retains a permit. Re-check the monotonic generation after
+        // registering the waiter so a signal cannot be lost between the first
+        // generation read and `notified()` creation.
+        let requested_generation = immediate_signal.requested_generation();
+        if requested_generation > *consumed_generation {
+            *consumed_generation = requested_generation;
+            return;
+        }
+
+        tokio::select! {
+            _ = tokio::time::sleep_until(deadline) => return,
+            _ = notified => {
+                // A permit from a request already acknowledged during the
+                // preceding kickoff is stale. Consume it and continue waiting
+                // rather than running the slow backstop early.
+            }
+        }
     }
 }
 
@@ -527,9 +580,15 @@ async fn run_single_slow_idle_queue_backstop(
     provider: &ProviderKind,
     channel_id: ChannelId,
     reason: &'static str,
-    immediate_signal: &tokio::sync::Notify,
+    immediate_signal: &DeferredIdleQueueWake,
+    consumed_generation: &mut u64,
 ) -> Option<IdleQueueBackstopRearm> {
-    wait_for_deferred_idle_queue_delay(DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY, immediate_signal).await;
+    wait_for_deferred_idle_queue_delay(
+        DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY,
+        immediate_signal,
+        consumed_generation,
+    )
+    .await;
     let snapshot = super::mailbox_snapshot(shared.as_ref(), channel_id).await;
     let backlog_units =
         idle_queue_backstop_backlog_units(shared.as_ref(), provider, channel_id, &snapshot);
@@ -588,7 +647,7 @@ fn schedule_single_slow_idle_queue_backstop(
             return false;
         }
         dashmap::mapref::entry::Entry::Vacant(entry) => {
-            entry.insert(Arc::new(tokio::sync::Notify::new()));
+            entry.insert(Arc::new(DeferredIdleQueueWake::new()));
         }
     };
     let immediate_signal = shared
@@ -607,12 +666,14 @@ fn schedule_single_slow_idle_queue_backstop(
             channel_id,
             active: true,
         };
+        let mut immediate_generation = immediate_signal.requested_generation();
         let rearm = run_single_slow_idle_queue_backstop(
             &shared,
             &provider,
             channel_id,
             reason,
             immediate_signal.as_ref(),
+            &mut immediate_generation,
         )
         .await;
         backlog_guard.release();
@@ -768,7 +829,7 @@ fn schedule_deferred_idle_queue_kickoff_inner(
     match shared.restart.deferred_hook_channels.entry(channel_id) {
         dashmap::mapref::entry::Entry::Occupied(entry) => {
             if profile.wakes_existing_task() {
-                entry.get().notify_one();
+                entry.get().request_immediate();
             }
             tracing::debug!(
                 provider = provider.as_str(),
@@ -781,7 +842,7 @@ fn schedule_deferred_idle_queue_kickoff_inner(
             return;
         }
         dashmap::mapref::entry::Entry::Vacant(entry) => {
-            entry.insert(Arc::new(tokio::sync::Notify::new()));
+            entry.insert(Arc::new(DeferredIdleQueueWake::new()));
         }
     };
     let immediate_signal = shared
@@ -803,21 +864,32 @@ fn schedule_deferred_idle_queue_kickoff_inner(
             active: true,
         };
 
+        let mut immediate_generation = immediate_signal.requested_generation();
         let initial_presleep = profile.initial_presleep();
         if !initial_presleep.is_zero() {
-            wait_for_deferred_idle_queue_delay(initial_presleep, immediate_signal.as_ref()).await;
+            wait_for_deferred_idle_queue_delay(
+                initial_presleep,
+                immediate_signal.as_ref(),
+                &mut immediate_generation,
+            )
+            .await;
         }
 
         let _ =
             kick_idle_queue_channel_if_context_available(&shared, &provider, channel_id, reason)
                 .await;
 
+        // An immediate request racing the kickoff is already represented by the
+        // same admission attempt. Acknowledge it before the slow wait so its
+        // retained Notify permit cannot turn the backstop into a second fast kick.
+        immediate_generation = immediate_signal.requested_generation();
         let rearm = run_single_slow_idle_queue_backstop(
             &shared,
             &provider,
             channel_id,
             reason,
             immediate_signal.as_ref(),
+            &mut immediate_generation,
         )
         .await;
         backlog_guard.release();
@@ -1183,6 +1255,143 @@ mod presleep_tests {
                 .active_user_message_id,
             Some(queued_message_id),
             "the existing queue authority, not the local-only branch, promotes the queued message"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn local_only_slash_second_half_during_kick_does_not_bypass_backstop_delay() {
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_024_284);
+        shared
+            .mailbox(channel_id)
+            .replace_queue(
+                vec![user_intervention(
+                    4_024_285,
+                    "pending through /model halves",
+                )],
+                queue_persistence_context(&shared, &provider, channel_id),
+            )
+            .await;
+
+        let kicks = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let entered_kick = Arc::new(tokio::sync::Notify::new());
+        let release_kick = Arc::new(tokio::sync::Notify::new());
+        let hook_kicks = kicks.clone();
+        let hook_entered_kick = entered_kick.clone();
+        let hook_release_kick = release_kick.clone();
+        let _hook = set_idle_queue_kick_hook_for_tests(Arc::new(
+            move |_shared, _provider, channel, _reason| {
+                let hook_kicks = hook_kicks.clone();
+                let hook_entered_kick = hook_entered_kick.clone();
+                let hook_release_kick = hook_release_kick.clone();
+                Box::pin(async move {
+                    if channel != channel_id {
+                        return None;
+                    }
+                    let call = hook_kicks.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    if call == 0 {
+                        hook_entered_kick.notify_one();
+                        hook_release_kick.notified().await;
+                    }
+                    Some(IdleQueueKickoffChannelOutcome::default())
+                })
+            },
+        ));
+
+        let before_first_half = tokio::time::Instant::now();
+        schedule_local_only_slash_idle_queue_kickoff(shared.clone(), provider.clone(), channel_id);
+        entered_kick.notified().await;
+        // `/model` commonly arrives as a command-name and stdout half. The second
+        // observation races while the existing task is already in its kickoff.
+        schedule_local_only_slash_idle_queue_kickoff(shared.clone(), provider, channel_id);
+        release_kick.notify_one();
+        yield_backstop_tasks().await;
+
+        assert_eq!(
+            kicks.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the second transcript half during kickoff must not create an immediate backstop rerun"
+        );
+        assert_eq!(
+            tokio::time::Instant::now(),
+            before_first_half,
+            "the retained second-half signal must not advance the 60s throttle"
+        );
+
+        tokio::time::advance(DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY).await;
+        yield_backstop_tasks().await;
+        assert_eq!(
+            kicks.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "queued work remaining after the normal 60s delay receives exactly one backstop kickoff"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn local_only_slash_burst_during_kick_coalesces_to_one_backstop_delay() {
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_024_286);
+        shared
+            .mailbox(channel_id)
+            .replace_queue(
+                vec![user_intervention(
+                    4_024_287,
+                    "pending through local slash burst",
+                )],
+                queue_persistence_context(&shared, &provider, channel_id),
+            )
+            .await;
+
+        let kicks = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let entered_kick = Arc::new(tokio::sync::Notify::new());
+        let release_kick = Arc::new(tokio::sync::Notify::new());
+        let hook_kicks = kicks.clone();
+        let hook_entered_kick = entered_kick.clone();
+        let hook_release_kick = release_kick.clone();
+        let _hook = set_idle_queue_kick_hook_for_tests(Arc::new(
+            move |_shared, _provider, channel, _reason| {
+                let hook_kicks = hook_kicks.clone();
+                let hook_entered_kick = hook_entered_kick.clone();
+                let hook_release_kick = hook_release_kick.clone();
+                Box::pin(async move {
+                    if channel != channel_id {
+                        return None;
+                    }
+                    let call = hook_kicks.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    if call == 0 {
+                        hook_entered_kick.notify_one();
+                        hook_release_kick.notified().await;
+                    }
+                    Some(IdleQueueKickoffChannelOutcome::default())
+                })
+            },
+        ));
+
+        schedule_local_only_slash_idle_queue_kickoff(shared.clone(), provider.clone(), channel_id);
+        entered_kick.notified().await;
+        for _ in 0..8 {
+            schedule_local_only_slash_idle_queue_kickoff(
+                shared.clone(),
+                provider.clone(),
+                channel_id,
+            );
+        }
+        release_kick.notify_one();
+        yield_backstop_tasks().await;
+
+        assert_eq!(
+            kicks.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a repeated immediate burst during kickoff must collapse to the in-flight admission"
+        );
+        tokio::time::advance(DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY).await;
+        yield_backstop_tasks().await;
+        assert_eq!(
+            kicks.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "the burst must preserve only the normal single delayed backstop retry"
         );
     }
 

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -288,6 +288,21 @@ pub(super) fn schedule_deferred_idle_queue_kickoff_immediate(
     );
 }
 
+/// Local-only slash observations have no completion event, so they independently
+/// re-arm the same channel-coalesced idle queue authority.
+pub(super) fn schedule_local_only_slash_idle_queue_kickoff(
+    shared: Arc<SharedData>,
+    provider: ProviderKind,
+    channel_id: ChannelId,
+) {
+    schedule_deferred_idle_queue_kickoff_immediate(
+        shared,
+        provider,
+        channel_id,
+        "local-only slash observation",
+    );
+}
+
 pub(super) fn schedule_post_enqueue_idle_queue_kick(
     shared: Arc<SharedData>,
     provider: ProviderKind,
@@ -1031,6 +1046,138 @@ mod presleep_tests {
         tokio::time::timeout(std::time::Duration::from_millis(1), notify.notified())
             .await
             .expect("immediate coalesce should wake the existing task");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn local_only_slash_two_halves_coalesce_without_lifecycle_artifacts() {
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_874_100);
+        let tmux_session_name = "local-model-two-halves";
+
+        // `/model` is observed as a command-name half followed by a local stdout half.
+        schedule_local_only_slash_idle_queue_kickoff(shared.clone(), provider.clone(), channel_id);
+        schedule_local_only_slash_idle_queue_kickoff(shared.clone(), provider.clone(), channel_id);
+
+        assert_eq!(
+            shared
+                .restart
+                .deferred_hook_backlog
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "both local-only transcript halves must share one channel kickoff task"
+        );
+        let snapshot = mailbox_snapshot(&shared, channel_id).await;
+        assert!(snapshot.cancel_token.is_none());
+        assert!(snapshot.active_user_message_id.is_none());
+        assert!(
+            !crate::services::tui_prompt_dedupe::external_input_relay_lease_present(
+                provider.as_str(),
+                tmux_session_name,
+                channel_id.get(),
+            ),
+            "local-only wakeup must not mint an external relay lease"
+        );
+        assert!(
+            !super::super::tui_direct_pending_start::pending_synthetic_start_blocks_idle_kickoff(
+                provider.as_str(),
+                channel_id.get(),
+            ),
+            "local-only wakeup must not mint a synthetic pending start"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn local_only_slash_kick_promotes_pending_user_work() {
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_874_110);
+        let queued_message_id = MessageId::new(4_874_111);
+        shared
+            .mailbox(channel_id)
+            .replace_queue(
+                vec![user_intervention(
+                    queued_message_id.get(),
+                    "queued after /model",
+                )],
+                queue_persistence_context(&shared, &provider, channel_id),
+            )
+            .await;
+
+        let kicks = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hook_kicks = kicks.clone();
+        let _hook = set_idle_queue_kick_hook_for_tests(Arc::new(
+            move |shared, provider, channel, reason| {
+                let hook_kicks = hook_kicks.clone();
+                Box::pin(async move {
+                    if channel != channel_id {
+                        return None;
+                    }
+                    assert_eq!(reason, "local-only slash observation");
+                    hook_kicks.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let taken = super::super::mailbox_take_next_automatic_intervention(
+                        &shared, &provider, channel,
+                    )
+                    .await;
+                    let intervention = taken.intervention.expect("pending work is promoted");
+                    let started = mailbox_try_start_turn(
+                        &shared,
+                        channel,
+                        Arc::new(CancelToken::new()),
+                        intervention.author_id,
+                        intervention.message_id,
+                    )
+                    .await;
+                    Some(IdleQueueKickoffChannelOutcome { started })
+                })
+            },
+        ));
+
+        schedule_local_only_slash_idle_queue_kickoff(shared.clone(), provider, channel_id);
+        yield_backstop_tasks().await;
+
+        assert_eq!(kicks.load(std::sync::atomic::Ordering::SeqCst), 1);
+        let snapshot = mailbox_snapshot(&shared, channel_id).await;
+        assert_eq!(snapshot.active_user_message_id, Some(queued_message_id));
+        assert!(snapshot.intervention_queue.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn local_only_slash_kick_preserves_real_active_turn() {
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_874_120);
+        let active_message_id = MessageId::new(4_874_121);
+        let queued_message_id = MessageId::new(4_874_122);
+        assert!(
+            mailbox_try_start_turn(
+                &shared,
+                channel_id,
+                Arc::new(CancelToken::new()),
+                UserId::new(4_874_123),
+                active_message_id,
+            )
+            .await
+        );
+        shared
+            .mailbox(channel_id)
+            .replace_queue(
+                vec![user_intervention(
+                    queued_message_id.get(),
+                    "must remain queued",
+                )],
+                queue_persistence_context(&shared, &provider, channel_id),
+            )
+            .await;
+
+        schedule_local_only_slash_idle_queue_kickoff(shared.clone(), provider, channel_id);
+        yield_backstop_tasks().await;
+
+        let snapshot = mailbox_snapshot(&shared, channel_id).await;
+        assert_eq!(snapshot.active_user_message_id, Some(active_message_id));
+        assert!(snapshot.cancel_token.is_some());
+        assert_eq!(snapshot.intervention_queue.len(), 1);
+        assert_eq!(snapshot.intervention_queue[0].message_id, queued_message_id);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/services/discord/shared_state.rs
+++ b/src/services/discord/shared_state.rs
@@ -662,7 +662,7 @@ pub(in crate::services) struct RestartLifecycle {
     /// most one fast/slow deferred drain task active; the task removes its entry
     /// when its backlog guard drops.
     pub(in crate::services) deferred_hook_channels:
-        dashmap::DashMap<ChannelId, Arc<tokio::sync::Notify>>,
+        dashmap::DashMap<ChannelId, Arc<super::queue_io::DeferredIdleQueueWake>>,
     /// When this provider started reconcile/recovery for the current boot.
     pub(in crate::services) recovery_started_at: std::time::Instant,
     /// Captured reconcile/recovery duration for the current boot in milliseconds.

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -341,7 +341,15 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
     };
     if let Some(control) = relay_prompt_decision.local_only_control.as_ref() {
         let kind = control.kind.as_str();
-        let Some(note) = prepare_local_only_slash_control_note(&prompt, kind) else {
+        let note = prepare_local_only_slash_control_note(&prompt, kind);
+        if let Some(provider) = ProviderKind::from_str(&prompt.provider) {
+            super::schedule_local_only_slash_idle_queue_kickoff(
+                shared.clone(),
+                provider,
+                channel_id,
+            );
+        }
+        let Some(note) = note else {
             tracing::info!(
                 provider = %prompt.provider,
                 channel_id = channel_id.get(),

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -1773,13 +1773,24 @@ fn local_control_prompt(tmux: &str, body: &str, entry_id: &str) -> ObservedTuiPr
 }
 
 #[test]
-fn local_slash_control_note_emission_is_wired_through_prepare_gate() {
+fn local_slash_control_note_and_queue_wakeup_are_independently_wired() {
     let relay_source = include_str!("../tui_prompt_relay.rs");
+    let note_prepare = relay_source
+        .find("let note = prepare_local_only_slash_control_note(&prompt, kind);")
+        .expect("local-only branch must prepare its note before delivery");
+    let queue_wakeup = relay_source
+        .find("super::schedule_local_only_slash_idle_queue_kickoff(")
+        .expect("local-only branch must re-arm the channel queue");
+    let note_gate = relay_source
+        .find("let Some(note) = note else {")
+        .expect("local-only branch must retain its note dedupe gate");
+    let notify_http = relay_source
+        .find("let Some(notify_http) = shared.serenity_http_or_token_fallback() else {")
+        .expect("local-only branch must retain the Discord delivery gate");
+
     assert!(
-        relay_source.contains(
-            "let Some(note) = prepare_local_only_slash_control_note(&prompt, kind) else {"
-        ),
-        "relay_observed_prompt must consume the gated note outcome before channel delivery"
+        note_prepare < queue_wakeup && queue_wakeup < note_gate && queue_wakeup < notify_http,
+        "queue wakeup must run after local-only classification but before either note-dedupe or Discord-delivery return"
     );
 }
 


### PR DESCRIPTION
## Summary
- Re-arm the existing channel-coalesced immediate idle-queue scheduler from the local-only slash observation branch.
- Keep queue scheduling independent from local slash note dedupe, Discord HTTP availability, and note-delivery success.
- Preserve existing dequeue and admission authority; no completion, relay lease, synthetic lifecycle, or mailbox release is created by the new path.

Closes #4874

## Invariants
- `/model` two-half observations coalesce to one channel task.
- A ready pending message is promoted only by the existing queue authority.
- A real foreground turn remains active and queued work stays pending.
- Local-only observations do not create relay leases or synthetic pending starts.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `cargo check --lib`
- [x] `cargo test --lib presleep_tests::local_only_slash_ -- --test-threads=1`
- [x] `cargo test --lib services::discord::tui_prompt_relay::tests::local_slash_control_note_and_queue_wakeup_are_independently_wired -- --exact --test-threads=1`
- [x] `cargo test --lib services::discord::tui_prompt_relay::tests::local_only_slash_prompt_skips_model_two_half_transcript -- --exact --test-threads=1`
- [x] `cargo test --lib services::discord::tui_prompt_relay::tests::relay_prompt_decision_skips_model_two_half_transcript -- --exact --test-threads=1`
- [x] `python3 scripts/generate_inventory_docs.py`
- [x] `python3 scripts/check_agent_maintenance_docs.py`

Generated with [Claude Code](https://claude.com/claude-code)