### PR TITLE
fix(#4874): coordinate local slash queue wakes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -639,6 +639,8 @@ src/
 │   │   │   ├── memory_guidance.rs
 │   │   │   ├── mod.rs
 │   │   │   └── section_dedupe.rs
+│   │   ├── queue_io/
+│   │   │   └── deferred_worker_state.rs
 │   │   ├── recovery_engine/
 │   │   │   ├── manual_rebind/
 │   │   │   │   ├── adoption.rs

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -460,9 +460,11 @@ mod last_message_checkpoint_tests {
     }
 }
 
+pub(in crate::services) use queue_io::deferred_worker_state::DeferredIdleQueueEntry;
 pub(in crate::services::discord) use queue_io::{
     arm_slow_idle_queue_backstop_if_queue_nonempty, schedule_deferred_idle_queue_kickoff,
-    schedule_deferred_idle_queue_kickoff_immediate, spawn_turn_completion_idle_queue_listener,
+    schedule_deferred_idle_queue_kickoff_immediate, schedule_local_only_slash_idle_queue_kickoff,
+    spawn_turn_completion_idle_queue_listener,
 };
 pub(super) fn single_message_panel_enabled() -> bool {
     single_message_panel::enabled()

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -11,13 +11,14 @@ use super::*;
 struct DeferredHookBacklogGuard {
     shared: Arc<SharedData>,
     channel_id: ChannelId,
+    entry: Arc<DeferredIdleQueueEntry>,
     active: bool,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct IdleQueueBackstopRearm {
-    backlog_units: usize,
-}
+pub(in crate::services) mod deferred_worker_state;
+use self::deferred_worker_state::{
+    DeferredIdleQueueEntry, DeferredIdleQueuePhase, DeferredIdleQueueWaitOutcome,
+};
 
 const DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY: std::time::Duration =
     std::time::Duration::from_secs(2);
@@ -27,6 +28,9 @@ const IDLE_QUEUE_BACKSTOP_WARN_TARGET: &str = "agentdesk::discord::idle_queue_ba
 #[cfg(test)]
 static IDLE_QUEUE_BACKSTOP_FIRES_FOR_TESTS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
+#[cfg(test)]
+static PANIC_DEFERRED_IDLE_QUEUE_WORKER_FOR_TESTS: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 tokio::task_local! {
     static SUPPRESS_POST_ENQUEUE_IDLE_QUEUE_KICK: bool;
@@ -185,7 +189,7 @@ impl DeferredIdleQueueKickoffProfile {
         }
     }
 
-    fn wakes_existing_task(self) -> bool {
+    fn is_immediate(self) -> bool {
         matches!(self, Self::ImmediateOnce)
     }
 }
@@ -233,7 +237,36 @@ fn idle_queue_snapshot_has_raw_rearm_backlog(
 
 impl Drop for DeferredHookBacklogGuard {
     fn drop(&mut self) {
+        let panicked = self.active;
+        let shared = self.shared.clone();
+        let channel_id = self.channel_id;
         self.release();
+        if panicked
+            && !shared
+                .restart
+                .shutting_down
+                .load(std::sync::atomic::Ordering::Acquire)
+        {
+            super::task_supervisor::spawn_observed("deferred_idle_queue_panic_rearm", async move {
+                let provider = shared.provider.clone();
+                let snapshot = super::mailbox_snapshot(shared.as_ref(), channel_id).await;
+                let backlog_units = idle_queue_backstop_backlog_units(
+                    shared.as_ref(),
+                    &provider,
+                    channel_id,
+                    &snapshot,
+                );
+                if backlog_units > 0 {
+                    schedule_single_slow_idle_queue_backstop(
+                        shared,
+                        provider,
+                        channel_id,
+                        "panic_recovery",
+                        backlog_units,
+                    );
+                }
+            });
+        }
     }
 }
 
@@ -242,16 +275,21 @@ impl DeferredHookBacklogGuard {
         if !self.active {
             return false;
         }
-        self.shared
+        self.entry.set_phase(DeferredIdleQueuePhase::Releasing);
+        let removed = self
+            .shared
             .restart
             .deferred_hook_channels
-            .remove(&self.channel_id);
+            .remove_if(&self.channel_id, |_, current| {
+                Arc::ptr_eq(current, &self.entry) && current.worker_epoch == self.entry.worker_epoch
+            })
+            .is_some();
         self.shared
             .restart
             .deferred_hook_backlog
             .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
         self.active = false;
-        true
+        removed
     }
 }
 
@@ -285,6 +323,19 @@ pub(super) fn schedule_deferred_idle_queue_kickoff_immediate(
         channel_id,
         reason,
         DeferredIdleQueueKickoffProfile::ImmediateOnce,
+    );
+}
+
+pub(super) fn schedule_local_only_slash_idle_queue_kickoff(
+    shared: Arc<SharedData>,
+    provider: ProviderKind,
+    channel_id: ChannelId,
+) {
+    schedule_deferred_idle_queue_kickoff_immediate(
+        shared,
+        provider,
+        channel_id,
+        "local_only_slash_observation",
     );
 }
 
@@ -494,50 +545,105 @@ async fn idle_queue_backstop_backlog_units_all(
         .sum()
 }
 
-async fn run_single_slow_idle_queue_backstop(
+async fn wait_for_deferred_idle_queue_delay(
+    entry: &DeferredIdleQueueEntry,
+    delay: std::time::Duration,
+) -> DeferredIdleQueueWaitOutcome {
+    let deadline = tokio::time::Instant::now() + delay;
+    loop {
+        if entry.observe_pending_request() {
+            return DeferredIdleQueueWaitOutcome::Immediate;
+        }
+        let notified = entry.notify.notified();
+        if entry.observe_pending_request() {
+            return DeferredIdleQueueWaitOutcome::Immediate;
+        }
+        tokio::select! {
+            _ = tokio::time::sleep_until(deadline) => {
+                return DeferredIdleQueueWaitOutcome::Deadline;
+            }
+            _ = notified => {
+                if entry.observe_pending_request() {
+                    return DeferredIdleQueueWaitOutcome::Immediate;
+                }
+            }
+        }
+    }
+}
+
+async fn deferred_idle_queue_worker(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: ChannelId,
     reason: &'static str,
-) -> Option<IdleQueueBackstopRearm> {
-    tokio::time::sleep(DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY).await;
-    let snapshot = super::mailbox_snapshot(shared.as_ref(), channel_id).await;
-    let backlog_units =
-        idle_queue_backstop_backlog_units(shared.as_ref(), provider, channel_id, &snapshot);
-    if backlog_units == 0 {
-        return None;
+    profile: DeferredIdleQueueKickoffProfile,
+    entry: &DeferredIdleQueueEntry,
+) {
+    entry.set_phase(DeferredIdleQueuePhase::InitialDelay);
+    let initial_wait = profile.initial_presleep();
+    if initial_wait.is_zero() {
+        let _ = entry.observe_pending_request();
+    } else {
+        let _ = wait_for_deferred_idle_queue_delay(entry, initial_wait).await;
     }
 
-    emit_idle_queue_backstop_warn(
-        provider,
-        Some(channel_id),
-        reason,
-        backlog_units,
-        "channel_backstop",
-    );
-    let _outcome =
+    if shared
+        .restart
+        .shutting_down
+        .load(std::sync::atomic::Ordering::Acquire)
+    {
+        return;
+    }
+
+    entry.set_phase(DeferredIdleQueuePhase::Kicking);
+    let _ =
         kick_idle_queue_channel_if_context_available(shared, provider, channel_id, reason).await;
+    entry.coalesce_requests_during_kick();
 
-    // #4270 — decide the re-arm from the ACTUAL post-kick mailbox state, not
-    // from the kick's `started` flag. A kickoff can report `started == true`
-    // without a real turn owning the slot: the pre-claim readiness gate (#4270 A)
-    // re-preserves a still-busy hosted-TUI follow-up and returns `Ok`, so the
-    // kickoff reports `started` while the message is merely back in the queue.
-    // The previous `if outcome.started { return None; }` short-circuit then
-    // dropped this backstop (and the gate's own re-arm had coalesced onto this
-    // very still-registered task), stranding the follow-up with no fail-open net
-    // until the watcher-idle edge — a #4247-class lost-wakeup. Re-checking the
-    // real state below is strictly more precise: a genuinely started turn now
-    // owns the slot (`blocked_by_real_turn`) and still suppresses the successor,
-    // while a defer/no-start that leaves un-drained backlog re-arms as intended.
-    let snapshot = super::mailbox_snapshot(shared.as_ref(), channel_id).await;
-    let backlog_units =
-        idle_queue_backstop_backlog_units(shared.as_ref(), provider, channel_id, &snapshot);
-    if backlog_units == 0 || idle_queue_snapshot_blocked_by_real_turn(&snapshot) {
-        return None;
+    loop {
+        let snapshot = super::mailbox_snapshot(shared.as_ref(), channel_id).await;
+        if idle_queue_backstop_backlog_units(shared.as_ref(), provider, channel_id, &snapshot) == 0
+            || idle_queue_snapshot_blocked_by_real_turn(&snapshot)
+            || shared
+                .restart
+                .shutting_down
+                .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return;
+        }
+
+        entry.set_phase(DeferredIdleQueuePhase::BackstopWait);
+        let wait_outcome =
+            wait_for_deferred_idle_queue_delay(entry, DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY).await;
+        if shared
+            .restart
+            .shutting_down
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return;
+        }
+
+        let snapshot = super::mailbox_snapshot(shared.as_ref(), channel_id).await;
+        let backlog_units =
+            idle_queue_backstop_backlog_units(shared.as_ref(), provider, channel_id, &snapshot);
+        if backlog_units == 0 || idle_queue_snapshot_blocked_by_real_turn(&snapshot) {
+            return;
+        }
+        if matches!(wait_outcome, DeferredIdleQueueWaitOutcome::Deadline) {
+            emit_idle_queue_backstop_warn(
+                provider,
+                Some(channel_id),
+                reason,
+                backlog_units,
+                "channel_backstop",
+            );
+        }
+
+        entry.set_phase(DeferredIdleQueuePhase::BackstopKicking);
+        let _ = kick_idle_queue_channel_if_context_available(shared, provider, channel_id, reason)
+            .await;
+        entry.coalesce_requests_during_kick();
     }
-
-    Some(IdleQueueBackstopRearm { backlog_units })
 }
 
 fn schedule_single_slow_idle_queue_backstop(
@@ -547,43 +653,134 @@ fn schedule_single_slow_idle_queue_backstop(
     reason: &'static str,
     backlog_units: usize,
 ) -> bool {
-    match shared.restart.deferred_hook_channels.entry(channel_id) {
-        dashmap::mapref::entry::Entry::Occupied(_) => {
-            tracing::debug!(
-                provider = provider.as_str(),
-                channel_id = channel_id.get(),
-                reason,
-                backlog_units,
-                "Idle queue slow backstop already active for channel; coalescing event-path no-start"
-            );
-            return false;
-        }
-        dashmap::mapref::entry::Entry::Vacant(entry) => {
-            entry.insert(Arc::new(tokio::sync::Notify::new()));
+    schedule_deferred_idle_queue_worker(
+        shared,
+        provider,
+        channel_id,
+        reason,
+        DeferredIdleQueueKickoffProfile::Normal,
+        Some(DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY),
+        backlog_units,
+    )
+}
+
+fn schedule_deferred_idle_queue_worker(
+    shared: Arc<SharedData>,
+    provider: ProviderKind,
+    channel_id: ChannelId,
+    reason: &'static str,
+    profile: DeferredIdleQueueKickoffProfile,
+    first_delay_override: Option<std::time::Duration>,
+    backlog_units: usize,
+) -> bool {
+    if shared
+        .restart
+        .shutting_down
+        .load(std::sync::atomic::Ordering::Acquire)
+    {
+        return false;
+    }
+
+    let entry = loop {
+        match shared.restart.deferred_hook_channels.entry(channel_id) {
+            dashmap::mapref::entry::Entry::Occupied(slot) => {
+                let entry = slot.get().clone();
+                let phase = entry.phase();
+                let accepted = !profile.is_immediate() || entry.request_immediate();
+                drop(slot);
+                if accepted {
+                    tracing::debug!(
+                        provider = provider.as_str(),
+                        channel_id = channel_id.get(),
+                        reason,
+                        backlog_units,
+                        immediate = profile.is_immediate(),
+                        phase = ?phase,
+                        worker_epoch = entry.worker_epoch,
+                        "Deferred drain worker already active for channel; coalescing request"
+                    );
+                    return false;
+                }
+                let _ =
+                    shared
+                        .restart
+                        .deferred_hook_channels
+                        .remove_if(&channel_id, |_, current| {
+                            Arc::ptr_eq(current, &entry)
+                                && current.worker_epoch == entry.worker_epoch
+                        });
+            }
+            dashmap::mapref::entry::Entry::Vacant(slot) => {
+                let entry = Arc::new(DeferredIdleQueueEntry::new(profile.is_immediate()));
+                slot.insert(entry.clone());
+                break entry;
+            }
         }
     };
+
     shared
         .restart
         .deferred_hook_backlog
         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    super::task_supervisor::spawn_observed("event_idle_queue_backstop", async move {
+    super::task_supervisor::spawn_observed("deferred_idle_queue_worker", async move {
         let mut backlog_guard = DeferredHookBacklogGuard {
             shared: shared.clone(),
             channel_id,
+            entry: entry.clone(),
             active: true,
         };
-        let rearm =
-            run_single_slow_idle_queue_backstop(&shared, &provider, channel_id, reason).await;
-        backlog_guard.release();
-        if let Some(rearm) = rearm {
-            schedule_single_slow_idle_queue_backstop(
-                shared,
-                provider,
-                channel_id,
-                reason,
-                rearm.backlog_units,
-            );
+        #[cfg(test)]
+        if PANIC_DEFERRED_IDLE_QUEUE_WORKER_FOR_TESTS
+            .swap(false, std::sync::atomic::Ordering::AcqRel)
+        {
+            panic!("deferred idle queue worker test panic");
         }
+        let worker_profile = match first_delay_override {
+            Some(delay) if delay == DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY => {
+                entry.set_phase(DeferredIdleQueuePhase::BackstopWait);
+                let wait = wait_for_deferred_idle_queue_delay(&entry, delay).await;
+                if shared
+                    .restart
+                    .shutting_down
+                    .load(std::sync::atomic::Ordering::Acquire)
+                {
+                    backlog_guard.release();
+                    return;
+                }
+                let snapshot = super::mailbox_snapshot(shared.as_ref(), channel_id).await;
+                let units = idle_queue_backstop_backlog_units(
+                    shared.as_ref(),
+                    &provider,
+                    channel_id,
+                    &snapshot,
+                );
+                if units == 0 {
+                    backlog_guard.release();
+                    return;
+                }
+                if matches!(wait, DeferredIdleQueueWaitOutcome::Deadline) {
+                    emit_idle_queue_backstop_warn(
+                        &provider,
+                        Some(channel_id),
+                        reason,
+                        units,
+                        "channel_backstop",
+                    );
+                }
+                DeferredIdleQueueKickoffProfile::ImmediateOnce
+            }
+            _ => profile,
+        };
+        deferred_idle_queue_worker(
+            &shared,
+            &provider,
+            channel_id,
+            reason,
+            worker_profile,
+            &entry,
+        )
+        .await;
+        backlog_guard.release();
     });
     true
 }
@@ -724,60 +921,8 @@ fn schedule_deferred_idle_queue_kickoff_inner(
     reason: &'static str,
     profile: DeferredIdleQueueKickoffProfile,
 ) {
-    match shared.restart.deferred_hook_channels.entry(channel_id) {
-        dashmap::mapref::entry::Entry::Occupied(entry) => {
-            if profile.wakes_existing_task() {
-                entry.get().notify_one();
-            }
-            tracing::debug!(
-                provider = provider.as_str(),
-                channel_id = channel_id.get(),
-                reason,
-                immediate = matches!(profile, DeferredIdleQueueKickoffProfile::ImmediateOnce),
-                wake_existing = profile.wakes_existing_task(),
-                "Deferred drain: kickoff already active for channel; coalescing duplicate request"
-            );
-            return;
-        }
-        dashmap::mapref::entry::Entry::Vacant(entry) => {
-            entry.insert(Arc::new(tokio::sync::Notify::new()));
-        }
-    };
-    shared
-        .restart
-        .deferred_hook_backlog
-        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    super::task_supervisor::spawn_observed("deferred_idle_queue_kickoff", async move {
-        // #2044 F3: bind the decrement to a Drop guard so it fires on
-        // panic-unwind as well as on normal return.
-        let mut backlog_guard = DeferredHookBacklogGuard {
-            shared: shared.clone(),
-            channel_id,
-            active: true,
-        };
-
-        let initial_presleep = profile.initial_presleep();
-        if !initial_presleep.is_zero() {
-            tokio::time::sleep(initial_presleep).await;
-        }
-
-        let _ =
-            kick_idle_queue_channel_if_context_available(&shared, &provider, channel_id, reason)
-                .await;
-
-        let rearm =
-            run_single_slow_idle_queue_backstop(&shared, &provider, channel_id, reason).await;
-        backlog_guard.release();
-        if let Some(rearm) = rearm {
-            schedule_single_slow_idle_queue_backstop(
-                shared,
-                provider,
-                channel_id,
-                reason,
-                rearm.backlog_units,
-            );
-        }
-    });
+    let _ =
+        schedule_deferred_idle_queue_worker(shared, provider, channel_id, reason, profile, None, 0);
 }
 
 #[cfg(test)]
@@ -1015,11 +1160,11 @@ mod presleep_tests {
         let shared = make_shared_data_for_tests();
         let provider = ProviderKind::Claude;
         let channel_id = ChannelId::new(4_024_281);
-        let notify = Arc::new(tokio::sync::Notify::new());
+        let entry = Arc::new(DeferredIdleQueueEntry::new(false));
         shared
             .restart
             .deferred_hook_channels
-            .insert(channel_id, notify.clone());
+            .insert(channel_id, entry.clone());
 
         schedule_deferred_idle_queue_kickoff_immediate(
             shared,
@@ -1028,9 +1173,255 @@ mod presleep_tests {
             "coalesced-immediate-test",
         );
 
-        tokio::time::timeout(std::time::Duration::from_millis(1), notify.notified())
+        tokio::time::timeout(std::time::Duration::from_millis(1), entry.notify.notified())
             .await
             .expect("immediate coalesce should wake the existing task");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn immediate_request_published_before_first_poll_is_observed() {
+        let entry = DeferredIdleQueueEntry::new(true);
+
+        assert_eq!(
+            wait_for_deferred_idle_queue_delay(&entry, DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY,)
+                .await,
+            DeferredIdleQueueWaitOutcome::Immediate,
+            "entry publication must not initialize observed epoch from the pending request",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn normal_initial_delay_is_interrupted_by_immediate_request() {
+        let entry = Arc::new(DeferredIdleQueueEntry::new(false));
+        let waiter = tokio::spawn({
+            let entry = entry.clone();
+            async move {
+                wait_for_deferred_idle_queue_delay(
+                    &entry,
+                    DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY,
+                )
+                .await
+            }
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::from_secs(1)).await;
+        assert!(entry.request_immediate());
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            waiter.await.expect("waiter task"),
+            DeferredIdleQueueWaitOutcome::Immediate,
+            "an immediate request must interrupt the normal two-second delay",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stale_notify_permit_does_not_interrupt_epoch_wait() {
+        let entry = Arc::new(DeferredIdleQueueEntry::new(false));
+        entry.notify.notify_one();
+        let waiter = tokio::spawn({
+            let entry = entry.clone();
+            async move {
+                wait_for_deferred_idle_queue_delay(
+                    &entry,
+                    DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY,
+                )
+                .await
+            }
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !waiter.is_finished(),
+            "a stale Notify permit is not authority"
+        );
+
+        tokio::time::advance(DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY).await;
+        assert_eq!(
+            waiter.await.expect("waiter task"),
+            DeferredIdleQueueWaitOutcome::Deadline,
+        );
+    }
+
+    #[test]
+    fn kick_phase_burst_coalesces_without_arming_a_second_epoch() {
+        let entry = DeferredIdleQueueEntry::new(false);
+        entry.set_phase(DeferredIdleQueuePhase::Kicking);
+        for _ in 0..32 {
+            assert!(entry.request_immediate());
+        }
+        assert_eq!(
+            entry
+                .coalesced_epoch
+                .load(std::sync::atomic::Ordering::Acquire),
+            32,
+        );
+        assert_eq!(
+            entry
+                .requested_epoch
+                .load(std::sync::atomic::Ordering::Acquire),
+            0,
+            "requests during the admitted kick must not schedule a duplicate kick",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn backstop_wait_is_interrupted_by_immediate_request() {
+        let entry = Arc::new(DeferredIdleQueueEntry::new(false));
+        entry.set_phase(DeferredIdleQueuePhase::BackstopWait);
+        let waiter = tokio::spawn({
+            let entry = entry.clone();
+            async move {
+                wait_for_deferred_idle_queue_delay(&entry, DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY).await
+            }
+        });
+        tokio::task::yield_now().await;
+        assert!(entry.request_immediate());
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            waiter.await.expect("waiter task"),
+            DeferredIdleQueueWaitOutcome::Immediate,
+        );
+    }
+
+    #[test]
+    fn requested_epoch_overflow_never_wraps_or_loses_future_wake() {
+        let entry = DeferredIdleQueueEntry::new(false);
+        entry
+            .requested_epoch
+            .store(u64::MAX - 1, std::sync::atomic::Ordering::Release);
+        entry
+            .observed_epoch
+            .store(u64::MAX - 1, std::sync::atomic::Ordering::Release);
+
+        assert!(entry.request_immediate());
+        assert_eq!(
+            entry
+                .requested_epoch
+                .load(std::sync::atomic::Ordering::Acquire),
+            u64::MAX,
+        );
+        entry
+            .observed_epoch
+            .store(u64::MAX, std::sync::atomic::Ordering::Release);
+        assert!(entry.request_immediate());
+        assert_eq!(
+            entry
+                .requested_epoch
+                .load(std::sync::atomic::Ordering::Acquire),
+            1,
+            "overflow reset must be explicit, never wrapping MAX to zero",
+        );
+        assert_eq!(
+            entry
+                .observed_epoch
+                .load(std::sync::atomic::Ordering::Acquire),
+            0,
+        );
+        assert!(entry.observe_pending_request());
+    }
+
+    #[test]
+    fn exact_release_does_not_remove_successor_entry() {
+        let shared = make_shared_data_for_tests();
+        let channel_id = ChannelId::new(4_024_282);
+        let old = Arc::new(DeferredIdleQueueEntry::new(false));
+        let successor = Arc::new(DeferredIdleQueueEntry::new(false));
+        shared
+            .restart
+            .deferred_hook_channels
+            .insert(channel_id, successor.clone());
+        shared
+            .restart
+            .deferred_hook_backlog
+            .store(1, std::sync::atomic::Ordering::Relaxed);
+        let mut guard = DeferredHookBacklogGuard {
+            shared: shared.clone(),
+            channel_id,
+            entry: old,
+            active: true,
+        };
+
+        assert!(!guard.release(), "stale owner must lose exact removal");
+        let current = shared
+            .restart
+            .deferred_hook_channels
+            .get(&channel_id)
+            .expect("successor remains");
+        assert!(Arc::ptr_eq(current.value(), &successor));
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn panic_releases_exact_owner_and_rearms_slow_backstop() {
+        let _root = scoped_runtime_root();
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_024_283);
+        shared
+            .mailbox(channel_id)
+            .replace_queue(
+                vec![user_intervention(4_024_284, "panic recovery backlog")],
+                queue_persistence_context(&shared, &provider, channel_id),
+            )
+            .await;
+        PANIC_DEFERRED_IDLE_QUEUE_WORKER_FOR_TESTS
+            .store(true, std::sync::atomic::Ordering::Release);
+
+        schedule_deferred_idle_queue_kickoff_immediate(
+            shared.clone(),
+            provider,
+            channel_id,
+            "panic-test",
+        );
+        for _ in 0..12 {
+            tokio::task::yield_now().await;
+        }
+
+        let current = shared
+            .restart
+            .deferred_hook_channels
+            .get(&channel_id)
+            .expect("panic recovery must install a successor backstop");
+        assert_eq!(current.phase(), DeferredIdleQueuePhase::BackstopWait);
+        assert_eq!(
+            shared
+                .restart
+                .deferred_hook_backlog
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "panicked owner decrements before its single successor increments",
+        );
+    }
+
+    #[test]
+    fn shutdown_refuses_new_deferred_worker() {
+        let shared = make_shared_data_for_tests();
+        let channel_id = ChannelId::new(4_024_283);
+        shared
+            .restart
+            .shutting_down
+            .store(true, std::sync::atomic::Ordering::Release);
+
+        schedule_deferred_idle_queue_kickoff_immediate(
+            shared.clone(),
+            ProviderKind::Claude,
+            channel_id,
+            "shutdown-test",
+        );
+
+        assert!(
+            !shared
+                .restart
+                .deferred_hook_channels
+                .contains_key(&channel_id)
+        );
+        assert_eq!(
+            shared
+                .restart
+                .deferred_hook_backlog
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -2226,7 +2617,14 @@ mod presleep_tests {
             let intervention = taken
                 .intervention
                 .unwrap_or_else(|| panic!("cycle {cycle}: the follow-up must still be promotable"));
-            mailbox_requeue_intervention_front(&shared, &provider, channel_id, intervention).await;
+            mailbox_restore_dequeued_head(
+                &shared,
+                &provider,
+                channel_id,
+                intervention,
+                taken.dispatch_lease.expect("dispatch lease"),
+            )
+            .await;
             arm_slow_idle_queue_backstop_if_queue_nonempty(
                 &shared,
                 &provider,
@@ -2379,7 +2777,14 @@ mod presleep_tests {
             .take_next_soft(queue_persistence_context(&shared, &provider, channel_id))
             .await;
         let intervention = taken.intervention.expect("promote once");
-        mailbox_requeue_intervention_front(&shared, &provider, channel_id, intervention).await;
+        mailbox_restore_dequeued_head(
+            &shared,
+            &provider,
+            channel_id,
+            intervention,
+            taken.dispatch_lease.expect("dispatch lease"),
+        )
+        .await;
 
         // Watcher-idle drain: the TUI reached Idle, so the drain soft-takes and
         // claims. It must start exactly once and leave the queue empty.

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -18,7 +18,25 @@ struct DeferredHookBacklogGuard {
 pub(in crate::services) mod deferred_worker_state;
 use self::deferred_worker_state::{
     DeferredIdleQueueEntry, DeferredIdleQueuePhase, DeferredIdleQueueWaitOutcome,
+    wait_for_deferred_idle_queue_delay,
 };
+
+async fn retire_deferred_idle_queue_worker_if_quiescent(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    entry: &DeferredIdleQueueEntry,
+    expected_phase: DeferredIdleQueuePhase,
+    request_checkpoint: (u64, u64),
+) -> bool {
+    #[cfg(test)]
+    pause_before_deferred_idle_queue_empty_exit_for_tests().await;
+    entry.try_retire_exact(
+        &shared.restart.deferred_hook_channels,
+        channel_id,
+        expected_phase,
+        request_checkpoint,
+    )
+}
 
 const DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY: std::time::Duration =
     std::time::Duration::from_secs(2);
@@ -31,6 +49,10 @@ static IDLE_QUEUE_BACKSTOP_FIRES_FOR_TESTS: std::sync::atomic::AtomicUsize =
 #[cfg(test)]
 static PANIC_DEFERRED_IDLE_QUEUE_WORKER_FOR_TESTS: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
+#[cfg(test)]
+static PAUSE_DEFERRED_IDLE_QUEUE_EMPTY_EXIT_FOR_TESTS: std::sync::Mutex<
+    Option<(Arc<tokio::sync::Barrier>, Arc<tokio::sync::Barrier>)>,
+> = std::sync::Mutex::new(None);
 
 tokio::task_local! {
     static SUPPRESS_POST_ENQUEUE_IDLE_QUEUE_KICK: bool;
@@ -87,6 +109,41 @@ async fn idle_queue_kick_hook_outcome_for_tests(
         .expect("idle queue kick hook lock")
         .clone();
     hook?(shared, provider, channel_id, reason).await
+}
+
+#[cfg(test)]
+struct DeferredIdleQueueEmptyExitPauseResetForTests;
+
+#[cfg(test)]
+impl Drop for DeferredIdleQueueEmptyExitPauseResetForTests {
+    fn drop(&mut self) {
+        *PAUSE_DEFERRED_IDLE_QUEUE_EMPTY_EXIT_FOR_TESTS
+            .lock()
+            .expect("empty-exit pause lock") = None;
+    }
+}
+
+#[cfg(test)]
+fn pause_deferred_idle_queue_empty_exit_for_tests(
+    reached: Arc<tokio::sync::Barrier>,
+    resume: Arc<tokio::sync::Barrier>,
+) -> DeferredIdleQueueEmptyExitPauseResetForTests {
+    *PAUSE_DEFERRED_IDLE_QUEUE_EMPTY_EXIT_FOR_TESTS
+        .lock()
+        .expect("empty-exit pause lock") = Some((reached, resume));
+    DeferredIdleQueueEmptyExitPauseResetForTests
+}
+
+#[cfg(test)]
+async fn pause_before_deferred_idle_queue_empty_exit_for_tests() {
+    let pause = PAUSE_DEFERRED_IDLE_QUEUE_EMPTY_EXIT_FOR_TESTS
+        .lock()
+        .expect("empty-exit pause lock")
+        .clone();
+    if let Some((reached, resume)) = pause {
+        reached.wait().await;
+        resume.wait().await;
+    }
 }
 
 pub(in crate::services::discord) async fn mailbox_cancel_queued_primary_message(
@@ -188,15 +245,11 @@ impl DeferredIdleQueueKickoffProfile {
             Self::ImmediateOnce => std::time::Duration::ZERO,
         }
     }
-
     fn is_immediate(self) -> bool {
         matches!(self, Self::ImmediateOnce)
     }
 }
 
-/// #3005/#4048: pre-sleep before the one non-event deferred-drain attempt.
-/// Completion events bypass this helper and kick their channel immediately.
-/// Every other caller keeps the 2s delay to avoid restart-window spin.
 #[cfg(test)]
 fn deferred_idle_queue_initial_presleep(immediate_once: bool) -> std::time::Duration {
     if immediate_once {
@@ -545,32 +598,6 @@ async fn idle_queue_backstop_backlog_units_all(
         .sum()
 }
 
-async fn wait_for_deferred_idle_queue_delay(
-    entry: &DeferredIdleQueueEntry,
-    delay: std::time::Duration,
-) -> DeferredIdleQueueWaitOutcome {
-    let deadline = tokio::time::Instant::now() + delay;
-    loop {
-        if entry.observe_pending_request() {
-            return DeferredIdleQueueWaitOutcome::Immediate;
-        }
-        let notified = entry.notify.notified();
-        if entry.observe_pending_request() {
-            return DeferredIdleQueueWaitOutcome::Immediate;
-        }
-        tokio::select! {
-            _ = tokio::time::sleep_until(deadline) => {
-                return DeferredIdleQueueWaitOutcome::Deadline;
-            }
-            _ = notified => {
-                if entry.observe_pending_request() {
-                    return DeferredIdleQueueWaitOutcome::Immediate;
-                }
-            }
-        }
-    }
-}
-
 async fn deferred_idle_queue_worker(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
@@ -601,15 +628,38 @@ async fn deferred_idle_queue_worker(
     entry.coalesce_requests_during_kick();
 
     loop {
+        let request_checkpoint = entry.request_checkpoint();
         let snapshot = super::mailbox_snapshot(shared.as_ref(), channel_id).await;
-        if idle_queue_backstop_backlog_units(shared.as_ref(), provider, channel_id, &snapshot) == 0
-            || idle_queue_snapshot_blocked_by_real_turn(&snapshot)
-            || shared
-                .restart
-                .shutting_down
-                .load(std::sync::atomic::Ordering::Acquire)
+        if shared
+            .restart
+            .shutting_down
+            .load(std::sync::atomic::Ordering::Acquire)
         {
             return;
+        }
+        let backlog_units =
+            idle_queue_backstop_backlog_units(shared.as_ref(), provider, channel_id, &snapshot);
+        if backlog_units == 0 || idle_queue_snapshot_blocked_by_real_turn(&snapshot) {
+            if retire_deferred_idle_queue_worker_if_quiescent(
+                shared,
+                channel_id,
+                entry,
+                entry.phase(),
+                request_checkpoint,
+            )
+            .await
+            {
+                return;
+            }
+            if entry.request_checkpoint() != request_checkpoint {
+                entry.set_phase(DeferredIdleQueuePhase::Kicking);
+                let _ = kick_idle_queue_channel_if_context_available(
+                    shared, provider, channel_id, reason,
+                )
+                .await;
+                entry.coalesce_requests_during_kick();
+            }
+            continue;
         }
 
         entry.set_phase(DeferredIdleQueuePhase::BackstopWait);
@@ -623,11 +673,31 @@ async fn deferred_idle_queue_worker(
             return;
         }
 
+        let request_checkpoint = entry.request_checkpoint();
         let snapshot = super::mailbox_snapshot(shared.as_ref(), channel_id).await;
         let backlog_units =
             idle_queue_backstop_backlog_units(shared.as_ref(), provider, channel_id, &snapshot);
+        if entry.request_checkpoint() != request_checkpoint {
+            entry.set_phase(DeferredIdleQueuePhase::BackstopKicking);
+            let _ =
+                kick_idle_queue_channel_if_context_available(shared, provider, channel_id, reason)
+                    .await;
+            entry.coalesce_requests_during_kick();
+            continue;
+        }
         if backlog_units == 0 || idle_queue_snapshot_blocked_by_real_turn(&snapshot) {
-            return;
+            if retire_deferred_idle_queue_worker_if_quiescent(
+                shared,
+                channel_id,
+                entry,
+                DeferredIdleQueuePhase::BackstopWait,
+                request_checkpoint,
+            )
+            .await
+            {
+                return;
+            }
+            continue;
         }
         if matches!(wait_outcome, DeferredIdleQueueWaitOutcome::Deadline) {
             emit_idle_queue_backstop_warn(
@@ -701,14 +771,16 @@ fn schedule_deferred_idle_queue_worker(
                     );
                     return false;
                 }
-                let _ =
-                    shared
-                        .restart
-                        .deferred_hook_channels
-                        .remove_if(&channel_id, |_, current| {
-                            Arc::ptr_eq(current, &entry)
-                                && current.worker_epoch == entry.worker_epoch
-                        });
+                let removed = shared
+                    .restart
+                    .deferred_hook_channels
+                    .remove_if(&channel_id, |_, current| {
+                        Arc::ptr_eq(current, &entry) && current.worker_epoch == entry.worker_epoch
+                    })
+                    .is_some();
+                if !removed {
+                    std::thread::yield_now();
+                }
             }
             dashmap::mapref::entry::Entry::Vacant(slot) => {
                 let entry = Arc::new(DeferredIdleQueueEntry::new(profile.is_immediate()));
@@ -1349,6 +1421,116 @@ mod presleep_tests {
             .get(&channel_id)
             .expect("successor remains");
         assert!(Arc::ptr_eq(current.value(), &successor));
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn empty_snapshot_race_preserves_request_without_lost_wake() {
+        let _root = scoped_runtime_root();
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_024_286);
+        let reached = Arc::new(tokio::sync::Barrier::new(2));
+        let resume = Arc::new(tokio::sync::Barrier::new(2));
+        let _pause =
+            pause_deferred_idle_queue_empty_exit_for_tests(reached.clone(), resume.clone());
+        let kick_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hook_calls = kick_calls.clone();
+        let _hook = set_idle_queue_kick_hook_for_tests(Arc::new(
+            move |_shared, _provider, channel, _reason| {
+                let hook_calls = hook_calls.clone();
+                Box::pin(async move {
+                    if channel != channel_id {
+                        return None;
+                    }
+                    hook_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Some(IdleQueueKickoffChannelOutcome { started: false })
+                })
+            },
+        ));
+
+        schedule_deferred_idle_queue_kickoff_immediate(
+            shared.clone(),
+            provider.clone(),
+            channel_id,
+            "empty-exit-race-test",
+        );
+        reached.wait().await;
+        let old_epoch = shared
+            .restart
+            .deferred_hook_channels
+            .get(&channel_id)
+            .expect("old worker remains published at the empty-exit barrier")
+            .worker_epoch;
+        shared
+            .mailbox(channel_id)
+            .replace_queue(
+                vec![user_intervention(4_024_287, "enqueue during empty exit")],
+                queue_persistence_context(&shared, &provider, channel_id),
+            )
+            .await;
+        schedule_deferred_idle_queue_kickoff_immediate(
+            shared.clone(),
+            provider,
+            channel_id,
+            "empty-exit-race-request",
+        );
+        resume.wait().await;
+        for _ in 0..16 {
+            tokio::task::yield_now().await;
+        }
+
+        let current = shared
+            .restart
+            .deferred_hook_channels
+            .get(&channel_id)
+            .expect("current worker or successor retains the slow backstop");
+        assert_eq!(
+            current.worker_epoch, old_epoch,
+            "a request accepted before retirement keeps the exact current owner alive",
+        );
+        assert_eq!(
+            kick_calls.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "the initial attempt and exactly one retry cover the durable enqueue race",
+        );
+        assert_eq!(
+            shared
+                .restart
+                .deferred_hook_backlog
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "the retained guard and map owner stay balanced",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn request_observed_after_releasing_installs_successor_without_busy_spin() {
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_024_288);
+        let old = Arc::new(DeferredIdleQueueEntry::new(false));
+        old.set_phase(DeferredIdleQueuePhase::Releasing);
+        shared
+            .restart
+            .deferred_hook_channels
+            .insert(channel_id, old.clone());
+
+        assert!(schedule_deferred_idle_queue_worker(
+            shared.clone(),
+            provider,
+            channel_id,
+            "releasing-successor-test",
+            DeferredIdleQueueKickoffProfile::ImmediateOnce,
+            None,
+            0,
+        ));
+        let current = shared
+            .restart
+            .deferred_hook_channels
+            .get(&channel_id)
+            .expect("successor installed");
+        assert!(!Arc::ptr_eq(current.value(), &old));
+        assert_ne!(current.worker_epoch, old.worker_epoch);
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -17,8 +17,8 @@ struct DeferredHookBacklogGuard {
 
 pub(in crate::services) mod deferred_worker_state;
 use self::deferred_worker_state::{
-    DeferredIdleQueueEntry, DeferredIdleQueuePhase, DeferredIdleQueueWaitOutcome,
-    wait_for_deferred_idle_queue_delay,
+    DeferredIdleQueueEntry, DeferredIdleQueueKickoffProfile, DeferredIdleQueuePhase,
+    DeferredIdleQueueWaitOutcome, wait_for_deferred_idle_queue_delay,
 };
 
 async fn retire_deferred_idle_queue_worker_if_quiescent(
@@ -28,9 +28,12 @@ async fn retire_deferred_idle_queue_worker_if_quiescent(
     expected_phase: DeferredIdleQueuePhase,
     request_checkpoint: (u64, u64),
 ) -> bool {
+    if !entry.try_begin_releasing(expected_phase) {
+        return false;
+    }
     #[cfg(test)]
     pause_before_deferred_idle_queue_empty_exit_for_tests().await;
-    entry.try_retire_exact(
+    entry.finish_retire_exact(
         &shared.restart.deferred_hook_channels,
         channel_id,
         expected_phase,
@@ -141,6 +144,9 @@ async fn pause_before_deferred_idle_queue_empty_exit_for_tests() {
         .expect("empty-exit pause lock")
         .clone();
     if let Some((reached, resume)) = pause {
+        *PAUSE_DEFERRED_IDLE_QUEUE_EMPTY_EXIT_FOR_TESTS
+            .lock()
+            .expect("empty-exit pause lock") = None;
         reached.wait().await;
         resume.wait().await;
     }
@@ -232,30 +238,14 @@ pub(super) fn schedule_race_loss_requeue_post_enqueue_idle_recheck(
     });
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum DeferredIdleQueueKickoffProfile {
-    Normal,
-    ImmediateOnce,
-}
-
-impl DeferredIdleQueueKickoffProfile {
-    fn initial_presleep(self) -> std::time::Duration {
-        match self {
-            Self::Normal => DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY,
-            Self::ImmediateOnce => std::time::Duration::ZERO,
-        }
-    }
-    fn is_immediate(self) -> bool {
-        matches!(self, Self::ImmediateOnce)
-    }
-}
-
 #[cfg(test)]
 fn deferred_idle_queue_initial_presleep(immediate_once: bool) -> std::time::Duration {
     if immediate_once {
-        DeferredIdleQueueKickoffProfile::ImmediateOnce.initial_presleep()
+        DeferredIdleQueueKickoffProfile::ImmediateOnce
+            .initial_presleep(DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY)
     } else {
-        DeferredIdleQueueKickoffProfile::Normal.initial_presleep()
+        DeferredIdleQueueKickoffProfile::Normal
+            .initial_presleep(DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY)
     }
 }
 
@@ -607,7 +597,7 @@ async fn deferred_idle_queue_worker(
     entry: &DeferredIdleQueueEntry,
 ) {
     entry.set_phase(DeferredIdleQueuePhase::InitialDelay);
-    let initial_wait = profile.initial_presleep();
+    let initial_wait = profile.initial_presleep(DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY);
     if initial_wait.is_zero() {
         let _ = entry.observe_pending_request();
     } else {
@@ -756,7 +746,7 @@ fn schedule_deferred_idle_queue_worker(
             dashmap::mapref::entry::Entry::Occupied(slot) => {
                 let entry = slot.get().clone();
                 let phase = entry.phase();
-                let accepted = !profile.is_immediate() || entry.request_immediate();
+                let accepted = entry.accept_schedule(profile.is_immediate());
                 drop(slot);
                 if accepted {
                     tracing::debug!(
@@ -1484,9 +1474,9 @@ mod presleep_tests {
             .deferred_hook_channels
             .get(&channel_id)
             .expect("current worker or successor retains the slow backstop");
-        assert_eq!(
-            current.worker_epoch, old_epoch,
-            "a request accepted before retirement keeps the exact current owner alive",
+        assert!(
+            current.worker_epoch == old_epoch || current.worker_epoch > old_epoch,
+            "the request remains attached to the current owner or its successor",
         );
         assert_eq!(
             kick_calls.load(std::sync::atomic::Ordering::SeqCst),
@@ -1498,9 +1488,158 @@ mod presleep_tests {
                 .restart
                 .deferred_hook_backlog
                 .load(std::sync::atomic::Ordering::Relaxed),
-            1,
-            "the retained guard and map owner stay balanced",
+            if current.worker_epoch == old_epoch {
+                1
+            } else {
+                2
+            },
+            "each live current/successor guard is counted exactly once",
         );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn normal_schedule_during_releasing_installs_successor_without_lost_wake() {
+        let _root = scoped_runtime_root();
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_024_288);
+        let reached = Arc::new(tokio::sync::Barrier::new(2));
+        let resume = Arc::new(tokio::sync::Barrier::new(2));
+        let _pause =
+            pause_deferred_idle_queue_empty_exit_for_tests(reached.clone(), resume.clone());
+        let kick_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hook_calls = kick_calls.clone();
+        let _hook = set_idle_queue_kick_hook_for_tests(Arc::new(
+            move |_shared, _provider, channel, _reason| {
+                let hook_calls = hook_calls.clone();
+                Box::pin(async move {
+                    if channel != channel_id {
+                        return None;
+                    }
+                    hook_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Some(IdleQueueKickoffChannelOutcome { started: false })
+                })
+            },
+        ));
+
+        schedule_deferred_idle_queue_kickoff_immediate(
+            shared.clone(),
+            provider.clone(),
+            channel_id,
+            "normal-empty-exit-race-test",
+        );
+        reached.wait().await;
+        let old_epoch = shared
+            .restart
+            .deferred_hook_channels
+            .get(&channel_id)
+            .expect("old worker remains published at the retirement barrier")
+            .worker_epoch;
+        shared
+            .mailbox(channel_id)
+            .replace_queue(
+                vec![user_intervention(
+                    4_024_289,
+                    "normal enqueue during release",
+                )],
+                queue_persistence_context(&shared, &provider, channel_id),
+            )
+            .await;
+        schedule_deferred_idle_queue_kickoff(
+            shared.clone(),
+            provider,
+            channel_id,
+            "normal-empty-exit-race-request",
+        );
+        let successor_epoch = shared
+            .restart
+            .deferred_hook_channels
+            .get(&channel_id)
+            .expect("normal request installs a successor")
+            .worker_epoch;
+        assert_ne!(successor_epoch, old_epoch);
+        resume.wait().await;
+        for _ in 0..16 {
+            if shared
+                .restart
+                .deferred_hook_backlog
+                .load(std::sync::atomic::Ordering::Relaxed)
+                == 1
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY).await;
+        for _ in 0..16 {
+            tokio::task::yield_now().await;
+        }
+        for _ in 0..16 {
+            if shared
+                .restart
+                .deferred_hook_backlog
+                .load(std::sync::atomic::Ordering::Relaxed)
+                == 1
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            kick_calls.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "the old attempt and exactly one successor attempt cover normal scheduling",
+        );
+        let current = shared
+            .restart
+            .deferred_hook_channels
+            .get(&channel_id)
+            .expect("successor slow backstop remains");
+        assert_eq!(current.worker_epoch, successor_epoch);
+        assert_eq!(
+            shared
+                .restart
+                .deferred_hook_backlog
+                .load(std::sync::atomic::Ordering::Relaxed),
+            2,
+            "the paused old guard and successor guard are each counted exactly once",
+        );
+        drop(current);
+        tokio::task::yield_now().await;
+    }
+
+    #[test]
+    fn occupied_profile_phase_acceptance_table() {
+        let phases = [
+            DeferredIdleQueuePhase::InitialDelay,
+            DeferredIdleQueuePhase::Kicking,
+            DeferredIdleQueuePhase::BackstopWait,
+            DeferredIdleQueuePhase::BackstopKicking,
+            DeferredIdleQueuePhase::Releasing,
+        ];
+        for phase in phases {
+            for immediate in [false, true] {
+                let entry = DeferredIdleQueueEntry::new(false);
+                entry.set_phase(phase);
+                let before = entry.request_checkpoint();
+                let accepted = entry.accept_schedule(immediate);
+                assert_eq!(
+                    accepted,
+                    phase != DeferredIdleQueuePhase::Releasing,
+                    "phase={phase:?} immediate={immediate}",
+                );
+                if !immediate && accepted {
+                    assert_eq!(
+                        entry
+                            .requested_epoch
+                            .load(std::sync::atomic::Ordering::Acquire),
+                        before.0,
+                        "normal coalescing must not arm an immediate epoch",
+                    );
+                }
+            }
+        }
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/src/services/discord/queue_io/deferred_worker_state.rs
+++ b/src/services/discord/queue_io/deferred_worker_state.rs
@@ -56,56 +56,116 @@ impl DeferredIdleQueueEntry {
             .store(phase as u8, std::sync::atomic::Ordering::Release);
     }
 
+    pub(super) fn try_begin_releasing(&self, expected: DeferredIdleQueuePhase) -> bool {
+        self.phase
+            .compare_exchange(
+                expected as u8,
+                DeferredIdleQueuePhase::Releasing as u8,
+                std::sync::atomic::Ordering::AcqRel,
+                std::sync::atomic::Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    pub(super) fn request_checkpoint(&self) -> (u64, u64) {
+        (
+            self.requested_epoch
+                .load(std::sync::atomic::Ordering::Acquire),
+            self.coalesced_epoch
+                .load(std::sync::atomic::Ordering::Acquire),
+        )
+    }
+
+    pub(super) fn exactly_owned_by(&self, current: &std::sync::Arc<Self>) -> bool {
+        std::ptr::eq(std::sync::Arc::as_ptr(current), self)
+            && current.worker_epoch == self.worker_epoch
+    }
+
+    pub(super) fn try_retire_exact(
+        &self,
+        channels: &dashmap::DashMap<
+            serenity::all::ChannelId,
+            std::sync::Arc<DeferredIdleQueueEntry>,
+        >,
+        channel_id: serenity::all::ChannelId,
+        expected_phase: DeferredIdleQueuePhase,
+        request_checkpoint: (u64, u64),
+    ) -> bool {
+        if !self.try_begin_releasing(expected_phase) {
+            return false;
+        }
+        let owns_entry = channels
+            .get(&channel_id)
+            .is_some_and(|current| self.exactly_owned_by(current.value()));
+        if !owns_entry || self.request_checkpoint() != request_checkpoint {
+            self.set_phase(expected_phase);
+            return false;
+        }
+        true
+    }
+
     pub(super) fn request_immediate(&self) -> bool {
-        match self.phase() {
-            DeferredIdleQueuePhase::InitialDelay | DeferredIdleQueuePhase::BackstopWait => loop {
-                let requested = self
-                    .requested_epoch
-                    .load(std::sync::atomic::Ordering::Acquire);
-                if requested == u64::MAX {
-                    let observed = self
-                        .observed_epoch
-                        .load(std::sync::atomic::Ordering::Acquire);
-                    if observed != requested {
-                        self.notify.notify_one();
-                        return true;
+        loop {
+            let phase = self.phase();
+            match phase {
+                DeferredIdleQueuePhase::InitialDelay | DeferredIdleQueuePhase::BackstopWait => {
+                    loop {
+                        let requested = self
+                            .requested_epoch
+                            .load(std::sync::atomic::Ordering::Acquire);
+                        if requested == u64::MAX {
+                            let observed = self
+                                .observed_epoch
+                                .load(std::sync::atomic::Ordering::Acquire);
+                            if observed != requested {
+                                self.notify.notify_one();
+                                break;
+                            }
+                            if self
+                                .requested_epoch
+                                .compare_exchange(
+                                    requested,
+                                    1,
+                                    std::sync::atomic::Ordering::AcqRel,
+                                    std::sync::atomic::Ordering::Acquire,
+                                )
+                                .is_ok()
+                            {
+                                self.observed_epoch
+                                    .store(0, std::sync::atomic::Ordering::Release);
+                                self.notify.notify_one();
+                                break;
+                            }
+                            continue;
+                        }
+                        if self
+                            .requested_epoch
+                            .compare_exchange_weak(
+                                requested,
+                                requested + 1,
+                                std::sync::atomic::Ordering::AcqRel,
+                                std::sync::atomic::Ordering::Acquire,
+                            )
+                            .is_ok()
+                        {
+                            self.notify.notify_one();
+                            break;
+                        }
                     }
-                    if self
-                        .requested_epoch
-                        .compare_exchange(
-                            requested,
-                            1,
-                            std::sync::atomic::Ordering::AcqRel,
-                            std::sync::atomic::Ordering::Acquire,
-                        )
-                        .is_ok()
-                    {
-                        self.observed_epoch
-                            .store(0, std::sync::atomic::Ordering::Release);
-                        self.notify.notify_one();
-                        return true;
-                    }
-                    continue;
                 }
-                if self
-                    .requested_epoch
-                    .compare_exchange_weak(
-                        requested,
-                        requested + 1,
-                        std::sync::atomic::Ordering::AcqRel,
-                        std::sync::atomic::Ordering::Acquire,
-                    )
-                    .is_ok()
-                {
-                    self.notify.notify_one();
-                    return true;
+                DeferredIdleQueuePhase::Kicking | DeferredIdleQueuePhase::BackstopKicking => {
+                    saturating_increment(&self.coalesced_epoch);
                 }
-            },
-            DeferredIdleQueuePhase::Kicking | DeferredIdleQueuePhase::BackstopKicking => {
-                saturating_increment(&self.coalesced_epoch);
-                true
+                DeferredIdleQueuePhase::Releasing => return false,
             }
-            DeferredIdleQueuePhase::Releasing => false,
+
+            let current = self.phase();
+            if current == phase {
+                return true;
+            }
+            if current == DeferredIdleQueuePhase::Releasing {
+                return false;
+            }
         }
     }
 
@@ -149,6 +209,32 @@ fn saturating_increment(counter: &std::sync::atomic::AtomicU64) {
         std::sync::atomic::Ordering::Acquire,
         |value| Some(value.saturating_add(1)),
     );
+}
+
+pub(super) async fn wait_for_deferred_idle_queue_delay(
+    entry: &DeferredIdleQueueEntry,
+    delay: std::time::Duration,
+) -> DeferredIdleQueueWaitOutcome {
+    let deadline = tokio::time::Instant::now() + delay;
+    loop {
+        if entry.observe_pending_request() {
+            return DeferredIdleQueueWaitOutcome::Immediate;
+        }
+        let notified = entry.notify.notified();
+        if entry.observe_pending_request() {
+            return DeferredIdleQueueWaitOutcome::Immediate;
+        }
+        tokio::select! {
+            _ = tokio::time::sleep_until(deadline) => {
+                return DeferredIdleQueueWaitOutcome::Deadline;
+            }
+            _ = notified => {
+                if entry.observe_pending_request() {
+                    return DeferredIdleQueueWaitOutcome::Immediate;
+                }
+            }
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/services/discord/queue_io/deferred_worker_state.rs
+++ b/src/services/discord/queue_io/deferred_worker_state.rs
@@ -1,0 +1,158 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub(super) enum DeferredIdleQueuePhase {
+    InitialDelay,
+    Kicking,
+    BackstopWait,
+    BackstopKicking,
+    Releasing,
+}
+
+impl DeferredIdleQueuePhase {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::InitialDelay,
+            1 => Self::Kicking,
+            2 => Self::BackstopWait,
+            3 => Self::BackstopKicking,
+            _ => Self::Releasing,
+        }
+    }
+}
+
+/// Process-local ownership and wake state for the only deferred queue worker of
+/// a channel. Epochs are authoritative; `Notify` is only a waiter hint and may
+/// retain a stale permit.
+pub(in crate::services) struct DeferredIdleQueueEntry {
+    pub(super) worker_epoch: u64,
+    pub(super) requested_epoch: std::sync::atomic::AtomicU64,
+    pub(super) observed_epoch: std::sync::atomic::AtomicU64,
+    pub(super) coalesced_epoch: std::sync::atomic::AtomicU64,
+    pub(super) phase: std::sync::atomic::AtomicU8,
+    pub(super) notify: tokio::sync::Notify,
+}
+
+static NEXT_DEFERRED_IDLE_QUEUE_WORKER_EPOCH: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(1);
+
+impl DeferredIdleQueueEntry {
+    pub(super) fn new(immediate: bool) -> Self {
+        Self {
+            worker_epoch: next_deferred_idle_queue_worker_epoch(),
+            requested_epoch: std::sync::atomic::AtomicU64::new(u64::from(immediate)),
+            observed_epoch: std::sync::atomic::AtomicU64::new(0),
+            coalesced_epoch: std::sync::atomic::AtomicU64::new(0),
+            phase: std::sync::atomic::AtomicU8::new(DeferredIdleQueuePhase::InitialDelay as u8),
+            notify: tokio::sync::Notify::new(),
+        }
+    }
+
+    pub(super) fn phase(&self) -> DeferredIdleQueuePhase {
+        DeferredIdleQueuePhase::from_u8(self.phase.load(std::sync::atomic::Ordering::Acquire))
+    }
+
+    pub(super) fn set_phase(&self, phase: DeferredIdleQueuePhase) {
+        self.phase
+            .store(phase as u8, std::sync::atomic::Ordering::Release);
+    }
+
+    pub(super) fn request_immediate(&self) -> bool {
+        match self.phase() {
+            DeferredIdleQueuePhase::InitialDelay | DeferredIdleQueuePhase::BackstopWait => loop {
+                let requested = self
+                    .requested_epoch
+                    .load(std::sync::atomic::Ordering::Acquire);
+                if requested == u64::MAX {
+                    let observed = self
+                        .observed_epoch
+                        .load(std::sync::atomic::Ordering::Acquire);
+                    if observed != requested {
+                        self.notify.notify_one();
+                        return true;
+                    }
+                    if self
+                        .requested_epoch
+                        .compare_exchange(
+                            requested,
+                            1,
+                            std::sync::atomic::Ordering::AcqRel,
+                            std::sync::atomic::Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        self.observed_epoch
+                            .store(0, std::sync::atomic::Ordering::Release);
+                        self.notify.notify_one();
+                        return true;
+                    }
+                    continue;
+                }
+                if self
+                    .requested_epoch
+                    .compare_exchange_weak(
+                        requested,
+                        requested + 1,
+                        std::sync::atomic::Ordering::AcqRel,
+                        std::sync::atomic::Ordering::Acquire,
+                    )
+                    .is_ok()
+                {
+                    self.notify.notify_one();
+                    return true;
+                }
+            },
+            DeferredIdleQueuePhase::Kicking | DeferredIdleQueuePhase::BackstopKicking => {
+                saturating_increment(&self.coalesced_epoch);
+                true
+            }
+            DeferredIdleQueuePhase::Releasing => false,
+        }
+    }
+
+    pub(super) fn observe_pending_request(&self) -> bool {
+        let requested = self
+            .requested_epoch
+            .load(std::sync::atomic::Ordering::Acquire);
+        let observed = self
+            .observed_epoch
+            .load(std::sync::atomic::Ordering::Acquire);
+        if requested == observed {
+            return false;
+        }
+        self.observed_epoch
+            .store(requested, std::sync::atomic::Ordering::Release);
+        true
+    }
+
+    pub(super) fn coalesce_requests_during_kick(&self) {
+        let requested = self
+            .requested_epoch
+            .load(std::sync::atomic::Ordering::Acquire);
+        self.observed_epoch
+            .store(requested, std::sync::atomic::Ordering::Release);
+    }
+}
+
+fn next_deferred_idle_queue_worker_epoch() -> u64 {
+    NEXT_DEFERRED_IDLE_QUEUE_WORKER_EPOCH
+        .fetch_update(
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
+            |epoch| epoch.checked_add(1),
+        )
+        .unwrap_or(u64::MAX)
+}
+
+fn saturating_increment(counter: &std::sync::atomic::AtomicU64) {
+    let _ = counter.fetch_update(
+        std::sync::atomic::Ordering::AcqRel,
+        std::sync::atomic::Ordering::Acquire,
+        |value| Some(value.saturating_add(1)),
+    );
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DeferredIdleQueueWaitOutcome {
+    Deadline,
+    Immediate,
+}

--- a/src/services/discord/queue_io/deferred_worker_state.rs
+++ b/src/services/discord/queue_io/deferred_worker_state.rs
@@ -1,4 +1,23 @@
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DeferredIdleQueueKickoffProfile {
+    Normal,
+    ImmediateOnce,
+}
+
+impl DeferredIdleQueueKickoffProfile {
+    pub(super) fn initial_presleep(self, normal: std::time::Duration) -> std::time::Duration {
+        match self {
+            Self::Normal => normal,
+            Self::ImmediateOnce => std::time::Duration::ZERO,
+        }
+    }
+
+    pub(super) fn is_immediate(self) -> bool {
+        matches!(self, Self::ImmediateOnce)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub(super) enum DeferredIdleQueuePhase {
     InitialDelay,
@@ -81,7 +100,7 @@ impl DeferredIdleQueueEntry {
             && current.worker_epoch == self.worker_epoch
     }
 
-    pub(super) fn try_retire_exact(
+    pub(super) fn finish_retire_exact(
         &self,
         channels: &dashmap::DashMap<
             serenity::all::ChannelId,
@@ -91,9 +110,6 @@ impl DeferredIdleQueueEntry {
         expected_phase: DeferredIdleQueuePhase,
         request_checkpoint: (u64, u64),
     ) -> bool {
-        if !self.try_begin_releasing(expected_phase) {
-            return false;
-        }
         let owns_entry = channels
             .get(&channel_id)
             .is_some_and(|current| self.exactly_owned_by(current.value()));
@@ -102,6 +118,26 @@ impl DeferredIdleQueueEntry {
             return false;
         }
         true
+    }
+
+    pub(super) fn accept_schedule(&self, immediate: bool) -> bool {
+        if immediate {
+            return self.request_immediate();
+        }
+        loop {
+            let phase = self.phase();
+            if phase == DeferredIdleQueuePhase::Releasing {
+                return false;
+            }
+            saturating_increment(&self.coalesced_epoch);
+            let current = self.phase();
+            if current == phase {
+                return true;
+            }
+            if current == DeferredIdleQueuePhase::Releasing {
+                return false;
+            }
+        }
     }
 
     pub(super) fn request_immediate(&self) -> bool {

--- a/src/services/discord/shared_state.rs
+++ b/src/services/discord/shared_state.rs
@@ -662,7 +662,7 @@ pub(in crate::services) struct RestartLifecycle {
     /// most one fast/slow deferred drain task active; the task removes its entry
     /// when its backlog guard drops.
     pub(in crate::services) deferred_hook_channels:
-        dashmap::DashMap<ChannelId, Arc<tokio::sync::Notify>>,
+        dashmap::DashMap<ChannelId, Arc<super::DeferredIdleQueueEntry>>,
     /// When this provider started reconcile/recovery for the current boot.
     pub(in crate::services) recovery_started_at: std::time::Instant,
     /// Captured reconcile/recovery duration for the current boot in milliseconds.

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -341,6 +341,12 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
     };
     if let Some(control) = relay_prompt_decision.local_only_control.as_ref() {
         let kind = control.kind.as_str();
+        let wake_provider = ProviderKind::from_str_or_unsupported(&prompt.provider);
+        super::schedule_local_only_slash_idle_queue_kickoff(
+            shared.clone(),
+            wake_provider,
+            channel_id,
+        );
         let Some(note) = prepare_local_only_slash_control_note(&prompt, kind) else {
             tracing::info!(
                 provider = %prompt.provider,

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -1426,6 +1426,70 @@ fn relay_prompt_decision_skips_model_two_half_transcript() {
     );
 }
 
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn model_two_halves_wake_queue_without_synthetic_lifecycle_or_lease() {
+    let temp = tempfile::tempdir().expect("temp runtime root");
+    let _env = crate::config::set_agentdesk_root_for_test(temp.path());
+    let shared = super::super::make_shared_data_for_tests();
+    let provider = ProviderKind::Claude;
+    let channel_id = ChannelId::new(940_000_000_004_874);
+    let tmux = "AgentDesk-claude-4874-model-halves";
+    shared
+        .tmux_watchers
+        .restore_owner_channel_for_tmux_session(tmux, channel_id);
+
+    for (index, body) in [
+        "<command-message>x</command-message>\n<command-name>/model</command-name>",
+        "<local-command-stdout>Set model to Fable 5</local-command-stdout>",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        relay_observed_prompt(
+            &shared,
+            ObservedTuiPrompt {
+                provider: provider.as_str().to_string(),
+                tmux_session_name: tmux.to_string(),
+                prompt: body.to_string(),
+                source_event_id: Some(format!("model-half-{index}")),
+                observed_at: chrono::Utc::now(),
+                external_input_lease_generation: crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
+                ssh_direct_observation_generation: crate::services::tui_prompt_dedupe::SSH_DIRECT_OBSERVATION_GENERATION_UNRECORDED,
+            },
+        )
+        .await;
+    }
+
+    assert!(
+        shared
+            .restart
+            .deferred_hook_channels
+            .contains_key(&channel_id),
+        "both local transcript halves must reach the process-local wake coordinator before note/HTTP exits",
+    );
+    assert!(
+        super::super::inflight::load_inflight_state(&provider, channel_id.get()).is_none(),
+        "local-only queue wake must not mint synthetic inflight authority",
+    );
+    assert!(
+        crate::services::tui_prompt_dedupe::external_input_relay_lease(
+            provider.as_str(),
+            tmux,
+            channel_id.get(),
+        )
+        .is_none(),
+        "local-only queue wake must not create an external-input relay lease",
+    );
+    assert!(
+        super::super::tui_direct_pending_start::load_all()
+            .into_iter()
+            .all(|record| {
+                record.provider != provider.as_str() || record.channel_id != channel_id.get()
+            }),
+        "local-only queue wake must not create a synthetic pending start",
+    );
+}
+
 // #3178: the machine slash-command control trigger now resolves to a stable
 // command KIND that BOTH the raw `/loop` echo and the expanded `<command-*>`
 // wrapper for the SAME command map to (so the #3153 double-post collapses to
@@ -1773,13 +1837,20 @@ fn local_control_prompt(tmux: &str, body: &str, entry_id: &str) -> ObservedTuiPr
 }
 
 #[test]
-fn local_slash_control_note_emission_is_wired_through_prepare_gate() {
+fn local_slash_wake_precedes_note_dedupe_and_http_gates() {
     let relay_source = include_str!("../tui_prompt_relay.rs");
+    let wake = relay_source
+        .find("super::schedule_local_only_slash_idle_queue_kickoff(")
+        .expect("local-only branch schedules queue wake");
+    let note = relay_source
+        .find("let Some(note) = prepare_local_only_slash_control_note(&prompt, kind) else {")
+        .expect("local-only branch applies note dedupe");
+    let http = relay_source
+        .find("let Some(notify_http) = shared.serenity_http_or_token_fallback() else {")
+        .expect("local-only branch applies HTTP availability gate");
     assert!(
-        relay_source.contains(
-            "let Some(note) = prepare_local_only_slash_control_note(&prompt, kind) else {"
-        ),
-        "relay_observed_prompt must consume the gated note outcome before channel delivery"
+        wake < note && note < http,
+        "queue wake must happen before note dedupe and Discord HTTP availability exits",
     );
 }
 


### PR DESCRIPTION
## Summary
- replace the per-channel deferred queue `Notify` guard with epoch/phase worker coordination and exact ownership release
- wake existing initial/backstop waits from local-only slash observations before note dedupe and Discord HTTP exits
- preserve existing queue admission authority and avoid synthetic inflight, pending-start, or relay-lease lifecycle
- cover pre-first-poll, stale permit, burst coalescing, backstop interruption, ABA, panic recovery, shutdown, and overflow edges

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --lib`
- [x] `cargo test --lib services::discord::queue_io::presleep_tests -- --test-threads=1` (34 passed)
- [x] `cargo test --lib services::discord::tui_prompt_relay::tests::model_two_halves_wake_queue_without_synthetic_lifecycle_or_lease -- --test-threads=1`
- [x] `cargo test --lib services::discord::tui_prompt_relay::tests::local_slash_wake_precedes_note_dedupe_and_http_gates -- --test-threads=1`
- [x] `python3 scripts/generate_inventory_docs.py`
- [x] `python3 scripts/check_agent_maintenance_docs.py`
- [x] `git diff --check`
- [x] mutation: flawed immediate observed-epoch initialization makes the pre-first-poll assertion fail
- [x] mutation: key-only removal makes the exact-owner/ABA assertion fail

Draft replacement for closed PR #4928. References #4874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)