### PR TITLE
feat(#4912): add dormant typed completion foundation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1364,6 +1364,7 @@ src/
 │   ├── settings.rs
 │   ├── shell_guard.rs
 │   ├── stale_turn_reconciler.rs
+│   ├── task_completion_v1.rs
 │   ├── terminal_status_formatting.rs
 │   ├── termination_audit.rs
 │   ├── tmux_common.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "glob",
  "hex",
  "hound",
+ "icu_properties",
  "json5",
  "libc",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ textwrap = "0.16"
 regex = "1"
 pulldown-cmark = "0.9.6"
 unicode-normalization = "0.1"
+icu_properties = "=2.1.2"
 
 # From RCC — crypto/encoding
 base64 = "0.22"

--- a/justfile
+++ b/justfile
@@ -28,6 +28,7 @@ test-active-usage-4631:
 # Stage 1 keeps the existing CI-safe subset. The broad non-PG sweep currently
 # fails legacy/full integration route tests; see docs/ci/rust-quality-gates.md.
 test-non-pg:
+    cargo test --lib services::task_completion_v1::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib source_registry -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib task_notification -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib delivery_lease_key -- --skip _pg --skip pg_ --skip postgres

--- a/src/services/codex_tmux_wrapper.rs
+++ b/src/services/codex_tmux_wrapper.rs
@@ -8,6 +8,7 @@ use crate::services::codex::{
     CODEX_BACKGROUND_TASK_NOTIFICATION_ID, CODEX_BACKGROUND_TASK_NOTIFICATION_STATUS,
     CodexLaunchOptions, build_codex_exec_args, codex_background_event_summary,
 };
+use crate::services::task_completion_v1::TaskCompletionV1;
 use crate::services::tmux_common::RotatingJsonlWriter;
 use crate::services::tmux_wrapper::{InputMode, render_for_terminal};
 
@@ -1257,9 +1258,6 @@ mod modern_event_tests {
         CodexWrapperTurnState, emit_schema_drift_result, handle_codex_wrapper_event,
         schema_drift_reason,
     };
-    use crate::services::codex::{
-        CODEX_BACKGROUND_TASK_NOTIFICATION_ID, CODEX_BACKGROUND_TASK_NOTIFICATION_STATUS,
-    };
     use crate::services::tmux_common::RotatingJsonlWriter;
     use serde_json::json;
 
@@ -2211,19 +2209,45 @@ mod modern_event_tests {
         )
         .unwrap();
 
-        let lines = read_jsonl(&path);
-        assert_eq!(lines.len(), 1);
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let raw_lines: Vec<_> = raw.lines().collect();
+        assert_eq!(raw_lines.len(), 2);
         assert_eq!(
-            lines[0],
-            json!({
-                "type": "system",
-                "subtype": "task_notification",
-                "task_id": CODEX_BACKGROUND_TASK_NOTIFICATION_ID,
-                "status": CODEX_BACKGROUND_TASK_NOTIFICATION_STATUS,
-                "summary": "CI green",
-                "task_notification_kind": "background",
-            })
+            raw_lines[0],
+            r#"{"status":"completed","subtype":"task_notification","summary":"CI green","task_id":"codex-background-event","task_notification_kind":"background","type":"system"}"#,
+            "legacy bytes and ordering must remain unchanged"
         );
+        assert_eq!(
+            raw_lines[1],
+            r#"{"type":"system","subtype":"task_completion","schema":"task_completion.v1","producer":"agentdesk.codex_tmux_wrapper","kind":"background","status":"completed","task_id":"codex-background-event","tool_use_id":null}"#
+        );
+        assert!(matches!(
+            crate::services::task_completion_v1::admit_raw(raw_lines[1]),
+            crate::services::task_completion_v1::TaskCompletionV1Admission::TypedCandidate(_)
+        ));
+        assert!(!raw_lines[1].contains("CI green"));
+
+        handle_codex_wrapper_event(
+            &mut output,
+            &json!({
+                "type": "background_event",
+                "message": "<@everyone> [link](https://invalid.example)"
+            }),
+            &mut thread_id,
+            &mut state,
+            std::time::Instant::now(),
+        )
+        .unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let raw_lines: Vec<_> = raw.lines().collect();
+        assert_eq!(raw_lines.len(), 4);
+        assert_ne!(raw_lines[0], raw_lines[2]);
+        assert_eq!(
+            raw_lines[1], raw_lines[3],
+            "provider prose must not affect typed shadow bytes"
+        );
+        assert!(!raw_lines[3].contains("everyone"));
+        assert!(!raw_lines[3].contains("https"));
         assert!(!state.saw_turn_completed);
     }
 
@@ -2380,7 +2404,14 @@ fn handle_background_event(
             "summary": summary,
             "task_notification_kind": "background",
         }),
-    )
+    )?;
+
+    // The typed receipt is a dormant, non-visible shadow. Its declared producer
+    // is not trust authority, and failure must not change the legacy event path.
+    if let Ok(line) = TaskCompletionV1::codex_background_completed().encode_canonical() {
+        let _ = output.write_line(&line);
+    }
+    Ok(())
 }
 
 fn emit_status(message: &str) {

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -122,6 +122,7 @@ pub mod settings;
 pub mod shell_guard;
 pub mod slo;
 pub(crate) mod stale_turn_reconciler;
+pub(crate) mod task_completion_v1;
 // #3034: 1 residual dead-code items; scoped here so the lint stays
 // live on clean sibling modules. Remove during termination_audit dead-code cleanup.
 pub(crate) mod terminal_status_formatting;

--- a/src/services/session_backend/stream_line.rs
+++ b/src/services/session_backend/stream_line.rs
@@ -62,6 +62,14 @@ pub fn process_stream_line(
         return true;
     }
 
+    match crate::services::task_completion_v1::admit_raw(line) {
+        crate::services::task_completion_v1::TaskCompletionV1Admission::Legacy => {}
+        crate::services::task_completion_v1::TaskCompletionV1Admission::TypedCandidate(_)
+        | crate::services::task_completion_v1::TaskCompletionV1Admission::Rejected(_) => {
+            return true;
+        }
+    }
+
     let json = match serde_json::from_str::<Value>(line) {
         Ok(json) => json,
         Err(_) => return true,
@@ -719,6 +727,56 @@ mod tests {
             !forwarded.is_empty(),
             "turn_duration must still reach the bridge as StatusUpdate telemetry"
         );
+    }
+
+    #[test]
+    fn typed_completion_shadow_has_zero_stream_authority_even_on_replay() {
+        let (sender, receiver) = mpsc::channel();
+        let mut state = StreamLineState::new();
+        let typed =
+            crate::services::task_completion_v1::TaskCompletionV1::codex_background_completed()
+                .encode_canonical()
+                .unwrap();
+
+        for _ in 0..4 {
+            assert!(process_stream_line(&typed, &sender, &mut state));
+        }
+
+        assert!(receiver.try_iter().next().is_none());
+        assert_eq!(state, StreamLineState::new());
+    }
+
+    #[test]
+    fn rejected_candidate_is_consumed_without_legacy_downgrade() {
+        let (sender, receiver) = mpsc::channel();
+        let mut state = StreamLineState::new();
+        let rejected = r#"{"type":"system","subtype":"task_completion","schema":"task_completion.v1","producer":"agentdesk.codex_tmux_wrapper","kind":"background","status":"completed","task_id":"codex-background-event","tool_use_id":null,"summary":"must not downgrade"}"#;
+
+        assert!(process_stream_line(rejected, &sender, &mut state));
+        assert!(receiver.try_iter().next().is_none());
+        assert_eq!(state, StreamLineState::new());
+    }
+
+    #[test]
+    fn legacy_plus_typed_emits_one_legacy_notification_only() {
+        let (sender, receiver) = mpsc::channel();
+        let mut state = StreamLineState::new();
+        let legacy = r#"{"type":"system","subtype":"task_notification","task_id":"codex-background-event","status":"completed","summary":"CI green","task_notification_kind":"background"}"#;
+        let typed =
+            crate::services::task_completion_v1::TaskCompletionV1::codex_background_completed()
+                .encode_canonical()
+                .unwrap();
+
+        assert!(process_stream_line(legacy, &sender, &mut state));
+        assert!(process_stream_line(&typed, &sender, &mut state));
+
+        let messages: Vec<_> = receiver.try_iter().collect();
+        assert!(matches!(
+            messages.as_slice(),
+            [StreamMessage::TaskNotification { summary, .. }] if summary == "CI green"
+        ));
+        assert_eq!(state.forwarded_message_count, 1);
+        assert!(state.final_result.is_none());
     }
 
     #[test]

--- a/src/services/task_completion_v1.rs
+++ b/src/services/task_completion_v1.rs
@@ -3,6 +3,8 @@
 //! This module validates shadow receipts only. It does not grant completion,
 //! lifecycle, delivery, or rendering authority.
 
+use icu_properties::props::{BidiControl, DefaultIgnorableCodePoint, GeneralCategory};
+use icu_properties::{CodePointMapData, CodePointSetData};
 use serde::de::{IgnoredAny, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -395,12 +397,16 @@ pub(crate) fn admit_raw(line: &str) -> TaskCompletionV1Admission {
     probe.validate()
 }
 
+fn forbidden_id_character(character: char) -> bool {
+    character.is_whitespace()
+        || character.is_control()
+        || CodePointMapData::<GeneralCategory>::new().get(character) == GeneralCategory::Format
+        || CodePointSetData::new::<DefaultIgnorableCodePoint>().contains(character)
+        || CodePointSetData::new::<BidiControl>().contains(character)
+}
+
 fn valid_id(value: &str) -> bool {
-    !value.is_empty()
-        && value.len() <= MAX_ID_BYTES
-        && !value
-            .chars()
-            .any(|character| character.is_whitespace() || character.is_control())
+    !value.is_empty() && value.len() <= MAX_ID_BYTES && !value.chars().any(forbidden_id_character)
 }
 
 #[cfg(test)]
@@ -543,6 +549,75 @@ mod tests {
     }
 
     #[test]
+    fn unicode_format_default_ignorable_and_bidi_controls_are_rejected_exhaustively() {
+        let general_category = CodePointMapData::<GeneralCategory>::new();
+        let default_ignorable = CodePointSetData::new::<DefaultIgnorableCodePoint>();
+        let bidi_control = CodePointSetData::new::<BidiControl>();
+        let mut covered = 0usize;
+        let mut format_only = 0usize;
+        let mut default_ignorable_only = 0usize;
+
+        for scalar in 0..=char::MAX as u32 {
+            let Some(character) = char::from_u32(scalar) else {
+                continue;
+            };
+            let is_format = general_category.get(character) == GeneralCategory::Format;
+            let is_default_ignorable = default_ignorable.contains(character);
+            let is_bidi_control = bidi_control.contains(character);
+            if is_format || is_default_ignorable || is_bidi_control {
+                covered += 1;
+                format_only += usize::from(is_format && !character.is_control());
+                default_ignorable_only += usize::from(
+                    is_default_ignorable && !character.is_control() && !character.is_whitespace(),
+                );
+                let id = format!("visible{character}suffix");
+                assert!(
+                    !valid_id(&id),
+                    "U+{scalar:04X} must be rejected by the opaque ID profile"
+                );
+            }
+        }
+
+        assert!(
+            covered > 4_000,
+            "expected the full default-ignorable profile"
+        );
+        assert!(format_only > 100, "format predicate must be exercised");
+        assert!(
+            default_ignorable_only > 4_000,
+            "default-ignorable predicate must be exercised beyond controls and whitespace"
+        );
+        for character in ['\u{202e}', '\u{200b}', '\u{feff}', '\u{2066}'] {
+            assert!(forbidden_id_character(character));
+        }
+    }
+
+    #[test]
+    fn format_and_default_ignorable_json_mutations_reject_both_id_fields() {
+        for character in [
+            '\u{00ad}',
+            '\u{034f}',
+            '\u{061c}',
+            '\u{180b}',
+            '\u{200b}',
+            '\u{200e}',
+            '\u{202e}',
+            '\u{2066}',
+            '\u{2069}',
+            '\u{fe00}',
+            '\u{feff}',
+            '\u{e0001}',
+            '\u{e0020}',
+            '\u{e007f}',
+            '\u{e0100}',
+        ] {
+            for key in ["task_id", "tool_use_id"] {
+                assert_rejected(&with_id(key, &format!("opaque{character}id")));
+            }
+        }
+    }
+
+    #[test]
     fn escaped_whitespace_ids_are_rejected_before_value_normalization() {
         for key in ["task_id", "tool_use_id"] {
             for escaped_id in [
@@ -577,6 +652,8 @@ mod tests {
         for id in [
             "task-id_1:segment",
             "opaque.id/@resource+token=1,2;3",
+            "작업-識別子_é:δ",
+            "cafe\u{0301}-नमस्ते",
             exact_ascii.as_str(),
             exact_multibyte.as_str(),
         ] {

--- a/src/services/task_completion_v1.rs
+++ b/src/services/task_completion_v1.rs
@@ -1,0 +1,549 @@
+//! Dormant JSON-only task-completion wire contract for #4912.
+//!
+//! This module validates shadow receipts only. It does not grant completion,
+//! lifecycle, delivery, or rendering authority.
+
+use serde::de::{IgnoredAny, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+const TYPE_LITERAL: &str = "system";
+const SUBTYPE_LITERAL: &str = "task_completion";
+const SCHEMA_LITERAL: &str = "task_completion.v1";
+const CODEX_PRODUCER_LITERAL: &str = "agentdesk.codex_tmux_wrapper";
+const CODEX_BACKGROUND_TASK_ID: &str = "codex-background-event";
+const MAX_ID_BYTES: usize = 256;
+const REQUIRED_FIELDS: [&str; 8] = [
+    "type",
+    "subtype",
+    "schema",
+    "producer",
+    "kind",
+    "status",
+    "task_id",
+    "tool_use_id",
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TaskCompletionKind {
+    Background,
+    Subagent,
+    MonitorAutoTurn,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TaskCompletionStatus {
+    Completed,
+    Failed,
+    Killed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub(crate) enum TaskCompletionProducer {
+    #[serde(rename = "agentdesk.codex_tmux_wrapper")]
+    CodexTmuxWrapper,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub(crate) struct TaskId(String);
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub(crate) struct ToolUseId(String);
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub(crate) struct TaskCompletionV1 {
+    #[serde(rename = "type")]
+    frame_type: &'static str,
+    subtype: &'static str,
+    schema: &'static str,
+    producer: TaskCompletionProducer,
+    kind: TaskCompletionKind,
+    status: TaskCompletionStatus,
+    task_id: TaskId,
+    tool_use_id: Option<ToolUseId>,
+}
+
+impl TaskCompletionV1 {
+    pub(crate) fn codex_background_completed() -> Self {
+        Self {
+            frame_type: TYPE_LITERAL,
+            subtype: SUBTYPE_LITERAL,
+            schema: SCHEMA_LITERAL,
+            producer: TaskCompletionProducer::CodexTmuxWrapper,
+            kind: TaskCompletionKind::Background,
+            status: TaskCompletionStatus::Completed,
+            task_id: TaskId(CODEX_BACKGROUND_TASK_ID.to_string()),
+            tool_use_id: None,
+        }
+    }
+
+    pub(crate) fn encode_canonical(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TaskCompletionV1Rejection {
+    MalformedJson,
+    DuplicateField,
+    UnknownField,
+    MissingField,
+    WrongType,
+    WrongLiteral,
+    MalformedId,
+    TrailingDocument,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TaskCompletionV1Admission {
+    Legacy,
+    TypedCandidate(TaskCompletionV1),
+    Rejected(TaskCompletionV1Rejection),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum CapturedValue {
+    String(String),
+    Null,
+    Other,
+}
+
+impl<'de> Deserialize<'de> for CapturedValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(CapturedValueVisitor)
+    }
+}
+
+struct CapturedValueVisitor;
+
+impl<'de> Visitor<'de> for CapturedValueVisitor {
+    type Value = CapturedValue;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("any JSON value")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(CapturedValue::String(value.to_string()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(CapturedValue::String(value))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(CapturedValue::Null)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(CapturedValue::Null)
+    }
+
+    fn visit_bool<E>(self, _value: bool) -> Result<Self::Value, E> {
+        Ok(CapturedValue::Other)
+    }
+
+    fn visit_i64<E>(self, _value: i64) -> Result<Self::Value, E> {
+        Ok(CapturedValue::Other)
+    }
+
+    fn visit_u64<E>(self, _value: u64) -> Result<Self::Value, E> {
+        Ok(CapturedValue::Other)
+    }
+
+    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E> {
+        Ok(CapturedValue::Other)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        while sequence.next_element::<IgnoredAny>()?.is_some() {}
+        Ok(CapturedValue::Other)
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        while map.next_entry::<IgnoredAny, IgnoredAny>()?.is_some() {}
+        Ok(CapturedValue::Other)
+    }
+}
+
+#[derive(Default)]
+struct AdmissionProbe {
+    fields: HashMap<String, CapturedValue>,
+    duplicate: bool,
+    unknown: bool,
+    saw_object: bool,
+    saw_candidate_marker: bool,
+}
+
+impl AdmissionProbe {
+    fn is_candidate(&self) -> bool {
+        self.saw_candidate_marker
+    }
+
+    fn observe_candidate_marker(&mut self, key: &str, value: &CapturedValue) {
+        let CapturedValue::String(value) = value else {
+            return;
+        };
+        self.saw_candidate_marker |= (key == "schema" && value == SCHEMA_LITERAL)
+            || (key == "subtype" && value == SUBTYPE_LITERAL);
+    }
+
+    fn required_text(&self, key: &str) -> Result<&str, TaskCompletionV1Rejection> {
+        match self.fields.get(key) {
+            Some(CapturedValue::String(value)) => Ok(value),
+            _ => Err(TaskCompletionV1Rejection::WrongType),
+        }
+    }
+
+    fn validate(self) -> TaskCompletionV1Admission {
+        if self.duplicate {
+            return TaskCompletionV1Admission::Rejected(TaskCompletionV1Rejection::DuplicateField);
+        }
+        if self.unknown {
+            return TaskCompletionV1Admission::Rejected(TaskCompletionV1Rejection::UnknownField);
+        }
+        if REQUIRED_FIELDS
+            .iter()
+            .any(|field| !self.fields.contains_key(*field))
+        {
+            return TaskCompletionV1Admission::Rejected(TaskCompletionV1Rejection::MissingField);
+        }
+
+        let frame_type = match self.required_text("type") {
+            Ok(value) => value,
+            Err(reason) => return TaskCompletionV1Admission::Rejected(reason),
+        };
+        let subtype = match self.required_text("subtype") {
+            Ok(value) => value,
+            Err(reason) => return TaskCompletionV1Admission::Rejected(reason),
+        };
+        let schema = match self.required_text("schema") {
+            Ok(value) => value,
+            Err(reason) => return TaskCompletionV1Admission::Rejected(reason),
+        };
+        let producer = match self.required_text("producer") {
+            Ok(value) => value,
+            Err(reason) => return TaskCompletionV1Admission::Rejected(reason),
+        };
+        if frame_type != TYPE_LITERAL
+            || subtype != SUBTYPE_LITERAL
+            || schema != SCHEMA_LITERAL
+            || producer != CODEX_PRODUCER_LITERAL
+        {
+            return TaskCompletionV1Admission::Rejected(TaskCompletionV1Rejection::WrongLiteral);
+        }
+
+        let kind = match self.required_text("kind") {
+            Ok("background") => TaskCompletionKind::Background,
+            Ok("subagent") => TaskCompletionKind::Subagent,
+            Ok("monitor_auto_turn") => TaskCompletionKind::MonitorAutoTurn,
+            Ok(_) => {
+                return TaskCompletionV1Admission::Rejected(
+                    TaskCompletionV1Rejection::WrongLiteral,
+                );
+            }
+            Err(reason) => return TaskCompletionV1Admission::Rejected(reason),
+        };
+        let status = match self.required_text("status") {
+            Ok("completed") => TaskCompletionStatus::Completed,
+            Ok("failed") => TaskCompletionStatus::Failed,
+            Ok("killed") => TaskCompletionStatus::Killed,
+            Ok(_) => {
+                return TaskCompletionV1Admission::Rejected(
+                    TaskCompletionV1Rejection::WrongLiteral,
+                );
+            }
+            Err(reason) => return TaskCompletionV1Admission::Rejected(reason),
+        };
+        let task_id = match self.required_text("task_id") {
+            Ok(value) if valid_id(value) => TaskId(value.to_string()),
+            Ok(_) => {
+                return TaskCompletionV1Admission::Rejected(TaskCompletionV1Rejection::MalformedId);
+            }
+            Err(reason) => return TaskCompletionV1Admission::Rejected(reason),
+        };
+        let tool_use_id = match self.fields.get("tool_use_id") {
+            Some(CapturedValue::Null) => None,
+            Some(CapturedValue::String(value)) if valid_id(value) => Some(ToolUseId(value.clone())),
+            Some(CapturedValue::String(_)) => {
+                return TaskCompletionV1Admission::Rejected(TaskCompletionV1Rejection::MalformedId);
+            }
+            _ => {
+                return TaskCompletionV1Admission::Rejected(TaskCompletionV1Rejection::WrongType);
+            }
+        };
+
+        TaskCompletionV1Admission::TypedCandidate(TaskCompletionV1 {
+            frame_type: TYPE_LITERAL,
+            subtype: SUBTYPE_LITERAL,
+            schema: SCHEMA_LITERAL,
+            producer: TaskCompletionProducer::CodexTmuxWrapper,
+            kind,
+            status,
+            task_id,
+            tool_use_id,
+        })
+    }
+}
+
+struct AdmissionVisitor<'a> {
+    probe: &'a mut AdmissionProbe,
+}
+
+impl<'de> Visitor<'de> for AdmissionVisitor<'_> {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON value")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        self.probe.saw_object = true;
+        let mut decoded_keys = HashSet::new();
+        while let Some(key) = map.next_key::<String>()? {
+            let duplicate = !decoded_keys.insert(key.clone());
+            let known = REQUIRED_FIELDS.contains(&key.as_str());
+            let value = map.next_value::<CapturedValue>()?;
+            self.probe.observe_candidate_marker(&key, &value);
+            if duplicate {
+                self.probe.duplicate = true;
+            }
+            if known {
+                self.probe.fields.entry(key).or_insert(value);
+            } else {
+                self.probe.unknown = true;
+            }
+        }
+        Ok(())
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        while sequence.next_element::<IgnoredAny>()?.is_some() {}
+        Ok(())
+    }
+
+    fn visit_bool<E>(self, _value: bool) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_i64<E>(self, _value: i64) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_u64<E>(self, _value: u64) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(())
+    }
+}
+
+pub(crate) fn admit_raw(line: &str) -> TaskCompletionV1Admission {
+    let mut probe = AdmissionProbe::default();
+    let mut deserializer = serde_json::Deserializer::from_str(line);
+    let parsed = deserializer.deserialize_any(AdmissionVisitor { probe: &mut probe });
+    if parsed.is_err() {
+        return if probe.is_candidate() {
+            TaskCompletionV1Admission::Rejected(TaskCompletionV1Rejection::MalformedJson)
+        } else {
+            TaskCompletionV1Admission::Legacy
+        };
+    }
+    if deserializer.end().is_err() {
+        return if probe.is_candidate() {
+            TaskCompletionV1Admission::Rejected(TaskCompletionV1Rejection::TrailingDocument)
+        } else {
+            TaskCompletionV1Admission::Legacy
+        };
+    }
+    if !probe.saw_object || !probe.is_candidate() {
+        return TaskCompletionV1Admission::Legacy;
+    }
+    probe.validate()
+}
+
+fn valid_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_ID_BYTES
+        && value.trim() == value
+        && !value.chars().any(char::is_control)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn canonical() -> String {
+        TaskCompletionV1::codex_background_completed()
+            .encode_canonical()
+            .unwrap()
+    }
+
+    fn assert_rejected(raw: &str) {
+        assert!(
+            matches!(admit_raw(raw), TaskCompletionV1Admission::Rejected(_)),
+            "expected strict rejection: {raw}"
+        );
+    }
+
+    #[test]
+    fn canonical_round_trip_and_field_permutation() {
+        let frame = TaskCompletionV1::codex_background_completed();
+        assert_eq!(
+            admit_raw(&frame.encode_canonical().unwrap()),
+            TaskCompletionV1Admission::TypedCandidate(frame)
+        );
+        assert!(matches!(
+            admit_raw(
+                r#"{"tool_use_id":null,"task_id":"codex-background-event","status":"completed","kind":"background","producer":"agentdesk.codex_tmux_wrapper","schema":"task_completion.v1","subtype":"task_completion","type":"system"}"#
+            ),
+            TaskCompletionV1Admission::TypedCandidate(_)
+        ));
+    }
+
+    #[test]
+    fn duplicate_and_escaped_duplicate_keys_are_rejected() {
+        for key in REQUIRED_FIELDS {
+            let raw = canonical();
+            let value = serde_json::from_str::<Value>(&raw).unwrap()[key].clone();
+            let insertion = format!(",\"{key}\":{value}");
+            assert_rejected(&raw.replacen('}', &format!("{insertion}}}"), 1));
+        }
+        assert_rejected(
+            r#"{"type":"system","subtype":"task_completion","schema":"task_completion.v1","producer":"agentdesk.codex_tmux_wrapper","kind":"background","status":"completed","status":"completed","task_id":"codex-background-event","tool_use_id":null}"#,
+        );
+        let escaped_duplicate = canonical().replacen(
+            "\"status\":\"completed\"",
+            "\"status\":\"completed\",\"sta\\u0074us\":\"completed\"",
+            1,
+        );
+        assert_rejected(&escaped_duplicate);
+    }
+
+    #[test]
+    fn missing_and_unknown_field_mutations_are_rejected() {
+        let value = serde_json::from_str::<Value>(&canonical()).unwrap();
+        for key in REQUIRED_FIELDS {
+            let mut mutated = value.clone();
+            mutated.as_object_mut().unwrap().remove(key);
+            assert_rejected(&mutated.to_string());
+        }
+        for key in [
+            "summary",
+            "result",
+            "label",
+            "description",
+            "url",
+            "<@user>",
+        ] {
+            let mut mutated = value.clone();
+            mutated[key] = Value::String("untrusted".to_string());
+            assert_rejected(&mutated.to_string());
+        }
+    }
+
+    #[test]
+    fn literal_enum_and_type_mutations_are_rejected() {
+        let base = serde_json::from_str::<Value>(&canonical()).unwrap();
+        for (key, value) in [
+            ("type", "System"),
+            ("subtype", "task-completion"),
+            ("schema", "task_completion.V1"),
+            ("producer", "codex"),
+            ("kind", "Background"),
+            ("status", "success"),
+        ] {
+            let mut mutated = base.clone();
+            mutated[key] = Value::String(value.to_string());
+            assert_rejected(&mutated.to_string());
+        }
+        for key in [
+            "type", "subtype", "schema", "producer", "kind", "status", "task_id",
+        ] {
+            let mut mutated = base.clone();
+            mutated[key] = Value::Bool(true);
+            if key == "schema" {
+                mutated["subtype"] = Value::String(SUBTYPE_LITERAL.to_string());
+            }
+            if key == "subtype" {
+                mutated["schema"] = Value::String(SCHEMA_LITERAL.to_string());
+            }
+            assert_rejected(&mutated.to_string());
+        }
+        let mut mutated = base;
+        mutated["tool_use_id"] = Value::Bool(true);
+        assert_rejected(&mutated.to_string());
+    }
+
+    #[test]
+    fn malformed_ids_are_rejected() {
+        let base = serde_json::from_str::<Value>(&canonical()).unwrap();
+        let oversized = "x".repeat(257);
+        for id in [
+            "",
+            " leading",
+            "trailing ",
+            "line\nbreak",
+            oversized.as_str(),
+        ] {
+            for key in ["task_id", "tool_use_id"] {
+                let mut mutated = base.clone();
+                mutated[key] = Value::String(id.to_string());
+                assert_rejected(&mutated.to_string());
+            }
+        }
+    }
+
+    #[test]
+    fn trailing_truncated_and_legacy_inputs_do_not_downgrade_candidates() {
+        assert_rejected(&format!("{} {{}}", canonical()));
+        assert_rejected(
+            r#"{"type":"system","subtype":"task_completion","schema":"task_completion.v1""#,
+        );
+        assert_rejected(
+            r#"{"schema":"task_completion.v1","schema":"other","type":"system","subtype":"task_notification","producer":"agentdesk.codex_tmux_wrapper","kind":"background","status":"completed","task_id":"codex-background-event","tool_use_id":null}"#,
+        );
+        assert!(matches!(
+            admit_raw(r#"{"type":"system","subtype":"task_notification","summary":"legacy"}"#),
+            TaskCompletionV1Admission::Legacy
+        ));
+        assert!(matches!(
+            admit_raw("<task-notification>legacy</task-notification>"),
+            TaskCompletionV1Admission::Legacy
+        ));
+    }
+}

--- a/src/services/task_completion_v1.rs
+++ b/src/services/task_completion_v1.rs
@@ -398,8 +398,9 @@ pub(crate) fn admit_raw(line: &str) -> TaskCompletionV1Admission {
 fn valid_id(value: &str) -> bool {
     !value.is_empty()
         && value.len() <= MAX_ID_BYTES
-        && value.trim() == value
-        && !value.chars().any(char::is_control)
+        && !value
+            .chars()
+            .any(|character| character.is_whitespace() || character.is_control())
 }
 
 #[cfg(test)]
@@ -418,6 +419,12 @@ mod tests {
             matches!(admit_raw(raw), TaskCompletionV1Admission::Rejected(_)),
             "expected strict rejection: {raw}"
         );
+    }
+
+    fn with_id(key: &str, id: &str) -> String {
+        let mut mutated = serde_json::from_str::<Value>(&canonical()).unwrap();
+        mutated[key] = Value::String(id.to_string());
+        mutated.to_string()
     }
 
     #[test]
@@ -510,20 +517,77 @@ mod tests {
     }
 
     #[test]
-    fn malformed_ids_are_rejected() {
-        let base = serde_json::from_str::<Value>(&canonical()).unwrap();
-        let oversized = "x".repeat(257);
+    fn whitespace_controls_and_oversized_ids_are_rejected_for_both_id_fields() {
+        let oversized_ascii = "x".repeat(MAX_ID_BYTES + 1);
+        let oversized_multibyte = format!("{}x", "é".repeat(MAX_ID_BYTES / 2));
         for id in [
             "",
             " leading",
             "trailing ",
+            "internal space",
+            "internal\ttab",
             "line\nbreak",
-            oversized.as_str(),
+            "non\u{00a0}breaking",
+            "em\u{2003}space",
+            "narrow\u{202f}no-break",
+            "ideographic\u{3000}space",
+            "control\u{0007}bell",
+            "control\u{007f}delete",
+            oversized_ascii.as_str(),
+            oversized_multibyte.as_str(),
         ] {
             for key in ["task_id", "tool_use_id"] {
-                let mut mutated = base.clone();
-                mutated[key] = Value::String(id.to_string());
-                assert_rejected(&mutated.to_string());
+                assert_rejected(&with_id(key, id));
+            }
+        }
+    }
+
+    #[test]
+    fn escaped_whitespace_ids_are_rejected_before_value_normalization() {
+        for key in ["task_id", "tool_use_id"] {
+            for escaped_id in [
+                r#""internal space""#,
+                r#""internal\ttab""#,
+                r#""line\nbreak""#,
+                r#""non breaking""#,
+                r#""em space""#,
+            ] {
+                let canonical = canonical();
+                let raw = canonical.replacen(
+                    &format!(
+                        "\"{key}\":{}",
+                        if key == "task_id" {
+                            r#""codex-background-event""#
+                        } else {
+                            "null"
+                        }
+                    ),
+                    &format!("\"{key}\":{escaped_id}"),
+                    1,
+                );
+                assert_rejected(&raw);
+            }
+        }
+    }
+
+    #[test]
+    fn opaque_punctuation_and_utf8_byte_bound_are_admitted_for_both_id_fields() {
+        let exact_ascii = "x".repeat(MAX_ID_BYTES);
+        let exact_multibyte = "é".repeat(MAX_ID_BYTES / 2);
+        for id in [
+            "task-id_1:segment",
+            "opaque.id/@resource+token=1,2;3",
+            exact_ascii.as_str(),
+            exact_multibyte.as_str(),
+        ] {
+            for key in ["task_id", "tool_use_id"] {
+                assert!(
+                    matches!(
+                        admit_raw(&with_id(key, id)),
+                        TaskCompletionV1Admission::TypedCandidate(_)
+                    ),
+                    "expected opaque id admission for {key}: {id:?}"
+                );
             }
         }
     }

--- a/src/services/task_completion_v1.rs
+++ b/src/services/task_completion_v1.rs
@@ -548,45 +548,86 @@ mod tests {
         }
     }
 
+    // Unicode 16.0 / ICU4X 2.1.2 golden fingerprints. Each SHA-256 hashes the
+    // sorted member scalars as four-byte big-endian integers. Regenerate these
+    // literals only during an intentional Unicode profile upgrade.
+    const FORMAT_GOLDEN: (usize, &str) = (
+        170,
+        "9b8328757c21f609db32f87ac55fb30060408c243041aa9ff602d8d79db0f471",
+    );
+    const DEFAULT_IGNORABLE_GOLDEN: (usize, &str) = (
+        4_174,
+        "af2bc3d9df7efe853444acbdac7278d97dea892bc187b24b50cca7e452f3077a",
+    );
+    const BIDI_CONTROL_GOLDEN: (usize, &str) = (
+        12,
+        "66619508d89567de1a781280be43dcf7522f806066355a6f9b80811d195c13d2",
+    );
+    const REJECTED_UNION_GOLDEN: (usize, &str) = (
+        4_206,
+        "35739b1ac598a2cc0e26a7ed6b92e96d24a65e63746f02fda41503060a0a4991",
+    );
+
+    fn property_scalars(predicate: impl Fn(char) -> bool) -> Vec<char> {
+        (0..=char::MAX as u32)
+            .filter_map(char::from_u32)
+            .filter(|character| predicate(*character))
+            .collect()
+    }
+
+    fn scalar_fingerprint(scalars: &[char]) -> String {
+        use sha2::{Digest, Sha256};
+
+        let mut digest = Sha256::new();
+        for character in scalars {
+            digest.update((*character as u32).to_be_bytes());
+        }
+        hex::encode(digest.finalize())
+    }
+
+    fn assert_golden_set(label: &str, scalars: &[char], golden: (usize, &str)) {
+        assert_eq!(
+            (scalars.len(), scalar_fingerprint(scalars)),
+            (golden.0, golden.1.to_string()),
+            "{label} Unicode 16.0 fingerprint drifted"
+        );
+    }
+
     #[test]
-    fn unicode_format_default_ignorable_and_bidi_controls_are_rejected_exhaustively() {
+    fn unicode_property_sets_match_pinned_unicode_16_golden_and_raw_admission_rejects_union() {
         let general_category = CodePointMapData::<GeneralCategory>::new();
         let default_ignorable = CodePointSetData::new::<DefaultIgnorableCodePoint>();
         let bidi_control = CodePointSetData::new::<BidiControl>();
-        let mut covered = 0usize;
-        let mut format_only = 0usize;
-        let mut default_ignorable_only = 0usize;
 
-        for scalar in 0..=char::MAX as u32 {
-            let Some(character) = char::from_u32(scalar) else {
-                continue;
-            };
-            let is_format = general_category.get(character) == GeneralCategory::Format;
-            let is_default_ignorable = default_ignorable.contains(character);
-            let is_bidi_control = bidi_control.contains(character);
-            if is_format || is_default_ignorable || is_bidi_control {
-                covered += 1;
-                format_only += usize::from(is_format && !character.is_control());
-                default_ignorable_only += usize::from(
-                    is_default_ignorable && !character.is_control() && !character.is_whitespace(),
-                );
-                let id = format!("visible{character}suffix");
-                assert!(
-                    !valid_id(&id),
-                    "U+{scalar:04X} must be rejected by the opaque ID profile"
-                );
+        let format = property_scalars(|character| {
+            general_category.get(character) == GeneralCategory::Format
+        });
+        let default_ignorable = property_scalars(|character| default_ignorable.contains(character));
+        let bidi_control = property_scalars(|character| bidi_control.contains(character));
+        let rejected_union = property_scalars(|character| {
+            general_category.get(character) == GeneralCategory::Format
+                || CodePointSetData::new::<DefaultIgnorableCodePoint>().contains(character)
+                || CodePointSetData::new::<BidiControl>().contains(character)
+        });
+
+        assert_golden_set("General_Category=Format", &format, FORMAT_GOLDEN);
+        assert_golden_set(
+            "Default_Ignorable_Code_Point",
+            &default_ignorable,
+            DEFAULT_IGNORABLE_GOLDEN,
+        );
+        assert_golden_set("Bidi_Control", &bidi_control, BIDI_CONTROL_GOLDEN);
+        assert_golden_set("rejected union", &rejected_union, REJECTED_UNION_GOLDEN);
+
+        for character in rejected_union {
+            for key in ["task_id", "tool_use_id"] {
+                assert_rejected(&with_id(key, &format!("visible{character}suffix")));
             }
         }
+    }
 
-        assert!(
-            covered > 4_000,
-            "expected the full default-ignorable profile"
-        );
-        assert!(format_only > 100, "format predicate must be exercised");
-        assert!(
-            default_ignorable_only > 4_000,
-            "default-ignorable predicate must be exercised beyond controls and whitespace"
-        );
+    #[test]
+    fn explicit_invisible_unicode_witnesses_hit_the_production_predicate() {
         for character in ['\u{202e}', '\u{200b}', '\u{feff}', '\u{2066}'] {
             assert!(forbidden_id_character(character));
         }

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -22,6 +22,7 @@ BUSY_RETRY_4888_TEST_COMMAND = (
 # update this test deliberately. The duplication is a drift-prevention gate, not an
 # attempt to derive the expected coverage from the justfile under test.
 EXPECTED_TEST_NON_PG_COMMANDS = (
+    "cargo test --lib services::task_completion_v1::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib source_registry -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib task_notification -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib delivery_lease_key -- --skip _pg --skip pg_ --skip postgres",


### PR DESCRIPTION
## Summary
- add a strict JSON-only `task_completion.v1` codec/admission layer with decoded duplicate-key, unknown/missing field, closed literal/type, trailing-document, and opaque-ID validation
- emit a Codex-owned `background + completed` typed shadow immediately after the byte-stable legacy task-notification frame
- consume valid and rejected typed candidates before `serde_json::Value` conversion with zero `StreamMessage`, terminal, status, lifecycle, outbox, or Discord authority

## Invariants
- dormant foundation only: no feature gate or authority activation
- `producer` is declared provenance only, never trust authority
- no XML parser/comparison/authority and no free-form summary/result/status fields in the typed schema
- typed shadow failures cannot turn a successful legacy emission into failure
- legacy + typed yields exactly one existing legacy task notification; typed replay remains side-effect free
- excludes #4931 watcher hotfiles, #4874 queue surfaces, #4891 status journal, #4916 lifecycle schema, and Discord delivery/card/outbox surfaces

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo check --lib`
- [x] `cargo test --lib task_completion_v1 -- --nocapture`
- [x] `cargo test --lib background_event_emits_task_notification_marker -- --nocapture`
- [x] `cargo test --lib typed_completion_shadow -- --nocapture`
- [x] `cargo test --lib rejected_candidate_is_consumed_without_legacy_downgrade -- --nocapture`
- [x] `cargo test --lib legacy_plus_typed_emits_one_legacy_notification_only -- --nocapture`
- [x] `python3 scripts/generate_inventory_docs.py`
- [x] `python3 scripts/check_agent_maintenance_docs.py`

References #4912. This PR implements Task #29 Slice 1 without activating completion authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)