### PR TITLE
feat(#4916): add dormant durable cleanup coordinator

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,6 +107,8 @@ src/
 │   │   ├── retention.rs
 │   │   ├── storage_stats.rs
 │   │   └── tests.rs
+│   ├── runtime_cleanup/
+│   │   └── postgres_tests.rs
 │   ├── scheduled_messages/
 │   │   ├── agent.rs
 │   │   ├── outbox.rs
@@ -125,6 +127,7 @@ src/
 │   ├── mod.rs
 │   ├── postgres.rs
 │   ├── relay_dead_letter.rs
+│   ├── runtime_cleanup.rs
 │   ├── scheduled_messages.rs
 │   ├── session_agent_resolution.rs
 │   ├── session_observability.rs

--- a/migrations/postgres/0102_durable_runtime_cleanup_coordinator.sql
+++ b/migrations/postgres/0102_durable_runtime_cleanup_coordinator.sql
@@ -1,0 +1,102 @@
+-- Task #25 Slice 1: dormant durable runtime cleanup coordinator foundation.
+--
+-- These tables are additive journal/authority primitives only. No production
+-- consumer reads or writes them until a later rollout slice activates the saga.
+
+CREATE TABLE runtime_cleanup_operations (
+    operation_id UUID PRIMARY KEY,
+    request_key TEXT NOT NULL UNIQUE CHECK (BTRIM(request_key) <> ''),
+    target_kind TEXT NOT NULL CHECK (target_kind IN ('discord_session')),
+    target_key TEXT NOT NULL CHECK (BTRIM(target_key) <> ''),
+    requested_action TEXT NOT NULL CHECK (requested_action IN ('clear_for_resume')),
+    state TEXT NOT NULL DEFAULT 'pending'
+        CHECK (state IN ('pending', 'fenced', 'applying', 'completed', 'aborted')),
+    fence BIGINT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    aborted_at TIMESTAMPTZ,
+    CHECK (
+        (state = 'pending' AND fence IS NULL AND completed_at IS NULL AND aborted_at IS NULL)
+        OR (state IN ('fenced', 'applying') AND fence IS NOT NULL AND fence > 0
+            AND completed_at IS NULL AND aborted_at IS NULL)
+        OR (state = 'completed' AND fence IS NOT NULL AND fence > 0
+            AND completed_at IS NOT NULL AND aborted_at IS NULL)
+        OR (state = 'aborted' AND completed_at IS NULL AND aborted_at IS NOT NULL)
+    )
+);
+
+CREATE INDEX runtime_cleanup_operations_target_history_idx
+    ON runtime_cleanup_operations (target_kind, target_key, created_at DESC);
+
+CREATE UNIQUE INDEX runtime_cleanup_operations_one_open_target_idx
+    ON runtime_cleanup_operations (target_kind, target_key)
+    WHERE state IN ('pending', 'fenced', 'applying');
+
+CREATE TABLE runtime_cleanup_intents (
+    operation_id UUID NOT NULL REFERENCES runtime_cleanup_operations(operation_id) ON DELETE RESTRICT,
+    intent_kind TEXT NOT NULL CHECK (
+        intent_kind IN (
+            'block_runtime_admission',
+            'clear_queued_input',
+            'expire_runtime_lease',
+            'cancel_active_runtime',
+            'clear_persisted_session',
+            'release_runtime_slot'
+        )
+    ),
+    ordinal SMALLINT NOT NULL CHECK (ordinal > 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (operation_id, intent_kind),
+    UNIQUE (operation_id, ordinal)
+);
+
+CREATE OR REPLACE FUNCTION agentdesk_reject_runtime_cleanup_intent_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION USING
+        ERRCODE = '55000',
+        MESSAGE = 'runtime cleanup intents are immutable';
+END;
+$$;
+
+CREATE TRIGGER trg_runtime_cleanup_intents_immutable
+BEFORE UPDATE OR DELETE ON runtime_cleanup_intents
+FOR EACH ROW
+EXECUTE FUNCTION agentdesk_reject_runtime_cleanup_intent_mutation();
+
+CREATE OR REPLACE FUNCTION agentdesk_guard_runtime_cleanup_operation_identity()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.operation_id IS DISTINCT FROM OLD.operation_id
+        OR NEW.request_key IS DISTINCT FROM OLD.request_key
+        OR NEW.target_kind IS DISTINCT FROM OLD.target_kind
+        OR NEW.target_key IS DISTINCT FROM OLD.target_key
+        OR NEW.requested_action IS DISTINCT FROM OLD.requested_action THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '55000',
+            MESSAGE = 'runtime cleanup operation identity is immutable';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_runtime_cleanup_operation_identity_immutable
+BEFORE UPDATE ON runtime_cleanup_operations
+FOR EACH ROW
+EXECUTE FUNCTION agentdesk_guard_runtime_cleanup_operation_identity();
+
+CREATE TABLE runtime_cleanup_fences (
+    target_kind TEXT NOT NULL CHECK (target_kind IN ('discord_session')),
+    target_key TEXT NOT NULL CHECK (BTRIM(target_key) <> ''),
+    last_fence BIGINT NOT NULL CHECK (last_fence > 0),
+    operation_id UUID NOT NULL REFERENCES runtime_cleanup_operations(operation_id) ON DELETE RESTRICT,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (target_kind, target_key),
+    UNIQUE (operation_id),
+    UNIQUE (target_kind, target_key, last_fence)
+);

--- a/migrations/postgres/0102_durable_runtime_cleanup_coordinator.sql
+++ b/migrations/postgres/0102_durable_runtime_cleanup_coordinator.sql
@@ -6,31 +6,62 @@
 CREATE TABLE runtime_cleanup_operations (
     operation_id UUID PRIMARY KEY,
     request_key TEXT NOT NULL UNIQUE CHECK (BTRIM(request_key) <> ''),
-    target_kind TEXT NOT NULL CHECK (target_kind IN ('discord_session')),
-    target_key TEXT NOT NULL CHECK (BTRIM(target_key) <> ''),
-    requested_action TEXT NOT NULL CHECK (requested_action IN ('clear_for_resume')),
+    target_session_id BIGINT NOT NULL REFERENCES sessions(id) ON DELETE RESTRICT,
+    requested_action TEXT NOT NULL CHECK (requested_action = 'clear_for_resume'),
     state TEXT NOT NULL DEFAULT 'pending'
         CHECK (state IN ('pending', 'fenced', 'applying', 'completed', 'aborted')),
     fence BIGINT,
+    claim_owner TEXT,
+    attempt_token UUID,
+    attempt_no BIGINT NOT NULL DEFAULT 0 CHECK (attempt_no >= 0),
+    lease_expires_at TIMESTAMPTZ,
+    attempt_started_at TIMESTAMPTZ,
+    commit_decided_at TIMESTAMPTZ,
+    aborted_from_state TEXT CHECK (aborted_from_state IN ('pending', 'fenced')),
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     completed_at TIMESTAMPTZ,
     aborted_at TIMESTAMPTZ,
     CHECK (
-        (state = 'pending' AND fence IS NULL AND completed_at IS NULL AND aborted_at IS NULL)
-        OR (state IN ('fenced', 'applying') AND fence IS NOT NULL AND fence > 0
-            AND completed_at IS NULL AND aborted_at IS NULL)
-        OR (state = 'completed' AND fence IS NOT NULL AND fence > 0
-            AND completed_at IS NOT NULL AND aborted_at IS NULL)
-        OR (state = 'aborted' AND completed_at IS NULL AND aborted_at IS NOT NULL)
+        (state = 'pending'
+            AND fence IS NULL
+            AND claim_owner IS NULL AND attempt_token IS NULL AND attempt_no = 0
+            AND lease_expires_at IS NULL AND attempt_started_at IS NULL AND commit_decided_at IS NULL
+            AND completed_at IS NULL AND aborted_at IS NULL AND aborted_from_state IS NULL)
+        OR (state = 'fenced'
+            AND fence IS NOT NULL AND fence > 0
+            AND claim_owner IS NULL AND attempt_token IS NULL AND attempt_no = 0
+            AND lease_expires_at IS NULL AND attempt_started_at IS NULL AND commit_decided_at IS NULL
+            AND completed_at IS NULL AND aborted_at IS NULL AND aborted_from_state IS NULL)
+        OR (state = 'applying'
+            AND fence IS NOT NULL AND fence > 0
+            AND claim_owner IS NOT NULL AND BTRIM(claim_owner) <> ''
+            AND attempt_token IS NOT NULL AND attempt_no > 0
+            AND lease_expires_at IS NOT NULL AND attempt_started_at IS NOT NULL
+            AND lease_expires_at > attempt_started_at AND commit_decided_at IS NOT NULL
+            AND completed_at IS NULL AND aborted_at IS NULL AND aborted_from_state IS NULL)
+        OR (state = 'completed'
+            AND fence IS NOT NULL AND fence > 0
+            AND claim_owner IS NOT NULL AND BTRIM(claim_owner) <> ''
+            AND attempt_token IS NOT NULL AND attempt_no > 0
+            AND lease_expires_at IS NOT NULL AND attempt_started_at IS NOT NULL
+            AND lease_expires_at > attempt_started_at AND commit_decided_at IS NOT NULL
+            AND completed_at IS NOT NULL AND aborted_at IS NULL AND aborted_from_state IS NULL)
+        OR (state = 'aborted'
+            AND claim_owner IS NULL AND attempt_token IS NULL AND attempt_no = 0
+            AND lease_expires_at IS NULL AND attempt_started_at IS NULL AND commit_decided_at IS NULL
+            AND completed_at IS NULL AND aborted_at IS NOT NULL
+            AND aborted_from_state IS NOT NULL
+            AND ((aborted_from_state = 'pending' AND fence IS NULL)
+                OR (aborted_from_state = 'fenced' AND fence IS NOT NULL AND fence > 0)))
     )
 );
 
 CREATE INDEX runtime_cleanup_operations_target_history_idx
-    ON runtime_cleanup_operations (target_kind, target_key, created_at DESC);
+    ON runtime_cleanup_operations (target_session_id, created_at DESC);
 
 CREATE UNIQUE INDEX runtime_cleanup_operations_one_open_target_idx
-    ON runtime_cleanup_operations (target_kind, target_key)
+    ON runtime_cleanup_operations (target_session_id)
     WHERE state IN ('pending', 'fenced', 'applying');
 
 CREATE TABLE runtime_cleanup_intents (
@@ -45,37 +76,192 @@ CREATE TABLE runtime_cleanup_intents (
             'release_runtime_slot'
         )
     ),
-    ordinal SMALLINT NOT NULL CHECK (ordinal > 0),
+    ordinal SMALLINT NOT NULL CHECK (ordinal BETWEEN 1 AND 6),
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (operation_id, intent_kind),
     UNIQUE (operation_id, ordinal)
 );
 
-CREATE OR REPLACE FUNCTION agentdesk_reject_runtime_cleanup_intent_mutation()
+CREATE TABLE runtime_cleanup_operation_archive (
+    operation_id UUID PRIMARY KEY,
+    request_key TEXT NOT NULL UNIQUE,
+    target_session_id BIGINT NOT NULL,
+    requested_action TEXT NOT NULL,
+    final_state TEXT NOT NULL CHECK (final_state IN ('completed', 'aborted')),
+    fence BIGINT,
+    final_attempt_no BIGINT NOT NULL,
+    intents JSONB NOT NULL,
+    retired_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+REVOKE ALL ON runtime_cleanup_operation_archive FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION agentdesk_validate_runtime_cleanup_plan()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    checked_operation_id UUID;
+    action_name TEXT;
+    actual_plan TEXT[];
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+
+    checked_operation_id := NEW.operation_id;
+    SELECT requested_action INTO action_name
+    FROM runtime_cleanup_operations
+    WHERE operation_id = checked_operation_id;
+
+    IF action_name IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT ARRAY_AGG(intent_kind ORDER BY ordinal) INTO actual_plan
+    FROM runtime_cleanup_intents
+    WHERE operation_id = checked_operation_id;
+
+    IF action_name = 'clear_for_resume' AND actual_plan IS DISTINCT FROM ARRAY[
+        'block_runtime_admission',
+        'clear_queued_input',
+        'expire_runtime_lease',
+        'cancel_active_runtime',
+        'clear_persisted_session',
+        'release_runtime_slot'
+    ]::TEXT[] THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23514',
+            CONSTRAINT = 'runtime_cleanup_intents_canonical_plan',
+            MESSAGE = 'clear_for_resume requires the exact canonical six-step intent plan';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE CONSTRAINT TRIGGER trg_runtime_cleanup_operation_plan
+AFTER INSERT OR UPDATE OF requested_action ON runtime_cleanup_operations
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW
+EXECUTE FUNCTION agentdesk_validate_runtime_cleanup_plan();
+
+CREATE CONSTRAINT TRIGGER trg_runtime_cleanup_intent_plan
+AFTER INSERT OR UPDATE OR DELETE ON runtime_cleanup_intents
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW
+EXECUTE FUNCTION agentdesk_validate_runtime_cleanup_plan();
+
+CREATE OR REPLACE FUNCTION agentdesk_guard_runtime_cleanup_intent_mutation()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
 BEGIN
-    RAISE EXCEPTION USING
-        ERRCODE = '55000',
-        MESSAGE = 'runtime cleanup intents are immutable';
+    IF TG_OP = 'DELETE' AND EXISTS (
+        SELECT 1
+        FROM runtime_cleanup_operation_archive archive
+        JOIN runtime_cleanup_operations operation USING (operation_id)
+        WHERE archive.operation_id = OLD.operation_id
+          AND operation.state IN ('completed', 'aborted')
+          AND archive.final_state = operation.state
+    ) THEN
+        RETURN OLD;
+    END IF;
+    IF TG_OP <> 'INSERT' THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '55000',
+            MESSAGE = 'runtime cleanup intents are immutable';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE OR REPLACE FUNCTION agentdesk_guard_runtime_cleanup_operation_transition()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.state = 'pending' AND NEW.state = 'fenced' THEN
+        IF NEW.fence IS NULL OR NEW.fence <= 0 THEN
+            RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'pending to fenced requires a positive fence';
+        END IF;
+    ELSIF OLD.state = 'pending' AND NEW.state = 'aborted' THEN
+        IF NEW.aborted_from_state IS DISTINCT FROM 'pending' THEN
+            RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'pending abort must preserve its origin';
+        END IF;
+    ELSIF OLD.state = 'fenced' AND NEW.state = 'applying' THEN
+        IF NEW.fence IS DISTINCT FROM OLD.fence
+            OR NEW.attempt_no <> 1
+            OR NEW.attempt_started_at IS NULL
+            OR NEW.lease_expires_at <= NEW.attempt_started_at THEN
+            RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'fenced to applying requires the first live claimant';
+        END IF;
+    ELSIF OLD.state = 'fenced' AND NEW.state = 'aborted' THEN
+        IF NEW.fence IS DISTINCT FROM OLD.fence
+            OR NEW.aborted_from_state IS DISTINCT FROM 'fenced' THEN
+            RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'fenced abort must preserve its fence and origin';
+        END IF;
+    ELSIF OLD.state = 'applying' AND NEW.state = 'applying' THEN
+        IF NEW.attempt_started_at IS NULL
+            OR OLD.lease_expires_at > NEW.attempt_started_at
+            OR NEW.fence IS DISTINCT FROM OLD.fence
+            OR NEW.attempt_no <> OLD.attempt_no + 1
+            OR NEW.attempt_token IS NOT DISTINCT FROM OLD.attempt_token
+            OR NEW.lease_expires_at <= NEW.attempt_started_at
+            OR NEW.commit_decided_at IS DISTINCT FROM OLD.commit_decided_at THEN
+            RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'applying takeover requires an expired lease and a new live attempt';
+        END IF;
+    ELSIF OLD.state = 'applying' AND NEW.state = 'completed' THEN
+        IF NEW.fence IS DISTINCT FROM OLD.fence
+            OR NEW.claim_owner IS DISTINCT FROM OLD.claim_owner
+            OR NEW.attempt_token IS DISTINCT FROM OLD.attempt_token
+            OR NEW.attempt_no IS DISTINCT FROM OLD.attempt_no
+            OR NEW.lease_expires_at IS DISTINCT FROM OLD.lease_expires_at
+            OR NEW.attempt_started_at IS DISTINCT FROM OLD.attempt_started_at
+            OR NEW.commit_decided_at IS DISTINCT FROM OLD.commit_decided_at THEN
+            RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'completion must preserve claimant authority';
+        END IF;
+    ELSE
+        RAISE EXCEPTION USING
+            ERRCODE = '55000',
+            MESSAGE = FORMAT('illegal runtime cleanup transition: %s to %s', OLD.state, NEW.state);
+    END IF;
+    RETURN NEW;
 END;
 $$;
 
+CREATE TRIGGER trg_runtime_cleanup_operation_transition
+BEFORE UPDATE ON runtime_cleanup_operations
+FOR EACH ROW
+EXECUTE FUNCTION agentdesk_guard_runtime_cleanup_operation_transition();
 CREATE TRIGGER trg_runtime_cleanup_intents_immutable
 BEFORE UPDATE OR DELETE ON runtime_cleanup_intents
 FOR EACH ROW
-EXECUTE FUNCTION agentdesk_reject_runtime_cleanup_intent_mutation();
+EXECUTE FUNCTION agentdesk_guard_runtime_cleanup_intent_mutation();
 
 CREATE OR REPLACE FUNCTION agentdesk_guard_runtime_cleanup_operation_identity()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
 BEGIN
+    IF TG_OP = 'DELETE' THEN
+        IF EXISTS (
+            SELECT 1
+            FROM runtime_cleanup_operation_archive archive
+            WHERE archive.operation_id = OLD.operation_id
+              AND archive.request_key = OLD.request_key
+              AND archive.target_session_id = OLD.target_session_id
+              AND archive.requested_action = OLD.requested_action
+              AND archive.final_state = OLD.state
+              AND archive.fence IS NOT DISTINCT FROM OLD.fence
+              AND archive.final_attempt_no = OLD.attempt_no
+        ) THEN
+            RETURN OLD;
+        END IF;
+        RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'runtime cleanup operations require terminal retention';
+    END IF;
     IF NEW.operation_id IS DISTINCT FROM OLD.operation_id
         OR NEW.request_key IS DISTINCT FROM OLD.request_key
-        OR NEW.target_kind IS DISTINCT FROM OLD.target_kind
-        OR NEW.target_key IS DISTINCT FROM OLD.target_key
+        OR NEW.target_session_id IS DISTINCT FROM OLD.target_session_id
         OR NEW.requested_action IS DISTINCT FROM OLD.requested_action THEN
         RAISE EXCEPTION USING
             ERRCODE = '55000',
@@ -86,17 +272,73 @@ END;
 $$;
 
 CREATE TRIGGER trg_runtime_cleanup_operation_identity_immutable
-BEFORE UPDATE ON runtime_cleanup_operations
+BEFORE UPDATE OR DELETE ON runtime_cleanup_operations
 FOR EACH ROW
 EXECUTE FUNCTION agentdesk_guard_runtime_cleanup_operation_identity();
 
+-- Fence authority deliberately keeps the last operation UUID after terminal
+-- journal retention, so a later operation continues from the previous epoch.
 CREATE TABLE runtime_cleanup_fences (
-    target_kind TEXT NOT NULL CHECK (target_kind IN ('discord_session')),
-    target_key TEXT NOT NULL CHECK (BTRIM(target_key) <> ''),
+    target_session_id BIGINT PRIMARY KEY REFERENCES sessions(id) ON DELETE RESTRICT,
     last_fence BIGINT NOT NULL CHECK (last_fence > 0),
-    operation_id UUID NOT NULL REFERENCES runtime_cleanup_operations(operation_id) ON DELETE RESTRICT,
+    operation_id UUID NOT NULL,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (target_kind, target_key),
     UNIQUE (operation_id),
-    UNIQUE (target_kind, target_key, last_fence)
+    UNIQUE (target_session_id, last_fence)
 );
+
+CREATE OR REPLACE FUNCTION agentdesk_retire_terminal_runtime_cleanup_operation(
+    retired_operation_id UUID,
+    terminal_before TIMESTAMPTZ
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    retired_rows BIGINT;
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM public.runtime_cleanup_operations
+        WHERE operation_id = retired_operation_id
+          AND state IN ('completed', 'aborted')
+          AND updated_at < terminal_before
+        FOR UPDATE
+    ) THEN
+        RETURN FALSE;
+    END IF;
+
+    INSERT INTO public.runtime_cleanup_operation_archive (
+        operation_id, request_key, target_session_id, requested_action,
+        final_state, fence, final_attempt_no, intents
+    )
+    SELECT
+        operation.operation_id,
+        operation.request_key,
+        operation.target_session_id,
+        operation.requested_action,
+        operation.state,
+        operation.fence,
+        operation.attempt_no,
+        COALESCE(
+            JSONB_AGG(
+                JSONB_BUILD_OBJECT('kind', intent.intent_kind, 'ordinal', intent.ordinal)
+                ORDER BY intent.ordinal
+            ) FILTER (WHERE intent.operation_id IS NOT NULL),
+            '[]'::JSONB
+        )
+    FROM public.runtime_cleanup_operations operation
+    LEFT JOIN public.runtime_cleanup_intents intent USING (operation_id)
+    WHERE operation.operation_id = retired_operation_id
+    GROUP BY operation.operation_id;
+
+    DELETE FROM public.runtime_cleanup_intents WHERE operation_id = retired_operation_id;
+    DELETE FROM public.runtime_cleanup_operations WHERE operation_id = retired_operation_id;
+    GET DIAGNOSTICS retired_rows = ROW_COUNT;
+    RETURN retired_rows = 1;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION agentdesk_retire_terminal_runtime_cleanup_operation(UUID, TIMESTAMPTZ) FROM PUBLIC;

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -520,6 +520,11 @@
       "path": "migrations/postgres/0101_canonical_discord_session_identity.sql",
       "sha256": "3f61d2c3944a55d7bce62312baed85a1f112d685fc4b733dc78c73066bfc867e",
       "version": 101
+    },
+    {
+      "path": "migrations/postgres/0102_durable_runtime_cleanup_coordinator.sql",
+      "sha256": "4eab76f8a3f0d325168750d6f6ea89296a0cf6ab512d3493d80525fd79eacb4e",
+      "version": 102
     }
   ],
   "version": 1

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -523,7 +523,7 @@
     },
     {
       "path": "migrations/postgres/0102_durable_runtime_cleanup_coordinator.sql",
-      "sha256": "4eab76f8a3f0d325168750d6f6ea89296a0cf6ab512d3493d80525fd79eacb4e",
+      "sha256": "de68bea01dcfc2223d78b7f892b5fe9728eee72f1f851ddff80977501579711c",
       "version": 102
     }
   ],

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -18,6 +18,7 @@ pub mod meetings;
 pub mod postgres;
 pub mod prompt_manifests;
 pub mod relay_dead_letter;
+pub(crate) mod runtime_cleanup;
 pub mod scheduled_messages;
 pub(crate) mod session_agent_resolution;
 pub mod session_observability;

--- a/src/db/runtime_cleanup.rs
+++ b/src/db/runtime_cleanup.rs
@@ -1,0 +1,409 @@
+#![allow(dead_code)] // Dormant Task #25 foundation; production consumers land in later slices.
+
+use chrono::{DateTime, Utc};
+use sqlx::{PgPool, Postgres, Transaction};
+use uuid::Uuid;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RuntimeCleanupTargetKind {
+    DiscordSession,
+}
+
+impl RuntimeCleanupTargetKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::DiscordSession => "discord_session",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RuntimeCleanupAction {
+    ClearForResume,
+}
+
+impl RuntimeCleanupAction {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ClearForResume => "clear_for_resume",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RuntimeCleanupIntentKind {
+    BlockRuntimeAdmission,
+    ClearQueuedInput,
+    ExpireRuntimeLease,
+    CancelActiveRuntime,
+    ClearPersistedSession,
+    ReleaseRuntimeSlot,
+}
+
+impl RuntimeCleanupIntentKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::BlockRuntimeAdmission => "block_runtime_admission",
+            Self::ClearQueuedInput => "clear_queued_input",
+            Self::ExpireRuntimeLease => "expire_runtime_lease",
+            Self::CancelActiveRuntime => "cancel_active_runtime",
+            Self::ClearPersistedSession => "clear_persisted_session",
+            Self::ReleaseRuntimeSlot => "release_runtime_slot",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, sqlx::Type)]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+pub(crate) enum RuntimeCleanupState {
+    Pending,
+    Fenced,
+    Applying,
+    Completed,
+    Aborted,
+}
+
+impl RuntimeCleanupState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Fenced => "fenced",
+            Self::Applying => "applying",
+            Self::Completed => "completed",
+            Self::Aborted => "aborted",
+        }
+    }
+
+    fn can_transition_to(self, next: Self) -> bool {
+        matches!(
+            (self, next),
+            (Self::Pending, Self::Fenced)
+                | (Self::Pending, Self::Aborted)
+                | (Self::Fenced, Self::Applying)
+                | (Self::Fenced, Self::Aborted)
+                | (Self::Applying, Self::Completed)
+                | (Self::Applying, Self::Aborted)
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RuntimeCleanupIntent {
+    pub(crate) kind: RuntimeCleanupIntentKind,
+    pub(crate) ordinal: i16,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CreateRuntimeCleanupOperation<'a> {
+    pub(crate) operation_id: Uuid,
+    pub(crate) request_key: &'a str,
+    pub(crate) target_kind: RuntimeCleanupTargetKind,
+    pub(crate) target_key: &'a str,
+    pub(crate) action: RuntimeCleanupAction,
+    pub(crate) intents: &'a [RuntimeCleanupIntent],
+}
+
+#[derive(Clone, Debug, sqlx::FromRow)]
+pub(crate) struct RuntimeCleanupOperation {
+    pub(crate) operation_id: Uuid,
+    pub(crate) request_key: String,
+    pub(crate) target_kind: String,
+    pub(crate) target_key: String,
+    pub(crate) requested_action: String,
+    pub(crate) state: RuntimeCleanupState,
+    pub(crate) fence: Option<i64>,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
+    pub(crate) completed_at: Option<DateTime<Utc>>,
+    pub(crate) aborted_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum CreateRuntimeCleanupResult {
+    Created { operation_id: Uuid },
+    Replayed { operation_id: Uuid },
+    RequestConflict { operation_id: Uuid },
+    TargetBusy { operation_id: Uuid },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TransitionRuntimeCleanupResult {
+    Advanced {
+        operation_id: Uuid,
+        state: RuntimeCleanupState,
+        fence: Option<i64>,
+    },
+    Replayed {
+        operation_id: Uuid,
+        state: RuntimeCleanupState,
+        fence: Option<i64>,
+    },
+    Stale {
+        operation_id: Uuid,
+        current_state: RuntimeCleanupState,
+        current_fence: Option<i64>,
+    },
+    Illegal {
+        operation_id: Uuid,
+        current_state: RuntimeCleanupState,
+    },
+    NotFound,
+}
+
+#[derive(sqlx::FromRow)]
+struct OperationIdentityRow {
+    operation_id: Uuid,
+    target_kind: String,
+    target_key: String,
+    requested_action: String,
+}
+
+#[derive(sqlx::FromRow)]
+struct OperationStateRow {
+    operation_id: Uuid,
+    state: RuntimeCleanupState,
+    fence: Option<i64>,
+}
+
+pub(crate) async fn create_runtime_cleanup_operation(
+    pool: &PgPool,
+    command: &CreateRuntimeCleanupOperation<'_>,
+) -> Result<CreateRuntimeCleanupResult, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let result = create_runtime_cleanup_operation_in_tx(&mut tx, command).await?;
+    tx.commit().await?;
+    Ok(result)
+}
+
+async fn create_runtime_cleanup_operation_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    command: &CreateRuntimeCleanupOperation<'_>,
+) -> Result<CreateRuntimeCleanupResult, sqlx::Error> {
+    lock_target(tx, command.target_kind, command.target_key).await?;
+
+    if let Some(existing) = sqlx::query_as::<_, OperationIdentityRow>(
+        "SELECT operation_id, target_kind, target_key, requested_action
+         FROM runtime_cleanup_operations WHERE request_key = $1 FOR UPDATE",
+    )
+    .bind(command.request_key)
+    .fetch_optional(&mut **tx)
+    .await?
+    {
+        return if existing.target_kind == command.target_kind.as_str()
+            && existing.target_key == command.target_key
+            && existing.requested_action == command.action.as_str()
+            && intents_match(tx, existing.operation_id, command.intents).await?
+        {
+            Ok(CreateRuntimeCleanupResult::Replayed {
+                operation_id: existing.operation_id,
+            })
+        } else {
+            Ok(CreateRuntimeCleanupResult::RequestConflict {
+                operation_id: existing.operation_id,
+            })
+        };
+    }
+
+    if let Some(operation_id) = sqlx::query_scalar::<_, Uuid>(
+        "SELECT operation_id FROM runtime_cleanup_operations
+         WHERE target_kind = $1 AND target_key = $2
+           AND state IN ('pending', 'fenced', 'applying')",
+    )
+    .bind(command.target_kind.as_str())
+    .bind(command.target_key)
+    .fetch_optional(&mut **tx)
+    .await?
+    {
+        return Ok(CreateRuntimeCleanupResult::TargetBusy { operation_id });
+    }
+
+    let operation_id = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO runtime_cleanup_operations (
+            operation_id, request_key, target_kind, target_key, requested_action
+        ) VALUES ($1, $2, $3, $4, $5)
+        RETURNING operation_id
+        "#,
+    )
+    .bind(command.operation_id)
+    .bind(command.request_key)
+    .bind(command.target_kind.as_str())
+    .bind(command.target_key)
+    .bind(command.action.as_str())
+    .fetch_one(&mut **tx)
+    .await?;
+
+    for intent in command.intents {
+        sqlx::query(
+            "INSERT INTO runtime_cleanup_intents (operation_id, intent_kind, ordinal)
+             VALUES ($1, $2, $3)",
+        )
+        .bind(operation_id)
+        .bind(intent.kind.as_str())
+        .bind(intent.ordinal)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(CreateRuntimeCleanupResult::Created { operation_id })
+}
+
+pub(crate) async fn transition_runtime_cleanup_operation(
+    pool: &PgPool,
+    operation_id: Uuid,
+    expected_state: RuntimeCleanupState,
+    expected_fence: Option<i64>,
+    next_state: RuntimeCleanupState,
+) -> Result<TransitionRuntimeCleanupResult, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let Some(current) = sqlx::query_as::<_, OperationStateRow>(
+        "SELECT operation_id, state, fence
+         FROM runtime_cleanup_operations WHERE operation_id = $1 FOR UPDATE",
+    )
+    .bind(operation_id)
+    .fetch_optional(&mut *tx)
+    .await?
+    else {
+        tx.commit().await?;
+        return Ok(TransitionRuntimeCleanupResult::NotFound);
+    };
+
+    let exact_replay = current.state == next_state
+        && (current.fence == expected_fence
+            || (expected_state == RuntimeCleanupState::Pending
+                && next_state == RuntimeCleanupState::Fenced
+                && expected_fence.is_none()
+                && current.fence.is_some()));
+    if exact_replay {
+        tx.commit().await?;
+        return Ok(TransitionRuntimeCleanupResult::Replayed {
+            operation_id,
+            state: current.state,
+            fence: current.fence,
+        });
+    }
+
+    if current.state != expected_state || current.fence != expected_fence {
+        tx.commit().await?;
+        return Ok(TransitionRuntimeCleanupResult::Stale {
+            operation_id,
+            current_state: current.state,
+            current_fence: current.fence,
+        });
+    }
+
+    if !current.state.can_transition_to(next_state) {
+        tx.commit().await?;
+        return Ok(TransitionRuntimeCleanupResult::Illegal {
+            operation_id,
+            current_state: current.state,
+        });
+    }
+
+    let next_fence = if next_state == RuntimeCleanupState::Fenced {
+        Some(allocate_fence(&mut tx, operation_id).await?)
+    } else {
+        current.fence
+    };
+
+    sqlx::query(
+        "UPDATE runtime_cleanup_operations
+         SET state = $2,
+             fence = $3,
+             updated_at = NOW(),
+             completed_at = CASE WHEN $2 = 'completed' THEN NOW() ELSE completed_at END,
+             aborted_at = CASE WHEN $2 = 'aborted' THEN NOW() ELSE aborted_at END
+         WHERE operation_id = $1",
+    )
+    .bind(operation_id)
+    .bind(next_state.as_str())
+    .bind(next_fence)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+
+    Ok(TransitionRuntimeCleanupResult::Advanced {
+        operation_id,
+        state: next_state,
+        fence: next_fence,
+    })
+}
+
+pub(crate) async fn load_runtime_cleanup_operation(
+    pool: &PgPool,
+    operation_id: Uuid,
+) -> Result<Option<RuntimeCleanupOperation>, sqlx::Error> {
+    sqlx::query_as(
+        "SELECT operation_id, request_key, target_kind, target_key,
+                requested_action, state, fence, created_at, updated_at,
+                completed_at, aborted_at
+         FROM runtime_cleanup_operations WHERE operation_id = $1",
+    )
+    .bind(operation_id)
+    .fetch_optional(pool)
+    .await
+}
+
+async fn intents_match(
+    tx: &mut Transaction<'_, Postgres>,
+    operation_id: Uuid,
+    intents: &[RuntimeCleanupIntent],
+) -> Result<bool, sqlx::Error> {
+    let stored = sqlx::query_as::<_, (String, i16)>(
+        "SELECT intent_kind, ordinal FROM runtime_cleanup_intents
+         WHERE operation_id = $1 ORDER BY ordinal",
+    )
+    .bind(operation_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    Ok(stored.len() == intents.len()
+        && stored.iter().zip(intents).all(|((kind, ordinal), intent)| {
+            kind == intent.kind.as_str() && *ordinal == intent.ordinal
+        }))
+}
+
+async fn lock_target(
+    tx: &mut Transaction<'_, Postgres>,
+    target_kind: RuntimeCleanupTargetKind,
+    target_key: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1 || ':' || $2, 4916))")
+        .bind(target_kind.as_str())
+        .bind(target_key)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+async fn allocate_fence(
+    tx: &mut Transaction<'_, Postgres>,
+    operation_id: Uuid,
+) -> Result<i64, sqlx::Error> {
+    let operation = sqlx::query_as::<_, OperationIdentityRow>(
+        "SELECT operation_id, target_kind, target_key, requested_action
+         FROM runtime_cleanup_operations WHERE operation_id = $1",
+    )
+    .bind(operation_id)
+    .fetch_one(&mut **tx)
+    .await?;
+
+    sqlx::query_scalar(
+        r#"
+        INSERT INTO runtime_cleanup_fences (
+            target_kind, target_key, last_fence, operation_id
+        ) VALUES ($1, $2, 1, $3)
+        ON CONFLICT (target_kind, target_key) DO UPDATE
+        SET last_fence = runtime_cleanup_fences.last_fence + 1,
+            operation_id = EXCLUDED.operation_id,
+            updated_at = NOW()
+        RETURNING last_fence
+        "#,
+    )
+    .bind(operation.target_kind)
+    .bind(operation.target_key)
+    .bind(operation_id)
+    .fetch_one(&mut **tx)
+    .await
+}
+
+#[cfg(test)]
+mod postgres_tests;

--- a/src/db/runtime_cleanup.rs
+++ b/src/db/runtime_cleanup.rs
@@ -4,17 +4,18 @@ use chrono::{DateTime, Utc};
 use sqlx::{PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum RuntimeCleanupTargetKind {
-    DiscordSession,
-}
+const CLEAR_FOR_RESUME_PLAN: [(&str, i16); 6] = [
+    ("block_runtime_admission", 1),
+    ("clear_queued_input", 2),
+    ("expire_runtime_lease", 3),
+    ("cancel_active_runtime", 4),
+    ("clear_persisted_session", 5),
+    ("release_runtime_slot", 6),
+];
 
-impl RuntimeCleanupTargetKind {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::DiscordSession => "discord_session",
-        }
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RuntimeCleanupTarget {
+    pub(crate) session_id: i64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -26,29 +27,6 @@ impl RuntimeCleanupAction {
     fn as_str(self) -> &'static str {
         match self {
             Self::ClearForResume => "clear_for_resume",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum RuntimeCleanupIntentKind {
-    BlockRuntimeAdmission,
-    ClearQueuedInput,
-    ExpireRuntimeLease,
-    CancelActiveRuntime,
-    ClearPersistedSession,
-    ReleaseRuntimeSlot,
-}
-
-impl RuntimeCleanupIntentKind {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::BlockRuntimeAdmission => "block_runtime_admission",
-            Self::ClearQueuedInput => "clear_queued_input",
-            Self::ExpireRuntimeLease => "expire_runtime_lease",
-            Self::CancelActiveRuntime => "cancel_active_runtime",
-            Self::ClearPersistedSession => "clear_persisted_session",
-            Self::ReleaseRuntimeSlot => "release_runtime_slot",
         }
     }
 }
@@ -73,45 +51,45 @@ impl RuntimeCleanupState {
             Self::Aborted => "aborted",
         }
     }
-
-    fn can_transition_to(self, next: Self) -> bool {
-        matches!(
-            (self, next),
-            (Self::Pending, Self::Fenced)
-                | (Self::Pending, Self::Aborted)
-                | (Self::Fenced, Self::Applying)
-                | (Self::Fenced, Self::Aborted)
-                | (Self::Applying, Self::Completed)
-                | (Self::Applying, Self::Aborted)
-        )
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct RuntimeCleanupIntent {
-    pub(crate) kind: RuntimeCleanupIntentKind,
-    pub(crate) ordinal: i16,
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct CreateRuntimeCleanupOperation<'a> {
     pub(crate) operation_id: Uuid,
     pub(crate) request_key: &'a str,
-    pub(crate) target_kind: RuntimeCleanupTargetKind,
-    pub(crate) target_key: &'a str,
+    pub(crate) target: RuntimeCleanupTarget,
     pub(crate) action: RuntimeCleanupAction,
-    pub(crate) intents: &'a [RuntimeCleanupIntent],
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct BeginRuntimeCleanupAttempt<'a> {
+    pub(crate) operation_id: Uuid,
+    pub(crate) expected_fence: i64,
+    pub(crate) claim_owner: &'a str,
+    pub(crate) attempt_token: Uuid,
+    pub(crate) lease_expires_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CompleteRuntimeCleanupAttempt {
+    pub(crate) operation_id: Uuid,
+    pub(crate) expected_fence: i64,
+    pub(crate) attempt_token: Uuid,
 }
 
 #[derive(Clone, Debug, sqlx::FromRow)]
 pub(crate) struct RuntimeCleanupOperation {
     pub(crate) operation_id: Uuid,
     pub(crate) request_key: String,
-    pub(crate) target_kind: String,
-    pub(crate) target_key: String,
+    pub(crate) target_session_id: i64,
     pub(crate) requested_action: String,
     pub(crate) state: RuntimeCleanupState,
     pub(crate) fence: Option<i64>,
+    pub(crate) claim_owner: Option<String>,
+    pub(crate) attempt_token: Option<Uuid>,
+    pub(crate) attempt_no: i64,
+    pub(crate) lease_expires_at: Option<DateTime<Utc>>,
+    pub(crate) commit_decided_at: Option<DateTime<Utc>>,
     pub(crate) created_at: DateTime<Utc>,
     pub(crate) updated_at: DateTime<Utc>,
     pub(crate) completed_at: Option<DateTime<Utc>>,
@@ -127,42 +105,75 @@ pub(crate) enum CreateRuntimeCleanupResult {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum TransitionRuntimeCleanupResult {
-    Advanced {
-        operation_id: Uuid,
-        state: RuntimeCleanupState,
-        fence: Option<i64>,
-    },
-    Replayed {
-        operation_id: Uuid,
-        state: RuntimeCleanupState,
-        fence: Option<i64>,
-    },
-    Stale {
-        operation_id: Uuid,
-        current_state: RuntimeCleanupState,
-        current_fence: Option<i64>,
-    },
-    Illegal {
-        operation_id: Uuid,
-        current_state: RuntimeCleanupState,
-    },
+pub(crate) enum FenceRuntimeCleanupResult {
+    Advanced { fence: i64 },
+    Replayed { fence: i64 },
+    Stale { state: RuntimeCleanupState },
+    NotFound,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum BeginRuntimeCleanupResult {
+    Acquired { attempt_no: i64 },
+    Replayed { attempt_no: i64 },
+    LeaseHeld { owner: String, attempt_no: i64 },
+    LostOwnership { attempt_no: i64 },
+    Stale { state: RuntimeCleanupState },
+    NotFound,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum CompleteRuntimeCleanupResult {
+    Completed,
+    Replayed,
+    LostOwnership,
+    Stale { state: RuntimeCleanupState },
+    NotFound,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum AbortRuntimeCleanupResult {
+    Aborted,
+    Replayed,
+    RollForwardRequired,
+    Stale { state: RuntimeCleanupState },
     NotFound,
 }
 
 #[derive(sqlx::FromRow)]
 struct OperationIdentityRow {
     operation_id: Uuid,
-    target_kind: String,
-    target_key: String,
+    target_session_id: i64,
     requested_action: String,
 }
 
 #[derive(sqlx::FromRow)]
 struct OperationStateRow {
-    operation_id: Uuid,
     state: RuntimeCleanupState,
     fence: Option<i64>,
+    claim_owner: Option<String>,
+    attempt_token: Option<Uuid>,
+    attempt_no: i64,
+    lease_expires_at: Option<DateTime<Utc>>,
+}
+
+pub(crate) async fn resolve_runtime_cleanup_target(
+    pool: &PgPool,
+    locator: &str,
+) -> Result<Option<RuntimeCleanupTarget>, sqlx::Error> {
+    let session_id = sqlx::query_scalar::<_, i64>(
+        "SELECT s.id
+         FROM sessions s
+         WHERE s.session_key = $1
+         UNION
+         SELECT a.session_id
+         FROM session_key_aliases a
+         WHERE a.session_key = $1",
+    )
+    .bind(locator)
+    .fetch_optional(pool)
+    .await?;
+    Ok(session_id.map(|session_id| RuntimeCleanupTarget { session_id }))
 }
 
 pub(crate) async fn create_runtime_cleanup_operation(
@@ -170,29 +181,23 @@ pub(crate) async fn create_runtime_cleanup_operation(
     command: &CreateRuntimeCleanupOperation<'_>,
 ) -> Result<CreateRuntimeCleanupResult, sqlx::Error> {
     let mut tx = pool.begin().await?;
-    let result = create_runtime_cleanup_operation_in_tx(&mut tx, command).await?;
-    tx.commit().await?;
-    Ok(result)
-}
-
-async fn create_runtime_cleanup_operation_in_tx(
-    tx: &mut Transaction<'_, Postgres>,
-    command: &CreateRuntimeCleanupOperation<'_>,
-) -> Result<CreateRuntimeCleanupResult, sqlx::Error> {
-    lock_target(tx, command.target_kind, command.target_key).await?;
+    lock_request_key(&mut tx, command.request_key).await?;
+    lock_target(&mut tx, command.target.session_id).await?;
 
     if let Some(existing) = sqlx::query_as::<_, OperationIdentityRow>(
-        "SELECT operation_id, target_kind, target_key, requested_action
-         FROM runtime_cleanup_operations WHERE request_key = $1 FOR UPDATE",
+        "SELECT operation_id, target_session_id, requested_action
+         FROM runtime_cleanup_operations WHERE request_key = $1
+         UNION ALL
+         SELECT operation_id, target_session_id, requested_action
+         FROM runtime_cleanup_operation_archive WHERE request_key = $1",
     )
     .bind(command.request_key)
-    .fetch_optional(&mut **tx)
+    .fetch_optional(&mut *tx)
     .await?
     {
-        return if existing.target_kind == command.target_kind.as_str()
-            && existing.target_key == command.target_key
+        tx.commit().await?;
+        return if existing.target_session_id == command.target.session_id
             && existing.requested_action == command.action.as_str()
-            && intents_match(tx, existing.operation_id, command.intents).await?
         {
             Ok(CreateRuntimeCleanupResult::Replayed {
                 operation_id: existing.operation_id,
@@ -206,126 +211,252 @@ async fn create_runtime_cleanup_operation_in_tx(
 
     if let Some(operation_id) = sqlx::query_scalar::<_, Uuid>(
         "SELECT operation_id FROM runtime_cleanup_operations
-         WHERE target_kind = $1 AND target_key = $2
-           AND state IN ('pending', 'fenced', 'applying')",
+         WHERE target_session_id = $1 AND state IN ('pending', 'fenced', 'applying')",
     )
-    .bind(command.target_kind.as_str())
-    .bind(command.target_key)
-    .fetch_optional(&mut **tx)
+    .bind(command.target.session_id)
+    .fetch_optional(&mut *tx)
     .await?
     {
+        tx.commit().await?;
         return Ok(CreateRuntimeCleanupResult::TargetBusy { operation_id });
     }
 
-    let operation_id = sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO runtime_cleanup_operations (
-            operation_id, request_key, target_kind, target_key, requested_action
-        ) VALUES ($1, $2, $3, $4, $5)
-        RETURNING operation_id
-        "#,
+    sqlx::query(
+        "INSERT INTO runtime_cleanup_operations
+         (operation_id, request_key, target_session_id, requested_action)
+         VALUES ($1, $2, $3, $4)",
     )
     .bind(command.operation_id)
     .bind(command.request_key)
-    .bind(command.target_kind.as_str())
-    .bind(command.target_key)
+    .bind(command.target.session_id)
     .bind(command.action.as_str())
-    .fetch_one(&mut **tx)
+    .execute(&mut *tx)
     .await?;
 
-    for intent in command.intents {
+    for (intent_kind, ordinal) in CLEAR_FOR_RESUME_PLAN {
         sqlx::query(
             "INSERT INTO runtime_cleanup_intents (operation_id, intent_kind, ordinal)
              VALUES ($1, $2, $3)",
         )
-        .bind(operation_id)
-        .bind(intent.kind.as_str())
-        .bind(intent.ordinal)
-        .execute(&mut **tx)
+        .bind(command.operation_id)
+        .bind(intent_kind)
+        .bind(ordinal)
+        .execute(&mut *tx)
         .await?;
     }
-    Ok(CreateRuntimeCleanupResult::Created { operation_id })
+    tx.commit().await?;
+    Ok(CreateRuntimeCleanupResult::Created {
+        operation_id: command.operation_id,
+    })
 }
 
-pub(crate) async fn transition_runtime_cleanup_operation(
+pub(crate) async fn fence_runtime_cleanup_operation(
     pool: &PgPool,
     operation_id: Uuid,
-    expected_state: RuntimeCleanupState,
-    expected_fence: Option<i64>,
-    next_state: RuntimeCleanupState,
-) -> Result<TransitionRuntimeCleanupResult, sqlx::Error> {
+) -> Result<FenceRuntimeCleanupResult, sqlx::Error> {
     let mut tx = pool.begin().await?;
-    let Some(current) = sqlx::query_as::<_, OperationStateRow>(
-        "SELECT operation_id, state, fence
-         FROM runtime_cleanup_operations WHERE operation_id = $1 FOR UPDATE",
-    )
-    .bind(operation_id)
-    .fetch_optional(&mut *tx)
-    .await?
-    else {
+    let Some(current) = load_state_for_update(&mut tx, operation_id).await? else {
         tx.commit().await?;
-        return Ok(TransitionRuntimeCleanupResult::NotFound);
+        return Ok(FenceRuntimeCleanupResult::NotFound);
     };
-
-    let exact_replay = current.state == next_state
-        && (current.fence == expected_fence
-            || (expected_state == RuntimeCleanupState::Pending
-                && next_state == RuntimeCleanupState::Fenced
-                && expected_fence.is_none()
-                && current.fence.is_some()));
-    if exact_replay {
+    if current.state == RuntimeCleanupState::Fenced {
+        let fence = current
+            .fence
+            .ok_or_else(|| sqlx::Error::Protocol("fenced cleanup operation has no fence".into()))?;
         tx.commit().await?;
-        return Ok(TransitionRuntimeCleanupResult::Replayed {
-            operation_id,
+        return Ok(FenceRuntimeCleanupResult::Replayed { fence });
+    }
+    if current.state != RuntimeCleanupState::Pending {
+        tx.commit().await?;
+        return Ok(FenceRuntimeCleanupResult::Stale {
             state: current.state,
-            fence: current.fence,
         });
     }
 
-    if current.state != expected_state || current.fence != expected_fence {
-        tx.commit().await?;
-        return Ok(TransitionRuntimeCleanupResult::Stale {
-            operation_id,
-            current_state: current.state,
-            current_fence: current.fence,
-        });
-    }
-
-    if !current.state.can_transition_to(next_state) {
-        tx.commit().await?;
-        return Ok(TransitionRuntimeCleanupResult::Illegal {
-            operation_id,
-            current_state: current.state,
-        });
-    }
-
-    let next_fence = if next_state == RuntimeCleanupState::Fenced {
-        Some(allocate_fence(&mut tx, operation_id).await?)
-    } else {
-        current.fence
-    };
-
+    let fence = allocate_fence(&mut tx, operation_id).await?;
     sqlx::query(
         "UPDATE runtime_cleanup_operations
-         SET state = $2,
-             fence = $3,
-             updated_at = NOW(),
-             completed_at = CASE WHEN $2 = 'completed' THEN NOW() ELSE completed_at END,
-             aborted_at = CASE WHEN $2 = 'aborted' THEN NOW() ELSE aborted_at END
+         SET state = 'fenced', fence = $2, updated_at = NOW()
          WHERE operation_id = $1",
     )
     .bind(operation_id)
-    .bind(next_state.as_str())
-    .bind(next_fence)
+    .bind(fence)
     .execute(&mut *tx)
     .await?;
     tx.commit().await?;
+    Ok(FenceRuntimeCleanupResult::Advanced { fence })
+}
 
-    Ok(TransitionRuntimeCleanupResult::Advanced {
-        operation_id,
-        state: next_state,
-        fence: next_fence,
-    })
+pub(crate) async fn begin_runtime_cleanup_attempt(
+    pool: &PgPool,
+    command: BeginRuntimeCleanupAttempt<'_>,
+) -> Result<BeginRuntimeCleanupResult, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let database_now = sqlx::query_scalar::<_, DateTime<Utc>>("SELECT NOW()")
+        .fetch_one(&mut *tx)
+        .await?;
+    let Some(current) = load_state_for_update(&mut tx, command.operation_id).await? else {
+        tx.commit().await?;
+        return Ok(BeginRuntimeCleanupResult::NotFound);
+    };
+    if current.fence != Some(command.expected_fence) {
+        tx.commit().await?;
+        return Ok(BeginRuntimeCleanupResult::Stale {
+            state: current.state,
+        });
+    }
+    if current.state == RuntimeCleanupState::Applying {
+        if current.attempt_token == Some(command.attempt_token) {
+            if current.claim_owner.as_deref() != Some(command.claim_owner)
+                || current.lease_expires_at != Some(command.lease_expires_at)
+            {
+                tx.commit().await?;
+                return Ok(BeginRuntimeCleanupResult::LostOwnership {
+                    attempt_no: current.attempt_no,
+                });
+            }
+            tx.commit().await?;
+            return Ok(BeginRuntimeCleanupResult::Replayed {
+                attempt_no: current.attempt_no,
+            });
+        }
+        if current
+            .lease_expires_at
+            .is_some_and(|expires| expires > database_now)
+        {
+            let owner = current.claim_owner.ok_or_else(|| {
+                sqlx::Error::Protocol("applying cleanup operation has no claim owner".into())
+            })?;
+            tx.commit().await?;
+            return Ok(BeginRuntimeCleanupResult::LeaseHeld {
+                owner,
+                attempt_no: current.attempt_no,
+            });
+        }
+    } else if current.state != RuntimeCleanupState::Fenced {
+        tx.commit().await?;
+        return Ok(BeginRuntimeCleanupResult::Stale {
+            state: current.state,
+        });
+    }
+
+    let attempt_no = current.attempt_no + 1;
+    sqlx::query(
+        "UPDATE runtime_cleanup_operations
+         SET state = 'applying', claim_owner = $2, attempt_token = $3,
+             attempt_no = $4, lease_expires_at = $5, attempt_started_at = $6,
+             commit_decided_at = COALESCE(commit_decided_at, NOW()), updated_at = NOW()
+         WHERE operation_id = $1",
+    )
+    .bind(command.operation_id)
+    .bind(command.claim_owner)
+    .bind(command.attempt_token)
+    .bind(attempt_no)
+    .bind(command.lease_expires_at)
+    .bind(database_now)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(BeginRuntimeCleanupResult::Acquired { attempt_no })
+}
+
+pub(crate) async fn complete_runtime_cleanup_attempt(
+    pool: &PgPool,
+    command: CompleteRuntimeCleanupAttempt,
+) -> Result<CompleteRuntimeCleanupResult, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let Some(current) = load_state_for_update(&mut tx, command.operation_id).await? else {
+        tx.commit().await?;
+        return Ok(CompleteRuntimeCleanupResult::NotFound);
+    };
+    if current.fence != Some(command.expected_fence) {
+        tx.commit().await?;
+        return Ok(CompleteRuntimeCleanupResult::Stale {
+            state: current.state,
+        });
+    }
+    if current.state == RuntimeCleanupState::Completed {
+        tx.commit().await?;
+        return if current.attempt_token == Some(command.attempt_token) {
+            Ok(CompleteRuntimeCleanupResult::Replayed)
+        } else {
+            Ok(CompleteRuntimeCleanupResult::LostOwnership)
+        };
+    }
+    if current.state != RuntimeCleanupState::Applying {
+        tx.commit().await?;
+        return Ok(CompleteRuntimeCleanupResult::Stale {
+            state: current.state,
+        });
+    }
+    if current.attempt_token != Some(command.attempt_token) {
+        tx.commit().await?;
+        return Ok(CompleteRuntimeCleanupResult::LostOwnership);
+    }
+
+    sqlx::query(
+        "UPDATE runtime_cleanup_operations
+         SET state = 'completed', completed_at = NOW(), updated_at = NOW()
+         WHERE operation_id = $1",
+    )
+    .bind(command.operation_id)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(CompleteRuntimeCleanupResult::Completed)
+}
+
+pub(crate) async fn abort_runtime_cleanup_operation(
+    pool: &PgPool,
+    operation_id: Uuid,
+) -> Result<AbortRuntimeCleanupResult, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let Some(current) = load_state_for_update(&mut tx, operation_id).await? else {
+        tx.commit().await?;
+        return Ok(AbortRuntimeCleanupResult::NotFound);
+    };
+    if current.state == RuntimeCleanupState::Aborted {
+        tx.commit().await?;
+        return Ok(AbortRuntimeCleanupResult::Replayed);
+    }
+    if current.state == RuntimeCleanupState::Applying
+        || current.state == RuntimeCleanupState::Completed
+    {
+        tx.commit().await?;
+        return Ok(AbortRuntimeCleanupResult::RollForwardRequired);
+    }
+    if current.state != RuntimeCleanupState::Pending && current.state != RuntimeCleanupState::Fenced
+    {
+        tx.commit().await?;
+        return Ok(AbortRuntimeCleanupResult::Stale {
+            state: current.state,
+        });
+    }
+
+    sqlx::query(
+        "UPDATE runtime_cleanup_operations
+         SET state = 'aborted', aborted_from_state = $2,
+             aborted_at = NOW(), updated_at = NOW()
+         WHERE operation_id = $1",
+    )
+    .bind(operation_id)
+    .bind(current.state.as_str())
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(AbortRuntimeCleanupResult::Aborted)
+}
+
+pub(crate) async fn retire_terminal_runtime_cleanup_operation(
+    pool: &PgPool,
+    operation_id: Uuid,
+    terminal_before: DateTime<Utc>,
+) -> Result<bool, sqlx::Error> {
+    sqlx::query_scalar("SELECT agentdesk_retire_terminal_runtime_cleanup_operation($1, $2)")
+        .bind(operation_id)
+        .bind(terminal_before)
+        .fetch_one(pool)
+        .await
 }
 
 pub(crate) async fn load_runtime_cleanup_operation(
@@ -333,8 +464,9 @@ pub(crate) async fn load_runtime_cleanup_operation(
     operation_id: Uuid,
 ) -> Result<Option<RuntimeCleanupOperation>, sqlx::Error> {
     sqlx::query_as(
-        "SELECT operation_id, request_key, target_kind, target_key,
-                requested_action, state, fence, created_at, updated_at,
+        "SELECT operation_id, request_key, target_session_id, requested_action,
+                state, fence, claim_owner, attempt_token, attempt_no,
+                lease_expires_at, commit_decided_at, created_at, updated_at,
                 completed_at, aborted_at
          FROM runtime_cleanup_operations WHERE operation_id = $1",
     )
@@ -343,32 +475,36 @@ pub(crate) async fn load_runtime_cleanup_operation(
     .await
 }
 
-async fn intents_match(
+async fn load_state_for_update(
     tx: &mut Transaction<'_, Postgres>,
     operation_id: Uuid,
-    intents: &[RuntimeCleanupIntent],
-) -> Result<bool, sqlx::Error> {
-    let stored = sqlx::query_as::<_, (String, i16)>(
-        "SELECT intent_kind, ordinal FROM runtime_cleanup_intents
-         WHERE operation_id = $1 ORDER BY ordinal",
+) -> Result<Option<OperationStateRow>, sqlx::Error> {
+    sqlx::query_as(
+        "SELECT state, fence, claim_owner, attempt_token, attempt_no, lease_expires_at
+         FROM runtime_cleanup_operations WHERE operation_id = $1 FOR UPDATE",
     )
     .bind(operation_id)
-    .fetch_all(&mut **tx)
-    .await?;
-    Ok(stored.len() == intents.len()
-        && stored.iter().zip(intents).all(|((kind, ordinal), intent)| {
-            kind == intent.kind.as_str() && *ordinal == intent.ordinal
-        }))
+    .fetch_optional(&mut **tx)
+    .await
+}
+
+async fn lock_request_key(
+    tx: &mut Transaction<'_, Postgres>,
+    request_key: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended('request:' || $1, 4916))")
+        .bind(request_key)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
 }
 
 async fn lock_target(
     tx: &mut Transaction<'_, Postgres>,
-    target_kind: RuntimeCleanupTargetKind,
-    target_key: &str,
+    session_id: i64,
 ) -> Result<(), sqlx::Error> {
-    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1 || ':' || $2, 4916))")
-        .bind(target_kind.as_str())
-        .bind(target_key)
+    sqlx::query("SELECT pg_advisory_xact_lock(4916, hashint8($1))")
+        .bind(session_id)
         .execute(&mut **tx)
         .await?;
     Ok(())
@@ -378,28 +514,23 @@ async fn allocate_fence(
     tx: &mut Transaction<'_, Postgres>,
     operation_id: Uuid,
 ) -> Result<i64, sqlx::Error> {
-    let operation = sqlx::query_as::<_, OperationIdentityRow>(
-        "SELECT operation_id, target_kind, target_key, requested_action
-         FROM runtime_cleanup_operations WHERE operation_id = $1",
+    let target_session_id = sqlx::query_scalar::<_, i64>(
+        "SELECT target_session_id FROM runtime_cleanup_operations WHERE operation_id = $1",
     )
     .bind(operation_id)
     .fetch_one(&mut **tx)
     .await?;
 
     sqlx::query_scalar(
-        r#"
-        INSERT INTO runtime_cleanup_fences (
-            target_kind, target_key, last_fence, operation_id
-        ) VALUES ($1, $2, 1, $3)
-        ON CONFLICT (target_kind, target_key) DO UPDATE
-        SET last_fence = runtime_cleanup_fences.last_fence + 1,
-            operation_id = EXCLUDED.operation_id,
-            updated_at = NOW()
-        RETURNING last_fence
-        "#,
+        "INSERT INTO runtime_cleanup_fences (target_session_id, last_fence, operation_id)
+         VALUES ($1, 1, $2)
+         ON CONFLICT (target_session_id) DO UPDATE
+         SET last_fence = runtime_cleanup_fences.last_fence + 1,
+             operation_id = EXCLUDED.operation_id,
+             updated_at = NOW()
+         RETURNING last_fence",
     )
-    .bind(operation.target_kind)
-    .bind(operation.target_key)
+    .bind(target_session_id)
     .bind(operation_id)
     .fetch_one(&mut **tx)
     .await

--- a/src/db/runtime_cleanup/postgres_tests.rs
+++ b/src/db/runtime_cleanup/postgres_tests.rs
@@ -1,0 +1,431 @@
+use super::*;
+use crate::dispatch::test_support::DispatchPostgresTestDb;
+
+fn intents() -> Vec<RuntimeCleanupIntent> {
+    vec![
+        RuntimeCleanupIntent {
+            kind: RuntimeCleanupIntentKind::BlockRuntimeAdmission,
+            ordinal: 1,
+        },
+        RuntimeCleanupIntent {
+            kind: RuntimeCleanupIntentKind::ClearQueuedInput,
+            ordinal: 2,
+        },
+        RuntimeCleanupIntent {
+            kind: RuntimeCleanupIntentKind::ExpireRuntimeLease,
+            ordinal: 3,
+        },
+        RuntimeCleanupIntent {
+            kind: RuntimeCleanupIntentKind::CancelActiveRuntime,
+            ordinal: 4,
+        },
+        RuntimeCleanupIntent {
+            kind: RuntimeCleanupIntentKind::ClearPersistedSession,
+            ordinal: 5,
+        },
+        RuntimeCleanupIntent {
+            kind: RuntimeCleanupIntentKind::ReleaseRuntimeSlot,
+            ordinal: 6,
+        },
+    ]
+}
+
+fn command<'a>(
+    operation_id: Uuid,
+    request_key: &'a str,
+    target_key: &'a str,
+    intents: &'a [RuntimeCleanupIntent],
+) -> CreateRuntimeCleanupOperation<'a> {
+    CreateRuntimeCleanupOperation {
+        operation_id,
+        request_key,
+        target_kind: RuntimeCleanupTargetKind::DiscordSession,
+        target_key,
+        action: RuntimeCleanupAction::ClearForResume,
+        intents,
+    }
+}
+
+async fn create_pool() -> (DispatchPostgresTestDb, PgPool) {
+    let db = DispatchPostgresTestDb::create(
+        "agentdesk_runtime_cleanup",
+        "runtime cleanup coordinator postgres tests",
+    )
+    .await;
+    let pool = db.connect_and_migrate_with_max_connections(8).await;
+    (db, pool)
+}
+
+async fn close(db: DispatchPostgresTestDb, pool: PgPool) {
+    pool.close().await;
+    db.drop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_is_atomic_and_exact_replay_is_idempotent_pg() {
+    let (db, pool) = create_pool().await;
+    let operation_id = Uuid::new_v4();
+    let expected_intents = intents();
+    let create = command(
+        operation_id,
+        "request-atomic",
+        "session-atomic",
+        &expected_intents,
+    );
+
+    assert_eq!(
+        create_runtime_cleanup_operation(&pool, &create)
+            .await
+            .unwrap(),
+        CreateRuntimeCleanupResult::Created { operation_id }
+    );
+    assert_eq!(
+        create_runtime_cleanup_operation(&pool, &create)
+            .await
+            .unwrap(),
+        CreateRuntimeCleanupResult::Replayed { operation_id }
+    );
+
+    let count = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM runtime_cleanup_intents WHERE operation_id = $1",
+    )
+    .bind(operation_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count, expected_intents.len() as i64);
+
+    let conflicting_intents = &expected_intents[..5];
+    let conflict = command(
+        Uuid::new_v4(),
+        "request-atomic",
+        "session-atomic",
+        conflicting_intents,
+    );
+    assert_eq!(
+        create_runtime_cleanup_operation(&pool, &conflict)
+            .await
+            .unwrap(),
+        CreateRuntimeCleanupResult::RequestConflict { operation_id }
+    );
+    close(db, pool).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_same_target_has_one_deterministic_owner_pg() {
+    let (db, pool) = create_pool().await;
+    let first_id = Uuid::from_u128(1);
+    let second_id = Uuid::from_u128(2);
+    let expected_intents = intents();
+    let first = command(
+        first_id,
+        "request-writer-a",
+        "session-shared",
+        &expected_intents,
+    );
+    let second = command(
+        second_id,
+        "request-writer-b",
+        "session-shared",
+        &expected_intents,
+    );
+    let (first_result, second_result) = tokio::join!(
+        create_runtime_cleanup_operation(&pool, &first),
+        create_runtime_cleanup_operation(&pool, &second),
+    );
+    let first_result = first_result.unwrap();
+    let second_result = second_result.unwrap();
+
+    let owner = match (&first_result, &second_result) {
+        (
+            CreateRuntimeCleanupResult::Created { operation_id },
+            CreateRuntimeCleanupResult::TargetBusy {
+                operation_id: busy_id,
+            },
+        )
+        | (
+            CreateRuntimeCleanupResult::TargetBusy {
+                operation_id: busy_id,
+            },
+            CreateRuntimeCleanupResult::Created { operation_id },
+        ) => {
+            assert_eq!(operation_id, busy_id);
+            *operation_id
+        }
+        other => panic!("expected one owner and one busy result, got {other:?}"),
+    };
+
+    let open = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM runtime_cleanup_operations
+         WHERE target_kind = 'discord_session' AND target_key = 'session-shared'
+           AND state IN ('pending', 'fenced', 'applying')",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(open, 1);
+    assert!(owner == first_id || owner == second_id);
+    close(db, pool).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn transitions_are_monotonic_fenced_and_idempotent_pg() {
+    let (db, pool) = create_pool().await;
+    let operation_id = Uuid::new_v4();
+    let expected_intents = intents();
+    create_runtime_cleanup_operation(
+        &pool,
+        &command(
+            operation_id,
+            "request-transition",
+            "session-transition",
+            &expected_intents,
+        ),
+    )
+    .await
+    .unwrap();
+
+    let fenced = transition_runtime_cleanup_operation(
+        &pool,
+        operation_id,
+        RuntimeCleanupState::Pending,
+        None,
+        RuntimeCleanupState::Fenced,
+    )
+    .await
+    .unwrap();
+    let fence = match fenced {
+        TransitionRuntimeCleanupResult::Advanced {
+            state: RuntimeCleanupState::Fenced,
+            fence: Some(fence),
+            ..
+        } => fence,
+        other => panic!("unexpected fence result: {other:?}"),
+    };
+    assert_eq!(fence, 1);
+
+    assert_eq!(
+        transition_runtime_cleanup_operation(
+            &pool,
+            operation_id,
+            RuntimeCleanupState::Pending,
+            Some(fence),
+            RuntimeCleanupState::Fenced,
+        )
+        .await
+        .unwrap(),
+        TransitionRuntimeCleanupResult::Replayed {
+            operation_id,
+            state: RuntimeCleanupState::Fenced,
+            fence: Some(fence),
+        }
+    );
+    assert!(matches!(
+        transition_runtime_cleanup_operation(
+            &pool,
+            operation_id,
+            RuntimeCleanupState::Fenced,
+            Some(fence),
+            RuntimeCleanupState::Completed,
+        )
+        .await
+        .unwrap(),
+        TransitionRuntimeCleanupResult::Illegal {
+            current_state: RuntimeCleanupState::Fenced,
+            ..
+        }
+    ));
+    assert!(matches!(
+        transition_runtime_cleanup_operation(
+            &pool,
+            operation_id,
+            RuntimeCleanupState::Fenced,
+            Some(fence + 1),
+            RuntimeCleanupState::Applying,
+        )
+        .await
+        .unwrap(),
+        TransitionRuntimeCleanupResult::Stale {
+            current_fence: Some(current),
+            ..
+        } if current == fence
+    ));
+
+    assert!(matches!(
+        transition_runtime_cleanup_operation(
+            &pool,
+            operation_id,
+            RuntimeCleanupState::Fenced,
+            Some(fence),
+            RuntimeCleanupState::Applying,
+        )
+        .await
+        .unwrap(),
+        TransitionRuntimeCleanupResult::Advanced {
+            state: RuntimeCleanupState::Applying,
+            ..
+        }
+    ));
+    assert!(matches!(
+        transition_runtime_cleanup_operation(
+            &pool,
+            operation_id,
+            RuntimeCleanupState::Applying,
+            Some(fence),
+            RuntimeCleanupState::Completed,
+        )
+        .await
+        .unwrap(),
+        TransitionRuntimeCleanupResult::Advanced {
+            state: RuntimeCleanupState::Completed,
+            ..
+        }
+    ));
+    assert!(matches!(
+        transition_runtime_cleanup_operation(
+            &pool,
+            operation_id,
+            RuntimeCleanupState::Completed,
+            Some(fence),
+            RuntimeCleanupState::Applying,
+        )
+        .await
+        .unwrap(),
+        TransitionRuntimeCleanupResult::Illegal {
+            current_state: RuntimeCleanupState::Completed,
+            ..
+        }
+    ));
+    close(db, pool).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_fence_writers_serialize_and_next_operation_advances_epoch_pg() {
+    let (db, pool) = create_pool().await;
+    let expected_intents = intents();
+    let first_id = Uuid::new_v4();
+    create_runtime_cleanup_operation(
+        &pool,
+        &command(
+            first_id,
+            "request-fence-1",
+            "session-fence",
+            &expected_intents,
+        ),
+    )
+    .await
+    .unwrap();
+
+    let (left, right) = tokio::join!(
+        transition_runtime_cleanup_operation(
+            &pool,
+            first_id,
+            RuntimeCleanupState::Pending,
+            None,
+            RuntimeCleanupState::Fenced,
+        ),
+        transition_runtime_cleanup_operation(
+            &pool,
+            first_id,
+            RuntimeCleanupState::Pending,
+            None,
+            RuntimeCleanupState::Fenced,
+        ),
+    );
+    let results = [left.unwrap(), right.unwrap()];
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| matches!(result, TransitionRuntimeCleanupResult::Advanced { .. }))
+            .count(),
+        1
+    );
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| matches!(result, TransitionRuntimeCleanupResult::Replayed { .. }))
+            .count(),
+        1
+    );
+    assert!(results.iter().all(|result| match result {
+        TransitionRuntimeCleanupResult::Advanced { fence, .. }
+        | TransitionRuntimeCleanupResult::Replayed { fence, .. } => *fence == Some(1),
+        _ => false,
+    }));
+
+    transition_runtime_cleanup_operation(
+        &pool,
+        first_id,
+        RuntimeCleanupState::Fenced,
+        Some(1),
+        RuntimeCleanupState::Aborted,
+    )
+    .await
+    .unwrap();
+    let second_id = Uuid::new_v4();
+    assert_eq!(
+        create_runtime_cleanup_operation(
+            &pool,
+            &command(
+                second_id,
+                "request-fence-2",
+                "session-fence",
+                &expected_intents,
+            ),
+        )
+        .await
+        .unwrap(),
+        CreateRuntimeCleanupResult::Created {
+            operation_id: second_id
+        }
+    );
+    assert!(matches!(
+        transition_runtime_cleanup_operation(
+            &pool,
+            second_id,
+            RuntimeCleanupState::Pending,
+            None,
+            RuntimeCleanupState::Fenced,
+        )
+        .await
+        .unwrap(),
+        TransitionRuntimeCleanupResult::Advanced { fence: Some(2), .. }
+    ));
+    close(db, pool).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn database_constraints_reject_mutable_intents_and_invalid_state_shape_pg() {
+    let (db, pool) = create_pool().await;
+    let operation_id = Uuid::new_v4();
+    let expected_intents = intents();
+    create_runtime_cleanup_operation(
+        &pool,
+        &command(
+            operation_id,
+            "request-constraints",
+            "session-constraints",
+            &expected_intents,
+        ),
+    )
+    .await
+    .unwrap();
+
+    let immutable = sqlx::query(
+        "UPDATE runtime_cleanup_intents SET ordinal = 7
+         WHERE operation_id = $1 AND intent_kind = 'block_runtime_admission'",
+    )
+    .bind(operation_id)
+    .execute(&pool)
+    .await;
+    assert!(immutable.is_err());
+
+    let invalid_shape = sqlx::query(
+        "UPDATE runtime_cleanup_operations SET state = 'completed' WHERE operation_id = $1",
+    )
+    .bind(operation_id)
+    .execute(&pool)
+    .await;
+    assert!(invalid_shape.is_err());
+    close(db, pool).await;
+}

--- a/src/db/runtime_cleanup/postgres_tests.rs
+++ b/src/db/runtime_cleanup/postgres_tests.rs
@@ -1,51 +1,6 @@
 use super::*;
 use crate::dispatch::test_support::DispatchPostgresTestDb;
 
-fn intents() -> Vec<RuntimeCleanupIntent> {
-    vec![
-        RuntimeCleanupIntent {
-            kind: RuntimeCleanupIntentKind::BlockRuntimeAdmission,
-            ordinal: 1,
-        },
-        RuntimeCleanupIntent {
-            kind: RuntimeCleanupIntentKind::ClearQueuedInput,
-            ordinal: 2,
-        },
-        RuntimeCleanupIntent {
-            kind: RuntimeCleanupIntentKind::ExpireRuntimeLease,
-            ordinal: 3,
-        },
-        RuntimeCleanupIntent {
-            kind: RuntimeCleanupIntentKind::CancelActiveRuntime,
-            ordinal: 4,
-        },
-        RuntimeCleanupIntent {
-            kind: RuntimeCleanupIntentKind::ClearPersistedSession,
-            ordinal: 5,
-        },
-        RuntimeCleanupIntent {
-            kind: RuntimeCleanupIntentKind::ReleaseRuntimeSlot,
-            ordinal: 6,
-        },
-    ]
-}
-
-fn command<'a>(
-    operation_id: Uuid,
-    request_key: &'a str,
-    target_key: &'a str,
-    intents: &'a [RuntimeCleanupIntent],
-) -> CreateRuntimeCleanupOperation<'a> {
-    CreateRuntimeCleanupOperation {
-        operation_id,
-        request_key,
-        target_kind: RuntimeCleanupTargetKind::DiscordSession,
-        target_key,
-        action: RuntimeCleanupAction::ClearForResume,
-        intents,
-    }
-}
-
 async fn create_pool() -> (DispatchPostgresTestDb, PgPool) {
     let db = DispatchPostgresTestDb::create(
         "agentdesk_runtime_cleanup",
@@ -61,371 +16,464 @@ async fn close(db: DispatchPostgresTestDb, pool: PgPool) {
     db.drop().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn create_is_atomic_and_exact_replay_is_idempotent_pg() {
-    let (db, pool) = create_pool().await;
-    let operation_id = Uuid::new_v4();
-    let expected_intents = intents();
-    let create = command(
-        operation_id,
-        "request-atomic",
-        "session-atomic",
-        &expected_intents,
-    );
+async fn seed_session(pool: &PgPool, key: &str) -> i64 {
+    sqlx::query_scalar(
+        "INSERT INTO sessions (session_key, provider, status)
+         VALUES ($1, 'claude', 'idle') RETURNING id",
+    )
+    .bind(key)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
 
+fn command<'a>(
+    operation_id: Uuid,
+    request_key: &'a str,
+    session_id: i64,
+) -> CreateRuntimeCleanupOperation<'a> {
+    CreateRuntimeCleanupOperation {
+        operation_id,
+        request_key,
+        target: RuntimeCleanupTarget { session_id },
+        action: RuntimeCleanupAction::ClearForResume,
+    }
+}
+
+async fn create_and_fence(pool: &PgPool, request_key: &str, session_id: i64) -> (Uuid, i64) {
+    let operation_id = Uuid::new_v4();
     assert_eq!(
-        create_runtime_cleanup_operation(&pool, &create)
+        create_runtime_cleanup_operation(pool, &command(operation_id, request_key, session_id))
             .await
             .unwrap(),
         CreateRuntimeCleanupResult::Created { operation_id }
     );
-    assert_eq!(
-        create_runtime_cleanup_operation(&pool, &create)
-            .await
-            .unwrap(),
-        CreateRuntimeCleanupResult::Replayed { operation_id }
-    );
-
-    let count = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM runtime_cleanup_intents WHERE operation_id = $1",
-    )
-    .bind(operation_id)
-    .fetch_one(&pool)
-    .await
-    .unwrap();
-    assert_eq!(count, expected_intents.len() as i64);
-
-    let conflicting_intents = &expected_intents[..5];
-    let conflict = command(
-        Uuid::new_v4(),
-        "request-atomic",
-        "session-atomic",
-        conflicting_intents,
-    );
-    assert_eq!(
-        create_runtime_cleanup_operation(&pool, &conflict)
-            .await
-            .unwrap(),
-        CreateRuntimeCleanupResult::RequestConflict { operation_id }
-    );
-    close(db, pool).await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn concurrent_same_target_has_one_deterministic_owner_pg() {
-    let (db, pool) = create_pool().await;
-    let first_id = Uuid::from_u128(1);
-    let second_id = Uuid::from_u128(2);
-    let expected_intents = intents();
-    let first = command(
-        first_id,
-        "request-writer-a",
-        "session-shared",
-        &expected_intents,
-    );
-    let second = command(
-        second_id,
-        "request-writer-b",
-        "session-shared",
-        &expected_intents,
-    );
-    let (first_result, second_result) = tokio::join!(
-        create_runtime_cleanup_operation(&pool, &first),
-        create_runtime_cleanup_operation(&pool, &second),
-    );
-    let first_result = first_result.unwrap();
-    let second_result = second_result.unwrap();
-
-    let owner = match (&first_result, &second_result) {
-        (
-            CreateRuntimeCleanupResult::Created { operation_id },
-            CreateRuntimeCleanupResult::TargetBusy {
-                operation_id: busy_id,
-            },
-        )
-        | (
-            CreateRuntimeCleanupResult::TargetBusy {
-                operation_id: busy_id,
-            },
-            CreateRuntimeCleanupResult::Created { operation_id },
-        ) => {
-            assert_eq!(operation_id, busy_id);
-            *operation_id
-        }
-        other => panic!("expected one owner and one busy result, got {other:?}"),
-    };
-
-    let open = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM runtime_cleanup_operations
-         WHERE target_kind = 'discord_session' AND target_key = 'session-shared'
-           AND state IN ('pending', 'fenced', 'applying')",
-    )
-    .fetch_one(&pool)
-    .await
-    .unwrap();
-    assert_eq!(open, 1);
-    assert!(owner == first_id || owner == second_id);
-    close(db, pool).await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn transitions_are_monotonic_fenced_and_idempotent_pg() {
-    let (db, pool) = create_pool().await;
-    let operation_id = Uuid::new_v4();
-    let expected_intents = intents();
-    create_runtime_cleanup_operation(
-        &pool,
-        &command(
-            operation_id,
-            "request-transition",
-            "session-transition",
-            &expected_intents,
-        ),
-    )
-    .await
-    .unwrap();
-
-    let fenced = transition_runtime_cleanup_operation(
-        &pool,
-        operation_id,
-        RuntimeCleanupState::Pending,
-        None,
-        RuntimeCleanupState::Fenced,
-    )
-    .await
-    .unwrap();
-    let fence = match fenced {
-        TransitionRuntimeCleanupResult::Advanced {
-            state: RuntimeCleanupState::Fenced,
-            fence: Some(fence),
-            ..
-        } => fence,
+    let fence = match fence_runtime_cleanup_operation(pool, operation_id)
+        .await
+        .unwrap()
+    {
+        FenceRuntimeCleanupResult::Advanced { fence } => fence,
         other => panic!("unexpected fence result: {other:?}"),
     };
-    assert_eq!(fence, 1);
-
-    assert_eq!(
-        transition_runtime_cleanup_operation(
-            &pool,
-            operation_id,
-            RuntimeCleanupState::Pending,
-            Some(fence),
-            RuntimeCleanupState::Fenced,
-        )
-        .await
-        .unwrap(),
-        TransitionRuntimeCleanupResult::Replayed {
-            operation_id,
-            state: RuntimeCleanupState::Fenced,
-            fence: Some(fence),
-        }
-    );
-    assert!(matches!(
-        transition_runtime_cleanup_operation(
-            &pool,
-            operation_id,
-            RuntimeCleanupState::Fenced,
-            Some(fence),
-            RuntimeCleanupState::Completed,
-        )
-        .await
-        .unwrap(),
-        TransitionRuntimeCleanupResult::Illegal {
-            current_state: RuntimeCleanupState::Fenced,
-            ..
-        }
-    ));
-    assert!(matches!(
-        transition_runtime_cleanup_operation(
-            &pool,
-            operation_id,
-            RuntimeCleanupState::Fenced,
-            Some(fence + 1),
-            RuntimeCleanupState::Applying,
-        )
-        .await
-        .unwrap(),
-        TransitionRuntimeCleanupResult::Stale {
-            current_fence: Some(current),
-            ..
-        } if current == fence
-    ));
-
-    assert!(matches!(
-        transition_runtime_cleanup_operation(
-            &pool,
-            operation_id,
-            RuntimeCleanupState::Fenced,
-            Some(fence),
-            RuntimeCleanupState::Applying,
-        )
-        .await
-        .unwrap(),
-        TransitionRuntimeCleanupResult::Advanced {
-            state: RuntimeCleanupState::Applying,
-            ..
-        }
-    ));
-    assert!(matches!(
-        transition_runtime_cleanup_operation(
-            &pool,
-            operation_id,
-            RuntimeCleanupState::Applying,
-            Some(fence),
-            RuntimeCleanupState::Completed,
-        )
-        .await
-        .unwrap(),
-        TransitionRuntimeCleanupResult::Advanced {
-            state: RuntimeCleanupState::Completed,
-            ..
-        }
-    ));
-    assert!(matches!(
-        transition_runtime_cleanup_operation(
-            &pool,
-            operation_id,
-            RuntimeCleanupState::Completed,
-            Some(fence),
-            RuntimeCleanupState::Applying,
-        )
-        .await
-        .unwrap(),
-        TransitionRuntimeCleanupResult::Illegal {
-            current_state: RuntimeCleanupState::Completed,
-            ..
-        }
-    ));
-    close(db, pool).await;
+    (operation_id, fence)
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn concurrent_fence_writers_serialize_and_next_operation_advances_epoch_pg() {
+async fn canonical_session_id_coalesces_primary_and_alias_target_pg() {
     let (db, pool) = create_pool().await;
-    let expected_intents = intents();
+    let session_id = seed_session(&pool, "primary-locator").await;
+    sqlx::query(
+        "INSERT INTO session_key_aliases (session_key, session_id) VALUES ('alias-locator', $1)",
+    )
+    .bind(session_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(
+        resolve_runtime_cleanup_target(&pool, "primary-locator")
+            .await
+            .unwrap(),
+        Some(RuntimeCleanupTarget { session_id })
+    );
+    assert_eq!(
+        resolve_runtime_cleanup_target(&pool, "alias-locator")
+            .await
+            .unwrap(),
+        Some(RuntimeCleanupTarget { session_id })
+    );
+
     let first_id = Uuid::new_v4();
-    create_runtime_cleanup_operation(
-        &pool,
-        &command(
-            first_id,
-            "request-fence-1",
-            "session-fence",
-            &expected_intents,
-        ),
-    )
-    .await
-    .unwrap();
-
-    let (left, right) = tokio::join!(
-        transition_runtime_cleanup_operation(
-            &pool,
-            first_id,
-            RuntimeCleanupState::Pending,
-            None,
-            RuntimeCleanupState::Fenced,
-        ),
-        transition_runtime_cleanup_operation(
-            &pool,
-            first_id,
-            RuntimeCleanupState::Pending,
-            None,
-            RuntimeCleanupState::Fenced,
-        ),
-    );
-    let results = [left.unwrap(), right.unwrap()];
-    assert_eq!(
-        results
-            .iter()
-            .filter(|result| matches!(result, TransitionRuntimeCleanupResult::Advanced { .. }))
-            .count(),
-        1
-    );
-    assert_eq!(
-        results
-            .iter()
-            .filter(|result| matches!(result, TransitionRuntimeCleanupResult::Replayed { .. }))
-            .count(),
-        1
-    );
-    assert!(results.iter().all(|result| match result {
-        TransitionRuntimeCleanupResult::Advanced { fence, .. }
-        | TransitionRuntimeCleanupResult::Replayed { fence, .. } => *fence == Some(1),
-        _ => false,
-    }));
-
-    transition_runtime_cleanup_operation(
-        &pool,
-        first_id,
-        RuntimeCleanupState::Fenced,
-        Some(1),
-        RuntimeCleanupState::Aborted,
-    )
-    .await
-    .unwrap();
-    let second_id = Uuid::new_v4();
     assert_eq!(
         create_runtime_cleanup_operation(
             &pool,
-            &command(
-                second_id,
-                "request-fence-2",
-                "session-fence",
-                &expected_intents,
-            ),
+            &command(first_id, "canonical-primary", session_id)
         )
         .await
         .unwrap(),
         CreateRuntimeCleanupResult::Created {
-            operation_id: second_id
+            operation_id: first_id
         }
     );
-    assert!(matches!(
-        transition_runtime_cleanup_operation(
+    assert_eq!(
+        create_runtime_cleanup_operation(
             &pool,
-            second_id,
-            RuntimeCleanupState::Pending,
-            None,
-            RuntimeCleanupState::Fenced,
+            &command(Uuid::new_v4(), "canonical-alias", session_id)
         )
         .await
         .unwrap(),
-        TransitionRuntimeCleanupResult::Advanced { fence: Some(2), .. }
+        CreateRuntimeCleanupResult::TargetBusy {
+            operation_id: first_id
+        }
+    );
+    close(db, pool).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_same_request_different_target_returns_typed_conflict_pg() {
+    let (db, pool) = create_pool().await;
+    let first_session = seed_session(&pool, "request-race-a").await;
+    let second_session = seed_session(&pool, "request-race-b").await;
+    let first_id = Uuid::new_v4();
+    let second_id = Uuid::new_v4();
+    let first = command(first_id, "shared-request-key", first_session);
+    let second = command(second_id, "shared-request-key", second_session);
+    let (left, right) = tokio::join!(
+        create_runtime_cleanup_operation(&pool, &first),
+        create_runtime_cleanup_operation(&pool, &second),
+    );
+    let results = [left.unwrap(), right.unwrap()];
+    let created_id = results
+        .iter()
+        .find_map(|result| match result {
+            CreateRuntimeCleanupResult::Created { operation_id } => Some(*operation_id),
+            _ => None,
+        })
+        .expect("one creator");
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| matches!(result, CreateRuntimeCleanupResult::Created { .. }))
+            .count(),
+        1
+    );
+    assert_eq!(results.iter().filter(|result| matches!(result, CreateRuntimeCleanupResult::RequestConflict { operation_id } if *operation_id == created_id)).count(), 1);
+    close(db, pool).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn canonical_plan_is_atomic_closed_and_database_enforced_pg() {
+    let (db, pool) = create_pool().await;
+    let session_id = seed_session(&pool, "canonical-plan").await;
+    let operation_id = Uuid::new_v4();
+    assert_eq!(
+        create_runtime_cleanup_operation(
+            &pool,
+            &command(operation_id, "canonical-plan", session_id)
+        )
+        .await
+        .unwrap(),
+        CreateRuntimeCleanupResult::Created { operation_id }
+    );
+    let plan = sqlx::query_as::<_, (String, i16)>(
+        "SELECT intent_kind, ordinal FROM runtime_cleanup_intents WHERE operation_id = $1 ORDER BY ordinal",
+    )
+    .bind(operation_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(plan.len(), CLEAR_FOR_RESUME_PLAN.len());
+    assert!(plan.iter().zip(CLEAR_FOR_RESUME_PLAN).all(
+        |((kind, ordinal), (expected_kind, expected_ordinal))| {
+            kind == expected_kind && *ordinal == expected_ordinal
+        }
+    ));
+
+    let mut tx = pool.begin().await.unwrap();
+    sqlx::query("SET CONSTRAINTS trg_runtime_cleanup_intent_plan DEFERRED")
+        .execute(&mut *tx)
+        .await
+        .unwrap();
+    let mutation =
+        sqlx::query("DELETE FROM runtime_cleanup_intents WHERE operation_id = $1 AND ordinal = 6")
+            .bind(operation_id)
+            .execute(&mut *tx)
+            .await;
+    assert!(mutation.is_err(), "ordinary intent deletion is forbidden");
+    tx.rollback().await.unwrap();
+    close(db, pool).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn attempt_token_distinguishes_replay_competitor_and_recovery_takeover_pg() {
+    let (db, pool) = create_pool().await;
+    let session_id = seed_session(&pool, "attempt-owner").await;
+    let (operation_id, fence) = create_and_fence(&pool, "attempt-owner", session_id).await;
+    let now = Utc::now();
+    let first_token = Uuid::new_v4();
+    let first = BeginRuntimeCleanupAttempt {
+        operation_id,
+        expected_fence: fence,
+        claim_owner: "worker-a",
+        attempt_token: first_token,
+        lease_expires_at: now + chrono::Duration::milliseconds(500),
+    };
+    assert_eq!(
+        begin_runtime_cleanup_attempt(&pool, first).await.unwrap(),
+        BeginRuntimeCleanupResult::Acquired { attempt_no: 1 }
+    );
+    assert_eq!(
+        begin_runtime_cleanup_attempt(&pool, first).await.unwrap(),
+        BeginRuntimeCleanupResult::Replayed { attempt_no: 1 }
+    );
+    assert_eq!(
+        begin_runtime_cleanup_attempt(
+            &pool,
+            BeginRuntimeCleanupAttempt {
+                claim_owner: "worker-b",
+                ..first
+            },
+        )
+        .await
+        .unwrap(),
+        BeginRuntimeCleanupResult::LostOwnership { attempt_no: 1 }
+    );
+
+    let competing = BeginRuntimeCleanupAttempt {
+        claim_owner: "worker-b",
+        attempt_token: Uuid::new_v4(),
+        ..first
+    };
+    assert_eq!(
+        begin_runtime_cleanup_attempt(&pool, competing)
+            .await
+            .unwrap(),
+        BeginRuntimeCleanupResult::LeaseHeld {
+            owner: "worker-a".into(),
+            attempt_no: 1
+        }
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+    let takeover_token = Uuid::new_v4();
+    let takeover = BeginRuntimeCleanupAttempt {
+        claim_owner: "worker-b",
+        attempt_token: takeover_token,
+        lease_expires_at: now + chrono::Duration::minutes(2),
+        ..first
+    };
+    assert_eq!(
+        begin_runtime_cleanup_attempt(&pool, takeover)
+            .await
+            .unwrap(),
+        BeginRuntimeCleanupResult::Acquired { attempt_no: 2 }
+    );
+    assert_eq!(
+        complete_runtime_cleanup_attempt(
+            &pool,
+            CompleteRuntimeCleanupAttempt {
+                operation_id,
+                expected_fence: fence,
+                attempt_token: first_token
+            }
+        )
+        .await
+        .unwrap(),
+        CompleteRuntimeCleanupResult::LostOwnership
+    );
+    assert_eq!(
+        complete_runtime_cleanup_attempt(
+            &pool,
+            CompleteRuntimeCleanupAttempt {
+                operation_id,
+                expected_fence: fence,
+                attempt_token: takeover_token
+            }
+        )
+        .await
+        .unwrap(),
+        CompleteRuntimeCleanupResult::Completed
+    );
+    assert_eq!(
+        complete_runtime_cleanup_attempt(
+            &pool,
+            CompleteRuntimeCleanupAttempt {
+                operation_id,
+                expected_fence: fence,
+                attempt_token: takeover_token
+            }
+        )
+        .await
+        .unwrap(),
+        CompleteRuntimeCleanupResult::Replayed
+    );
+    close(db, pool).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn applying_is_commit_decided_and_abort_requires_roll_forward_pg() {
+    let (db, pool) = create_pool().await;
+    let session_id = seed_session(&pool, "roll-forward").await;
+    let (operation_id, fence) = create_and_fence(&pool, "roll-forward", session_id).await;
+    let token = Uuid::new_v4();
+    let now = Utc::now();
+    begin_runtime_cleanup_attempt(
+        &pool,
+        BeginRuntimeCleanupAttempt {
+            operation_id,
+            expected_fence: fence,
+            claim_owner: "worker-a",
+            attempt_token: token,
+            lease_expires_at: now + chrono::Duration::minutes(1),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        abort_runtime_cleanup_operation(&pool, operation_id)
+            .await
+            .unwrap(),
+        AbortRuntimeCleanupResult::RollForwardRequired
+    );
+    let row = load_runtime_cleanup_operation(&pool, operation_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.state, RuntimeCleanupState::Applying);
+    assert!(row.commit_decided_at.is_some());
+    let illegal_abort = sqlx::query(
+        "UPDATE runtime_cleanup_operations
+         SET state = 'aborted', claim_owner = NULL, attempt_token = NULL,
+             attempt_no = 0, lease_expires_at = NULL, attempt_started_at = NULL,
+             commit_decided_at = NULL,
+             aborted_from_state = 'fenced', aborted_at = NOW()
+         WHERE operation_id = $1",
+    )
+    .bind(operation_id)
+    .execute(&pool)
+    .await;
+    assert!(illegal_abort.is_err(), "database rejects applying rollback");
+    close(db, pool).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn transition_replay_requires_exact_transition_identity_pg() {
+    let (db, pool) = create_pool().await;
+    let session_id = seed_session(&pool, "exact-transition").await;
+    let operation_id = Uuid::new_v4();
+    create_runtime_cleanup_operation(
+        &pool,
+        &command(operation_id, "exact-transition", session_id),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        abort_runtime_cleanup_operation(&pool, operation_id)
+            .await
+            .unwrap(),
+        AbortRuntimeCleanupResult::Aborted
+    );
+    assert!(matches!(
+        fence_runtime_cleanup_operation(&pool, operation_id)
+            .await
+            .unwrap(),
+        FenceRuntimeCleanupResult::Stale {
+            state: RuntimeCleanupState::Aborted
+        }
+    ));
+    let fake_attempt = BeginRuntimeCleanupAttempt {
+        operation_id,
+        expected_fence: 1,
+        claim_owner: "worker",
+        attempt_token: Uuid::new_v4(),
+        lease_expires_at: Utc::now() + chrono::Duration::minutes(1),
+    };
+    assert!(matches!(
+        begin_runtime_cleanup_attempt(&pool, fake_attempt)
+            .await
+            .unwrap(),
+        BeginRuntimeCleanupResult::Stale {
+            state: RuntimeCleanupState::Aborted
+        }
     ));
     close(db, pool).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn database_constraints_reject_mutable_intents_and_invalid_state_shape_pg() {
+async fn terminal_retention_archives_plan_and_preserves_latest_fence_pg() {
     let (db, pool) = create_pool().await;
-    let operation_id = Uuid::new_v4();
-    let expected_intents = intents();
-    create_runtime_cleanup_operation(
+    let session_id = seed_session(&pool, "retention").await;
+    let (operation_id, fence) = create_and_fence(&pool, "retention", session_id).await;
+    let token = Uuid::new_v4();
+    let now = Utc::now();
+    begin_runtime_cleanup_attempt(
         &pool,
-        &command(
+        BeginRuntimeCleanupAttempt {
             operation_id,
-            "request-constraints",
-            "session-constraints",
-            &expected_intents,
-        ),
+            expected_fence: fence,
+            claim_owner: "retention-worker",
+            attempt_token: token,
+            lease_expires_at: now + chrono::Duration::minutes(1),
+        },
+    )
+    .await
+    .unwrap();
+    complete_runtime_cleanup_attempt(
+        &pool,
+        CompleteRuntimeCleanupAttempt {
+            operation_id,
+            expected_fence: fence,
+            attempt_token: token,
+        },
     )
     .await
     .unwrap();
 
-    let immutable = sqlx::query(
-        "UPDATE runtime_cleanup_intents SET ordinal = 7
-         WHERE operation_id = $1 AND intent_kind = 'block_runtime_admission'",
+    assert!(
+        retire_terminal_runtime_cleanup_operation(
+            &pool,
+            operation_id,
+            Utc::now() + chrono::Duration::seconds(1)
+        )
+        .await
+        .unwrap()
+    );
+    assert!(
+        load_runtime_cleanup_operation(&pool, operation_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let archived_intents = sqlx::query_scalar::<_, i32>("SELECT JSONB_ARRAY_LENGTH(intents) FROM runtime_cleanup_operation_archive WHERE operation_id = $1")
+        .bind(operation_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(archived_intents, 6);
+    let authority = sqlx::query_as::<_, (i64, Uuid)>(
+        "SELECT last_fence, operation_id FROM runtime_cleanup_fences WHERE target_session_id = $1",
     )
-    .bind(operation_id)
-    .execute(&pool)
-    .await;
-    assert!(immutable.is_err());
+    .bind(session_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(authority, (fence, operation_id));
+    assert_eq!(
+        create_runtime_cleanup_operation(&pool, &command(Uuid::new_v4(), "retention", session_id))
+            .await
+            .unwrap(),
+        CreateRuntimeCleanupResult::Replayed { operation_id }
+    );
+    let different_session = seed_session(&pool, "retention-conflict").await;
+    assert_eq!(
+        create_runtime_cleanup_operation(
+            &pool,
+            &command(Uuid::new_v4(), "retention", different_session)
+        )
+        .await
+        .unwrap(),
+        CreateRuntimeCleanupResult::RequestConflict { operation_id }
+    );
 
-    let invalid_shape = sqlx::query(
-        "UPDATE runtime_cleanup_operations SET state = 'completed' WHERE operation_id = $1",
-    )
-    .bind(operation_id)
-    .execute(&pool)
-    .await;
-    assert!(invalid_shape.is_err());
+    let second_id = Uuid::new_v4();
+    create_runtime_cleanup_operation(&pool, &command(second_id, "retention-next", session_id))
+        .await
+        .unwrap();
+    assert_eq!(
+        fence_runtime_cleanup_operation(&pool, second_id)
+            .await
+            .unwrap(),
+        FenceRuntimeCleanupResult::Advanced { fence: fence + 1 }
+    );
+    assert!(
+        !retire_terminal_runtime_cleanup_operation(
+            &pool,
+            second_id,
+            Utc::now() + chrono::Duration::days(1)
+        )
+        .await
+        .unwrap(),
+        "active operation cannot be retired"
+    );
     close(db, pool).await;
 }


### PR DESCRIPTION
## Summary
- add an additive PostgreSQL coordinator journal for dormant runtime cleanup operations, an exact immutable six-step intent plan, and per-session monotonic fences
- canonicalize every locator to `sessions.id`, serialize request and target creation, and preserve request-key idempotency after terminal archival
- add durable claimant/attempt-token/lease ownership, database-enforced monotonic transitions, roll-forward-only applying state, and safe terminal retention
- add real PostgreSQL mutation, replay, retention, alias-coalescing, takeover, and concurrent-writer coverage without wiring a production consumer or activating cleanup authority

## Scope
Task #25 Slice 1 foundation only. This intentionally does **not** modify relay hotfiles, runtime configuration, production consumers, deploy paths, or live cleanup authority.

The design replaces the closed #4920 mailbox-only reservation approach with dormant PostgreSQL coordinator primitives. Later saga slices can use the journal to coordinate runtime admission, queued input, lease expiry, cancellation, persisted session cleanup, and slot release under one durable plan.

References #4916

## Invariants
- primary keys and aliases resolve to one canonical `sessions.id`; only one `pending | fenced | applying` operation may own that session
- request-key advisory locking returns deterministic typed replay/conflict outcomes, including after the live row is archived
- `clear_for_resume` always has exactly the closed ordered six-step plan, created atomically and protected by database constraints and immutable-intent triggers
- only the current `(claim_owner, attempt_token, lease)` identity may replay or complete an attempt; an expired lease is recoverable through a new token and incremented attempt number
- applying records the commit decision and cannot abort; only pending/fenced may abort, while applying can only recover in place or complete
- a database trigger accepts only legal monotonic edges and preserves fence, claimant, attempt, lease, and commit-decision evidence
- per-session fences increase monotonically and remain authoritative after terminal journal archival
- terminal retention archives operation identity and ordered intents before deleting live rows; ordinary mutation/deletion remains forbidden

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --lib`
- [x] `cargo test --lib db::runtime_cleanup::postgres_tests -- --nocapture --test-threads=1` (7 passed)
- [x] `python3 scripts/check_postgres_migration_checksums.py`
- [x] `python3 scripts/check_test_lane_coverage.py --baseline-ref origin/main`
- [x] `python3 scripts/audit_state_lint_hardening.py --check`
- [x] `python3 scripts/generate_inventory_docs.py`
- [x] `python3 scripts/check_agent_maintenance_docs.py`
- [x] `git diff --check`

Generated with Claude Code