### PR TITLE
feat: add dormant PostgreSQL cleanup substrate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,6 +107,9 @@ src/
 │   │   ├── retention.rs
 │   │   ├── storage_stats.rs
 │   │   └── tests.rs
+│   ├── runtime_cleanup/
+│   │   ├── model.rs
+│   │   └── postgres_tests.rs
 │   ├── scheduled_messages/
 │   │   ├── agent.rs
 │   │   ├── outbox.rs
@@ -125,6 +128,7 @@ src/
 │   ├── mod.rs
 │   ├── postgres.rs
 │   ├── relay_dead_letter.rs
+│   ├── runtime_cleanup.rs
 │   ├── scheduled_messages.rs
 │   ├── session_agent_resolution.rs
 │   ├── session_observability.rs

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -446,6 +446,17 @@
   before merging.
 
 ### Audited touches
+- 2026-07-27 — #4916 Task #25 dormant cleanup substrate: PostgreSQL migration
+  0102 adds no worker, route, or production authority. It records session-independent
+  cleanup targets, monotonic operation/attempt epochs, locator generations,
+  hash-at-rest per-intent capabilities, permanent request UUID identities, and
+  bounded receipt GC as shared PG authority for future consumers. Session bindings
+  are disposable and cannot delete targets. Every API transaction follows the
+  documented request → identity → sorted locator → target → operation → intent →
+  capability/request/receipt lock order. Classification: PG-backed dormant substrate;
+  no leader-only action, runtime lease replacement, cross-node side effect, or deploy
+  cutover. PostgreSQL cannot prove an external destination fenced stale side effects;
+  destination high-watermark enforcement remains a future slice.
 - 2026-07-26 — #4898 untrusted deploy-gate containment: PostgreSQL migration
   0100 adds a validated cluster-wide `CHECK` constraint that rejects normalized
   `deploy-gate` provenance. The `ALTER TABLE` lock serializes concurrent legacy

--- a/migrations/postgres/0102_dormant_runtime_cleanup_substrate.sql
+++ b/migrations/postgres/0102_dormant_runtime_cleanup_substrate.sql
@@ -154,6 +154,7 @@ CREATE TABLE runtime_cleanup_capabilities (
     intent_id UUID NOT NULL,
     attempt_epoch BIGINT NOT NULL CHECK (attempt_epoch > 0),
     audience TEXT NOT NULL CHECK (BTRIM(audience) <> ''),
+    claim_owner TEXT NOT NULL CHECK (BTRIM(claim_owner) <> ''),
     expires_at TIMESTAMPTZ NOT NULL,
     idempotency_identity UUID NOT NULL,
     consumed_at TIMESTAMPTZ,
@@ -227,9 +228,10 @@ BEFORE UPDATE OR DELETE ON runtime_cleanup_request_identities
 FOR EACH ROW EXECUTE FUNCTION agentdesk_guard_runtime_cleanup_immutable();
 
 -- Explicit lock order for every API transaction:
--- request UUID advisory lock -> canonical identity advisory lock -> sorted locator
--- locks via agentdesk_lock_session_locator -> target row -> operation row -> intent
--- row -> capability/request/receipt row. Callers must never acquire in reverse.
+-- request UUID advisory lock -> semantic idempotency advisory lock -> canonical
+-- identity advisory lock -> sorted locator locks via agentdesk_lock_session_locator
+-- -> target row -> operation row -> intent row -> capability/request/receipt row.
+-- Callers must never acquire in reverse.
 
 CREATE OR REPLACE FUNCTION agentdesk_gc_runtime_cleanup_receipts(batch_size INTEGER)
 RETURNS INTEGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, public AS $$
@@ -251,3 +253,39 @@ BEGIN
 END;
 $$;
 REVOKE ALL ON FUNCTION agentdesk_gc_runtime_cleanup_receipts(INTEGER) FROM PUBLIC;
+
+-- Capability secrets are disposable only after they cannot authorize work and no
+-- unresolved request depends on them. Permanent operation/request authority and
+-- terminal receipt evidence remain in their respective tables.
+CREATE OR REPLACE FUNCTION agentdesk_gc_runtime_cleanup_capabilities(batch_size INTEGER)
+RETURNS INTEGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, public AS $$
+DECLARE deleted_count INTEGER;
+BEGIN
+    IF batch_size < 1 OR batch_size > 1000 THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'batch_size must be between 1 and 1000';
+    END IF;
+    WITH doomed AS (
+        SELECT capability_id FROM public.runtime_cleanup_capabilities capability
+        JOIN public.runtime_cleanup_operations operation USING (operation_id)
+        WHERE capability.expires_at <= clock_timestamp() - INTERVAL '30 days'
+          AND (operation.state IN ('completed', 'aborted')
+               OR capability.expires_at <= clock_timestamp())
+          AND NOT EXISTS (
+              SELECT 1
+              FROM public.runtime_cleanup_request_identities request
+              LEFT JOIN public.runtime_cleanup_receipts receipt USING (request_id)
+              WHERE request.operation_id = capability.operation_id
+                AND request.intent_id = capability.intent_id
+                AND request.idempotency_identity = capability.idempotency_identity
+                AND (receipt.request_id IS NULL OR receipt.receipt_state = 'unknown')
+          )
+        ORDER BY capability.expires_at, capability.capability_id
+        FOR UPDATE OF capability SKIP LOCKED LIMIT batch_size
+    )
+    DELETE FROM public.runtime_cleanup_capabilities capability
+    USING doomed WHERE capability.capability_id = doomed.capability_id;
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END;
+$$;
+REVOKE ALL ON FUNCTION agentdesk_gc_runtime_cleanup_capabilities(INTEGER) FROM PUBLIC;

--- a/migrations/postgres/0102_dormant_runtime_cleanup_substrate.sql
+++ b/migrations/postgres/0102_dormant_runtime_cleanup_substrate.sql
@@ -17,6 +17,34 @@ CREATE TABLE runtime_cleanup_targets (
     UNIQUE (identity_kind, provider, discord_token_hash, channel_id)
 );
 
+CREATE OR REPLACE FUNCTION agentdesk_guard_runtime_cleanup_target()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE authority TEXT := current_setting('agentdesk.cleanup_authority', TRUE);
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'runtime cleanup targets are permanent authority';
+    END IF;
+    IF NEW.target_id IS DISTINCT FROM OLD.target_id
+       OR NEW.identity_kind IS DISTINCT FROM OLD.identity_kind
+       OR NEW.provider IS DISTINCT FROM OLD.provider
+       OR NEW.discord_token_hash IS DISTINCT FROM OLD.discord_token_hash
+       OR NEW.channel_id IS DISTINCT FROM OLD.channel_id
+       OR NEW.created_at IS DISTINCT FROM OLD.created_at
+       OR NEW.operation_high_watermark < OLD.operation_high_watermark
+       OR (OLD.retired_at IS NOT NULL AND NEW.retired_at IS DISTINCT FROM OLD.retired_at)
+       OR (NEW.operation_high_watermark > OLD.operation_high_watermark
+           AND authority <> FORMAT('operation:%s', OLD.target_id))
+       OR (OLD.retired_at IS NULL AND NEW.retired_at IS NOT NULL
+           AND authority <> FORMAT('retire:%s', OLD.target_id)) THEN
+        RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'runtime cleanup target authority is immutable or API-governed';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE TRIGGER trg_runtime_cleanup_target_guard
+BEFORE UPDATE OR DELETE ON runtime_cleanup_targets
+FOR EACH ROW EXECUTE FUNCTION agentdesk_guard_runtime_cleanup_target();
+
 CREATE TABLE runtime_cleanup_target_session_bindings (
     session_id BIGINT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
     target_id UUID NOT NULL REFERENCES runtime_cleanup_targets(target_id) ON DELETE RESTRICT,
@@ -169,13 +197,20 @@ CREATE TABLE runtime_cleanup_capabilities (
 -- a separate row so 30-day GC can never make the UUID reusable.
 CREATE TABLE runtime_cleanup_request_identities (
     request_id UUID PRIMARY KEY,
+    target_id UUID NOT NULL REFERENCES runtime_cleanup_targets(target_id) ON DELETE RESTRICT,
     operation_id UUID NOT NULL REFERENCES runtime_cleanup_operations(operation_id) ON DELETE RESTRICT,
     intent_id UUID NOT NULL,
     idempotency_identity UUID NOT NULL,
+    capability_id UUID NOT NULL,
+    capability_binding_digest BYTEA NOT NULL CHECK (OCTET_LENGTH(capability_binding_digest) = 32),
+    audience TEXT NOT NULL CHECK (BTRIM(audience) <> ''),
+    accepted_attempt_epoch BIGINT NOT NULL CHECK (accepted_attempt_epoch > 0),
+    accepted_claim_owner TEXT NOT NULL CHECK (BTRIM(accepted_claim_owner) <> ''),
     request_fingerprint BYTEA NOT NULL CHECK (OCTET_LENGTH(request_fingerprint) = 32),
     created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
-    FOREIGN KEY (operation_id, intent_id)
-        REFERENCES runtime_cleanup_intents(operation_id, intent_id) ON DELETE RESTRICT,
+    FOREIGN KEY (operation_id, intent_id, target_id, idempotency_identity)
+        REFERENCES runtime_cleanup_intents(operation_id, intent_id, target_id, idempotency_identity)
+        ON DELETE RESTRICT,
     UNIQUE (operation_id, intent_id, idempotency_identity)
 );
 
@@ -183,10 +218,37 @@ CREATE TABLE runtime_cleanup_receipts (
     request_id UUID PRIMARY KEY REFERENCES runtime_cleanup_request_identities(request_id) ON DELETE RESTRICT,
     receipt_state TEXT NOT NULL CHECK (receipt_state IN ('applied', 'not_applied', 'unknown')),
     result_fingerprint BYTEA CHECK (result_fingerprint IS NULL OR OCTET_LENGTH(result_fingerprint) = 32),
+    authority_attempt_epoch BIGINT NOT NULL CHECK (authority_attempt_epoch > 0),
+    authority_claim_owner TEXT NOT NULL CHECK (BTRIM(authority_claim_owner) <> ''),
     terminal_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
     retain_until TIMESTAMPTZ NOT NULL,
     CHECK (retain_until >= terminal_at + INTERVAL '30 days')
 );
+
+CREATE OR REPLACE FUNCTION agentdesk_guard_runtime_cleanup_receipt()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE authority TEXT := current_setting('agentdesk.cleanup_authority', TRUE);
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        IF authority = 'receipt_gc' THEN
+            RETURN OLD;
+        END IF;
+        RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'runtime cleanup receipts are API-governed';
+    END IF;
+    IF authority <> 'receipt'
+       OR NEW.request_id IS DISTINCT FROM OLD.request_id
+       OR NEW.terminal_at IS DISTINCT FROM OLD.terminal_at
+       OR NOT (OLD.receipt_state = 'unknown'
+               AND NEW.receipt_state IN ('applied', 'not_applied')
+               AND NEW.authority_attempt_epoch > OLD.authority_attempt_epoch) THEN
+        RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'illegal runtime cleanup receipt transition';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE TRIGGER trg_runtime_cleanup_receipt_guard
+BEFORE UPDATE OR DELETE ON runtime_cleanup_receipts
+FOR EACH ROW EXECUTE FUNCTION agentdesk_guard_runtime_cleanup_receipt();
 
 CREATE OR REPLACE FUNCTION agentdesk_guard_runtime_cleanup_operation()
 RETURNS TRIGGER LANGUAGE plpgsql AS $$
@@ -240,6 +302,7 @@ BEGIN
     IF batch_size < 1 OR batch_size > 1000 THEN
         RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'batch_size must be between 1 and 1000';
     END IF;
+    PERFORM set_config('agentdesk.cleanup_authority', 'receipt_gc', TRUE);
     WITH doomed AS (
         SELECT request_id FROM public.runtime_cleanup_receipts
         WHERE retain_until <= clock_timestamp()

--- a/migrations/postgres/0102_dormant_runtime_cleanup_substrate.sql
+++ b/migrations/postgres/0102_dormant_runtime_cleanup_substrate.sql
@@ -1,0 +1,193 @@
+-- Task #25 replacement: dormant PostgreSQL cleanup substrate only.
+--
+-- No production consumer or external-side-effect authority is activated by this
+-- migration. Database epochs and capabilities reject stale database mutations;
+-- they cannot prove that an external destination fenced an already issued side
+-- effect. Future consumers must enforce target high-watermarks at destinations.
+
+CREATE TABLE runtime_cleanup_targets (
+    target_id UUID PRIMARY KEY,
+    identity_kind TEXT NOT NULL CHECK (identity_kind IN ('discord_channel', 'scheduled_snapshot')),
+    provider TEXT NOT NULL CHECK (BTRIM(provider) <> ''),
+    discord_token_hash TEXT NOT NULL CHECK (discord_token_hash ~ '^discord_[0-9a-f]{16}$'),
+    channel_id TEXT NOT NULL CHECK (BTRIM(channel_id) <> ''),
+    operation_high_watermark BIGINT NOT NULL DEFAULT 0 CHECK (operation_high_watermark >= 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    retired_at TIMESTAMPTZ,
+    UNIQUE (identity_kind, provider, discord_token_hash, channel_id)
+);
+
+CREATE TABLE runtime_cleanup_target_session_bindings (
+    session_id BIGINT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    target_id UUID NOT NULL REFERENCES runtime_cleanup_targets(target_id) ON DELETE RESTRICT,
+    bound_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
+);
+CREATE INDEX runtime_cleanup_target_session_bindings_target_idx
+    ON runtime_cleanup_target_session_bindings (target_id);
+
+-- A locator history row is never deleted or reused. active=false is the retired
+-- generation watermark; a later claim receives max(generation)+1.
+CREATE TABLE runtime_cleanup_locator_claims (
+    locator TEXT NOT NULL CHECK (BTRIM(locator) <> ''),
+    generation BIGINT NOT NULL CHECK (generation > 0),
+    target_id UUID NOT NULL REFERENCES runtime_cleanup_targets(target_id) ON DELETE RESTRICT,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    claimed_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    retired_at TIMESTAMPTZ,
+    PRIMARY KEY (locator, generation),
+    CHECK ((active AND retired_at IS NULL) OR (NOT active AND retired_at IS NOT NULL))
+);
+CREATE UNIQUE INDEX runtime_cleanup_locator_claims_one_active_idx
+    ON runtime_cleanup_locator_claims (locator) WHERE active;
+
+CREATE TABLE runtime_cleanup_operations (
+    operation_id UUID PRIMARY KEY,
+    target_id UUID NOT NULL REFERENCES runtime_cleanup_targets(target_id) ON DELETE RESTRICT,
+    operation_epoch BIGINT NOT NULL CHECK (operation_epoch > 0),
+    operation_kind TEXT NOT NULL CHECK (operation_kind = 'clear_for_resume'),
+    state TEXT NOT NULL DEFAULT 'open' CHECK (state IN ('open', 'committed', 'completed', 'aborted')),
+    claim_owner TEXT,
+    attempt_epoch BIGINT NOT NULL DEFAULT 0 CHECK (attempt_epoch >= 0),
+    claim_expires_at TIMESTAMPTZ,
+    committed_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    aborted_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    UNIQUE (target_id, operation_epoch),
+    CHECK (
+        (state = 'open' AND committed_at IS NULL AND completed_at IS NULL AND aborted_at IS NULL)
+        OR (state = 'committed' AND committed_at IS NOT NULL AND completed_at IS NULL AND aborted_at IS NULL)
+        OR (state = 'completed' AND committed_at IS NOT NULL AND completed_at IS NOT NULL AND aborted_at IS NULL)
+        OR (state = 'aborted' AND committed_at IS NULL AND completed_at IS NULL AND aborted_at IS NOT NULL)
+    ),
+    CHECK (
+        (claim_owner IS NULL AND claim_expires_at IS NULL)
+        OR (claim_owner IS NOT NULL AND BTRIM(claim_owner) <> '' AND claim_expires_at IS NOT NULL AND attempt_epoch > 0)
+    )
+);
+CREATE UNIQUE INDEX runtime_cleanup_operations_one_open_target_idx
+    ON runtime_cleanup_operations (target_id) WHERE state IN ('open', 'committed');
+
+CREATE TABLE runtime_cleanup_intents (
+    operation_id UUID NOT NULL REFERENCES runtime_cleanup_operations(operation_id) ON DELETE RESTRICT,
+    intent_id UUID NOT NULL,
+    ordinal SMALLINT NOT NULL CHECK (ordinal > 0),
+    intent_kind TEXT NOT NULL CHECK (intent_kind IN (
+        'block_runtime_admission', 'clear_queued_input', 'expire_runtime_lease',
+        'cancel_active_runtime', 'clear_persisted_session', 'release_runtime_slot'
+    )),
+    target_id UUID NOT NULL REFERENCES runtime_cleanup_targets(target_id) ON DELETE RESTRICT,
+    idempotency_identity UUID NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (operation_id, intent_id),
+    UNIQUE (operation_id, ordinal),
+    UNIQUE (operation_id, idempotency_identity)
+);
+
+-- The plaintext capability is returned once by the API. Only its SHA-256 digest
+-- is stored. All binding fields are exact typed columns, never hash-only identity.
+CREATE TABLE runtime_cleanup_capabilities (
+    capability_id UUID PRIMARY KEY,
+    capability_hash BYTEA NOT NULL UNIQUE CHECK (OCTET_LENGTH(capability_hash) = 32),
+    target_id UUID NOT NULL REFERENCES runtime_cleanup_targets(target_id) ON DELETE RESTRICT,
+    operation_id UUID NOT NULL REFERENCES runtime_cleanup_operations(operation_id) ON DELETE RESTRICT,
+    intent_id UUID NOT NULL,
+    attempt_epoch BIGINT NOT NULL CHECK (attempt_epoch > 0),
+    audience TEXT NOT NULL CHECK (BTRIM(audience) <> ''),
+    expires_at TIMESTAMPTZ NOT NULL,
+    idempotency_identity UUID NOT NULL,
+    consumed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    FOREIGN KEY (operation_id, intent_id)
+        REFERENCES runtime_cleanup_intents(operation_id, intent_id) ON DELETE RESTRICT,
+    UNIQUE (operation_id, intent_id, attempt_epoch, audience, idempotency_identity)
+);
+
+-- request_id is server-issued and permanent. Payload/result retention is kept in
+-- a separate row so 30-day GC can never make the UUID reusable.
+CREATE TABLE runtime_cleanup_request_identities (
+    request_id UUID PRIMARY KEY,
+    operation_id UUID NOT NULL REFERENCES runtime_cleanup_operations(operation_id) ON DELETE RESTRICT,
+    intent_id UUID NOT NULL,
+    idempotency_identity UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (OCTET_LENGTH(request_fingerprint) = 32),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    FOREIGN KEY (operation_id, intent_id)
+        REFERENCES runtime_cleanup_intents(operation_id, intent_id) ON DELETE RESTRICT,
+    UNIQUE (operation_id, intent_id, idempotency_identity)
+);
+
+CREATE TABLE runtime_cleanup_receipts (
+    request_id UUID PRIMARY KEY REFERENCES runtime_cleanup_request_identities(request_id) ON DELETE RESTRICT,
+    receipt_state TEXT NOT NULL CHECK (receipt_state IN ('applied', 'not_applied', 'unknown')),
+    result_fingerprint BYTEA CHECK (result_fingerprint IS NULL OR OCTET_LENGTH(result_fingerprint) = 32),
+    terminal_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    retain_until TIMESTAMPTZ NOT NULL,
+    CHECK (retain_until >= terminal_at + INTERVAL '30 days')
+);
+
+CREATE OR REPLACE FUNCTION agentdesk_guard_runtime_cleanup_operation()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'runtime cleanup operations are permanent authority';
+    END IF;
+    IF NEW.operation_id IS DISTINCT FROM OLD.operation_id
+       OR NEW.target_id IS DISTINCT FROM OLD.target_id
+       OR NEW.operation_epoch IS DISTINCT FROM OLD.operation_epoch
+       OR NEW.operation_kind IS DISTINCT FROM OLD.operation_kind
+       OR NEW.attempt_epoch < OLD.attempt_epoch THEN
+        RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'runtime cleanup operation identity and epochs are immutable or monotonic';
+    END IF;
+    IF NOT ((OLD.state = 'open' AND NEW.state IN ('open', 'committed', 'aborted'))
+         OR (OLD.state = 'committed' AND NEW.state IN ('committed', 'completed'))
+         OR (OLD.state = 'completed' AND NEW.state = 'completed')
+         OR (OLD.state = 'aborted' AND NEW.state = 'aborted')) THEN
+        RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = FORMAT('illegal runtime cleanup transition: %s to %s', OLD.state, NEW.state);
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE TRIGGER trg_runtime_cleanup_operation_guard
+BEFORE UPDATE OR DELETE ON runtime_cleanup_operations
+FOR EACH ROW EXECUTE FUNCTION agentdesk_guard_runtime_cleanup_operation();
+
+CREATE OR REPLACE FUNCTION agentdesk_guard_runtime_cleanup_immutable()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = FORMAT('%s rows are immutable', TG_TABLE_NAME);
+END;
+$$;
+CREATE TRIGGER trg_runtime_cleanup_intents_immutable
+BEFORE UPDATE OR DELETE ON runtime_cleanup_intents
+FOR EACH ROW EXECUTE FUNCTION agentdesk_guard_runtime_cleanup_immutable();
+CREATE TRIGGER trg_runtime_cleanup_request_identities_immutable
+BEFORE UPDATE OR DELETE ON runtime_cleanup_request_identities
+FOR EACH ROW EXECUTE FUNCTION agentdesk_guard_runtime_cleanup_immutable();
+
+-- Explicit lock order for every API transaction:
+-- request UUID advisory lock -> canonical identity advisory lock -> sorted locator
+-- locks via agentdesk_lock_session_locator -> target row -> operation row -> intent
+-- row -> capability/request/receipt row. Callers must never acquire in reverse.
+
+CREATE OR REPLACE FUNCTION agentdesk_gc_runtime_cleanup_receipts(batch_size INTEGER)
+RETURNS INTEGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, public AS $$
+DECLARE deleted_count INTEGER;
+BEGIN
+    IF batch_size < 1 OR batch_size > 1000 THEN
+        RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'batch_size must be between 1 and 1000';
+    END IF;
+    WITH doomed AS (
+        SELECT request_id FROM public.runtime_cleanup_receipts
+        WHERE retain_until <= clock_timestamp()
+        ORDER BY retain_until, request_id
+        FOR UPDATE SKIP LOCKED LIMIT batch_size
+    )
+    DELETE FROM public.runtime_cleanup_receipts receipt
+    USING doomed WHERE receipt.request_id = doomed.request_id;
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END;
+$$;
+REVOKE ALL ON FUNCTION agentdesk_gc_runtime_cleanup_receipts(INTEGER) FROM PUBLIC;

--- a/migrations/postgres/0102_dormant_runtime_cleanup_substrate.sql
+++ b/migrations/postgres/0102_dormant_runtime_cleanup_substrate.sql
@@ -40,6 +40,26 @@ CREATE TABLE runtime_cleanup_locator_claims (
 CREATE UNIQUE INDEX runtime_cleanup_locator_claims_one_active_idx
     ON runtime_cleanup_locator_claims (locator) WHERE active;
 
+CREATE OR REPLACE FUNCTION agentdesk_guard_runtime_cleanup_locator_claim()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'runtime cleanup locator generations are permanent authority';
+    END IF;
+    IF NEW.locator IS DISTINCT FROM OLD.locator
+       OR NEW.generation IS DISTINCT FROM OLD.generation
+       OR NEW.target_id IS DISTINCT FROM OLD.target_id
+       OR NEW.claimed_at IS DISTINCT FROM OLD.claimed_at
+       OR NOT (OLD.active AND NOT NEW.active AND OLD.retired_at IS NULL AND NEW.retired_at IS NOT NULL) THEN
+        RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'runtime cleanup locator generations are immutable except retirement';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE TRIGGER trg_runtime_cleanup_locator_claim_guard
+BEFORE UPDATE OR DELETE ON runtime_cleanup_locator_claims
+FOR EACH ROW EXECUTE FUNCTION agentdesk_guard_runtime_cleanup_locator_claim();
+
 CREATE TABLE runtime_cleanup_operations (
     operation_id UUID PRIMARY KEY,
     target_id UUID NOT NULL REFERENCES runtime_cleanup_targets(target_id) ON DELETE RESTRICT,
@@ -55,6 +75,7 @@ CREATE TABLE runtime_cleanup_operations (
     created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
     UNIQUE (target_id, operation_epoch),
+    UNIQUE (operation_id, target_id),
     CHECK (
         (state = 'open' AND committed_at IS NULL AND completed_at IS NULL AND aborted_at IS NULL)
         OR (state = 'committed' AND committed_at IS NOT NULL AND completed_at IS NULL AND aborted_at IS NULL)
@@ -82,11 +103,49 @@ CREATE TABLE runtime_cleanup_intents (
     created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
     PRIMARY KEY (operation_id, intent_id),
     UNIQUE (operation_id, ordinal),
-    UNIQUE (operation_id, idempotency_identity)
+    UNIQUE (operation_id, idempotency_identity),
+    UNIQUE (operation_id, intent_id, target_id, idempotency_identity),
+    FOREIGN KEY (operation_id, target_id)
+        REFERENCES runtime_cleanup_operations(operation_id, target_id) ON DELETE RESTRICT,
+    CHECK ((ordinal, intent_kind) IN (
+        (1, 'block_runtime_admission'),
+        (2, 'clear_queued_input'),
+        (3, 'expire_runtime_lease'),
+        (4, 'cancel_active_runtime'),
+        (5, 'clear_persisted_session'),
+        (6, 'release_runtime_slot')
+    ))
 );
 
 -- The plaintext capability is returned once by the API. Only its SHA-256 digest
 -- is stored. All binding fields are exact typed columns, never hash-only identity.
+CREATE OR REPLACE FUNCTION agentdesk_require_runtime_cleanup_plan()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE plan_is_canonical BOOLEAN;
+BEGIN
+    SELECT COUNT(*) = 6
+       AND BOOL_AND((ordinal, intent_kind) IN (
+           (1, 'block_runtime_admission'),
+           (2, 'clear_queued_input'),
+           (3, 'expire_runtime_lease'),
+           (4, 'cancel_active_runtime'),
+           (5, 'clear_persisted_session'),
+           (6, 'release_runtime_slot')
+       ))
+    INTO plan_is_canonical
+    FROM runtime_cleanup_intents
+    WHERE operation_id = NEW.operation_id;
+    IF NOT plan_is_canonical THEN
+        RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'runtime cleanup operation requires the canonical six-intent plan';
+    END IF;
+    RETURN NULL;
+END;
+$$;
+CREATE CONSTRAINT TRIGGER trg_runtime_cleanup_operation_plan
+AFTER INSERT ON runtime_cleanup_operations
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION agentdesk_require_runtime_cleanup_plan();
+
 CREATE TABLE runtime_cleanup_capabilities (
     capability_id UUID PRIMARY KEY,
     capability_hash BYTEA NOT NULL UNIQUE CHECK (OCTET_LENGTH(capability_hash) = 32),
@@ -99,8 +158,9 @@ CREATE TABLE runtime_cleanup_capabilities (
     idempotency_identity UUID NOT NULL,
     consumed_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
-    FOREIGN KEY (operation_id, intent_id)
-        REFERENCES runtime_cleanup_intents(operation_id, intent_id) ON DELETE RESTRICT,
+    FOREIGN KEY (operation_id, intent_id, target_id, idempotency_identity)
+        REFERENCES runtime_cleanup_intents(operation_id, intent_id, target_id, idempotency_identity)
+        ON DELETE RESTRICT,
     UNIQUE (operation_id, intent_id, attempt_epoch, audience, idempotency_identity)
 );
 

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -523,7 +523,7 @@
     },
     {
       "path": "migrations/postgres/0102_dormant_runtime_cleanup_substrate.sql",
-      "sha256": "43d64eea47b9cd36e85f99ce3894a86dc69429801af28124d169c56c12d6a58a",
+      "sha256": "4d75c72fb09e6f37d1e89c98de2ade97777726cea8b3671191c6479d1a0f12e9",
       "version": 102
     }
   ],

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -523,7 +523,7 @@
     },
     {
       "path": "migrations/postgres/0102_dormant_runtime_cleanup_substrate.sql",
-      "sha256": "4a57497594a554380197f233205102786fd8bd02bdc0c174a5bc9f0c6f0ebd3c",
+      "sha256": "43d64eea47b9cd36e85f99ce3894a86dc69429801af28124d169c56c12d6a58a",
       "version": 102
     }
   ],

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -523,7 +523,7 @@
     },
     {
       "path": "migrations/postgres/0102_dormant_runtime_cleanup_substrate.sql",
-      "sha256": "4d75c72fb09e6f37d1e89c98de2ade97777726cea8b3671191c6479d1a0f12e9",
+      "sha256": "13debf04c223389a4c2d66ef0eca665e47bc623ce4a33b113964aef631b7ec82",
       "version": 102
     }
   ],

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -520,6 +520,11 @@
       "path": "migrations/postgres/0101_canonical_discord_session_identity.sql",
       "sha256": "3f61d2c3944a55d7bce62312baed85a1f112d685fc4b733dc78c73066bfc867e",
       "version": 101
+    },
+    {
+      "path": "migrations/postgres/0102_dormant_runtime_cleanup_substrate.sql",
+      "sha256": "4a57497594a554380197f233205102786fd8bd02bdc0c174a5bc9f0c6f0ebd3c",
+      "version": 102
     }
   ],
   "version": 1

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -18,6 +18,7 @@ pub mod meetings;
 pub mod postgres;
 pub mod prompt_manifests;
 pub mod relay_dead_letter;
+pub(crate) mod runtime_cleanup;
 pub mod scheduled_messages;
 pub(crate) mod session_agent_resolution;
 pub mod session_observability;

--- a/src/db/runtime_cleanup.rs
+++ b/src/db/runtime_cleanup.rs
@@ -76,11 +76,30 @@ pub(crate) async fn converge_target(
     Ok(target)
 }
 
+pub(crate) async fn retire_target(pool: &PgPool, target_id: Uuid) -> Result<bool, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    lock_target(&mut tx, target_id).await?;
+    let changed = sqlx::query(
+        "UPDATE runtime_cleanup_targets SET retired_at = clock_timestamp()
+         WHERE target_id = $1 AND retired_at IS NULL",
+    )
+    .bind(target_id)
+    .execute(&mut *tx)
+    .await?
+    .rows_affected()
+        == 1;
+    tx.commit().await?;
+    Ok(changed)
+}
+
 pub(crate) async fn bind_session(
     pool: &PgPool,
     target_id: Uuid,
     session_id: i64,
 ) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    lock_target(&mut tx, target_id).await?;
+    ensure_active_target(&mut tx, target_id).await?;
     sqlx::query(
         "INSERT INTO runtime_cleanup_target_session_bindings (session_id, target_id)
          VALUES ($1, $2)
@@ -89,8 +108,9 @@ pub(crate) async fn bind_session(
     )
     .bind(session_id)
     .bind(target_id)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
+    tx.commit().await?;
     Ok(())
 }
 
@@ -102,6 +122,7 @@ pub(crate) async fn reserve_locator(
     let mut tx = pool.begin().await?;
     lock_locators(&mut tx, &[locator]).await?;
     lock_target(&mut tx, target_id).await?;
+    ensure_active_target(&mut tx, target_id).await?;
     if let Some(row) = sqlx::query(
         "SELECT target_id, generation FROM runtime_cleanup_locator_claims
          WHERE locator = $1 AND active FOR UPDATE",
@@ -144,24 +165,25 @@ pub(crate) async fn resolve_locator(
     pool: &PgPool,
     locator: &str,
 ) -> Result<Option<LocatorClaim>, sqlx::Error> {
-    sqlx::query("SELECT agentdesk_lock_session_locator($1)")
-        .bind(locator)
-        .execute(pool)
-        .await?;
+    let mut tx = pool.begin().await?;
+    lock_locators(&mut tx, &[locator]).await?;
     let row = sqlx::query(
         "SELECT target_id, generation FROM runtime_cleanup_locator_claims
-         WHERE locator = $1 AND active",
+         WHERE locator = $1 AND active FOR UPDATE",
     )
     .bind(locator)
-    .fetch_optional(pool)
+    .fetch_optional(&mut *tx)
     .await?;
-    row.map(|row| {
-        Ok(LocatorClaim {
-            target_id: row.try_get("target_id")?,
-            generation: row.try_get("generation")?,
+    let claim = row
+        .map(|row| -> Result<LocatorClaim, sqlx::Error> {
+            Ok(LocatorClaim {
+                target_id: row.try_get("target_id")?,
+                generation: row.try_get("generation")?,
+            })
         })
-    })
-    .transpose()
+        .transpose()?;
+    tx.commit().await?;
+    Ok(claim)
 }
 
 pub(crate) async fn retire_locator(
@@ -292,7 +314,10 @@ async fn claim_or_renew(
     let current_epoch: i64 = row.try_get("attempt_epoch")?;
     let current_expiry: Option<DateTime<Utc>> = row.try_get("claim_expires_at")?;
     if let Some(expected) = renew_epoch {
-        if current_owner.as_deref() != Some(owner) || current_epoch != expected {
+        if current_owner.as_deref() != Some(owner)
+            || current_epoch != expected
+            || current_expiry.is_none_or(|expires_at| expires_at <= database_now)
+        {
             tx.commit().await?;
             return Ok(ClaimResult::Stale);
         }
@@ -343,6 +368,7 @@ async fn claim_or_renew(
 pub(crate) async fn transition_operation(
     pool: &PgPool,
     operation_id: Uuid,
+    owner: &str,
     expected_attempt_epoch: i64,
     next: OperationState,
 ) -> Result<bool, sqlx::Error> {
@@ -353,11 +379,13 @@ pub(crate) async fn transition_operation(
         OperationState::Open => return Ok(false),
     };
     let query = format!(
-        "UPDATE runtime_cleanup_operations SET state = $3, {timestamp_column} = clock_timestamp(),
-         updated_at = clock_timestamp() WHERE operation_id = $1 AND attempt_epoch = $2"
+        "UPDATE runtime_cleanup_operations SET state = $4, {timestamp_column} = clock_timestamp(),
+         updated_at = clock_timestamp() WHERE operation_id = $1 AND claim_owner = $2
+         AND attempt_epoch = $3 AND claim_expires_at > clock_timestamp()"
     );
     Ok(sqlx::query(&query)
         .bind(operation_id)
+        .bind(owner)
         .bind(expected_attempt_epoch)
         .bind(next.as_str())
         .execute(pool)
@@ -407,8 +435,37 @@ pub(crate) async fn begin_capability_request(
     pool: &PgPool,
     secret: &[u8],
     binding: CapabilityBinding<'_>,
+    request_fingerprint: [u8; 32],
+) -> Result<CapabilityUse, sqlx::Error> {
+    begin_or_replay_capability_request(
+        pool,
+        secret,
+        binding,
+        Uuid::new_v4(),
+        request_fingerprint,
+        false,
+    )
+    .await
+}
+
+pub(crate) async fn replay_capability_request(
+    pool: &PgPool,
+    secret: &[u8],
+    binding: CapabilityBinding<'_>,
     request_id: Uuid,
     request_fingerprint: [u8; 32],
+) -> Result<CapabilityUse, sqlx::Error> {
+    begin_or_replay_capability_request(pool, secret, binding, request_id, request_fingerprint, true)
+        .await
+}
+
+async fn begin_or_replay_capability_request(
+    pool: &PgPool,
+    secret: &[u8],
+    binding: CapabilityBinding<'_>,
+    request_id: Uuid,
+    request_fingerprint: [u8; 32],
+    replay_only: bool,
 ) -> Result<CapabilityUse, sqlx::Error> {
     let mut tx = pool.begin().await?;
     lock_request(&mut tx, request_id).await?;
@@ -469,6 +526,44 @@ pub(crate) async fn begin_capability_request(
         .await?;
         tx.commit().await?;
         return Ok(CapabilityUse::Replay {
+            request_id,
+            state: receipt
+                .as_deref()
+                .map(parse_receipt)
+                .unwrap_or(ReceiptState::Unknown),
+        });
+    }
+    if replay_only {
+        tx.commit().await?;
+        return Ok(CapabilityUse::NotFound);
+    }
+    if let Some(existing) = sqlx::query(
+        "SELECT request_id, request_fingerprint
+         FROM runtime_cleanup_request_identities
+         WHERE operation_id = $1 AND intent_id = $2 AND idempotency_identity = $3
+         FOR UPDATE",
+    )
+    .bind(binding.operation_id)
+    .bind(binding.intent_id)
+    .bind(binding.idempotency_identity)
+    .fetch_optional(&mut *tx)
+    .await?
+    {
+        let existing_request_id: Uuid = existing.try_get("request_id")?;
+        let prior: Vec<u8> = existing.try_get("request_fingerprint")?;
+        if prior.as_slice() != request_fingerprint {
+            tx.commit().await?;
+            return Ok(CapabilityUse::FingerprintConflict);
+        }
+        let receipt = sqlx::query_scalar::<_, String>(
+            "SELECT receipt_state FROM runtime_cleanup_receipts WHERE request_id = $1",
+        )
+        .bind(existing_request_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        return Ok(CapabilityUse::Replay {
+            request_id: existing_request_id,
             state: receipt
                 .as_deref()
                 .map(parse_receipt)
@@ -488,7 +583,7 @@ pub(crate) async fn begin_capability_request(
     .execute(&mut *tx)
     .await?;
     tx.commit().await?;
-    Ok(CapabilityUse::Accepted)
+    Ok(CapabilityUse::Accepted { request_id })
 }
 
 pub(crate) async fn record_receipt(
@@ -594,5 +689,21 @@ async fn lock_target(
         .bind(target_id)
         .fetch_one(&mut **tx)
         .await?;
+    Ok(())
+}
+
+async fn ensure_active_target(
+    tx: &mut Transaction<'_, Postgres>,
+    target_id: Uuid,
+) -> Result<(), sqlx::Error> {
+    let active: bool = sqlx::query_scalar(
+        "SELECT retired_at IS NULL FROM runtime_cleanup_targets WHERE target_id = $1",
+    )
+    .bind(target_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    if !active {
+        return Err(sqlx::Error::Protocol("cleanup target is retired".into()));
+    }
     Ok(())
 }

--- a/src/db/runtime_cleanup.rs
+++ b/src/db/runtime_cleanup.rs
@@ -80,6 +80,7 @@ pub(crate) async fn converge_target(
 pub(crate) async fn retire_target(pool: &PgPool, target_id: Uuid) -> Result<bool, sqlx::Error> {
     let mut tx = pool.begin().await?;
     lock_target(&mut tx, target_id).await?;
+    set_authority(&mut tx, &format!("retire:{target_id}")).await?;
     let changed = sqlx::query(
         "UPDATE runtime_cleanup_targets SET retired_at = clock_timestamp()
          WHERE target_id = $1 AND retired_at IS NULL",
@@ -216,6 +217,7 @@ pub(crate) async fn create_operation(
 ) -> Result<CreatedOperation, sqlx::Error> {
     let mut tx = pool.begin().await?;
     lock_target(&mut tx, target_id).await?;
+    set_authority(&mut tx, &format!("operation:{target_id}")).await?;
     let operation_epoch: i64 = sqlx::query_scalar(
         "UPDATE runtime_cleanup_targets
          SET operation_high_watermark = operation_high_watermark + 1
@@ -499,18 +501,29 @@ async fn begin_or_replay_capability_request(
     let mut tx = pool.begin().await?;
     lock_request(&mut tx, request_id).await?;
     if replay_only {
+        let replay_hash = Sha256::digest(secret).to_vec();
+        let replay_binding_digest = capability_binding_digest(&binding, &replay_hash);
         if let Some(existing) = sqlx::query(
-            "SELECT operation_id, intent_id, idempotency_identity, request_fingerprint
+            "SELECT target_id, operation_id, intent_id, idempotency_identity,
+                    capability_id, capability_binding_digest, audience,
+                    accepted_attempt_epoch, accepted_claim_owner, request_fingerprint
              FROM runtime_cleanup_request_identities WHERE request_id = $1",
         )
         .bind(request_id)
         .fetch_optional(&mut *tx)
         .await?
         {
-            if existing.try_get::<Uuid, _>("operation_id")? != binding.operation_id
+            if existing.try_get::<Uuid, _>("target_id")? != binding.target_id
+                || existing.try_get::<Uuid, _>("operation_id")? != binding.operation_id
                 || existing.try_get::<Uuid, _>("intent_id")? != binding.intent_id
                 || existing.try_get::<Uuid, _>("idempotency_identity")?
                     != binding.idempotency_identity
+                || existing.try_get::<Uuid, _>("capability_id")? != binding.capability_id
+                || existing.try_get::<Vec<u8>, _>("capability_binding_digest")?
+                    != replay_binding_digest
+                || existing.try_get::<String, _>("audience")? != binding.audience
+                || existing.try_get::<i64, _>("accepted_attempt_epoch")? != binding.attempt_epoch
+                || existing.try_get::<String, _>("accepted_claim_owner")? != binding.claim_owner
             {
                 tx.commit().await?;
                 return Ok(CapabilityUse::BindingMismatch);
@@ -546,6 +559,7 @@ async fn begin_or_replay_capability_request(
         .fetch_one(&mut *tx)
         .await?;
     let capability_hash = Sha256::digest(secret).to_vec();
+    let binding_digest = capability_binding_digest(&binding, &capability_hash);
     let Some(row) = sqlx::query(
         "SELECT c.target_id, c.operation_id, c.intent_id, c.attempt_epoch,
                 c.audience, c.claim_owner, c.expires_at, c.idempotency_identity,
@@ -661,13 +675,21 @@ async fn begin_or_replay_capability_request(
     }
     sqlx::query(
         "INSERT INTO runtime_cleanup_request_identities
-         (request_id, operation_id, intent_id, idempotency_identity, request_fingerprint)
-         VALUES ($1,$2,$3,$4,$5)",
+         (request_id, target_id, operation_id, intent_id, idempotency_identity,
+          capability_id, capability_binding_digest, audience, accepted_attempt_epoch,
+          accepted_claim_owner, request_fingerprint)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)",
     )
     .bind(request_id)
+    .bind(binding.target_id)
     .bind(binding.operation_id)
     .bind(binding.intent_id)
     .bind(binding.idempotency_identity)
+    .bind(binding.capability_id)
+    .bind(binding_digest)
+    .bind(binding.audience)
+    .bind(binding.attempt_epoch)
+    .bind(binding.claim_owner)
     .bind(request_fingerprint.to_vec())
     .execute(&mut *tx)
     .await?;
@@ -677,23 +699,126 @@ async fn begin_or_replay_capability_request(
 
 pub(crate) async fn record_receipt(
     pool: &PgPool,
+    secret: &[u8],
+    binding: CapabilityBinding<'_>,
     request_id: Uuid,
+    request_fingerprint: [u8; 32],
+    authority_owner: &str,
+    authority_attempt_epoch: i64,
     state: ReceiptState,
     result_fingerprint: Option<[u8; 32]>,
-) -> Result<bool, sqlx::Error> {
-    Ok(sqlx::query(
+) -> Result<ReceiptWrite, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    lock_request(&mut tx, request_id).await?;
+    let now: DateTime<Utc> = sqlx::query_scalar("SELECT clock_timestamp()")
+        .fetch_one(&mut *tx)
+        .await?;
+    let capability_hash = Sha256::digest(secret).to_vec();
+    let binding_digest = capability_binding_digest(&binding, &capability_hash);
+    let Some(request) = sqlx::query(
+        "SELECT target_id, operation_id, intent_id, idempotency_identity,
+                capability_id, capability_binding_digest, audience,
+                accepted_attempt_epoch, accepted_claim_owner, request_fingerprint
+         FROM runtime_cleanup_request_identities WHERE request_id = $1 FOR UPDATE",
+    )
+    .bind(request_id)
+    .fetch_optional(&mut *tx)
+    .await?
+    else {
+        tx.commit().await?;
+        return Ok(ReceiptWrite::NotFound);
+    };
+    if request.try_get::<Uuid, _>("target_id")? != binding.target_id
+        || request.try_get::<Uuid, _>("operation_id")? != binding.operation_id
+        || request.try_get::<Uuid, _>("intent_id")? != binding.intent_id
+        || request.try_get::<Uuid, _>("idempotency_identity")? != binding.idempotency_identity
+        || request.try_get::<Uuid, _>("capability_id")? != binding.capability_id
+        || request.try_get::<Vec<u8>, _>("capability_binding_digest")? != binding_digest
+        || request.try_get::<String, _>("audience")? != binding.audience
+        || request.try_get::<Vec<u8>, _>("request_fingerprint")? != request_fingerprint
+    {
+        tx.commit().await?;
+        return Ok(ReceiptWrite::BindingMismatch);
+    }
+    let operation = sqlx::query(
+        "SELECT state, attempt_epoch, claim_owner, claim_expires_at
+         FROM runtime_cleanup_operations WHERE operation_id = $1 FOR UPDATE",
+    )
+    .bind(binding.operation_id)
+    .fetch_one(&mut *tx)
+    .await?;
+    let operation_attempt: i64 = operation.try_get("attempt_epoch")?;
+    let operation_owner: Option<String> = operation.try_get("claim_owner")?;
+    let operation_expiry: Option<DateTime<Utc>> = operation.try_get("claim_expires_at")?;
+    if operation_expiry.is_none_or(|expires_at| expires_at <= now) {
+        tx.commit().await?;
+        return Ok(ReceiptWrite::Expired);
+    }
+    if operation_attempt != authority_attempt_epoch
+        || operation_owner.as_deref() != Some(authority_owner)
+        || authority_attempt_epoch < binding.attempt_epoch
+        || !matches!(
+            operation.try_get::<String, _>("state")?.as_str(),
+            "open" | "committed"
+        )
+    {
+        tx.commit().await?;
+        return Ok(ReceiptWrite::LostOwnership);
+    }
+    if let Some(existing) = sqlx::query(
+        "SELECT receipt_state, result_fingerprint, authority_attempt_epoch
+         FROM runtime_cleanup_receipts WHERE request_id = $1 FOR UPDATE",
+    )
+    .bind(request_id)
+    .fetch_optional(&mut *tx)
+    .await?
+    {
+        let prior = parse_receipt(&existing.try_get::<String, _>("receipt_state")?);
+        let prior_result: Option<Vec<u8>> = existing.try_get("result_fingerprint")?;
+        if prior == state && prior_result == result_fingerprint.map(|value| value.to_vec()) {
+            tx.commit().await?;
+            return Ok(ReceiptWrite::Replay { state });
+        }
+        if prior != ReceiptState::Unknown
+            || state == ReceiptState::Unknown
+            || operation_attempt <= existing.try_get::<i64, _>("authority_attempt_epoch")?
+        {
+            tx.commit().await?;
+            return Ok(ReceiptWrite::Conflict);
+        }
+        set_authority(&mut tx, "receipt").await?;
+        sqlx::query(
+            "UPDATE runtime_cleanup_receipts
+             SET receipt_state = $2, result_fingerprint = $3,
+                 authority_attempt_epoch = $4, authority_claim_owner = $5,
+                 retain_until = clock_timestamp() + INTERVAL '30 days'
+             WHERE request_id = $1",
+        )
+        .bind(request_id)
+        .bind(state.as_str())
+        .bind(result_fingerprint.map(|value| value.to_vec()))
+        .bind(operation_attempt)
+        .bind(authority_owner)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        return Ok(ReceiptWrite::Reconciled);
+    }
+    sqlx::query(
         "INSERT INTO runtime_cleanup_receipts
-         (request_id, receipt_state, result_fingerprint, terminal_at, retain_until)
-         VALUES ($1,$2,$3,clock_timestamp(),clock_timestamp() + INTERVAL '30 days')
-         ON CONFLICT (request_id) DO NOTHING",
+         (request_id, receipt_state, result_fingerprint, authority_attempt_epoch,
+          authority_claim_owner, terminal_at, retain_until)
+         VALUES ($1,$2,$3,$4,$5,clock_timestamp(),clock_timestamp() + INTERVAL '30 days')",
     )
     .bind(request_id)
     .bind(state.as_str())
     .bind(result_fingerprint.map(|value| value.to_vec()))
-    .execute(pool)
-    .await?
-    .rows_affected()
-        == 1)
+    .bind(operation_attempt)
+    .bind(authority_owner)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(ReceiptWrite::Recorded)
 }
 
 pub(crate) async fn gc_terminal_receipts(
@@ -716,6 +841,21 @@ pub(crate) async fn gc_expired_capabilities(
         .await
 }
 
+fn capability_binding_digest(binding: &CapabilityBinding<'_>, capability_hash: &[u8]) -> Vec<u8> {
+    let mut digest = Sha256::new();
+    digest.update(capability_hash);
+    digest.update(binding.capability_id.as_bytes());
+    digest.update(binding.target_id.as_bytes());
+    digest.update(binding.operation_id.as_bytes());
+    digest.update(binding.intent_id.as_bytes());
+    digest.update(binding.attempt_epoch.to_be_bytes());
+    digest.update(binding.audience.as_bytes());
+    digest.update(binding.claim_owner.as_bytes());
+    digest.update(binding.expires_at.timestamp_micros().to_be_bytes());
+    digest.update(binding.idempotency_identity.as_bytes());
+    digest.finalize().to_vec()
+}
+
 fn parse_receipt(value: &str) -> ReceiptState {
     match value {
         "applied" => ReceiptState::Applied,
@@ -730,6 +870,17 @@ fn validate_duration(duration: Duration, maximum_seconds: i64) -> Result<(), sql
             "duration is outside database-clock bounds".into(),
         ));
     }
+    Ok(())
+}
+
+async fn set_authority(
+    tx: &mut Transaction<'_, Postgres>,
+    authority: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("SELECT set_config('agentdesk.cleanup_authority', $1, TRUE)")
+        .bind(authority)
+        .execute(&mut **tx)
+        .await?;
     Ok(())
 }
 

--- a/src/db/runtime_cleanup.rs
+++ b/src/db/runtime_cleanup.rs
@@ -6,9 +6,10 @@
 //! cannot prove that an external destination fenced a side effect already sent by
 //! a stale actor. Destination high-watermark enforcement is a future slice.
 //!
-//! Lock order is global and mandatory: request UUID advisory lock, canonical
-//! identity advisory lock, sorted locator locks, target row, operation row,
-//! intent row, then capability/request/receipt row.
+//! Lock order is global and mandatory: request UUID advisory lock, semantic
+//! idempotency advisory lock, canonical identity advisory lock, sorted locator
+//! locks, target row, operation row, intent row, then capability/request/receipt
+//! row.
 
 mod model;
 
@@ -398,14 +399,40 @@ pub(crate) async fn issue_capability(
     pool: &PgPool,
     binding: CapabilityBinding<'_>,
 ) -> Result<Vec<u8>, sqlx::Error> {
+    let mut tx = pool.begin().await?;
     let database_now: DateTime<Utc> = sqlx::query_scalar("SELECT clock_timestamp()")
-        .fetch_one(pool)
+        .fetch_one(&mut *tx)
         .await?;
-    if binding.expires_at <= database_now
-        || binding.expires_at > database_now + Duration::seconds(MAX_CAPABILITY_DURATION_SECONDS)
+    let operation = sqlx::query(
+        "SELECT target_id, state, claim_owner, attempt_epoch, claim_expires_at
+         FROM runtime_cleanup_operations WHERE operation_id = $1 FOR UPDATE",
+    )
+    .bind(binding.operation_id)
+    .fetch_one(&mut *tx)
+    .await?;
+    let claim_expires_at: Option<DateTime<Utc>> = operation.try_get("claim_expires_at")?;
+    if operation.try_get::<Uuid, _>("target_id")? != binding.target_id
+        || operation.try_get::<i64, _>("attempt_epoch")? != binding.attempt_epoch
+        || operation
+            .try_get::<Option<String>, _>("claim_owner")?
+            .as_deref()
+            != Some(binding.claim_owner)
+        || !matches!(
+            operation.try_get::<String, _>("state")?.as_str(),
+            "open" | "committed"
+        )
     {
         return Err(sqlx::Error::Protocol(
-            "capability duration is outside database-clock bounds".into(),
+            "capability binding does not own the current operation claim".into(),
+        ));
+    }
+    if binding.expires_at <= database_now
+        || binding.expires_at > database_now + Duration::seconds(MAX_CAPABILITY_DURATION_SECONDS)
+        || claim_expires_at
+            .is_none_or(|expires_at| expires_at <= database_now || binding.expires_at > expires_at)
+    {
+        return Err(sqlx::Error::Protocol(
+            "capability expiry exceeds database-clock claim bounds".into(),
         ));
     }
     let mut secret = vec![0_u8; 32];
@@ -414,8 +441,8 @@ pub(crate) async fn issue_capability(
     sqlx::query(
         "INSERT INTO runtime_cleanup_capabilities
          (capability_id, capability_hash, target_id, operation_id, intent_id,
-          attempt_epoch, audience, expires_at, idempotency_identity)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
+          attempt_epoch, audience, claim_owner, expires_at, idempotency_identity)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)",
     )
     .bind(binding.capability_id)
     .bind(hash)
@@ -424,10 +451,12 @@ pub(crate) async fn issue_capability(
     .bind(binding.intent_id)
     .bind(binding.attempt_epoch)
     .bind(binding.audience)
+    .bind(binding.claim_owner)
     .bind(binding.expires_at)
     .bind(binding.idempotency_identity)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
+    tx.commit().await?;
     Ok(secret)
 }
 
@@ -469,14 +498,59 @@ async fn begin_or_replay_capability_request(
 ) -> Result<CapabilityUse, sqlx::Error> {
     let mut tx = pool.begin().await?;
     lock_request(&mut tx, request_id).await?;
+    if replay_only {
+        if let Some(existing) = sqlx::query(
+            "SELECT operation_id, intent_id, idempotency_identity, request_fingerprint
+             FROM runtime_cleanup_request_identities WHERE request_id = $1",
+        )
+        .bind(request_id)
+        .fetch_optional(&mut *tx)
+        .await?
+        {
+            if existing.try_get::<Uuid, _>("operation_id")? != binding.operation_id
+                || existing.try_get::<Uuid, _>("intent_id")? != binding.intent_id
+                || existing.try_get::<Uuid, _>("idempotency_identity")?
+                    != binding.idempotency_identity
+            {
+                tx.commit().await?;
+                return Ok(CapabilityUse::BindingMismatch);
+            }
+            let prior: Vec<u8> = existing.try_get("request_fingerprint")?;
+            if prior.as_slice() != request_fingerprint {
+                tx.commit().await?;
+                return Ok(CapabilityUse::FingerprintConflict);
+            }
+            let receipt = sqlx::query_scalar::<_, String>(
+                "SELECT receipt_state FROM runtime_cleanup_receipts WHERE request_id = $1",
+            )
+            .bind(request_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            return Ok(match receipt.as_deref().map(parse_receipt) {
+                Some(ReceiptState::Applied) => CapabilityUse::Replay {
+                    request_id,
+                    state: ReceiptState::Applied,
+                },
+                Some(ReceiptState::NotApplied) => CapabilityUse::Replay {
+                    request_id,
+                    state: ReceiptState::NotApplied,
+                },
+                _ => CapabilityUse::NeedsReconcile { request_id },
+            });
+        }
+    } else {
+        lock_semantic_request(&mut tx, &binding).await?;
+    }
     let now: DateTime<Utc> = sqlx::query_scalar("SELECT clock_timestamp()")
         .fetch_one(&mut *tx)
         .await?;
     let capability_hash = Sha256::digest(secret).to_vec();
     let Some(row) = sqlx::query(
         "SELECT c.target_id, c.operation_id, c.intent_id, c.attempt_epoch,
-                c.audience, c.expires_at, c.idempotency_identity,
-                o.attempt_epoch AS operation_attempt_epoch
+                c.audience, c.claim_owner, c.expires_at, c.idempotency_identity,
+                o.attempt_epoch AS operation_attempt_epoch, o.claim_owner AS operation_claim_owner,
+                o.claim_expires_at AS operation_claim_expires_at, o.state AS operation_state
          FROM runtime_cleanup_capabilities c
          JOIN runtime_cleanup_operations o USING (operation_id)
          WHERE c.capability_hash = $1 FOR UPDATE OF c, o",
@@ -493,18 +567,33 @@ async fn begin_or_replay_capability_request(
         || row.try_get::<Uuid, _>("intent_id")? != binding.intent_id
         || row.try_get::<i64, _>("attempt_epoch")? != binding.attempt_epoch
         || row.try_get::<String, _>("audience")? != binding.audience
+        || row.try_get::<String, _>("claim_owner")? != binding.claim_owner
+        || row.try_get::<DateTime<Utc>, _>("expires_at")? != binding.expires_at
         || row.try_get::<Uuid, _>("idempotency_identity")? != binding.idempotency_identity
     {
         tx.commit().await?;
         return Ok(CapabilityUse::BindingMismatch);
     }
-    if row.try_get::<DateTime<Utc>, _>("expires_at")? <= now {
+    let capability_expired = row.try_get::<DateTime<Utc>, _>("expires_at")? <= now;
+    let claim_expired = row
+        .try_get::<Option<DateTime<Utc>>, _>("operation_claim_expires_at")?
+        .is_none_or(|expires_at| expires_at <= now);
+    let lost_ownership = row
+        .try_get::<Option<String>, _>("operation_claim_owner")?
+        .as_deref()
+        != Some(binding.claim_owner)
+        || row.try_get::<i64, _>("operation_attempt_epoch")? != binding.attempt_epoch
+        || !matches!(
+            row.try_get::<String, _>("operation_state")?.as_str(),
+            "open" | "committed"
+        );
+    if capability_expired || claim_expired || lost_ownership {
         tx.commit().await?;
-        return Ok(CapabilityUse::Expired);
-    }
-    if row.try_get::<i64, _>("operation_attempt_epoch")? != binding.attempt_epoch {
-        tx.commit().await?;
-        return Ok(CapabilityUse::StaleAttempt);
+        return Ok(if lost_ownership {
+            CapabilityUse::LostOwnership
+        } else {
+            CapabilityUse::Expired
+        });
     }
     if let Some(existing) = sqlx::query(
         "SELECT request_fingerprint FROM runtime_cleanup_request_identities WHERE request_id = $1",
@@ -617,6 +706,16 @@ pub(crate) async fn gc_terminal_receipts(
         .await
 }
 
+pub(crate) async fn gc_expired_capabilities(
+    pool: &PgPool,
+    batch_size: i32,
+) -> Result<i32, sqlx::Error> {
+    sqlx::query_scalar("SELECT agentdesk_gc_runtime_cleanup_capabilities($1)")
+        .bind(batch_size)
+        .fetch_one(pool)
+        .await
+}
+
 fn parse_receipt(value: &str) -> ReceiptState {
     match value {
         "applied" => ReceiptState::Applied,
@@ -641,6 +740,21 @@ async fn lock_request(
     sqlx::query("SELECT pg_advisory_xact_lock($1, hashtext($2))")
         .bind(LOCK_NAMESPACE)
         .bind(format!("request:{request_id}"))
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+async fn lock_semantic_request(
+    tx: &mut Transaction<'_, Postgres>,
+    binding: &CapabilityBinding<'_>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("SELECT pg_advisory_xact_lock($1, hashtext($2))")
+        .bind(LOCK_NAMESPACE)
+        .bind(format!(
+            "semantic:{}:{}:{}",
+            binding.operation_id, binding.intent_id, binding.idempotency_identity
+        ))
         .execute(&mut **tx)
         .await?;
     Ok(())

--- a/src/db/runtime_cleanup.rs
+++ b/src/db/runtime_cleanup.rs
@@ -1,0 +1,598 @@
+#![allow(dead_code)] // Dormant Task #25 substrate; no production consumer exists.
+
+//! PostgreSQL-only runtime cleanup substrate.
+//!
+//! The database can serialize identities, epochs, capabilities, and receipts. It
+//! cannot prove that an external destination fenced a side effect already sent by
+//! a stale actor. Destination high-watermark enforcement is a future slice.
+//!
+//! Lock order is global and mandatory: request UUID advisory lock, canonical
+//! identity advisory lock, sorted locator locks, target row, operation row,
+//! intent row, then capability/request/receipt row.
+
+mod model;
+
+#[cfg(test)]
+mod postgres_tests;
+
+use chrono::{DateTime, Duration, Utc};
+pub(crate) use model::*;
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+use sqlx::{PgPool, Postgres, Row, Transaction};
+use uuid::Uuid;
+
+const LOCK_NAMESPACE: i32 = 4926;
+const MAX_CLAIM_DURATION_SECONDS: i64 = 300;
+const MAX_CAPABILITY_DURATION_SECONDS: i64 = 300;
+const PLAN: [(&str, i16); 6] = [
+    ("block_runtime_admission", 1),
+    ("clear_queued_input", 2),
+    ("expire_runtime_lease", 3),
+    ("cancel_active_runtime", 4),
+    ("clear_persisted_session", 5),
+    ("release_runtime_slot", 6),
+];
+
+pub(crate) async fn converge_target(
+    pool: &PgPool,
+    identity: CanonicalCleanupIdentity<'_>,
+    preferred_target_id: Uuid,
+) -> Result<CleanupTarget, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    lock_identity(&mut tx, identity).await?;
+    sqlx::query(
+        "INSERT INTO runtime_cleanup_targets
+         (target_id, identity_kind, provider, discord_token_hash, channel_id)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (identity_kind, provider, discord_token_hash, channel_id) DO NOTHING",
+    )
+    .bind(preferred_target_id)
+    .bind(identity.kind.as_str())
+    .bind(identity.provider)
+    .bind(identity.discord_token_hash)
+    .bind(identity.channel_id)
+    .execute(&mut *tx)
+    .await?;
+    let row = sqlx::query(
+        "SELECT target_id, operation_high_watermark, retired_at IS NOT NULL AS retired
+         FROM runtime_cleanup_targets
+         WHERE identity_kind = $1 AND provider = $2
+           AND discord_token_hash = $3 AND channel_id = $4
+         FOR UPDATE",
+    )
+    .bind(identity.kind.as_str())
+    .bind(identity.provider)
+    .bind(identity.discord_token_hash)
+    .bind(identity.channel_id)
+    .fetch_one(&mut *tx)
+    .await?;
+    let target = CleanupTarget {
+        target_id: row.try_get("target_id")?,
+        operation_high_watermark: row.try_get("operation_high_watermark")?,
+        retired: row.try_get("retired")?,
+    };
+    tx.commit().await?;
+    Ok(target)
+}
+
+pub(crate) async fn bind_session(
+    pool: &PgPool,
+    target_id: Uuid,
+    session_id: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO runtime_cleanup_target_session_bindings (session_id, target_id)
+         VALUES ($1, $2)
+         ON CONFLICT (session_id) DO UPDATE SET target_id = EXCLUDED.target_id,
+             bound_at = clock_timestamp()",
+    )
+    .bind(session_id)
+    .bind(target_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub(crate) async fn reserve_locator(
+    pool: &PgPool,
+    locator: &str,
+    target_id: Uuid,
+) -> Result<LocatorClaim, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    lock_locators(&mut tx, &[locator]).await?;
+    lock_target(&mut tx, target_id).await?;
+    if let Some(row) = sqlx::query(
+        "SELECT target_id, generation FROM runtime_cleanup_locator_claims
+         WHERE locator = $1 AND active FOR UPDATE",
+    )
+    .bind(locator)
+    .fetch_optional(&mut *tx)
+    .await?
+    {
+        let claim = LocatorClaim {
+            target_id: row.try_get("target_id")?,
+            generation: row.try_get("generation")?,
+        };
+        tx.commit().await?;
+        return Ok(claim);
+    }
+    let generation: i64 = sqlx::query_scalar(
+        "SELECT COALESCE(MAX(generation), 0) + 1
+         FROM runtime_cleanup_locator_claims WHERE locator = $1",
+    )
+    .bind(locator)
+    .fetch_one(&mut *tx)
+    .await?;
+    sqlx::query(
+        "INSERT INTO runtime_cleanup_locator_claims
+         (locator, generation, target_id) VALUES ($1, $2, $3)",
+    )
+    .bind(locator)
+    .bind(generation)
+    .bind(target_id)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(LocatorClaim {
+        target_id,
+        generation,
+    })
+}
+
+pub(crate) async fn resolve_locator(
+    pool: &PgPool,
+    locator: &str,
+) -> Result<Option<LocatorClaim>, sqlx::Error> {
+    sqlx::query("SELECT agentdesk_lock_session_locator($1)")
+        .bind(locator)
+        .execute(pool)
+        .await?;
+    let row = sqlx::query(
+        "SELECT target_id, generation FROM runtime_cleanup_locator_claims
+         WHERE locator = $1 AND active",
+    )
+    .bind(locator)
+    .fetch_optional(pool)
+    .await?;
+    row.map(|row| {
+        Ok(LocatorClaim {
+            target_id: row.try_get("target_id")?,
+            generation: row.try_get("generation")?,
+        })
+    })
+    .transpose()
+}
+
+pub(crate) async fn retire_locator(
+    pool: &PgPool,
+    locator: &str,
+    expected_generation: i64,
+) -> Result<bool, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    lock_locators(&mut tx, &[locator]).await?;
+    let changed = sqlx::query(
+        "UPDATE runtime_cleanup_locator_claims
+         SET active = FALSE, retired_at = clock_timestamp()
+         WHERE locator = $1 AND generation = $2 AND active",
+    )
+    .bind(locator)
+    .bind(expected_generation)
+    .execute(&mut *tx)
+    .await?
+    .rows_affected()
+        == 1;
+    tx.commit().await?;
+    Ok(changed)
+}
+
+pub(crate) async fn create_operation(
+    pool: &PgPool,
+    target_id: Uuid,
+    operation_id: Uuid,
+) -> Result<CreatedOperation, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    lock_target(&mut tx, target_id).await?;
+    let operation_epoch: i64 = sqlx::query_scalar(
+        "UPDATE runtime_cleanup_targets
+         SET operation_high_watermark = operation_high_watermark + 1
+         WHERE target_id = $1 AND retired_at IS NULL
+         RETURNING operation_high_watermark",
+    )
+    .bind(target_id)
+    .fetch_one(&mut *tx)
+    .await?;
+    sqlx::query(
+        "INSERT INTO runtime_cleanup_operations
+         (operation_id, target_id, operation_epoch, operation_kind)
+         VALUES ($1, $2, $3, 'clear_for_resume')",
+    )
+    .bind(operation_id)
+    .bind(target_id)
+    .bind(operation_epoch)
+    .execute(&mut *tx)
+    .await?;
+    for (intent_kind, ordinal) in PLAN {
+        sqlx::query(
+            "INSERT INTO runtime_cleanup_intents
+             (operation_id, intent_id, ordinal, intent_kind, target_id, idempotency_identity)
+             VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(operation_id)
+        .bind(Uuid::new_v4())
+        .bind(ordinal)
+        .bind(intent_kind)
+        .bind(target_id)
+        .bind(Uuid::new_v4())
+        .execute(&mut *tx)
+        .await?;
+    }
+    tx.commit().await?;
+    Ok(CreatedOperation {
+        operation_id,
+        operation_epoch,
+    })
+}
+
+pub(crate) async fn claim_operation(
+    pool: &PgPool,
+    operation_id: Uuid,
+    owner: &str,
+    duration: Duration,
+) -> Result<ClaimResult, sqlx::Error> {
+    claim_or_renew(pool, operation_id, owner, None, duration).await
+}
+
+pub(crate) async fn renew_operation(
+    pool: &PgPool,
+    operation_id: Uuid,
+    owner: &str,
+    expected_attempt_epoch: i64,
+    duration: Duration,
+) -> Result<ClaimResult, sqlx::Error> {
+    claim_or_renew(
+        pool,
+        operation_id,
+        owner,
+        Some(expected_attempt_epoch),
+        duration,
+    )
+    .await
+}
+
+async fn claim_or_renew(
+    pool: &PgPool,
+    operation_id: Uuid,
+    owner: &str,
+    renew_epoch: Option<i64>,
+    duration: Duration,
+) -> Result<ClaimResult, sqlx::Error> {
+    validate_duration(duration, MAX_CLAIM_DURATION_SECONDS)?;
+    let mut tx = pool.begin().await?;
+    let database_now: DateTime<Utc> = sqlx::query_scalar("SELECT clock_timestamp()")
+        .fetch_one(&mut *tx)
+        .await?;
+    let Some(row) = sqlx::query(
+        "SELECT target_id, state, claim_owner, attempt_epoch, claim_expires_at
+         FROM runtime_cleanup_operations WHERE operation_id = $1 FOR UPDATE",
+    )
+    .bind(operation_id)
+    .fetch_optional(&mut *tx)
+    .await?
+    else {
+        tx.commit().await?;
+        return Ok(ClaimResult::NotFound);
+    };
+    let state: String = row.try_get("state")?;
+    if !matches!(state.as_str(), "open" | "committed") {
+        tx.commit().await?;
+        return Ok(ClaimResult::Stale);
+    }
+    let current_owner: Option<String> = row.try_get("claim_owner")?;
+    let current_epoch: i64 = row.try_get("attempt_epoch")?;
+    let current_expiry: Option<DateTime<Utc>> = row.try_get("claim_expires_at")?;
+    if let Some(expected) = renew_epoch {
+        if current_owner.as_deref() != Some(owner) || current_epoch != expected {
+            tx.commit().await?;
+            return Ok(ClaimResult::Stale);
+        }
+        let expires_at = database_now + duration;
+        sqlx::query(
+            "UPDATE runtime_cleanup_operations SET claim_expires_at = $2,
+             updated_at = clock_timestamp() WHERE operation_id = $1",
+        )
+        .bind(operation_id)
+        .bind(expires_at)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        return Ok(ClaimResult::Renewed {
+            attempt_epoch: current_epoch,
+            expires_at,
+        });
+    }
+    if let (Some(held_owner), Some(expires_at)) = (current_owner, current_expiry)
+        && expires_at > database_now
+    {
+        tx.commit().await?;
+        return Ok(ClaimResult::Held {
+            owner: held_owner,
+            attempt_epoch: current_epoch,
+            expires_at,
+        });
+    }
+    let attempt_epoch = current_epoch + 1;
+    let expires_at = database_now + duration;
+    sqlx::query(
+        "UPDATE runtime_cleanup_operations SET claim_owner = $2, attempt_epoch = $3,
+         claim_expires_at = $4, updated_at = clock_timestamp() WHERE operation_id = $1",
+    )
+    .bind(operation_id)
+    .bind(owner)
+    .bind(attempt_epoch)
+    .bind(expires_at)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(ClaimResult::Claimed {
+        attempt_epoch,
+        expires_at,
+    })
+}
+
+pub(crate) async fn transition_operation(
+    pool: &PgPool,
+    operation_id: Uuid,
+    expected_attempt_epoch: i64,
+    next: OperationState,
+) -> Result<bool, sqlx::Error> {
+    let timestamp_column = match next {
+        OperationState::Committed => "committed_at",
+        OperationState::Completed => "completed_at",
+        OperationState::Aborted => "aborted_at",
+        OperationState::Open => return Ok(false),
+    };
+    let query = format!(
+        "UPDATE runtime_cleanup_operations SET state = $3, {timestamp_column} = clock_timestamp(),
+         updated_at = clock_timestamp() WHERE operation_id = $1 AND attempt_epoch = $2"
+    );
+    Ok(sqlx::query(&query)
+        .bind(operation_id)
+        .bind(expected_attempt_epoch)
+        .bind(next.as_str())
+        .execute(pool)
+        .await?
+        .rows_affected()
+        == 1)
+}
+
+pub(crate) async fn issue_capability(
+    pool: &PgPool,
+    binding: CapabilityBinding<'_>,
+) -> Result<Vec<u8>, sqlx::Error> {
+    let database_now: DateTime<Utc> = sqlx::query_scalar("SELECT clock_timestamp()")
+        .fetch_one(pool)
+        .await?;
+    if binding.expires_at <= database_now
+        || binding.expires_at > database_now + Duration::seconds(MAX_CAPABILITY_DURATION_SECONDS)
+    {
+        return Err(sqlx::Error::Protocol(
+            "capability duration is outside database-clock bounds".into(),
+        ));
+    }
+    let mut secret = vec![0_u8; 32];
+    rand::thread_rng().fill_bytes(&mut secret);
+    let hash = Sha256::digest(&secret).to_vec();
+    sqlx::query(
+        "INSERT INTO runtime_cleanup_capabilities
+         (capability_id, capability_hash, target_id, operation_id, intent_id,
+          attempt_epoch, audience, expires_at, idempotency_identity)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
+    )
+    .bind(binding.capability_id)
+    .bind(hash)
+    .bind(binding.target_id)
+    .bind(binding.operation_id)
+    .bind(binding.intent_id)
+    .bind(binding.attempt_epoch)
+    .bind(binding.audience)
+    .bind(binding.expires_at)
+    .bind(binding.idempotency_identity)
+    .execute(pool)
+    .await?;
+    Ok(secret)
+}
+
+pub(crate) async fn begin_capability_request(
+    pool: &PgPool,
+    secret: &[u8],
+    binding: CapabilityBinding<'_>,
+    request_id: Uuid,
+    request_fingerprint: [u8; 32],
+) -> Result<CapabilityUse, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    lock_request(&mut tx, request_id).await?;
+    let now: DateTime<Utc> = sqlx::query_scalar("SELECT clock_timestamp()")
+        .fetch_one(&mut *tx)
+        .await?;
+    let capability_hash = Sha256::digest(secret).to_vec();
+    let Some(row) = sqlx::query(
+        "SELECT c.target_id, c.operation_id, c.intent_id, c.attempt_epoch,
+                c.audience, c.expires_at, c.idempotency_identity,
+                o.attempt_epoch AS operation_attempt_epoch
+         FROM runtime_cleanup_capabilities c
+         JOIN runtime_cleanup_operations o USING (operation_id)
+         WHERE c.capability_hash = $1 FOR UPDATE OF c, o",
+    )
+    .bind(capability_hash)
+    .fetch_optional(&mut *tx)
+    .await?
+    else {
+        tx.commit().await?;
+        return Ok(CapabilityUse::NotFound);
+    };
+    if row.try_get::<Uuid, _>("target_id")? != binding.target_id
+        || row.try_get::<Uuid, _>("operation_id")? != binding.operation_id
+        || row.try_get::<Uuid, _>("intent_id")? != binding.intent_id
+        || row.try_get::<i64, _>("attempt_epoch")? != binding.attempt_epoch
+        || row.try_get::<String, _>("audience")? != binding.audience
+        || row.try_get::<Uuid, _>("idempotency_identity")? != binding.idempotency_identity
+    {
+        tx.commit().await?;
+        return Ok(CapabilityUse::BindingMismatch);
+    }
+    if row.try_get::<DateTime<Utc>, _>("expires_at")? <= now {
+        tx.commit().await?;
+        return Ok(CapabilityUse::Expired);
+    }
+    if row.try_get::<i64, _>("operation_attempt_epoch")? != binding.attempt_epoch {
+        tx.commit().await?;
+        return Ok(CapabilityUse::StaleAttempt);
+    }
+    if let Some(existing) = sqlx::query(
+        "SELECT request_fingerprint FROM runtime_cleanup_request_identities WHERE request_id = $1",
+    )
+    .bind(request_id)
+    .fetch_optional(&mut *tx)
+    .await?
+    {
+        let prior: Vec<u8> = existing.try_get("request_fingerprint")?;
+        if prior.as_slice() != request_fingerprint {
+            tx.commit().await?;
+            return Ok(CapabilityUse::FingerprintConflict);
+        }
+        let receipt = sqlx::query_scalar::<_, String>(
+            "SELECT receipt_state FROM runtime_cleanup_receipts WHERE request_id = $1",
+        )
+        .bind(request_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        return Ok(CapabilityUse::Replay {
+            state: receipt
+                .as_deref()
+                .map(parse_receipt)
+                .unwrap_or(ReceiptState::Unknown),
+        });
+    }
+    sqlx::query(
+        "INSERT INTO runtime_cleanup_request_identities
+         (request_id, operation_id, intent_id, idempotency_identity, request_fingerprint)
+         VALUES ($1,$2,$3,$4,$5)",
+    )
+    .bind(request_id)
+    .bind(binding.operation_id)
+    .bind(binding.intent_id)
+    .bind(binding.idempotency_identity)
+    .bind(request_fingerprint.to_vec())
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(CapabilityUse::Accepted)
+}
+
+pub(crate) async fn record_receipt(
+    pool: &PgPool,
+    request_id: Uuid,
+    state: ReceiptState,
+    result_fingerprint: Option<[u8; 32]>,
+) -> Result<bool, sqlx::Error> {
+    Ok(sqlx::query(
+        "INSERT INTO runtime_cleanup_receipts
+         (request_id, receipt_state, result_fingerprint, terminal_at, retain_until)
+         VALUES ($1,$2,$3,clock_timestamp(),clock_timestamp() + INTERVAL '30 days')
+         ON CONFLICT (request_id) DO NOTHING",
+    )
+    .bind(request_id)
+    .bind(state.as_str())
+    .bind(result_fingerprint.map(|value| value.to_vec()))
+    .execute(pool)
+    .await?
+    .rows_affected()
+        == 1)
+}
+
+pub(crate) async fn gc_terminal_receipts(
+    pool: &PgPool,
+    batch_size: i32,
+) -> Result<i32, sqlx::Error> {
+    sqlx::query_scalar("SELECT agentdesk_gc_runtime_cleanup_receipts($1)")
+        .bind(batch_size)
+        .fetch_one(pool)
+        .await
+}
+
+fn parse_receipt(value: &str) -> ReceiptState {
+    match value {
+        "applied" => ReceiptState::Applied,
+        "not_applied" => ReceiptState::NotApplied,
+        _ => ReceiptState::Unknown,
+    }
+}
+
+fn validate_duration(duration: Duration, maximum_seconds: i64) -> Result<(), sqlx::Error> {
+    if duration <= Duration::zero() || duration > Duration::seconds(maximum_seconds) {
+        return Err(sqlx::Error::Protocol(
+            "duration is outside database-clock bounds".into(),
+        ));
+    }
+    Ok(())
+}
+
+async fn lock_request(
+    tx: &mut Transaction<'_, Postgres>,
+    request_id: Uuid,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("SELECT pg_advisory_xact_lock($1, hashtext($2))")
+        .bind(LOCK_NAMESPACE)
+        .bind(format!("request:{request_id}"))
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+async fn lock_identity(
+    tx: &mut Transaction<'_, Postgres>,
+    identity: CanonicalCleanupIdentity<'_>,
+) -> Result<(), sqlx::Error> {
+    let key = format!(
+        "identity:{}:{}:{}:{}",
+        identity.kind.as_str(),
+        identity.provider,
+        identity.discord_token_hash,
+        identity.channel_id
+    );
+    sqlx::query("SELECT pg_advisory_xact_lock($1, hashtext($2))")
+        .bind(LOCK_NAMESPACE)
+        .bind(key)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+async fn lock_locators(
+    tx: &mut Transaction<'_, Postgres>,
+    locators: &[&str],
+) -> Result<(), sqlx::Error> {
+    let mut ordered = locators.to_vec();
+    ordered.sort_unstable();
+    ordered.dedup();
+    for locator in ordered {
+        sqlx::query("SELECT agentdesk_lock_session_locator($1)")
+            .bind(locator)
+            .execute(&mut **tx)
+            .await?;
+    }
+    Ok(())
+}
+
+async fn lock_target(
+    tx: &mut Transaction<'_, Postgres>,
+    target_id: Uuid,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("SELECT target_id FROM runtime_cleanup_targets WHERE target_id = $1 FOR UPDATE")
+        .bind(target_id)
+        .fetch_one(&mut **tx)
+        .await?;
+    Ok(())
+}

--- a/src/db/runtime_cleanup/model.rs
+++ b/src/db/runtime_cleanup/model.rs
@@ -121,6 +121,10 @@ pub(crate) enum CapabilityUse {
     FingerprintConflict,
     BindingMismatch,
     Expired,
+    LostOwnership,
+    NeedsReconcile {
+        request_id: Uuid,
+    },
     StaleAttempt,
     NotFound,
 }
@@ -133,6 +137,7 @@ pub(crate) struct CapabilityBinding<'a> {
     pub(crate) intent_id: Uuid,
     pub(crate) attempt_epoch: i64,
     pub(crate) audience: &'a str,
+    pub(crate) claim_owner: &'a str,
     pub(crate) expires_at: DateTime<Utc>,
     pub(crate) idempotency_identity: Uuid,
 }

--- a/src/db/runtime_cleanup/model.rs
+++ b/src/db/runtime_cleanup/model.rs
@@ -1,0 +1,133 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CleanupIdentityKind {
+    DiscordChannel,
+    ScheduledSnapshot,
+}
+
+impl CleanupIdentityKind {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::DiscordChannel => "discord_channel",
+            Self::ScheduledSnapshot => "scheduled_snapshot",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CanonicalCleanupIdentity<'a> {
+    pub(crate) kind: CleanupIdentityKind,
+    pub(crate) provider: &'a str,
+    pub(crate) discord_token_hash: &'a str,
+    pub(crate) channel_id: &'a str,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CleanupTarget {
+    pub(crate) target_id: Uuid,
+    pub(crate) operation_high_watermark: i64,
+    pub(crate) retired: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct LocatorClaim {
+    pub(crate) target_id: Uuid,
+    pub(crate) generation: i64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OperationState {
+    Open,
+    Committed,
+    Completed,
+    Aborted,
+}
+
+impl OperationState {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Committed => "committed",
+            Self::Completed => "completed",
+            Self::Aborted => "aborted",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CleanupOperation {
+    pub(crate) operation_id: Uuid,
+    pub(crate) target_id: Uuid,
+    pub(crate) operation_epoch: i64,
+    pub(crate) state: OperationState,
+    pub(crate) claim_owner: Option<String>,
+    pub(crate) attempt_epoch: i64,
+    pub(crate) claim_expires_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CreatedOperation {
+    pub(crate) operation_id: Uuid,
+    pub(crate) operation_epoch: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ClaimResult {
+    Claimed {
+        attempt_epoch: i64,
+        expires_at: DateTime<Utc>,
+    },
+    Renewed {
+        attempt_epoch: i64,
+        expires_at: DateTime<Utc>,
+    },
+    Held {
+        owner: String,
+        attempt_epoch: i64,
+        expires_at: DateTime<Utc>,
+    },
+    Stale,
+    NotFound,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ReceiptState {
+    Applied,
+    NotApplied,
+    Unknown,
+}
+
+impl ReceiptState {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Applied => "applied",
+            Self::NotApplied => "not_applied",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum CapabilityUse {
+    Accepted,
+    Replay { state: ReceiptState },
+    FingerprintConflict,
+    BindingMismatch,
+    Expired,
+    StaleAttempt,
+    NotFound,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CapabilityBinding<'a> {
+    pub(crate) capability_id: Uuid,
+    pub(crate) target_id: Uuid,
+    pub(crate) operation_id: Uuid,
+    pub(crate) intent_id: Uuid,
+    pub(crate) attempt_epoch: i64,
+    pub(crate) audience: &'a str,
+    pub(crate) expires_at: DateTime<Utc>,
+    pub(crate) idempotency_identity: Uuid,
+}

--- a/src/db/runtime_cleanup/model.rs
+++ b/src/db/runtime_cleanup/model.rs
@@ -111,8 +111,13 @@ impl ReceiptState {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum CapabilityUse {
-    Accepted,
-    Replay { state: ReceiptState },
+    Accepted {
+        request_id: Uuid,
+    },
+    Replay {
+        request_id: Uuid,
+        state: ReceiptState,
+    },
     FingerprintConflict,
     BindingMismatch,
     Expired,

--- a/src/db/runtime_cleanup/model.rs
+++ b/src/db/runtime_cleanup/model.rs
@@ -129,6 +129,18 @@ pub(crate) enum CapabilityUse {
     NotFound,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ReceiptWrite {
+    Recorded,
+    Reconciled,
+    Replay { state: ReceiptState },
+    Conflict,
+    BindingMismatch,
+    Expired,
+    LostOwnership,
+    NotFound,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct CapabilityBinding<'a> {
     pub(crate) capability_id: Uuid,

--- a/src/db/runtime_cleanup/postgres_tests.rs
+++ b/src/db/runtime_cleanup/postgres_tests.rs
@@ -331,6 +331,7 @@ async fn capability_binding_expiry_replay_conflict_and_unknown_are_typed_pg() {
         intent_id,
         attempt_epoch: attempt,
         audience: "cleanup-worker",
+        claim_owner: "worker",
         expires_at: now + Duration::seconds(3),
         idempotency_identity,
     };
@@ -347,10 +348,7 @@ async fn capability_binding_expiry_replay_conflict_and_unknown_are_typed_pg() {
         replay_capability_request(&pool, &secret, binding.clone(), request_id, fingerprint)
             .await
             .unwrap(),
-        CapabilityUse::Replay {
-            request_id,
-            state: ReceiptState::Unknown
-        }
+        CapabilityUse::NeedsReconcile { request_id }
     );
     assert_eq!(
         begin_capability_request(&pool, &secret, binding.clone(), fingerprint)
@@ -389,14 +387,246 @@ async fn capability_binding_expiry_replay_conflict_and_unknown_are_typed_pg() {
             state: ReceiptState::Applied
         }
     );
-    sqlx::query("UPDATE runtime_cleanup_capabilities SET expires_at = clock_timestamp() - INTERVAL '1 second' WHERE capability_id = $1")
-        .bind(binding.capability_id).execute(&pool).await.unwrap();
+    let expired: DateTime<Utc> = sqlx::query_scalar(
+        "UPDATE runtime_cleanup_capabilities
+         SET expires_at = clock_timestamp() - INTERVAL '1 second'
+         WHERE capability_id = $1 RETURNING expires_at",
+    )
+    .bind(binding.capability_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let mut expired_binding = binding;
+    expired_binding.expires_at = expired;
     assert_eq!(
-        begin_capability_request(&pool, &secret, binding, fingerprint)
+        begin_capability_request(&pool, &secret, expired_binding, fingerprint)
             .await
             .unwrap(),
         CapabilityUse::Expired
     );
+    close(db, pool).await;
+}
+
+#[tokio::test]
+async fn capability_admission_requires_live_exact_claim_pg() {
+    let (db, pool) = pool().await;
+    let (target, operation) = operation(&pool, "capability-claim").await;
+    let claimed = claim_operation(
+        &pool,
+        operation.operation_id,
+        "worker-a",
+        Duration::milliseconds(250),
+    )
+    .await
+    .unwrap();
+    let (attempt, claim_expiry) = match claimed {
+        ClaimResult::Claimed {
+            attempt_epoch,
+            expires_at,
+        } => (attempt_epoch, expires_at),
+        other => panic!("{other:?}"),
+    };
+    let (intent_id, idempotency_identity) = intent(&pool, operation.operation_id).await;
+    let binding = CapabilityBinding {
+        capability_id: Uuid::new_v4(),
+        target_id: target.target_id,
+        operation_id: operation.operation_id,
+        intent_id,
+        attempt_epoch: attempt,
+        audience: "claim-bound",
+        claim_owner: "worker-a",
+        expires_at: claim_expiry - Duration::milliseconds(50),
+        idempotency_identity,
+    };
+    let mut too_long = binding.clone();
+    too_long.capability_id = Uuid::new_v4();
+    too_long.expires_at = claim_expiry + Duration::milliseconds(1);
+    assert!(issue_capability(&pool, too_long).await.is_err());
+    let secret = issue_capability(&pool, binding.clone()).await.unwrap();
+    let mut wrong_owner = binding.clone();
+    wrong_owner.claim_owner = "worker-b";
+    assert_eq!(
+        begin_capability_request(&pool, &secret, wrong_owner, [1; 32])
+            .await
+            .unwrap(),
+        CapabilityUse::BindingMismatch
+    );
+    tokio::time::sleep(std::time::Duration::from_millis(275)).await;
+    assert_eq!(
+        begin_capability_request(&pool, &secret, binding.clone(), [1; 32])
+            .await
+            .unwrap(),
+        CapabilityUse::Expired
+    );
+    let takeover = claim_operation(
+        &pool,
+        operation.operation_id,
+        "worker-b",
+        Duration::seconds(1),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(takeover, ClaimResult::Claimed { .. }));
+    assert_eq!(
+        begin_capability_request(&pool, &secret, binding, [1; 32])
+            .await
+            .unwrap(),
+        CapabilityUse::LostOwnership
+    );
+    close(db, pool).await;
+}
+
+#[tokio::test]
+async fn lost_response_replay_after_lease_expiry_needs_reconcile_pg() {
+    let (db, pool) = pool().await;
+    let (target, operation) = operation(&pool, "capability-reconcile").await;
+    let claimed = claim_operation(
+        &pool,
+        operation.operation_id,
+        "worker",
+        Duration::milliseconds(250),
+    )
+    .await
+    .unwrap();
+    let (attempt, claim_expiry) = match claimed {
+        ClaimResult::Claimed {
+            attempt_epoch,
+            expires_at,
+        } => (attempt_epoch, expires_at),
+        other => panic!("{other:?}"),
+    };
+    let (intent_id, idempotency_identity) = intent(&pool, operation.operation_id).await;
+    let binding = CapabilityBinding {
+        capability_id: Uuid::new_v4(),
+        target_id: target.target_id,
+        operation_id: operation.operation_id,
+        intent_id,
+        attempt_epoch: attempt,
+        audience: "reconcile",
+        claim_owner: "worker",
+        expires_at: claim_expiry - Duration::milliseconds(25),
+        idempotency_identity,
+    };
+    let secret = issue_capability(&pool, binding.clone()).await.unwrap();
+    let request_id = match begin_capability_request(&pool, &secret, binding.clone(), [2; 32])
+        .await
+        .unwrap()
+    {
+        CapabilityUse::Accepted { request_id } => request_id,
+        other => panic!("{other:?}"),
+    };
+    tokio::time::sleep(std::time::Duration::from_millis(275)).await;
+    assert_eq!(
+        replay_capability_request(&pool, &secret, binding.clone(), request_id, [2; 32])
+            .await
+            .unwrap(),
+        CapabilityUse::NeedsReconcile { request_id }
+    );
+    assert!(
+        record_receipt(&pool, request_id, ReceiptState::Applied, None)
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        replay_capability_request(&pool, &secret, binding, request_id, [2; 32])
+            .await
+            .unwrap(),
+        CapabilityUse::Replay {
+            request_id,
+            state: ReceiptState::Applied
+        }
+    );
+    close(db, pool).await;
+}
+
+#[tokio::test]
+async fn bounded_capability_gc_preserves_active_and_unresolved_pg() {
+    let (db, pool) = pool().await;
+    let (target, operation) = operation(&pool, "capability-gc").await;
+    let claimed = claim_operation(
+        &pool,
+        operation.operation_id,
+        "worker",
+        Duration::seconds(5),
+    )
+    .await
+    .unwrap();
+    let attempt = match claimed {
+        ClaimResult::Claimed { attempt_epoch, .. } => attempt_epoch,
+        other => panic!("{other:?}"),
+    };
+    let intents: Vec<(Uuid, Uuid)> = sqlx::query_as(
+        "SELECT intent_id, idempotency_identity FROM runtime_cleanup_intents
+         WHERE operation_id = $1 ORDER BY ordinal LIMIT 3",
+    )
+    .bind(operation.operation_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let now: DateTime<Utc> = sqlx::query_scalar("SELECT clock_timestamp()")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let mut bindings = Vec::new();
+    let mut secrets = Vec::new();
+    for (index, (intent_id, idempotency_identity)) in intents.into_iter().enumerate() {
+        let binding = CapabilityBinding {
+            capability_id: Uuid::new_v4(),
+            target_id: target.target_id,
+            operation_id: operation.operation_id,
+            intent_id,
+            attempt_epoch: attempt,
+            audience: "gc",
+            claim_owner: "worker",
+            expires_at: now + Duration::seconds(index as i64 + 1),
+            idempotency_identity,
+        };
+        secrets.push(issue_capability(&pool, binding.clone()).await.unwrap());
+        bindings.push(binding);
+    }
+    let unresolved_request =
+        match begin_capability_request(&pool, &secrets[1], bindings[1].clone(), [4; 32])
+            .await
+            .unwrap()
+        {
+            CapabilityUse::Accepted { request_id } => request_id,
+            other => panic!("{other:?}"),
+        };
+    record_receipt(&pool, unresolved_request, ReceiptState::Unknown, None)
+        .await
+        .unwrap();
+    let terminal_request =
+        match begin_capability_request(&pool, &secrets[2], bindings[2].clone(), [5; 32])
+            .await
+            .unwrap()
+        {
+            CapabilityUse::Accepted { request_id } => request_id,
+            other => panic!("{other:?}"),
+        };
+    record_receipt(&pool, terminal_request, ReceiptState::Applied, None)
+        .await
+        .unwrap();
+    sqlx::query(
+        "UPDATE runtime_cleanup_capabilities
+         SET expires_at = clock_timestamp() - INTERVAL '31 days'
+         WHERE capability_id <> $1",
+    )
+    .bind(bindings[0].capability_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    assert_eq!(gc_expired_capabilities(&pool, 1).await.unwrap(), 1);
+    let remaining: Vec<Uuid> = sqlx::query_scalar(
+        "SELECT capability_id FROM runtime_cleanup_capabilities ORDER BY capability_id",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(remaining.len(), 2);
+    assert!(remaining.contains(&bindings[1].capability_id));
+    assert_eq!(gc_expired_capabilities(&pool, 10).await.unwrap(), 0);
+    assert!(gc_expired_capabilities(&pool, 0).await.is_err());
+    assert!(gc_expired_capabilities(&pool, 1001).await.is_err());
     close(db, pool).await;
 }
 
@@ -521,7 +751,8 @@ async fn receipt_gc_preserves_request_target_and_locator_authority_pg() {
         intent_id,
         attempt_epoch: epoch,
         audience: "gc",
-        expires_at: now + Duration::seconds(2),
+        claim_owner: "worker",
+        expires_at: now + Duration::seconds(1),
         idempotency_identity: idem,
     };
     let secret = issue_capability(&pool, binding.clone()).await.unwrap();

--- a/src/db/runtime_cleanup/postgres_tests.rs
+++ b/src/db/runtime_cleanup/postgres_tests.rs
@@ -92,6 +92,55 @@ async fn locator_retirement_never_reuses_generation_pg() {
     .await
     .unwrap();
     assert_eq!(history, vec![(1, false), (2, true)]);
+    assert!(
+        sqlx::query(
+            "DELETE FROM runtime_cleanup_locator_claims
+             WHERE locator = 'host:session' AND generation = 1",
+        )
+        .execute(&pool)
+        .await
+        .is_err()
+    );
+    assert!(
+        sqlx::query(
+            "UPDATE runtime_cleanup_locator_claims SET target_id = $1
+             WHERE locator = 'host:session' AND generation = 2",
+        )
+        .bind(first.target_id)
+        .execute(&pool)
+        .await
+        .is_err()
+    );
+    close(db, pool).await;
+}
+
+#[tokio::test]
+async fn target_retirement_is_a_permanent_admission_tombstone_pg() {
+    let (db, pool) = pool().await;
+    let cleanup_target = target(&pool, "target-tombstone").await;
+    assert!(
+        retire_target(&pool, cleanup_target.target_id)
+            .await
+            .unwrap()
+    );
+    assert!(
+        !retire_target(&pool, cleanup_target.target_id)
+            .await
+            .unwrap()
+    );
+    assert!(
+        reserve_locator(&pool, "retired-target-locator", cleanup_target.target_id)
+            .await
+            .is_err()
+    );
+    assert!(
+        create_operation(&pool, cleanup_target.target_id, Uuid::new_v4())
+            .await
+            .is_err()
+    );
+    let converged = target(&pool, "target-tombstone").await;
+    assert_eq!(converged.target_id, cleanup_target.target_id);
+    assert!(converged.retired);
     close(db, pool).await;
 }
 
@@ -157,19 +206,37 @@ async fn operation_and_attempt_epochs_are_monotonic_and_stale_tokens_fail_pg() {
     };
     assert!(epoch2 > epoch1);
     assert!(
-        !transition_operation(&pool, first.operation_id, epoch1, OperationState::Committed)
-            .await
-            .unwrap()
+        !transition_operation(
+            &pool,
+            first.operation_id,
+            "worker-a",
+            epoch1,
+            OperationState::Committed,
+        )
+        .await
+        .unwrap()
     );
     assert!(
-        transition_operation(&pool, first.operation_id, epoch2, OperationState::Committed)
-            .await
-            .unwrap()
+        transition_operation(
+            &pool,
+            first.operation_id,
+            "worker-b",
+            epoch2,
+            OperationState::Committed,
+        )
+        .await
+        .unwrap()
     );
     assert!(
-        transition_operation(&pool, first.operation_id, epoch2, OperationState::Completed)
-            .await
-            .unwrap()
+        transition_operation(
+            &pool,
+            first.operation_id,
+            "worker-b",
+            epoch2,
+            OperationState::Completed,
+        )
+        .await
+        .unwrap()
     );
     let second = create_operation(&pool, target.target_id, Uuid::new_v4())
         .await
@@ -268,24 +335,34 @@ async fn capability_binding_expiry_replay_conflict_and_unknown_are_typed_pg() {
         idempotency_identity,
     };
     let secret = issue_capability(&pool, binding.clone()).await.unwrap();
-    let request_id = Uuid::new_v4();
     let fingerprint = [7_u8; 32];
+    let request_id = match begin_capability_request(&pool, &secret, binding.clone(), fingerprint)
+        .await
+        .unwrap()
+    {
+        CapabilityUse::Accepted { request_id } => request_id,
+        other => panic!("{other:?}"),
+    };
     assert_eq!(
-        begin_capability_request(&pool, &secret, binding.clone(), request_id, fingerprint)
-            .await
-            .unwrap(),
-        CapabilityUse::Accepted
-    );
-    assert_eq!(
-        begin_capability_request(&pool, &secret, binding.clone(), request_id, fingerprint)
+        replay_capability_request(&pool, &secret, binding.clone(), request_id, fingerprint)
             .await
             .unwrap(),
         CapabilityUse::Replay {
+            request_id,
             state: ReceiptState::Unknown
         }
     );
     assert_eq!(
-        begin_capability_request(&pool, &secret, binding.clone(), request_id, [8_u8; 32])
+        begin_capability_request(&pool, &secret, binding.clone(), fingerprint)
+            .await
+            .unwrap(),
+        CapabilityUse::Replay {
+            request_id,
+            state: ReceiptState::Unknown
+        }
+    );
+    assert_eq!(
+        replay_capability_request(&pool, &secret, binding.clone(), request_id, [8_u8; 32])
             .await
             .unwrap(),
         CapabilityUse::FingerprintConflict
@@ -293,7 +370,7 @@ async fn capability_binding_expiry_replay_conflict_and_unknown_are_typed_pg() {
     let mut wrong = binding.clone();
     wrong.audience = "other-worker";
     assert_eq!(
-        begin_capability_request(&pool, &secret, wrong, Uuid::new_v4(), fingerprint)
+        begin_capability_request(&pool, &secret, wrong, fingerprint)
             .await
             .unwrap(),
         CapabilityUse::BindingMismatch
@@ -304,20 +381,71 @@ async fn capability_binding_expiry_replay_conflict_and_unknown_are_typed_pg() {
             .unwrap()
     );
     assert_eq!(
-        begin_capability_request(&pool, &secret, binding.clone(), request_id, fingerprint)
+        replay_capability_request(&pool, &secret, binding.clone(), request_id, fingerprint)
             .await
             .unwrap(),
         CapabilityUse::Replay {
+            request_id,
             state: ReceiptState::Applied
         }
     );
     sqlx::query("UPDATE runtime_cleanup_capabilities SET expires_at = clock_timestamp() - INTERVAL '1 second' WHERE capability_id = $1")
         .bind(binding.capability_id).execute(&pool).await.unwrap();
     assert_eq!(
-        begin_capability_request(&pool, &secret, binding, Uuid::new_v4(), fingerprint)
+        begin_capability_request(&pool, &secret, binding, fingerprint)
             .await
             .unwrap(),
         CapabilityUse::Expired
+    );
+    close(db, pool).await;
+}
+
+#[tokio::test]
+async fn canonical_plan_and_intent_target_are_database_enforced_pg() {
+    let (db, pool) = pool().await;
+    let (cleanup_target, operation) = operation(&pool, "canonical-plan").await;
+    let rows: Vec<(i16, String)> = sqlx::query_as(
+        "SELECT ordinal, intent_kind FROM runtime_cleanup_intents
+         WHERE operation_id = $1 ORDER BY ordinal",
+    )
+    .bind(operation.operation_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        rows,
+        PLAN.into_iter()
+            .map(|(kind, ordinal)| (ordinal, kind.to_owned()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        sqlx::query(
+            "INSERT INTO runtime_cleanup_intents
+             (operation_id, intent_id, ordinal, intent_kind, target_id, idempotency_identity)
+             VALUES ($1, $2, 2, 'block_runtime_admission', $3, $4)",
+        )
+        .bind(operation.operation_id)
+        .bind(Uuid::new_v4())
+        .bind(cleanup_target.target_id)
+        .bind(Uuid::new_v4())
+        .execute(&pool)
+        .await
+        .is_err()
+    );
+    let other = target(&pool, "canonical-plan-other").await;
+    assert!(
+        sqlx::query(
+            "INSERT INTO runtime_cleanup_intents
+             (operation_id, intent_id, ordinal, intent_kind, target_id, idempotency_identity)
+             VALUES ($1, $2, 7, 'release_runtime_slot', $3, $4)",
+        )
+        .bind(operation.operation_id)
+        .bind(Uuid::new_v4())
+        .bind(other.target_id)
+        .bind(Uuid::new_v4())
+        .execute(&pool)
+        .await
+        .is_err()
     );
     close(db, pool).await;
 }
@@ -347,6 +475,7 @@ async fn legal_state_graph_is_database_enforced_pg() {
         transition_operation(
             &pool,
             operation.operation_id,
+            "worker",
             epoch,
             OperationState::Aborted
         )
@@ -396,10 +525,13 @@ async fn receipt_gc_preserves_request_target_and_locator_authority_pg() {
         idempotency_identity: idem,
     };
     let secret = issue_capability(&pool, binding.clone()).await.unwrap();
-    let request_id = Uuid::new_v4();
-    begin_capability_request(&pool, &secret, binding.clone(), request_id, [1; 32])
+    let request_id = match begin_capability_request(&pool, &secret, binding.clone(), [1; 32])
         .await
-        .unwrap();
+        .unwrap()
+    {
+        CapabilityUse::Accepted { request_id } => request_id,
+        other => panic!("{other:?}"),
+    };
     record_receipt(&pool, request_id, ReceiptState::Unknown, None)
         .await
         .unwrap();
@@ -425,7 +557,7 @@ async fn receipt_gc_preserves_request_target_and_locator_authority_pg() {
     ).bind(target.target_id).bind(request_id).fetch_one(&pool).await.unwrap();
     assert_eq!(authority, (operation.operation_epoch, 1, 1));
     assert_eq!(
-        begin_capability_request(&pool, &secret, binding, request_id, [2; 32])
+        replay_capability_request(&pool, &secret, binding, request_id, [2; 32])
             .await
             .unwrap(),
         CapabilityUse::FingerprintConflict

--- a/src/db/runtime_cleanup/postgres_tests.rs
+++ b/src/db/runtime_cleanup/postgres_tests.rs
@@ -119,6 +119,35 @@ async fn target_retirement_is_a_permanent_admission_tombstone_pg() {
     let (db, pool) = pool().await;
     let cleanup_target = target(&pool, "target-tombstone").await;
     assert!(
+        sqlx::query(
+            "UPDATE runtime_cleanup_targets SET channel_id = 'forged',
+             operation_high_watermark = operation_high_watermark + 1
+             WHERE target_id = $1",
+        )
+        .bind(cleanup_target.target_id)
+        .execute(&pool)
+        .await
+        .is_err()
+    );
+    assert!(
+        sqlx::query("DELETE FROM runtime_cleanup_targets WHERE target_id = $1")
+            .bind(cleanup_target.target_id)
+            .execute(&pool)
+            .await
+            .is_err()
+    );
+    let duplicate = sqlx::query(
+        "INSERT INTO runtime_cleanup_targets
+         (target_id, identity_kind, provider, discord_token_hash, channel_id,
+          operation_high_watermark)
+         VALUES ($1, 'discord_channel', 'claude', 'discord_0123456789abcdef',
+                 'target-tombstone', 0)",
+    )
+    .bind(Uuid::new_v4())
+    .execute(&pool)
+    .await;
+    assert!(duplicate.is_err());
+    assert!(
         retire_target(&pool, cleanup_target.target_id)
             .await
             .unwrap()
@@ -350,6 +379,19 @@ async fn capability_binding_expiry_replay_conflict_and_unknown_are_typed_pg() {
             .unwrap(),
         CapabilityUse::NeedsReconcile { request_id }
     );
+    let arbitrary_secret = [0_u8; 32];
+    assert_eq!(
+        replay_capability_request(
+            &pool,
+            &arbitrary_secret,
+            binding.clone(),
+            request_id,
+            fingerprint,
+        )
+        .await
+        .unwrap(),
+        CapabilityUse::BindingMismatch
+    );
     assert_eq!(
         begin_capability_request(&pool, &secret, binding.clone(), fingerprint)
             .await
@@ -373,10 +415,21 @@ async fn capability_binding_expiry_replay_conflict_and_unknown_are_typed_pg() {
             .unwrap(),
         CapabilityUse::BindingMismatch
     );
-    assert!(
-        record_receipt(&pool, request_id, ReceiptState::Applied, Some([9_u8; 32]))
-            .await
-            .unwrap()
+    assert_eq!(
+        record_receipt(
+            &pool,
+            &secret,
+            binding.clone(),
+            request_id,
+            fingerprint,
+            "worker",
+            attempt,
+            ReceiptState::Applied,
+            Some([9_u8; 32]),
+        )
+        .await
+        .unwrap(),
+        ReceiptWrite::Recorded
     );
     assert_eq!(
         replay_capability_request(&pool, &secret, binding.clone(), request_id, fingerprint)
@@ -522,10 +575,49 @@ async fn lost_response_replay_after_lease_expiry_needs_reconcile_pg() {
             .unwrap(),
         CapabilityUse::NeedsReconcile { request_id }
     );
-    assert!(
-        record_receipt(&pool, request_id, ReceiptState::Applied, None)
-            .await
-            .unwrap()
+    assert_eq!(
+        record_receipt(
+            &pool,
+            &secret,
+            binding.clone(),
+            request_id,
+            [2; 32],
+            "worker",
+            attempt,
+            ReceiptState::Applied,
+            None,
+        )
+        .await
+        .unwrap(),
+        ReceiptWrite::Expired
+    );
+    let takeover = claim_operation(
+        &pool,
+        operation.operation_id,
+        "worker-b",
+        Duration::seconds(1),
+    )
+    .await
+    .unwrap();
+    let takeover_attempt = match takeover {
+        ClaimResult::Claimed { attempt_epoch, .. } => attempt_epoch,
+        other => panic!("{other:?}"),
+    };
+    assert_eq!(
+        record_receipt(
+            &pool,
+            &secret,
+            binding.clone(),
+            request_id,
+            [2; 32],
+            "worker-b",
+            takeover_attempt,
+            ReceiptState::Applied,
+            None,
+        )
+        .await
+        .unwrap(),
+        ReceiptWrite::Recorded
     );
     assert_eq!(
         replay_capability_request(&pool, &secret, binding, request_id, [2; 32])
@@ -535,6 +627,142 @@ async fn lost_response_replay_after_lease_expiry_needs_reconcile_pg() {
             request_id,
             state: ReceiptState::Applied
         }
+    );
+    close(db, pool).await;
+}
+
+#[tokio::test]
+async fn receipt_state_graph_requires_current_reconciliation_authority_pg() {
+    let (db, pool) = pool().await;
+    let (target, operation) = operation(&pool, "receipt-state").await;
+    let first = claim_operation(
+        &pool,
+        operation.operation_id,
+        "worker-a",
+        Duration::milliseconds(250),
+    )
+    .await
+    .unwrap();
+    let (first_attempt, first_expiry) = match first {
+        ClaimResult::Claimed {
+            attempt_epoch,
+            expires_at,
+        } => (attempt_epoch, expires_at),
+        other => panic!("{other:?}"),
+    };
+    let (intent_id, idempotency_identity) = intent(&pool, operation.operation_id).await;
+    let binding = CapabilityBinding {
+        capability_id: Uuid::new_v4(),
+        target_id: target.target_id,
+        operation_id: operation.operation_id,
+        intent_id,
+        attempt_epoch: first_attempt,
+        audience: "receipt-state",
+        claim_owner: "worker-a",
+        expires_at: first_expiry - Duration::milliseconds(25),
+        idempotency_identity,
+    };
+    let secret = issue_capability(&pool, binding.clone()).await.unwrap();
+    let request_id = match begin_capability_request(&pool, &secret, binding.clone(), [6; 32])
+        .await
+        .unwrap()
+    {
+        CapabilityUse::Accepted { request_id } => request_id,
+        other => panic!("{other:?}"),
+    };
+    assert_eq!(
+        record_receipt(
+            &pool,
+            &secret,
+            binding.clone(),
+            request_id,
+            [6; 32],
+            "worker-a",
+            first_attempt,
+            ReceiptState::Unknown,
+            None,
+        )
+        .await
+        .unwrap(),
+        ReceiptWrite::Recorded
+    );
+    assert!(
+        sqlx::query(
+            "UPDATE runtime_cleanup_receipts SET receipt_state = 'applied'
+             WHERE request_id = $1",
+        )
+        .bind(request_id)
+        .execute(&pool)
+        .await
+        .is_err()
+    );
+    assert!(
+        sqlx::query("DELETE FROM runtime_cleanup_receipts WHERE request_id = $1")
+            .bind(request_id)
+            .execute(&pool)
+            .await
+            .is_err()
+    );
+    tokio::time::sleep(std::time::Duration::from_millis(275)).await;
+    let takeover = claim_operation(
+        &pool,
+        operation.operation_id,
+        "worker-b",
+        Duration::seconds(1),
+    )
+    .await
+    .unwrap();
+    let takeover_attempt = match takeover {
+        ClaimResult::Claimed { attempt_epoch, .. } => attempt_epoch,
+        other => panic!("{other:?}"),
+    };
+    assert_eq!(
+        record_receipt(
+            &pool,
+            &secret,
+            binding.clone(),
+            request_id,
+            [6; 32],
+            "worker-a",
+            first_attempt,
+            ReceiptState::Applied,
+            Some([7; 32]),
+        )
+        .await
+        .unwrap(),
+        ReceiptWrite::LostOwnership
+    );
+    assert_eq!(
+        record_receipt(
+            &pool,
+            &secret,
+            binding.clone(),
+            request_id,
+            [6; 32],
+            "worker-b",
+            takeover_attempt,
+            ReceiptState::Applied,
+            Some([7; 32]),
+        )
+        .await
+        .unwrap(),
+        ReceiptWrite::Reconciled
+    );
+    assert_eq!(
+        record_receipt(
+            &pool,
+            &secret,
+            binding,
+            request_id,
+            [6; 32],
+            "worker-b",
+            takeover_attempt,
+            ReceiptState::NotApplied,
+            Some([8; 32]),
+        )
+        .await
+        .unwrap(),
+        ReceiptWrite::Conflict
     );
     close(db, pool).await;
 }
@@ -592,9 +820,19 @@ async fn bounded_capability_gc_preserves_active_and_unresolved_pg() {
             CapabilityUse::Accepted { request_id } => request_id,
             other => panic!("{other:?}"),
         };
-    record_receipt(&pool, unresolved_request, ReceiptState::Unknown, None)
-        .await
-        .unwrap();
+    record_receipt(
+        &pool,
+        &secrets[1],
+        bindings[1].clone(),
+        unresolved_request,
+        [4; 32],
+        "worker",
+        attempt,
+        ReceiptState::Unknown,
+        None,
+    )
+    .await
+    .unwrap();
     let terminal_request =
         match begin_capability_request(&pool, &secrets[2], bindings[2].clone(), [5; 32])
             .await
@@ -603,9 +841,19 @@ async fn bounded_capability_gc_preserves_active_and_unresolved_pg() {
             CapabilityUse::Accepted { request_id } => request_id,
             other => panic!("{other:?}"),
         };
-    record_receipt(&pool, terminal_request, ReceiptState::Applied, None)
-        .await
-        .unwrap();
+    record_receipt(
+        &pool,
+        &secrets[2],
+        bindings[2].clone(),
+        terminal_request,
+        [5; 32],
+        "worker",
+        attempt,
+        ReceiptState::Applied,
+        None,
+    )
+    .await
+    .unwrap();
     sqlx::query(
         "UPDATE runtime_cleanup_capabilities
          SET expires_at = clock_timestamp() - INTERVAL '31 days'
@@ -627,6 +875,77 @@ async fn bounded_capability_gc_preserves_active_and_unresolved_pg() {
     assert_eq!(gc_expired_capabilities(&pool, 10).await.unwrap(), 0);
     assert!(gc_expired_capabilities(&pool, 0).await.is_err());
     assert!(gc_expired_capabilities(&pool, 1001).await.is_err());
+    close(db, pool).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn semantic_idempotency_concurrent_request_ids_converge_pg() {
+    let (db, pool) = pool().await;
+    let (target, operation) = operation(&pool, "semantic-race").await;
+    let claimed = claim_operation(
+        &pool,
+        operation.operation_id,
+        "worker",
+        Duration::seconds(3),
+    )
+    .await
+    .unwrap();
+    let attempt = match claimed {
+        ClaimResult::Claimed { attempt_epoch, .. } => attempt_epoch,
+        other => panic!("{other:?}"),
+    };
+    let (intent_id, idempotency_identity) = intent(&pool, operation.operation_id).await;
+    let now: DateTime<Utc> = sqlx::query_scalar("SELECT clock_timestamp()")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let binding = CapabilityBinding {
+        capability_id: Uuid::new_v4(),
+        target_id: target.target_id,
+        operation_id: operation.operation_id,
+        intent_id,
+        attempt_epoch: attempt,
+        audience: "semantic-race",
+        claim_owner: "worker",
+        expires_at: now + Duration::seconds(2),
+        idempotency_identity,
+    };
+    let secret = issue_capability(&pool, binding.clone()).await.unwrap();
+    let left = begin_capability_request(&pool, &secret, binding.clone(), [8; 32]);
+    let right = begin_capability_request(&pool, &secret, binding.clone(), [8; 32]);
+    let (left, right) = tokio::join!(left, right);
+    let left = left.unwrap();
+    let right = right.unwrap();
+    let request_id = match (&left, &right) {
+        (
+            CapabilityUse::Accepted { request_id },
+            CapabilityUse::Replay {
+                request_id: replay, ..
+            },
+        )
+        | (
+            CapabilityUse::Replay {
+                request_id: replay, ..
+            },
+            CapabilityUse::Accepted { request_id },
+        ) => {
+            assert_eq!(request_id, replay);
+            *request_id
+        }
+        other => panic!("{other:?}"),
+    };
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM runtime_cleanup_request_identities
+         WHERE operation_id = $1 AND intent_id = $2 AND idempotency_identity = $3",
+    )
+    .bind(operation.operation_id)
+    .bind(intent_id)
+    .bind(idempotency_identity)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 1);
+    assert_ne!(request_id, Uuid::nil());
     close(db, pool).await;
 }
 
@@ -763,9 +1082,19 @@ async fn receipt_gc_preserves_request_target_and_locator_authority_pg() {
         CapabilityUse::Accepted { request_id } => request_id,
         other => panic!("{other:?}"),
     };
-    record_receipt(&pool, request_id, ReceiptState::Unknown, None)
-        .await
-        .unwrap();
+    record_receipt(
+        &pool,
+        &secret,
+        binding.clone(),
+        request_id,
+        [1; 32],
+        "worker",
+        epoch,
+        ReceiptState::Unknown,
+        None,
+    )
+    .await
+    .unwrap();
     sqlx::query(
         "ALTER TABLE runtime_cleanup_receipts
          DROP CONSTRAINT runtime_cleanup_receipts_check",
@@ -773,6 +1102,10 @@ async fn receipt_gc_preserves_request_target_and_locator_authority_pg() {
     .execute(&pool)
     .await
     .unwrap();
+    sqlx::query("DROP TRIGGER trg_runtime_cleanup_receipt_guard ON runtime_cleanup_receipts")
+        .execute(&pool)
+        .await
+        .unwrap();
     sqlx::query(
         "UPDATE runtime_cleanup_receipts
          SET retain_until = clock_timestamp() - INTERVAL '1 second'",

--- a/src/db/runtime_cleanup/postgres_tests.rs
+++ b/src/db/runtime_cleanup/postgres_tests.rs
@@ -1,0 +1,453 @@
+use super::*;
+use crate::dispatch::test_support::DispatchPostgresTestDb;
+use sqlx::PgPool;
+
+async fn pool() -> (DispatchPostgresTestDb, PgPool) {
+    let db = DispatchPostgresTestDb::create("adk_cleanup_substrate", "cleanup substrate pg").await;
+    let pool = db.connect_and_migrate_with_max_connections(12).await;
+    (db, pool)
+}
+
+async fn close(db: DispatchPostgresTestDb, pool: PgPool) {
+    pool.close().await;
+    db.drop().await;
+}
+
+fn identity<'a>(channel: &'a str) -> CanonicalCleanupIdentity<'a> {
+    CanonicalCleanupIdentity {
+        kind: CleanupIdentityKind::DiscordChannel,
+        provider: "claude",
+        discord_token_hash: "discord_0123456789abcdef",
+        channel_id: channel,
+    }
+}
+
+async fn target(pool: &PgPool, channel: &str) -> CleanupTarget {
+    converge_target(pool, identity(channel), Uuid::new_v4())
+        .await
+        .unwrap()
+}
+
+async fn operation(pool: &PgPool, channel: &str) -> (CleanupTarget, CreatedOperation) {
+    let target = target(pool, channel).await;
+    let operation = create_operation(pool, target.target_id, Uuid::new_v4())
+        .await
+        .unwrap();
+    (target, operation)
+}
+
+async fn intent(pool: &PgPool, operation_id: Uuid) -> (Uuid, Uuid) {
+    sqlx::query_as(
+        "SELECT intent_id, idempotency_identity FROM runtime_cleanup_intents
+         WHERE operation_id = $1 ORDER BY ordinal LIMIT 1",
+    )
+    .bind(operation_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn canonical_concurrent_target_converges_pg() {
+    let (db, pool) = pool().await;
+    let (left, right) = tokio::join!(
+        converge_target(&pool, identity("canonical-race"), Uuid::new_v4()),
+        converge_target(&pool, identity("canonical-race"), Uuid::new_v4())
+    );
+    assert_eq!(left.unwrap().target_id, right.unwrap().target_id);
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM runtime_cleanup_targets")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1);
+    close(db, pool).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn locator_retirement_never_reuses_generation_pg() {
+    let (db, pool) = pool().await;
+    let first = target(&pool, "locator-a").await;
+    let second = target(&pool, "locator-b").await;
+    let initial = reserve_locator(&pool, "host:session", first.target_id)
+        .await
+        .unwrap();
+    assert_eq!(initial.generation, 1);
+    assert!(retire_locator(&pool, "host:session", 1).await.unwrap());
+    assert!(
+        resolve_locator(&pool, "host:session")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let replacement = reserve_locator(&pool, "host:session", second.target_id)
+        .await
+        .unwrap();
+    assert_eq!(replacement.generation, 2);
+    assert_eq!(replacement.target_id, second.target_id);
+    let history: Vec<(i64, bool)> = sqlx::query_as(
+        "SELECT generation, active FROM runtime_cleanup_locator_claims
+         WHERE locator = 'host:session' ORDER BY generation",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(history, vec![(1, false), (2, true)]);
+    close(db, pool).await;
+}
+
+#[tokio::test]
+async fn deleting_session_binding_never_deletes_target_pg() {
+    let (db, pool) = pool().await;
+    let target = target(&pool, "session-independent").await;
+    let session_id: i64 = sqlx::query_scalar(
+        "INSERT INTO sessions (session_key, provider, status)
+         VALUES ('cleanup-session', 'claude', 'idle') RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    bind_session(&pool, target.target_id, session_id)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM sessions WHERE id = $1")
+        .bind(session_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let target_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM runtime_cleanup_targets WHERE target_id = $1")
+            .bind(target.target_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let binding_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM runtime_cleanup_target_session_bindings WHERE session_id = $1",
+    )
+    .bind(session_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!((target_count, binding_count), (1, 0));
+    close(db, pool).await;
+}
+
+#[tokio::test]
+async fn operation_and_attempt_epochs_are_monotonic_and_stale_tokens_fail_pg() {
+    let (db, pool) = pool().await;
+    let (target, first) = operation(&pool, "epochs").await;
+    let claim1 = claim_operation(
+        &pool,
+        first.operation_id,
+        "worker-a",
+        Duration::milliseconds(30),
+    )
+    .await
+    .unwrap();
+    let epoch1 = match claim1 {
+        ClaimResult::Claimed { attempt_epoch, .. } => attempt_epoch,
+        other => panic!("{other:?}"),
+    };
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let claim2 = claim_operation(&pool, first.operation_id, "worker-b", Duration::seconds(1))
+        .await
+        .unwrap();
+    let epoch2 = match claim2 {
+        ClaimResult::Claimed { attempt_epoch, .. } => attempt_epoch,
+        other => panic!("{other:?}"),
+    };
+    assert!(epoch2 > epoch1);
+    assert!(
+        !transition_operation(&pool, first.operation_id, epoch1, OperationState::Committed)
+            .await
+            .unwrap()
+    );
+    assert!(
+        transition_operation(&pool, first.operation_id, epoch2, OperationState::Committed)
+            .await
+            .unwrap()
+    );
+    assert!(
+        transition_operation(&pool, first.operation_id, epoch2, OperationState::Completed)
+            .await
+            .unwrap()
+    );
+    let second = create_operation(&pool, target.target_id, Uuid::new_v4())
+        .await
+        .unwrap();
+    assert!(second.operation_epoch > first.operation_epoch);
+    close(db, pool).await;
+}
+
+#[tokio::test]
+async fn database_clock_bounds_and_renew_are_enforced_pg() {
+    let (db, pool) = pool().await;
+    let (_, operation) = operation(&pool, "db-clock").await;
+    assert!(
+        claim_operation(
+            &pool,
+            operation.operation_id,
+            "worker",
+            Duration::seconds(301)
+        )
+        .await
+        .is_err()
+    );
+    let claimed = claim_operation(
+        &pool,
+        operation.operation_id,
+        "worker",
+        Duration::seconds(2),
+    )
+    .await
+    .unwrap();
+    let (epoch, expires) = match claimed {
+        ClaimResult::Claimed {
+            attempt_epoch,
+            expires_at,
+        } => (attempt_epoch, expires_at),
+        other => panic!("{other:?}"),
+    };
+    let renewed = renew_operation(
+        &pool,
+        operation.operation_id,
+        "worker",
+        epoch,
+        Duration::seconds(4),
+    )
+    .await
+    .unwrap();
+    let renewed_expires = match renewed {
+        ClaimResult::Renewed { expires_at, .. } => expires_at,
+        other => panic!("{other:?}"),
+    };
+    assert!(renewed_expires > expires);
+    assert_eq!(
+        renew_operation(
+            &pool,
+            operation.operation_id,
+            "worker",
+            epoch + 1,
+            Duration::seconds(1)
+        )
+        .await
+        .unwrap(),
+        ClaimResult::Stale
+    );
+    close(db, pool).await;
+}
+
+#[tokio::test]
+async fn capability_binding_expiry_replay_conflict_and_unknown_are_typed_pg() {
+    let (db, pool) = pool().await;
+    let (target, operation) = operation(&pool, "capability").await;
+    let claimed = claim_operation(
+        &pool,
+        operation.operation_id,
+        "worker",
+        Duration::seconds(5),
+    )
+    .await
+    .unwrap();
+    let attempt = match claimed {
+        ClaimResult::Claimed { attempt_epoch, .. } => attempt_epoch,
+        other => panic!("{other:?}"),
+    };
+    let (intent_id, idempotency_identity) = intent(&pool, operation.operation_id).await;
+    let now: DateTime<Utc> = sqlx::query_scalar("SELECT clock_timestamp()")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let binding = CapabilityBinding {
+        capability_id: Uuid::new_v4(),
+        target_id: target.target_id,
+        operation_id: operation.operation_id,
+        intent_id,
+        attempt_epoch: attempt,
+        audience: "cleanup-worker",
+        expires_at: now + Duration::seconds(3),
+        idempotency_identity,
+    };
+    let secret = issue_capability(&pool, binding.clone()).await.unwrap();
+    let request_id = Uuid::new_v4();
+    let fingerprint = [7_u8; 32];
+    assert_eq!(
+        begin_capability_request(&pool, &secret, binding.clone(), request_id, fingerprint)
+            .await
+            .unwrap(),
+        CapabilityUse::Accepted
+    );
+    assert_eq!(
+        begin_capability_request(&pool, &secret, binding.clone(), request_id, fingerprint)
+            .await
+            .unwrap(),
+        CapabilityUse::Replay {
+            state: ReceiptState::Unknown
+        }
+    );
+    assert_eq!(
+        begin_capability_request(&pool, &secret, binding.clone(), request_id, [8_u8; 32])
+            .await
+            .unwrap(),
+        CapabilityUse::FingerprintConflict
+    );
+    let mut wrong = binding.clone();
+    wrong.audience = "other-worker";
+    assert_eq!(
+        begin_capability_request(&pool, &secret, wrong, Uuid::new_v4(), fingerprint)
+            .await
+            .unwrap(),
+        CapabilityUse::BindingMismatch
+    );
+    assert!(
+        record_receipt(&pool, request_id, ReceiptState::Applied, Some([9_u8; 32]))
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        begin_capability_request(&pool, &secret, binding.clone(), request_id, fingerprint)
+            .await
+            .unwrap(),
+        CapabilityUse::Replay {
+            state: ReceiptState::Applied
+        }
+    );
+    sqlx::query("UPDATE runtime_cleanup_capabilities SET expires_at = clock_timestamp() - INTERVAL '1 second' WHERE capability_id = $1")
+        .bind(binding.capability_id).execute(&pool).await.unwrap();
+    assert_eq!(
+        begin_capability_request(&pool, &secret, binding, Uuid::new_v4(), fingerprint)
+            .await
+            .unwrap(),
+        CapabilityUse::Expired
+    );
+    close(db, pool).await;
+}
+
+#[tokio::test]
+async fn legal_state_graph_is_database_enforced_pg() {
+    let (db, pool) = pool().await;
+    let (_, operation) = operation(&pool, "state-graph").await;
+    let epoch = match claim_operation(
+        &pool,
+        operation.operation_id,
+        "worker",
+        Duration::seconds(2),
+    )
+    .await
+    .unwrap()
+    {
+        ClaimResult::Claimed { attempt_epoch, .. } => attempt_epoch,
+        other => panic!("{other:?}"),
+    };
+    let illegal = sqlx::query(
+        "UPDATE runtime_cleanup_operations SET state = 'completed', committed_at = clock_timestamp(),
+         completed_at = clock_timestamp() WHERE operation_id = $1",
+    ).bind(operation.operation_id).execute(&pool).await;
+    assert!(illegal.is_err());
+    assert!(
+        transition_operation(
+            &pool,
+            operation.operation_id,
+            epoch,
+            OperationState::Aborted
+        )
+        .await
+        .unwrap()
+    );
+    let resurrection = sqlx::query(
+        "UPDATE runtime_cleanup_operations SET state = 'open', aborted_at = NULL WHERE operation_id = $1",
+    ).bind(operation.operation_id).execute(&pool).await;
+    assert!(resurrection.is_err());
+    close(db, pool).await;
+}
+
+#[tokio::test]
+async fn receipt_gc_preserves_request_target_and_locator_authority_pg() {
+    let (db, pool) = pool().await;
+    let (target, operation) = operation(&pool, "gc").await;
+    reserve_locator(&pool, "gc-locator", target.target_id)
+        .await
+        .unwrap();
+    retire_locator(&pool, "gc-locator", 1).await.unwrap();
+    let epoch = match claim_operation(
+        &pool,
+        operation.operation_id,
+        "worker",
+        Duration::seconds(2),
+    )
+    .await
+    .unwrap()
+    {
+        ClaimResult::Claimed { attempt_epoch, .. } => attempt_epoch,
+        other => panic!("{other:?}"),
+    };
+    let (intent_id, idem) = intent(&pool, operation.operation_id).await;
+    let now: DateTime<Utc> = sqlx::query_scalar("SELECT clock_timestamp()")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let binding = CapabilityBinding {
+        capability_id: Uuid::new_v4(),
+        target_id: target.target_id,
+        operation_id: operation.operation_id,
+        intent_id,
+        attempt_epoch: epoch,
+        audience: "gc",
+        expires_at: now + Duration::seconds(2),
+        idempotency_identity: idem,
+    };
+    let secret = issue_capability(&pool, binding.clone()).await.unwrap();
+    let request_id = Uuid::new_v4();
+    begin_capability_request(&pool, &secret, binding.clone(), request_id, [1; 32])
+        .await
+        .unwrap();
+    record_receipt(&pool, request_id, ReceiptState::Unknown, None)
+        .await
+        .unwrap();
+    sqlx::query(
+        "ALTER TABLE runtime_cleanup_receipts
+         DROP CONSTRAINT runtime_cleanup_receipts_check",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE runtime_cleanup_receipts
+         SET retain_until = clock_timestamp() - INTERVAL '1 second'",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    assert_eq!(gc_terminal_receipts(&pool, 1).await.unwrap(), 1);
+    let authority: (i64, i64, i64) = sqlx::query_as(
+        "SELECT (SELECT operation_high_watermark FROM runtime_cleanup_targets WHERE target_id = $1),
+                (SELECT COUNT(*) FROM runtime_cleanup_locator_claims WHERE locator = 'gc-locator'),
+                (SELECT COUNT(*) FROM runtime_cleanup_request_identities WHERE request_id = $2)",
+    ).bind(target.target_id).bind(request_id).fetch_one(&pool).await.unwrap();
+    assert_eq!(authority, (operation.operation_epoch, 1, 1));
+    assert_eq!(
+        begin_capability_request(&pool, &secret, binding, request_id, [2; 32])
+            .await
+            .unwrap(),
+        CapabilityUse::FingerprintConflict
+    );
+    close(db, pool).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn bounded_gc_and_lock_order_complete_without_deadlock_pg() {
+    let (db, pool) = pool().await;
+    let first = target(&pool, "deadlock-a").await;
+    let second = target(&pool, "deadlock-b").await;
+    let left = reserve_locator(&pool, "same-locator", first.target_id);
+    let right = reserve_locator(&pool, "same-locator", second.target_id);
+    let (left, right) = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        tokio::join!(left, right)
+    })
+    .await
+    .expect("locator contenders must not deadlock");
+    let winner = left.unwrap();
+    assert_eq!(right.unwrap(), winner);
+    assert!(gc_terminal_receipts(&pool, 0).await.is_err());
+    assert!(gc_terminal_receipts(&pool, 1001).await.is_err());
+    close(db, pool).await;
+}


### PR DESCRIPTION
## Summary
- add a dormant PostgreSQL-only cleanup target, locator, operation, intent, capability, request identity, receipt, and bounded-GC substrate
- enforce canonical typed identities, permanent monotonic authority, legal state transitions, exact intent/capability bindings, DB-clock leases, and hash-at-rest capability secrets
- add real PostgreSQL concurrency and mutation tests without wiring any production consumer or runtime authority

## Scope and non-claims
- Replaces Task #25 under #4916 and supersedes the closed draft #4932.
- No Discord hotfile, runtime configuration, deployment path, or production callsite is changed.
- The database can fence database mutations but cannot prove that an external destination fenced an already-issued side effect. Destination high-watermark enforcement remains a future slice.
- This PR is intentionally Draft. Do not merge or deploy from this PR yet.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --lib`
- [x] `cargo test --lib db::runtime_cleanup::postgres_tests`
- [x] `python3 scripts/check_postgres_migration_checksums.py`
- [x] `python3 scripts/check_test_lane_coverage.py --baseline-ref origin/main`
- [x] `python3 scripts/generate_inventory_docs.py`
- [x] `python3 scripts/check_agent_maintenance_docs.py`
- [x] `git diff --check`
- [x] locator immutability mutation proof: guard removed -> focused test failed; guard restored -> focused test passed

Refs #4916
Supersedes #4932

🤖 Generated with [Claude Code](https://claude.com/claude-code)