### PR TITLE
feat(#4891): add dormant status panel journal

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -774,6 +774,12 @@ src/
 │   │   │   ├── read.rs
 │   │   │   ├── validation.rs
 │   │   │   └── write.rs
+│   │   ├── status_panel_transition_v2/
+│   │   │   ├── journal/
+│   │   │   │   ├── codec.rs
+│   │   │   │   ├── storage.rs
+│   │   │   │   └── tests.rs
+│   │   │   └── journal.rs
 │   │   ├── task_notification_delivery/
 │   │   │   ├── store/
 │   │   │   │   ├── card_claim.rs

--- a/src/services/discord/status_panel_transition_v2.rs
+++ b/src/services/discord/status_panel_transition_v2.rs
@@ -1,64 +1,64 @@
-//! Dormant status-panel transition model for #4891.
+//! Dormant status-panel transition model and filesystem journal for #4891.
 //!
-//! This module is intentionally pure and has no production caller. It cannot
-//! perform Discord I/O, persist state, mutate legacy stores, or replace legacy
-//! authority. A later slice must provide separately reviewed adapter wiring.
+//! This module has no production caller. It cannot perform Discord I/O, mutate
+//! legacy stores, replace legacy authority, or activate a cutover. The journal
+//! adapter models durable authorization that a later slice may wire separately.
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct Candidate {
-    pub channel_id: u64,
-    pub message_id: u64,
-    pub generation: u64,
+mod journal;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PanelIdentity {
+    provider: journal::CanonicalProvider,
+    canonical_token_hash: journal::CanonicalTokenHash,
+    channel_id: u64,
+}
+
+impl PanelIdentity {
+    pub(super) fn provider(&self) -> &str {
+        self.provider.as_str()
+    }
+
+    pub(super) fn canonical_token_hash(&self) -> &str {
+        self.canonical_token_hash.as_str()
+    }
+
+    pub(super) fn channel_id(&self) -> u64 {
+        self.channel_id
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PanelPlan {
+    pub identity: PanelIdentity,
     pub turn_id: u64,
     pub expected_prior_message_id: Option<u64>,
 }
 
-impl Candidate {
-    fn is_valid(self) -> bool {
-        self.channel_id != 0
-            && self.message_id != 0
-            && self.generation != 0
+impl PanelPlan {
+    fn is_valid(&self) -> bool {
+        self.identity.channel_id != 0
             && self.turn_id != 0
             && self.expected_prior_message_id != Some(0)
-            && self.expected_prior_message_id != Some(self.message_id)
     }
 }
 
-/// Protection evidence presented at the bind boundary.
-///
-/// The legacy variants are observations only. They deliberately cannot satisfy
-/// either initial or recovery bind authorization.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum ProtectionEvidence {
-    Missing,
-    PendingBind,
-    CandidateAcknowledged,
-    JournalOwned,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Candidate {
+    pub plan: PanelPlan,
+    pub message_id: u64,
+    pub generation: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct BindGuard {
-    pub candidate: Candidate,
-    pub protection: ProtectionEvidence,
-    pub candidate_identity_matches: bool,
-    pub turn_identity_matches: bool,
-    pub generation_matches: bool,
-    pub expected_binding_matches: bool,
-}
-
-impl BindGuard {
-    fn is_complete_for(self, candidate: Candidate) -> bool {
-        candidate.is_valid()
-            && self.candidate == candidate
-            && self.protection == ProtectionEvidence::JournalOwned
-            && self.candidate_identity_matches
-            && self.turn_identity_matches
-            && self.generation_matches
-            && self.expected_binding_matches
+impl Candidate {
+    fn is_valid(&self) -> bool {
+        self.plan.is_valid()
+            && self.message_id != 0
+            && self.generation != 0
+            && self.plan.expected_prior_message_id != Some(self.message_id)
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct BoundPanel {
     pub candidate: Candidate,
 }
@@ -66,7 +66,7 @@ pub(super) struct BoundPanel {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum FailurePhase {
     Prepare,
-    AuthorizeBind,
+    RecordSent,
     CommitBind,
     AuthorizeRetire,
     Delete,
@@ -86,25 +86,26 @@ pub(super) enum QuarantineReason {
     InvariantViolation,
 }
 
-/// The future journal's tagged state.
+/// Tagged state consumed by the dormant journal adapter.
 ///
-/// `PendingBind` and `CandidateAcknowledged` are intentionally absent: legacy
-/// observations are not states in this authority model.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// The journal-owned handle has private fields and no constructor outside the
+/// adapter. Legacy observations are intentionally absent from this bind model.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum JournalState {
     Prepared {
-        candidate: Candidate,
+        plan: PanelPlan,
+        generation: u64,
     },
     BindAuthorized {
         candidate: Candidate,
-        guard: BindGuard,
+        authorization: journal::JournalOwnedBind,
     },
     Bound {
         panel: BoundPanel,
     },
     RetireAuthorized {
         panel: BoundPanel,
-        delete_message_id: u64,
+        authorization: journal::JournalOwnedRetire,
     },
     Retired {
         panel: BoundPanel,
@@ -120,11 +121,11 @@ pub(super) enum JournalState {
 }
 
 impl JournalState {
-    pub(super) fn prepared(candidate: Candidate) -> Self {
-        Self::Prepared { candidate }
+    pub(super) fn prepared(plan: PanelPlan, generation: u64) -> Self {
+        Self::Prepared { plan, generation }
     }
 
-    fn is_terminal(self) -> bool {
+    fn is_terminal(&self) -> bool {
         matches!(
             self,
             Self::Retired { .. } | Self::Failed { .. } | Self::Quarantined { .. }
@@ -132,14 +133,14 @@ impl JournalState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum TransitionEvent {
     AuthorizeBind {
-        guard: BindGuard,
+        authorization: journal::JournalOwnedBind,
     },
     CommitBind,
     AuthorizeRetire {
-        delete_message_id: u64,
+        authorization: journal::JournalOwnedRetire,
     },
     CommitRetire,
     Fail {
@@ -154,8 +155,8 @@ pub(super) enum TransitionEvent {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum TransitionError {
     IllegalTransition,
-    IncompleteBindGuard,
-    InvalidRetirementTarget,
+    IncompleteBindAuthorization,
+    InvalidRetirementAuthorization,
     TerminalState,
 }
 
@@ -169,40 +170,52 @@ pub(super) fn transition(
     }
 
     match (state, event) {
-        (JournalState::Prepared { candidate }, TransitionEvent::AuthorizeBind { guard }) => {
-            if !guard.is_complete_for(candidate) {
-                return Err(TransitionError::IncompleteBindGuard);
+        (
+            JournalState::Prepared { plan, generation },
+            TransitionEvent::AuthorizeBind { authorization },
+        ) => {
+            let candidate = authorization.candidate().clone();
+            if !candidate.is_valid()
+                || candidate.plan != plan
+                || candidate.generation != generation
+                || !authorization.matches_candidate(&candidate)
+            {
+                return Err(TransitionError::IncompleteBindAuthorization);
             }
-            Ok(JournalState::BindAuthorized { candidate, guard })
+            Ok(JournalState::BindAuthorized {
+                candidate,
+                authorization,
+            })
         }
-        (JournalState::BindAuthorized { candidate, guard }, TransitionEvent::CommitBind)
-            if guard.is_complete_for(candidate) =>
-        {
+        (
+            JournalState::BindAuthorized {
+                candidate,
+                authorization,
+            },
+            TransitionEvent::CommitBind,
+        ) if candidate.is_valid() && authorization.matches_candidate(&candidate) => {
             Ok(JournalState::Bound {
                 panel: BoundPanel { candidate },
             })
         }
-        (JournalState::Bound { panel }, TransitionEvent::AuthorizeRetire { delete_message_id }) => {
-            if delete_message_id == 0
-                || delete_message_id == panel.candidate.message_id
-                || panel.candidate.expected_prior_message_id != Some(delete_message_id)
-            {
-                return Err(TransitionError::InvalidRetirementTarget);
+        (JournalState::Bound { panel }, TransitionEvent::AuthorizeRetire { authorization }) => {
+            if !authorization.matches_panel(&panel) {
+                return Err(TransitionError::InvalidRetirementAuthorization);
             }
             Ok(JournalState::RetireAuthorized {
                 panel,
-                delete_message_id,
+                authorization,
             })
         }
         (
             JournalState::RetireAuthorized {
                 panel,
-                delete_message_id,
+                authorization,
             },
             TransitionEvent::CommitRetire,
-        ) => Ok(JournalState::Retired {
+        ) if authorization.matches_panel(&panel) => Ok(JournalState::Retired {
+            retired_message_id: authorization.delete_message_id(),
             panel,
-            retired_message_id: delete_message_id,
         }),
         (_, TransitionEvent::Fail { phase, reason }) => Ok(JournalState::Failed { phase, reason }),
         (_, TransitionEvent::Quarantine { reason }) => Ok(JournalState::Quarantined { reason }),
@@ -210,61 +223,81 @@ pub(super) fn transition(
     }
 }
 
-/// Recovery may bind only the exact journal-owned candidate whose complete
-/// guard was durably represented by `BindAuthorized`.
-pub(super) fn recovery_bind_is_authorized(state: JournalState) -> bool {
-    matches!(
-        state,
-        JournalState::BindAuthorized { candidate, guard }
-            if guard.protection == ProtectionEvidence::JournalOwned
-                && guard.is_complete_for(candidate)
-    )
+/// Recovery may bind only an opaque authorization rehydrated from the exact
+/// durable `BindAuthorized` operation record.
+pub(super) fn recovery_bind_authorization(
+    state: &JournalState,
+) -> Option<&journal::JournalOwnedBind> {
+    match state {
+        JournalState::BindAuthorized {
+            candidate,
+            authorization,
+        } if authorization.matches_candidate(candidate) => Some(authorization),
+        _ => None,
+    }
 }
 
-/// Physical deletion may begin only from the explicit retirement authority
-/// state and only for its exact target.
-pub(super) fn deletion_is_authorized(state: JournalState, message_id: u64) -> bool {
-    matches!(
-        state,
+/// Physical deletion may begin only with the exact durable retirement handle.
+pub(super) fn deletion_authorization(state: &JournalState) -> Option<&journal::JournalOwnedRetire> {
+    match state {
         JournalState::RetireAuthorized {
-            delete_message_id,
-            ..
-        } if message_id != 0 && message_id == delete_message_id
-    )
+            panel,
+            authorization,
+        } if authorization.matches_panel(panel) => Some(authorization),
+        _ => None,
+    }
+}
+
+/// Legacy inputs remain observations only and have no conversion into bind
+/// authorization. A later migration may separately evaluate them for retirement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LegacyRetireObservation {
+    pub identity: PanelIdentity,
+    pub message_id: u64,
+}
+
+impl LegacyRetireObservation {
+    pub(super) fn new(identity: PanelIdentity, message_id: u64) -> Option<Self> {
+        (message_id != 0).then_some(Self {
+            identity,
+            message_id,
+        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    const CANDIDATE: Candidate = Candidate {
-        channel_id: 11,
-        message_id: 22,
-        generation: 33,
-        turn_id: 44,
-        expected_prior_message_id: Some(21),
-    };
-
-    fn complete_guard() -> BindGuard {
-        BindGuard {
-            candidate: CANDIDATE,
-            protection: ProtectionEvidence::JournalOwned,
-            candidate_identity_matches: true,
-            turn_identity_matches: true,
-            generation_matches: true,
-            expected_binding_matches: true,
+    fn plan() -> PanelPlan {
+        PanelPlan {
+            identity: journal::identity_for_test("claude", "discord_0123456789abcdef", 11),
+            turn_id: 44,
+            expected_prior_message_id: Some(21),
         }
     }
 
+    fn candidate() -> Candidate {
+        Candidate {
+            plan: plan(),
+            message_id: 22,
+            generation: 33,
+        }
+    }
+
+    fn bind_authorization() -> journal::JournalOwnedBind {
+        journal::bind_authorization_for_test(candidate())
+    }
+
     fn prepared() -> JournalState {
-        JournalState::prepared(CANDIDATE)
+        JournalState::prepared(plan(), 33)
     }
 
     fn bind_authorized() -> JournalState {
         transition(
             prepared(),
             TransitionEvent::AuthorizeBind {
-                guard: complete_guard(),
+                authorization: bind_authorization(),
             },
         )
         .unwrap()
@@ -275,136 +308,96 @@ mod tests {
     }
 
     fn retire_authorized() -> JournalState {
+        let panel = match bound() {
+            JournalState::Bound { panel } => panel,
+            _ => unreachable!(),
+        };
         transition(
-            bound(),
+            JournalState::Bound {
+                panel: panel.clone(),
+            },
             TransitionEvent::AuthorizeRetire {
-                delete_message_id: 21,
+                authorization: journal::retire_authorization_for_test(panel, 21),
             },
         )
         .unwrap()
     }
 
-    fn failed() -> JournalState {
-        JournalState::Failed {
-            phase: FailurePhase::CommitBind,
-            reason: FailureReason::CommitFailed,
-        }
-    }
-
-    fn quarantined() -> JournalState {
-        JournalState::Quarantined {
-            reason: QuarantineReason::InvariantViolation,
-        }
-    }
-
-    fn retired() -> JournalState {
-        transition(retire_authorized(), TransitionEvent::CommitRetire).unwrap()
-    }
-
     #[test]
     fn happy_path_is_strictly_monotonic() {
         let authorized = bind_authorized();
-        assert!(recovery_bind_is_authorized(authorized));
-
+        assert!(recovery_bind_authorization(&authorized).is_some());
         let bound = transition(authorized, TransitionEvent::CommitBind).unwrap();
-        assert!(!recovery_bind_is_authorized(bound));
+        assert!(recovery_bind_authorization(&bound).is_none());
 
-        let retire_authorized = transition(
+        let panel = match &bound {
+            JournalState::Bound { panel } => panel.clone(),
+            _ => unreachable!(),
+        };
+        let retire = transition(
             bound,
             TransitionEvent::AuthorizeRetire {
-                delete_message_id: 21,
+                authorization: journal::retire_authorization_for_test(panel, 21),
             },
         )
         .unwrap();
-        assert!(deletion_is_authorized(retire_authorized, 21));
-
-        let retired = transition(retire_authorized, TransitionEvent::CommitRetire).unwrap();
-        assert!(!deletion_is_authorized(retired, 21));
+        assert_eq!(
+            deletion_authorization(&retire).map(|proof| proof.delete_message_id()),
+            Some(21)
+        );
+        let retired = transition(retire, TransitionEvent::CommitRetire).unwrap();
+        assert!(deletion_authorization(&retired).is_none());
     }
 
     #[test]
-    fn exhaustive_normal_transition_table_accepts_only_adjacent_edges() {
-        #[derive(Clone, Copy)]
-        enum StateCase {
-            Prepared,
-            BindAuthorized,
-            Bound,
-            RetireAuthorized,
-            Retired,
-            Failed,
-            Quarantined,
-        }
+    fn mismatched_adapter_authorizations_are_rejected() {
+        let mut wrong_candidate = candidate();
+        wrong_candidate.message_id += 1;
+        assert_eq!(
+            transition(
+                prepared(),
+                TransitionEvent::AuthorizeBind {
+                    authorization: journal::mutate_bind_authorization_for_test(
+                        bind_authorization(),
+                        wrong_candidate,
+                    ),
+                },
+            ),
+            Err(TransitionError::IncompleteBindAuthorization)
+        );
 
-        #[derive(Clone, Copy)]
-        enum EventCase {
-            AuthorizeBind,
-            CommitBind,
-            AuthorizeRetire,
-            CommitRetire,
-        }
-
-        let states = [
-            StateCase::Prepared,
-            StateCase::BindAuthorized,
-            StateCase::Bound,
-            StateCase::RetireAuthorized,
-            StateCase::Retired,
-            StateCase::Failed,
-            StateCase::Quarantined,
-        ];
-        let events = [
-            EventCase::AuthorizeBind,
-            EventCase::CommitBind,
-            EventCase::AuthorizeRetire,
-            EventCase::CommitRetire,
-        ];
-
-        for (state_index, state_case) in states.into_iter().enumerate() {
-            for (event_index, event_case) in events.into_iter().enumerate() {
-                let state = match state_case {
-                    StateCase::Prepared => prepared(),
-                    StateCase::BindAuthorized => bind_authorized(),
-                    StateCase::Bound => bound(),
-                    StateCase::RetireAuthorized => retire_authorized(),
-                    StateCase::Retired => retired(),
-                    StateCase::Failed => failed(),
-                    StateCase::Quarantined => quarantined(),
-                };
-                let event = match event_case {
-                    EventCase::AuthorizeBind => TransitionEvent::AuthorizeBind {
-                        guard: complete_guard(),
-                    },
-                    EventCase::CommitBind => TransitionEvent::CommitBind,
-                    EventCase::AuthorizeRetire => TransitionEvent::AuthorizeRetire {
-                        delete_message_id: 21,
-                    },
-                    EventCase::CommitRetire => TransitionEvent::CommitRetire,
-                };
-                let accepted = transition(state, event).is_ok();
-                assert_eq!(
-                    accepted,
-                    state_index == event_index,
-                    "state {state_index}, event {event_index}"
-                );
-            }
-        }
+        let panel = match bound() {
+            JournalState::Bound { panel } => panel,
+            _ => unreachable!(),
+        };
+        assert_eq!(
+            transition(
+                JournalState::Bound {
+                    panel: panel.clone(),
+                },
+                TransitionEvent::AuthorizeRetire {
+                    authorization: journal::retire_authorization_for_test(panel, 20),
+                },
+            ),
+            Err(TransitionError::InvalidRetirementAuthorization)
+        );
     }
 
     #[test]
-    fn failure_and_quarantine_are_terminal_from_every_live_state() {
-        let live_states = [prepared(), bind_authorized(), bound(), retire_authorized()];
-
-        for state in live_states {
+    fn failure_and_quarantine_are_terminal() {
+        for state in [prepared(), bind_authorized(), bound(), retire_authorized()] {
             let failed = transition(
-                state,
+                state.clone(),
                 TransitionEvent::Fail {
                     phase: FailurePhase::Prepare,
                     reason: FailureReason::AdapterFailed,
                 },
             )
             .unwrap();
-            assert!(matches!(failed, JournalState::Failed { .. }));
-
+            assert_eq!(
+                transition(failed, TransitionEvent::CommitBind),
+                Err(TransitionError::TerminalState)
+            );
             let quarantined = transition(
                 state,
                 TransitionEvent::Quarantine {
@@ -412,236 +405,37 @@ mod tests {
                 },
             )
             .unwrap();
-            assert!(matches!(quarantined, JournalState::Quarantined { .. }));
-        }
-
-        for terminal in [retired(), failed(), quarantined()] {
             assert_eq!(
-                transition(
-                    terminal,
-                    TransitionEvent::Quarantine {
-                        reason: QuarantineReason::UnknownState,
-                    },
-                ),
+                transition(quarantined, TransitionEvent::CommitBind),
                 Err(TransitionError::TerminalState)
             );
         }
     }
 
     #[test]
-    fn every_bind_guard_clause_is_required() {
-        let mutations: [(&str, fn(&mut BindGuard)); 6] = [
-            ("journal ownership", |guard| {
-                guard.protection = ProtectionEvidence::Missing
-            }),
-            ("candidate identity", |guard| {
-                guard.candidate_identity_matches = false
-            }),
-            ("turn identity", |guard| guard.turn_identity_matches = false),
-            ("generation", |guard| guard.generation_matches = false),
-            ("expected binding", |guard| {
-                guard.expected_binding_matches = false
-            }),
-            ("exact candidate", |guard| guard.candidate.message_id += 1),
-        ];
-
-        for (name, mutate) in mutations {
-            let mut guard = complete_guard();
-            mutate(&mut guard);
-            assert_eq!(
-                transition(prepared(), TransitionEvent::AuthorizeBind { guard }),
-                Err(TransitionError::IncompleteBindGuard),
-                "removed guard: {name}"
-            );
-        }
+    fn legacy_observation_has_no_bind_conversion_surface() {
+        let observation = LegacyRetireObservation::new(plan().identity, 21).unwrap();
+        assert_eq!(observation.message_id, 21);
+        let source = include_str!("status_panel_transition_v2.rs");
+        let production = source.split("#[cfg(test)]").next().unwrap();
+        assert!(!production.contains("impl From<LegacyRetireObservation"));
+        assert!(!production.contains("JournalOwnedBind::new"));
     }
 
     #[test]
-    fn legacy_pending_bind_and_candidate_acknowledged_never_authorize_bind() {
-        for protection in [
-            ProtectionEvidence::PendingBind,
-            ProtectionEvidence::CandidateAcknowledged,
-        ] {
-            let mut guard = complete_guard();
-            guard.protection = protection;
-            assert_eq!(
-                transition(prepared(), TransitionEvent::AuthorizeBind { guard }),
-                Err(TransitionError::IncompleteBindGuard)
-            );
-
-            let forged = JournalState::BindAuthorized {
-                candidate: CANDIDATE,
-                guard,
-            };
-            assert!(!recovery_bind_is_authorized(forged));
-            assert_eq!(
-                transition(forged, TransitionEvent::CommitBind),
-                Err(TransitionError::IllegalTransition)
-            );
-        }
-    }
-
-    #[test]
-    fn recovery_bind_requires_bind_authorized_state_and_complete_journal_guard() {
-        let live_non_authority = [prepared(), bound(), retire_authorized()];
-        for state in live_non_authority {
-            assert!(!recovery_bind_is_authorized(state));
-        }
-
-        let mutations: [fn(&mut BindGuard); 6] = [
-            |guard| guard.protection = ProtectionEvidence::Missing,
-            |guard| guard.candidate_identity_matches = false,
-            |guard| guard.turn_identity_matches = false,
-            |guard| guard.generation_matches = false,
-            |guard| guard.expected_binding_matches = false,
-            |guard| guard.candidate.turn_id += 1,
-        ];
-        for mutate in mutations {
-            let mut guard = complete_guard();
-            mutate(&mut guard);
-            assert!(!recovery_bind_is_authorized(JournalState::BindAuthorized {
-                candidate: CANDIDATE,
-                guard,
-            }));
-        }
-        assert!(recovery_bind_is_authorized(bind_authorized()));
-    }
-
-    #[test]
-    fn deletion_requires_retire_authorized_and_exact_target() {
-        for state in [prepared(), bind_authorized(), bound(), retired(), failed()] {
-            assert!(!deletion_is_authorized(state, 21));
-        }
-        let state = retire_authorized();
-        assert!(!deletion_is_authorized(state, 0));
-        assert!(!deletion_is_authorized(state, 20));
-        assert!(!deletion_is_authorized(state, CANDIDATE.message_id));
-        assert!(deletion_is_authorized(state, 21));
-    }
-
-    #[test]
-    fn retirement_rejects_current_or_unexpected_message() {
-        for delete_message_id in [0, 20, CANDIDATE.message_id] {
-            assert_eq!(
-                transition(
-                    bound(),
-                    TransitionEvent::AuthorizeRetire { delete_message_id },
-                ),
-                Err(TransitionError::InvalidRetirementTarget)
-            );
-        }
-    }
-
-    #[test]
-    fn invalid_candidate_cannot_receive_bind_authority() {
-        let invalid_candidates = [
-            Candidate {
-                channel_id: 0,
-                ..CANDIDATE
-            },
-            Candidate {
-                message_id: 0,
-                ..CANDIDATE
-            },
-            Candidate {
-                generation: 0,
-                ..CANDIDATE
-            },
-            Candidate {
-                turn_id: 0,
-                ..CANDIDATE
-            },
-            Candidate {
-                expected_prior_message_id: Some(0),
-                ..CANDIDATE
-            },
-            Candidate {
-                expected_prior_message_id: Some(CANDIDATE.message_id),
-                ..CANDIDATE
-            },
-        ];
-
-        for candidate in invalid_candidates {
-            let mut guard = complete_guard();
-            guard.candidate = candidate;
-            assert_eq!(
-                transition(
-                    JournalState::prepared(candidate),
-                    TransitionEvent::AuthorizeBind { guard },
-                ),
-                Err(TransitionError::IncompleteBindGuard)
-            );
-        }
-    }
-
-    #[test]
-    fn forged_incomplete_bind_authority_cannot_commit() {
-        let mut guard = complete_guard();
-        guard.generation_matches = false;
-        let forged = JournalState::BindAuthorized {
-            candidate: CANDIDATE,
-            guard,
-        };
-        assert_eq!(
-            transition(forged, TransitionEvent::CommitBind),
-            Err(TransitionError::IllegalTransition)
-        );
-    }
-
-    #[test]
-    fn proof_model_has_no_legacy_or_io_authority_surface() {
+    fn model_has_no_discord_or_legacy_authority_surface() {
         let source = include_str!("status_panel_transition_v2.rs");
         let production = source.split("#[cfg(test)]").next().unwrap();
         for forbidden in [
             "serenity",
             "reqwest",
-            "std::fs",
-            "tokio::fs",
             "status_panel_orphan_store",
             "status_panel_singleton_store",
             "inflight::",
         ] {
             assert!(
                 !production.contains(forbidden),
-                "forbidden production authority surface: {forbidden}"
-            );
-        }
-    }
-
-    #[test]
-    fn failure_taxonomy_covers_each_transition_phase() {
-        let phases = [
-            FailurePhase::Prepare,
-            FailurePhase::AuthorizeBind,
-            FailurePhase::CommitBind,
-            FailurePhase::AuthorizeRetire,
-            FailurePhase::Delete,
-        ];
-        let reasons = [
-            FailureReason::GuardRejected,
-            FailureReason::CommitFailed,
-            FailureReason::AdapterFailed,
-        ];
-        for phase in phases {
-            for reason in reasons {
-                assert_eq!(
-                    transition(prepared(), TransitionEvent::Fail { phase, reason }),
-                    Ok(JournalState::Failed { phase, reason })
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn quarantine_taxonomy_remains_typed() {
-        for reason in [
-            QuarantineReason::MalformedRecord,
-            QuarantineReason::UnknownState,
-            QuarantineReason::InvariantViolation,
-        ] {
-            assert_eq!(
-                transition(prepared(), TransitionEvent::Quarantine { reason }),
-                Ok(JournalState::Quarantined { reason })
+                "forbidden surface: {forbidden}"
             );
         }
     }

--- a/src/services/discord/status_panel_transition_v2/journal.rs
+++ b/src/services/discord/status_panel_transition_v2/journal.rs
@@ -10,14 +10,16 @@
 mod codec;
 mod storage;
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use codec::{
     ChannelWire, OperationStamp, ReplayMetadata, bind_digest, commit_bind_digest, delete_digest,
     prepare_digest, retire_digest,
 };
 use serde::{Deserialize, Serialize};
-use storage::{ChannelLock, Failpoint, WriteTarget};
+#[cfg(test)]
+use storage::WriteTarget;
+use storage::{ChannelLock, ChannelStorage, Directory, Failpoint};
 use uuid::Uuid;
 
 use super::{BoundPanel, Candidate, JournalState, PanelIdentity, PanelPlan};
@@ -73,6 +75,7 @@ pub(super) enum StoreError {
     LockFailed,
     ReadFailed,
     MalformedRecord,
+    Quarantined,
     InvariantViolation,
     WriteFailed(WriteStage),
 }
@@ -193,7 +196,7 @@ pub(super) struct ChannelSnapshot {
 }
 
 pub(super) struct ChannelJournal {
-    channel_dir: PathBuf,
+    storage: ChannelStorage,
     identity: PanelIdentity,
     #[cfg(test)]
     failpoint: Option<Failpoint>,
@@ -211,17 +214,14 @@ impl ChannelJournal {
         if channel_id == 0 {
             return Err(StoreError::InvalidPathComponent("channel_id"));
         }
-        storage::ensure_directory(root)?;
-        let provider_dir = root.join(provider.as_str());
-        storage::ensure_child_directory(root, &provider_dir)?;
-        let token_dir = provider_dir.join(canonical_token_hash.as_str());
-        storage::ensure_child_directory(root, &token_dir)?;
-        let channel_dir = token_dir.join(channel_id.to_string());
-        storage::ensure_child_directory(root, &channel_dir)?;
-        storage::ensure_child_directory(root, &channel_dir.join("operations"))?;
-        storage::ensure_child_directory(root, &channel_dir.join("quarantine"))?;
+        let storage = ChannelStorage::open(
+            root,
+            provider.as_str(),
+            canonical_token_hash.as_str(),
+            channel_id,
+        )?;
         Ok(Self {
-            channel_dir,
+            storage,
             identity: PanelIdentity {
                 provider,
                 canonical_token_hash,
@@ -606,7 +606,7 @@ impl ChannelJournal {
     }
 
     fn lock(&self) -> Result<ChannelLock, StoreError> {
-        storage::lock_channel(&self.channel_dir)
+        self.storage.lock()
     }
 
     fn require_locked(&self) -> Result<ChannelSnapshot, StoreError> {
@@ -615,66 +615,87 @@ impl ChannelJournal {
     }
 
     fn load_optional_locked(&self) -> Result<Option<ChannelSnapshot>, StoreError> {
-        let path = self.channel_dir.join(CHANNEL_FILE);
-        let bytes = match storage::read_nofollow(&path)? {
+        if self.storage.quarantine_marker_present()? {
+            return Err(StoreError::Quarantined);
+        }
+        let bytes = match self.storage.read_channel()? {
             Some(bytes) => bytes,
             None => return Ok(None),
         };
         let wire: ChannelWire = match serde_json::from_slice(&bytes) {
             Ok(wire) => wire,
-            Err(_) => {
-                let _ = storage::quarantine(&self.channel_dir, &path);
-                return Err(StoreError::MalformedRecord);
-            }
+            Err(_) => return Err(self.quarantine_locked(&bytes, StoreError::MalformedRecord)),
         };
-        let operation_path = self.operation_path(&wire.last_operation);
-        let operation_bytes = match storage::read_nofollow(&operation_path)? {
+        let operation_name = Self::operation_name(&wire.last_operation);
+        let operation_bytes = match self.storage.read_operation(&operation_name)? {
             Some(bytes) => bytes,
             None => {
-                let _ = storage::quarantine(&self.channel_dir, &path);
-                return Err(StoreError::InvariantViolation);
+                return Err(self.quarantine_locked(&bytes, StoreError::InvariantViolation));
             }
         };
         if operation_bytes != bytes {
-            let _ = storage::quarantine(&self.channel_dir, &path);
-            return Err(StoreError::InvariantViolation);
+            return Err(self.quarantine_locked(&bytes, StoreError::InvariantViolation));
         }
         wire.into_snapshot(&self.identity)
             .map(Some)
-            .map_err(|error| {
-                let _ = storage::quarantine(&self.channel_dir, &path);
-                error
-            })
+            .map_err(|error| self.quarantine_locked(&bytes, error))
+    }
+
+    fn quarantine_locked(&self, bytes: &[u8], source: StoreError) -> StoreError {
+        let high_watermark = self.operation_high_watermark_locked();
+        match self.storage.quarantine_channel(bytes, high_watermark) {
+            Ok(()) => StoreError::Quarantined,
+            Err(_) => source,
+        }
+    }
+
+    fn operation_high_watermark_locked(&self) -> Option<(u64, u64)> {
+        let records = self.storage.read_operation_records().ok()?;
+        let mut high_watermark: Option<(u64, u64)> = None;
+        for (_, bytes) in records {
+            let Ok(wire) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+                continue;
+            };
+            let Some(revision) = wire.get("revision").and_then(serde_json::Value::as_u64) else {
+                continue;
+            };
+            let Some(generation) = wire
+                .get("channel_generation")
+                .and_then(serde_json::Value::as_u64)
+            else {
+                continue;
+            };
+            high_watermark = Some(high_watermark.map_or((revision, generation), |current| {
+                current.max((revision, generation))
+            }));
+        }
+        high_watermark
     }
 
     fn persist_locked(&self, snapshot: &ChannelSnapshot) -> Result<(), StoreError> {
+        if self.storage.quarantine_marker_present()? {
+            return Err(StoreError::Quarantined);
+        }
         let wire = ChannelWire::from_snapshot(&self.identity, snapshot);
         let body = serde_json::to_vec(&wire).map_err(|_| StoreError::InvariantViolation)?;
-        storage::atomic_write(
-            &self.operation_path(&snapshot.last_operation),
+        self.storage.write_operation(
+            &Self::operation_name(&snapshot.last_operation),
             &body,
-            WriteTarget::Operation,
             self.failpoint(),
         )?;
-        storage::atomic_write(
-            &self.channel_dir.join(CHANNEL_FILE),
-            &body,
-            WriteTarget::Channel,
-            self.failpoint(),
-        )?;
+        self.storage.write_channel(&body, self.failpoint())?;
         self.gc_locked()
     }
 
-    fn operation_path(&self, stamp: &OperationStamp) -> PathBuf {
-        self.channel_dir.join("operations").join(format!(
-            "{:020}-{}.json",
-            stamp.revision, stamp.operation_id
-        ))
+    fn operation_name(stamp: &OperationStamp) -> String {
+        format!("{:020}-{}.json", stamp.revision, stamp.operation_id)
     }
 
     fn gc_locked(&self) -> Result<(), StoreError> {
-        storage::prune_directory(&self.channel_dir.join("operations"), MAX_OPERATION_RECORDS)?;
-        storage::prune_directory(&self.channel_dir.join("quarantine"), MAX_QUARANTINE_RECORDS)
+        self.storage
+            .prune(Directory::Operations, MAX_OPERATION_RECORDS)?;
+        self.storage
+            .prune(Directory::Quarantine, MAX_QUARANTINE_RECORDS)
     }
 
     #[cfg(test)]

--- a/src/services/discord/status_panel_transition_v2/journal.rs
+++ b/src/services/discord/status_panel_transition_v2/journal.rs
@@ -1,0 +1,760 @@
+//! Dormant channel journal adapter.
+//!
+//! The files provide crash-consistent local durability, not a transaction with
+//! Discord. A successful send can still be orphaned before `record_sent`, and
+//! recovery cannot prove every such orphan. The journal also does not provide
+//! cryptographic protection from an attacker who can modify the runtime tree.
+//! Cross-process correctness comes from `channel.lock`; every read-modify-write
+//! holds that same kernel flock.
+
+mod codec;
+mod storage;
+
+use std::path::{Path, PathBuf};
+
+use codec::{
+    ChannelWire, OperationStamp, ReplayMetadata, bind_digest, commit_bind_digest, delete_digest,
+    prepare_digest, retire_digest,
+};
+use serde::{Deserialize, Serialize};
+use storage::{ChannelLock, Failpoint, WriteTarget};
+use uuid::Uuid;
+
+use super::{BoundPanel, Candidate, JournalState, PanelIdentity, PanelPlan};
+
+pub(super) use storage::WriteStage;
+
+const MAX_OPERATION_RECORDS: usize = 64;
+const MAX_QUARANTINE_RECORDS: usize = 16;
+const CHANNEL_FILE: &str = "channel.json";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CanonicalProvider(String);
+
+impl CanonicalProvider {
+    fn parse(value: &str) -> Result<Self, StoreError> {
+        matches!(value, "claude" | "codex" | "gemini" | "opencode" | "qwen")
+            .then(|| Self(value.to_owned()))
+            .ok_or(StoreError::InvalidPathComponent("provider"))
+    }
+
+    pub(super) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CanonicalTokenHash(String);
+
+impl CanonicalTokenHash {
+    fn parse(value: &str) -> Result<Self, StoreError> {
+        value
+            .strip_prefix("discord_")
+            .filter(|suffix| {
+                suffix.len() == 16
+                    && suffix
+                        .bytes()
+                        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            })
+            .map(|_| Self(value.to_owned()))
+            .ok_or(StoreError::InvalidPathComponent("canonical_token_hash"))
+    }
+
+    pub(super) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum StoreError {
+    InvalidPathComponent(&'static str),
+    SymlinkRejected,
+    UnexpectedFileType,
+    LockFailed,
+    ReadFailed,
+    MalformedRecord,
+    InvariantViolation,
+    WriteFailed(WriteStage),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ReadOutcome<T> {
+    Present(T),
+    Missing,
+    DurabilityFailure(StoreError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Mutation<T> {
+    Applied(T),
+    Replayed(T),
+    Stale,
+    DurabilityFailure(StoreError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum DeleteObservation {
+    Deleted,
+    NotFound404,
+    UnknownMessage10008,
+    Forbidden403,
+    Transient,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DeleteDisposition {
+    Retired,
+    RetainAuthorization,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PreparedOperation {
+    operation_id: String,
+    owner_nonce: String,
+    digest: String,
+    expected_revision: u64,
+    plan: PanelPlan,
+    generation: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::services::discord) struct JournalOwnedBind {
+    operation_id: String,
+    owner_nonce: String,
+    digest: String,
+    revision: u64,
+    candidate: Candidate,
+    _seal: AdapterSeal,
+}
+
+impl JournalOwnedBind {
+    pub(super) fn candidate(&self) -> &Candidate {
+        &self.candidate
+    }
+
+    pub(super) fn matches_candidate(&self, candidate: &Candidate) -> bool {
+        self.candidate == *candidate
+            && self.digest == bind_digest(&self.operation_id, &self.owner_nonce, candidate)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct BoundOperation {
+    operation_id: String,
+    owner_nonce: String,
+    bind_digest: String,
+    revision: u64,
+    panel: BoundPanel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::services::discord) struct JournalOwnedRetire {
+    operation_id: String,
+    owner_nonce: String,
+    digest: String,
+    revision: u64,
+    panel: BoundPanel,
+    delete_message_id: u64,
+    _seal: AdapterSeal,
+}
+
+impl JournalOwnedRetire {
+    pub(super) fn delete_message_id(&self) -> u64 {
+        self.delete_message_id
+    }
+
+    pub(super) fn matches_panel(&self, panel: &BoundPanel) -> bool {
+        self.panel == *panel
+            && self.delete_message_id != 0
+            && self.delete_message_id != panel.candidate.message_id
+            && panel.candidate.plan.expected_prior_message_id == Some(self.delete_message_id)
+            && self.digest
+                == retire_digest(
+                    &self.operation_id,
+                    &self.owner_nonce,
+                    panel,
+                    self.delete_message_id,
+                )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AdapterSeal;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ChannelSnapshot {
+    pub revision: u64,
+    pub channel_generation: u64,
+    pub current_singleton_message_id: Option<u64>,
+    pub state: JournalState,
+    last_operation: OperationStamp,
+    replay: ReplayMetadata,
+}
+
+pub(super) struct ChannelJournal {
+    channel_dir: PathBuf,
+    identity: PanelIdentity,
+    #[cfg(test)]
+    failpoint: Option<Failpoint>,
+}
+
+impl ChannelJournal {
+    pub(super) fn open(
+        root: &Path,
+        provider: &str,
+        canonical_token_hash: &str,
+        channel_id: u64,
+    ) -> Result<Self, StoreError> {
+        let provider = CanonicalProvider::parse(provider)?;
+        let canonical_token_hash = CanonicalTokenHash::parse(canonical_token_hash)?;
+        if channel_id == 0 {
+            return Err(StoreError::InvalidPathComponent("channel_id"));
+        }
+        storage::ensure_directory(root)?;
+        let provider_dir = root.join(provider.as_str());
+        storage::ensure_child_directory(root, &provider_dir)?;
+        let token_dir = provider_dir.join(canonical_token_hash.as_str());
+        storage::ensure_child_directory(root, &token_dir)?;
+        let channel_dir = token_dir.join(channel_id.to_string());
+        storage::ensure_child_directory(root, &channel_dir)?;
+        storage::ensure_child_directory(root, &channel_dir.join("operations"))?;
+        storage::ensure_child_directory(root, &channel_dir.join("quarantine"))?;
+        Ok(Self {
+            channel_dir,
+            identity: PanelIdentity {
+                provider,
+                canonical_token_hash,
+                channel_id,
+            },
+            #[cfg(test)]
+            failpoint: None,
+        })
+    }
+
+    pub(super) fn identity(&self) -> &PanelIdentity {
+        &self.identity
+    }
+
+    pub(super) fn load(&self) -> ReadOutcome<ChannelSnapshot> {
+        let _lock = match self.lock() {
+            Ok(lock) => lock,
+            Err(error) => return ReadOutcome::DurabilityFailure(error),
+        };
+        match self.load_optional_locked() {
+            Ok(Some(snapshot)) => ReadOutcome::Present(snapshot),
+            Ok(None) => ReadOutcome::Missing,
+            Err(error) => ReadOutcome::DurabilityFailure(error),
+        }
+    }
+
+    pub(super) fn prepare(
+        &self,
+        plan: PanelPlan,
+        expected_revision: u64,
+    ) -> Mutation<PreparedOperation> {
+        if !plan.is_valid() || plan.identity != self.identity {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        }
+        let _lock = match self.lock() {
+            Ok(lock) => lock,
+            Err(error) => return Mutation::DurabilityFailure(error),
+        };
+        let current = match self.load_optional_locked() {
+            Ok(current) => current,
+            Err(error) => return Mutation::DurabilityFailure(error),
+        };
+        if current.as_ref().map_or(0, |state| state.revision) != expected_revision {
+            return Mutation::Stale;
+        }
+        let generation = match current
+            .as_ref()
+            .map_or(Some(1), |state| state.channel_generation.checked_add(1))
+        {
+            Some(generation) => generation,
+            None => return Mutation::DurabilityFailure(StoreError::InvariantViolation),
+        };
+        let revision = match expected_revision.checked_add(1) {
+            Some(revision) => revision,
+            None => return Mutation::DurabilityFailure(StoreError::InvariantViolation),
+        };
+        let operation_id = Uuid::new_v4().simple().to_string();
+        let owner_nonce = Uuid::new_v4().simple().to_string();
+        let digest = prepare_digest(&operation_id, &owner_nonce, &plan, generation);
+        let operation = PreparedOperation {
+            operation_id,
+            owner_nonce,
+            digest,
+            expected_revision,
+            plan: plan.clone(),
+            generation,
+        };
+        let stamp = operation.stamp(revision);
+        let snapshot = ChannelSnapshot {
+            revision,
+            channel_generation: generation,
+            current_singleton_message_id: current
+                .and_then(|state| state.current_singleton_message_id),
+            state: JournalState::prepared(plan, generation),
+            last_operation: stamp.clone(),
+            replay: ReplayMetadata::Prepared,
+        };
+        self.persist_locked(&snapshot)
+            .map_or_else(Mutation::DurabilityFailure, |_| {
+                Mutation::Applied(operation)
+            })
+    }
+
+    pub(super) fn record_sent(
+        &self,
+        operation: &PreparedOperation,
+        message_id: u64,
+    ) -> Mutation<JournalOwnedBind> {
+        if message_id == 0 || operation.plan.identity != self.identity {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        }
+        let candidate = Candidate {
+            plan: operation.plan.clone(),
+            message_id,
+            generation: operation.generation,
+        };
+        if !candidate.is_valid() {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        }
+        let Some(expected_revision) = operation.expected_revision.checked_add(1) else {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        };
+        let Some(revision) = expected_revision.checked_add(1) else {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        };
+        let digest = bind_digest(&operation.operation_id, &operation.owner_nonce, &candidate);
+        let authorization = JournalOwnedBind {
+            operation_id: operation.operation_id.clone(),
+            owner_nonce: operation.owner_nonce.clone(),
+            digest: digest.clone(),
+            revision,
+            candidate: candidate.clone(),
+            _seal: AdapterSeal,
+        };
+        let stamp = OperationStamp::new(
+            &operation.operation_id,
+            &operation.owner_nonce,
+            &digest,
+            revision,
+        );
+        let _lock = match self.lock() {
+            Ok(lock) => lock,
+            Err(error) => return Mutation::DurabilityFailure(error),
+        };
+        let mut snapshot = match self.require_locked() {
+            Ok(snapshot) => snapshot,
+            Err(error) => return Mutation::DurabilityFailure(error),
+        };
+        if snapshot.revision == revision {
+            return if snapshot.last_operation == stamp
+                && snapshot.replay == ReplayMetadata::BindAuthorized
+                && matches!(&snapshot.state, JournalState::BindAuthorized { candidate: stored, authorization: proof } if stored == &candidate && proof == &authorization)
+            {
+                Mutation::Replayed(authorization)
+            } else {
+                Mutation::Stale
+            };
+        }
+        if snapshot.revision != expected_revision
+            || snapshot.last_operation != operation.stamp(expected_revision)
+            || !matches!(&snapshot.state, JournalState::Prepared { plan, generation } if plan == &operation.plan && *generation == operation.generation)
+        {
+            return Mutation::Stale;
+        }
+        snapshot.revision = revision;
+        snapshot.last_operation = stamp;
+        snapshot.replay = ReplayMetadata::BindAuthorized;
+        snapshot.state = JournalState::BindAuthorized {
+            candidate,
+            authorization: authorization.clone(),
+        };
+        self.persist_locked(&snapshot)
+            .map_or_else(Mutation::DurabilityFailure, |_| {
+                Mutation::Applied(authorization)
+            })
+    }
+
+    pub(super) fn commit_bind(&self, authorization: &JournalOwnedBind) -> Mutation<BoundOperation> {
+        if !authorization.matches_candidate(&authorization.candidate) {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        }
+        let Some(revision) = authorization.revision.checked_add(1) else {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        };
+        let digest = commit_bind_digest(authorization);
+        let stamp = OperationStamp::new(
+            &authorization.operation_id,
+            &authorization.owner_nonce,
+            &digest,
+            revision,
+        );
+        let panel = BoundPanel {
+            candidate: authorization.candidate.clone(),
+        };
+        let bound = BoundOperation {
+            operation_id: authorization.operation_id.clone(),
+            owner_nonce: authorization.owner_nonce.clone(),
+            bind_digest: authorization.digest.clone(),
+            revision,
+            panel: panel.clone(),
+        };
+        let _lock = match self.lock() {
+            Ok(lock) => lock,
+            Err(error) => return Mutation::DurabilityFailure(error),
+        };
+        let mut snapshot = match self.require_locked() {
+            Ok(snapshot) => snapshot,
+            Err(error) => return Mutation::DurabilityFailure(error),
+        };
+        if snapshot.revision == revision {
+            return if snapshot.last_operation == stamp
+                && snapshot.replay
+                    == (ReplayMetadata::Bound {
+                        bind_digest: authorization.digest.clone(),
+                    })
+                && snapshot.state == (JournalState::Bound { panel })
+            {
+                Mutation::Replayed(bound)
+            } else {
+                Mutation::Stale
+            };
+        }
+        if snapshot.revision != authorization.revision
+            || !matches!(&snapshot.state, JournalState::BindAuthorized { candidate, authorization: stored } if candidate == &authorization.candidate && stored == authorization)
+        {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        }
+        snapshot.revision = revision;
+        snapshot.current_singleton_message_id = Some(panel.candidate.message_id);
+        snapshot.last_operation = stamp;
+        snapshot.replay = ReplayMetadata::Bound {
+            bind_digest: authorization.digest.clone(),
+        };
+        snapshot.state = JournalState::Bound { panel };
+        self.persist_locked(&snapshot)
+            .map_or_else(Mutation::DurabilityFailure, |_| Mutation::Applied(bound))
+    }
+
+    pub(super) fn authorize_retire(&self, bound: &BoundOperation) -> Mutation<JournalOwnedRetire> {
+        let Some(delete_message_id) = bound.panel.candidate.plan.expected_prior_message_id else {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        };
+        let Some(revision) = bound.revision.checked_add(1) else {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        };
+        let digest = retire_digest(
+            &bound.operation_id,
+            &bound.owner_nonce,
+            &bound.panel,
+            delete_message_id,
+        );
+        let authorization = JournalOwnedRetire {
+            operation_id: bound.operation_id.clone(),
+            owner_nonce: bound.owner_nonce.clone(),
+            digest: digest.clone(),
+            revision,
+            panel: bound.panel.clone(),
+            delete_message_id,
+            _seal: AdapterSeal,
+        };
+        if !authorization.matches_panel(&bound.panel) {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        }
+        let stamp = OperationStamp::new(&bound.operation_id, &bound.owner_nonce, &digest, revision);
+        let _lock = match self.lock() {
+            Ok(lock) => lock,
+            Err(error) => return Mutation::DurabilityFailure(error),
+        };
+        let mut snapshot = match self.require_locked() {
+            Ok(snapshot) => snapshot,
+            Err(error) => return Mutation::DurabilityFailure(error),
+        };
+        if snapshot.revision == revision {
+            return if snapshot.last_operation == stamp
+                && snapshot.replay == ReplayMetadata::RetireAuthorized
+                && matches!(&snapshot.state, JournalState::RetireAuthorized { panel, authorization: stored } if panel == &bound.panel && stored == &authorization)
+            {
+                Mutation::Replayed(authorization)
+            } else {
+                Mutation::Stale
+            };
+        }
+        if snapshot.revision != bound.revision
+            || snapshot.replay
+                != (ReplayMetadata::Bound {
+                    bind_digest: bound.bind_digest.clone(),
+                })
+            || snapshot.state
+                != (JournalState::Bound {
+                    panel: bound.panel.clone(),
+                })
+        {
+            return Mutation::Stale;
+        }
+        snapshot.revision = revision;
+        snapshot.last_operation = stamp;
+        snapshot.replay = ReplayMetadata::RetireAuthorized;
+        snapshot.state = JournalState::RetireAuthorized {
+            panel: bound.panel.clone(),
+            authorization: authorization.clone(),
+        };
+        self.persist_locked(&snapshot)
+            .map_or_else(Mutation::DurabilityFailure, |_| {
+                Mutation::Applied(authorization)
+            })
+    }
+
+    pub(super) fn record_delete_observation(
+        &self,
+        authorization: &JournalOwnedRetire,
+        observation: DeleteObservation,
+    ) -> Mutation<DeleteDisposition> {
+        if !authorization.matches_panel(&authorization.panel) {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        }
+        if matches!(
+            observation,
+            DeleteObservation::Forbidden403 | DeleteObservation::Transient
+        ) {
+            return match self.load() {
+                ReadOutcome::Present(snapshot)
+                    if matches!(
+                        snapshot.state,
+                        JournalState::RetireAuthorized {
+                            authorization: ref stored,
+                            ..
+                        } if stored == authorization
+                    ) =>
+                {
+                    Mutation::Replayed(DeleteDisposition::RetainAuthorization)
+                }
+                ReadOutcome::Present(_) | ReadOutcome::Missing => Mutation::Stale,
+                ReadOutcome::DurabilityFailure(error) => Mutation::DurabilityFailure(error),
+            };
+        }
+        let Some(revision) = authorization.revision.checked_add(1) else {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        };
+        let digest = delete_digest(authorization, observation);
+        let stamp = OperationStamp::new(
+            &authorization.operation_id,
+            &authorization.owner_nonce,
+            &digest,
+            revision,
+        );
+        let _lock = match self.lock() {
+            Ok(lock) => lock,
+            Err(error) => return Mutation::DurabilityFailure(error),
+        };
+        let mut snapshot = match self.require_locked() {
+            Ok(snapshot) => snapshot,
+            Err(error) => return Mutation::DurabilityFailure(error),
+        };
+        if snapshot.revision == revision {
+            return if snapshot.last_operation == stamp
+                && snapshot.replay
+                    == (ReplayMetadata::Retired {
+                        retire_digest: authorization.digest.clone(),
+                        observation,
+                    })
+            {
+                Mutation::Replayed(DeleteDisposition::Retired)
+            } else {
+                Mutation::Stale
+            };
+        }
+        if snapshot.revision != authorization.revision
+            || !matches!(&snapshot.state, JournalState::RetireAuthorized { panel, authorization: stored } if panel == &authorization.panel && stored == authorization)
+        {
+            return Mutation::DurabilityFailure(StoreError::InvariantViolation);
+        }
+        snapshot.revision = revision;
+        snapshot.last_operation = stamp;
+        snapshot.replay = ReplayMetadata::Retired {
+            retire_digest: authorization.digest.clone(),
+            observation,
+        };
+        snapshot.state = JournalState::Retired {
+            panel: authorization.panel.clone(),
+            retired_message_id: authorization.delete_message_id,
+        };
+        self.persist_locked(&snapshot)
+            .map_or_else(Mutation::DurabilityFailure, |_| {
+                Mutation::Applied(DeleteDisposition::Retired)
+            })
+    }
+
+    pub(super) fn recover_bind_authorization(&self) -> ReadOutcome<JournalOwnedBind> {
+        match self.load() {
+            ReadOutcome::Present(snapshot) => match snapshot.state {
+                JournalState::BindAuthorized {
+                    candidate,
+                    authorization,
+                } if authorization.matches_candidate(&candidate) => {
+                    ReadOutcome::Present(authorization)
+                }
+                _ => ReadOutcome::Missing,
+            },
+            ReadOutcome::Missing => ReadOutcome::Missing,
+            ReadOutcome::DurabilityFailure(error) => ReadOutcome::DurabilityFailure(error),
+        }
+    }
+
+    fn lock(&self) -> Result<ChannelLock, StoreError> {
+        storage::lock_channel(&self.channel_dir)
+    }
+
+    fn require_locked(&self) -> Result<ChannelSnapshot, StoreError> {
+        self.load_optional_locked()?
+            .ok_or(StoreError::InvariantViolation)
+    }
+
+    fn load_optional_locked(&self) -> Result<Option<ChannelSnapshot>, StoreError> {
+        let path = self.channel_dir.join(CHANNEL_FILE);
+        let bytes = match storage::read_nofollow(&path)? {
+            Some(bytes) => bytes,
+            None => return Ok(None),
+        };
+        let wire: ChannelWire = match serde_json::from_slice(&bytes) {
+            Ok(wire) => wire,
+            Err(_) => {
+                let _ = storage::quarantine(&self.channel_dir, &path);
+                return Err(StoreError::MalformedRecord);
+            }
+        };
+        let operation_path = self.operation_path(&wire.last_operation);
+        let operation_bytes = match storage::read_nofollow(&operation_path)? {
+            Some(bytes) => bytes,
+            None => {
+                let _ = storage::quarantine(&self.channel_dir, &path);
+                return Err(StoreError::InvariantViolation);
+            }
+        };
+        if operation_bytes != bytes {
+            let _ = storage::quarantine(&self.channel_dir, &path);
+            return Err(StoreError::InvariantViolation);
+        }
+        wire.into_snapshot(&self.identity)
+            .map(Some)
+            .map_err(|error| {
+                let _ = storage::quarantine(&self.channel_dir, &path);
+                error
+            })
+    }
+
+    fn persist_locked(&self, snapshot: &ChannelSnapshot) -> Result<(), StoreError> {
+        let wire = ChannelWire::from_snapshot(&self.identity, snapshot);
+        let body = serde_json::to_vec(&wire).map_err(|_| StoreError::InvariantViolation)?;
+        storage::atomic_write(
+            &self.operation_path(&snapshot.last_operation),
+            &body,
+            WriteTarget::Operation,
+            self.failpoint(),
+        )?;
+        storage::atomic_write(
+            &self.channel_dir.join(CHANNEL_FILE),
+            &body,
+            WriteTarget::Channel,
+            self.failpoint(),
+        )?;
+        self.gc_locked()
+    }
+
+    fn operation_path(&self, stamp: &OperationStamp) -> PathBuf {
+        self.channel_dir.join("operations").join(format!(
+            "{:020}-{}.json",
+            stamp.revision, stamp.operation_id
+        ))
+    }
+
+    fn gc_locked(&self) -> Result<(), StoreError> {
+        storage::prune_directory(&self.channel_dir.join("operations"), MAX_OPERATION_RECORDS)?;
+        storage::prune_directory(&self.channel_dir.join("quarantine"), MAX_QUARANTINE_RECORDS)
+    }
+
+    #[cfg(test)]
+    fn with_failpoint(mut self, target: WriteTarget, stage: WriteStage) -> Self {
+        self.failpoint = Some(Failpoint { target, stage });
+        self
+    }
+
+    fn failpoint(&self) -> Option<Failpoint> {
+        #[cfg(test)]
+        {
+            self.failpoint
+        }
+        #[cfg(not(test))]
+        {
+            None
+        }
+    }
+}
+
+impl PreparedOperation {
+    fn stamp(&self, revision: u64) -> OperationStamp {
+        OperationStamp::new(
+            &self.operation_id,
+            &self.owner_nonce,
+            &self.digest,
+            revision,
+        )
+    }
+}
+
+#[cfg(test)]
+pub(super) fn identity_for_test(provider: &str, hash: &str, channel_id: u64) -> PanelIdentity {
+    PanelIdentity {
+        provider: CanonicalProvider::parse(provider).unwrap(),
+        canonical_token_hash: CanonicalTokenHash::parse(hash).unwrap(),
+        channel_id,
+    }
+}
+
+#[cfg(test)]
+pub(super) fn bind_authorization_for_test(candidate: Candidate) -> JournalOwnedBind {
+    let operation_id = "00000000000000000000000000000001".to_string();
+    let owner_nonce = "00000000000000000000000000000002".to_string();
+    JournalOwnedBind {
+        digest: bind_digest(&operation_id, &owner_nonce, &candidate),
+        operation_id,
+        owner_nonce,
+        revision: 2,
+        candidate,
+        _seal: AdapterSeal,
+    }
+}
+
+#[cfg(test)]
+pub(super) fn mutate_bind_authorization_for_test(
+    mut authorization: JournalOwnedBind,
+    candidate: Candidate,
+) -> JournalOwnedBind {
+    authorization.candidate = candidate;
+    authorization
+}
+
+#[cfg(test)]
+pub(super) fn retire_authorization_for_test(
+    panel: BoundPanel,
+    delete_message_id: u64,
+) -> JournalOwnedRetire {
+    let operation_id = "00000000000000000000000000000001".to_string();
+    let owner_nonce = "00000000000000000000000000000002".to_string();
+    JournalOwnedRetire {
+        digest: retire_digest(&operation_id, &owner_nonce, &panel, delete_message_id),
+        operation_id,
+        owner_nonce,
+        revision: 4,
+        panel,
+        delete_message_id,
+        _seal: AdapterSeal,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/services/discord/status_panel_transition_v2/journal/codec.rs
+++ b/src/services/discord/status_panel_transition_v2/journal/codec.rs
@@ -1,0 +1,554 @@
+use serde::{Deserialize, Serialize};
+
+use super::{
+    AdapterSeal, ChannelSnapshot, DeleteObservation, JournalOwnedBind, JournalOwnedRetire,
+    StoreError,
+};
+use crate::services::discord::status_panel_transition_v2::{
+    BoundPanel, Candidate, JournalState, PanelIdentity, PanelPlan, QuarantineReason,
+};
+
+const SCHEMA_VERSION: u32 = 2;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct OperationStamp {
+    pub operation_id: String,
+    pub owner_nonce: String,
+    pub digest: String,
+    pub revision: u64,
+}
+
+impl OperationStamp {
+    pub(super) fn new(operation_id: &str, owner_nonce: &str, digest: &str, revision: u64) -> Self {
+        Self {
+            operation_id: operation_id.to_owned(),
+            owner_nonce: owner_nonce.to_owned(),
+            digest: digest.to_owned(),
+            revision,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(super) enum ReplayMetadata {
+    Prepared,
+    BindAuthorized,
+    Bound {
+        bind_digest: String,
+    },
+    RetireAuthorized,
+    Retired {
+        retire_digest: String,
+        observation: DeleteObservation,
+    },
+    Quarantined,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct ChannelWire {
+    schema_version: u32,
+    provider: String,
+    canonical_token_hash: String,
+    channel_id: u64,
+    revision: u64,
+    channel_generation: u64,
+    current_singleton_message_id: Option<u64>,
+    pub last_operation: OperationStamp,
+    replay: ReplayMetadata,
+    state: StateWire,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum StateWire {
+    Prepared {
+        turn_id: u64,
+        expected_prior_message_id: Option<u64>,
+        generation: u64,
+    },
+    BindAuthorized {
+        turn_id: u64,
+        expected_prior_message_id: Option<u64>,
+        message_id: u64,
+        generation: u64,
+    },
+    Bound {
+        turn_id: u64,
+        expected_prior_message_id: Option<u64>,
+        message_id: u64,
+        generation: u64,
+    },
+    RetireAuthorized {
+        turn_id: u64,
+        expected_prior_message_id: u64,
+        message_id: u64,
+        generation: u64,
+    },
+    Retired {
+        turn_id: u64,
+        expected_prior_message_id: u64,
+        message_id: u64,
+        generation: u64,
+    },
+    Quarantined,
+}
+
+impl ChannelWire {
+    pub(super) fn from_snapshot(identity: &PanelIdentity, snapshot: &ChannelSnapshot) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            provider: identity.provider().to_owned(),
+            canonical_token_hash: identity.canonical_token_hash().to_owned(),
+            channel_id: identity.channel_id(),
+            revision: snapshot.revision,
+            channel_generation: snapshot.channel_generation,
+            current_singleton_message_id: snapshot.current_singleton_message_id,
+            last_operation: snapshot.last_operation.clone(),
+            replay: snapshot.replay.clone(),
+            state: StateWire::from_state(&snapshot.state),
+        }
+    }
+
+    pub(super) fn into_snapshot(
+        self,
+        expected: &PanelIdentity,
+    ) -> Result<ChannelSnapshot, StoreError> {
+        if self.schema_version != SCHEMA_VERSION
+            || self.provider != expected.provider()
+            || self.canonical_token_hash != expected.canonical_token_hash()
+            || self.channel_id != expected.channel_id()
+            || self.revision == 0
+            || self.channel_generation == 0
+            || self.last_operation.revision != self.revision
+            || !valid_id(&self.last_operation.operation_id)
+            || !valid_id(&self.last_operation.owner_nonce)
+            || !valid_digest(&self.last_operation.digest)
+        {
+            return Err(StoreError::InvariantViolation);
+        }
+        let state = self
+            .state
+            .into_state(expected, &self.last_operation, &self.replay)?;
+        validate_replay(&state, &self.replay, &self.last_operation)?;
+        validate_snapshot_invariants(
+            &state,
+            self.channel_generation,
+            self.current_singleton_message_id,
+        )?;
+        Ok(ChannelSnapshot {
+            revision: self.revision,
+            channel_generation: self.channel_generation,
+            current_singleton_message_id: self.current_singleton_message_id,
+            state,
+            last_operation: self.last_operation,
+            replay: self.replay,
+        })
+    }
+}
+
+impl StateWire {
+    fn from_state(state: &JournalState) -> Self {
+        let fields = |candidate: &Candidate| {
+            (
+                candidate.plan.turn_id,
+                candidate.plan.expected_prior_message_id,
+                candidate.message_id,
+                candidate.generation,
+            )
+        };
+        match state {
+            JournalState::Prepared { plan, generation } => Self::Prepared {
+                turn_id: plan.turn_id,
+                expected_prior_message_id: plan.expected_prior_message_id,
+                generation: *generation,
+            },
+            JournalState::BindAuthorized { candidate, .. } => {
+                let (turn_id, expected_prior_message_id, message_id, generation) =
+                    fields(candidate);
+                Self::BindAuthorized {
+                    turn_id,
+                    expected_prior_message_id,
+                    message_id,
+                    generation,
+                }
+            }
+            JournalState::Bound { panel } => {
+                let (turn_id, expected_prior_message_id, message_id, generation) =
+                    fields(&panel.candidate);
+                Self::Bound {
+                    turn_id,
+                    expected_prior_message_id,
+                    message_id,
+                    generation,
+                }
+            }
+            JournalState::RetireAuthorized { panel, .. } => {
+                let (turn_id, expected_prior_message_id, message_id, generation) =
+                    fields(&panel.candidate);
+                Self::RetireAuthorized {
+                    turn_id,
+                    expected_prior_message_id: expected_prior_message_id.unwrap_or(0),
+                    message_id,
+                    generation,
+                }
+            }
+            JournalState::Retired { panel, .. } => {
+                let (turn_id, expected_prior_message_id, message_id, generation) =
+                    fields(&panel.candidate);
+                Self::Retired {
+                    turn_id,
+                    expected_prior_message_id: expected_prior_message_id.unwrap_or(0),
+                    message_id,
+                    generation,
+                }
+            }
+            _ => Self::Quarantined,
+        }
+    }
+
+    fn into_state(
+        self,
+        identity: &PanelIdentity,
+        stamp: &OperationStamp,
+        replay: &ReplayMetadata,
+    ) -> Result<JournalState, StoreError> {
+        let plan = |turn_id, prior| PanelPlan {
+            identity: identity.clone(),
+            turn_id,
+            expected_prior_message_id: prior,
+        };
+        let candidate = |turn_id, prior, message_id, generation| Candidate {
+            plan: plan(turn_id, prior),
+            message_id,
+            generation,
+        };
+        match self {
+            Self::Prepared {
+                turn_id,
+                expected_prior_message_id,
+                generation,
+            } => Ok(JournalState::Prepared {
+                plan: plan(turn_id, expected_prior_message_id),
+                generation,
+            }),
+            Self::BindAuthorized {
+                turn_id,
+                expected_prior_message_id,
+                message_id,
+                generation,
+            } => {
+                let candidate =
+                    candidate(turn_id, expected_prior_message_id, message_id, generation);
+                let authorization = JournalOwnedBind {
+                    operation_id: stamp.operation_id.clone(),
+                    owner_nonce: stamp.owner_nonce.clone(),
+                    digest: stamp.digest.clone(),
+                    revision: stamp.revision,
+                    candidate: candidate.clone(),
+                    _seal: AdapterSeal,
+                };
+                authorization
+                    .matches_candidate(&candidate)
+                    .then_some(JournalState::BindAuthorized {
+                        candidate,
+                        authorization,
+                    })
+                    .ok_or(StoreError::InvariantViolation)
+            }
+            Self::Bound {
+                turn_id,
+                expected_prior_message_id,
+                message_id,
+                generation,
+            } => Ok(JournalState::Bound {
+                panel: BoundPanel {
+                    candidate: candidate(
+                        turn_id,
+                        expected_prior_message_id,
+                        message_id,
+                        generation,
+                    ),
+                },
+            }),
+            Self::RetireAuthorized {
+                turn_id,
+                expected_prior_message_id,
+                message_id,
+                generation,
+            } => {
+                let panel = BoundPanel {
+                    candidate: candidate(
+                        turn_id,
+                        Some(expected_prior_message_id),
+                        message_id,
+                        generation,
+                    ),
+                };
+                let authorization = JournalOwnedRetire {
+                    operation_id: stamp.operation_id.clone(),
+                    owner_nonce: stamp.owner_nonce.clone(),
+                    digest: stamp.digest.clone(),
+                    revision: stamp.revision,
+                    panel: panel.clone(),
+                    delete_message_id: expected_prior_message_id,
+                    _seal: AdapterSeal,
+                };
+                authorization
+                    .matches_panel(&panel)
+                    .then_some(JournalState::RetireAuthorized {
+                        panel,
+                        authorization,
+                    })
+                    .ok_or(StoreError::InvariantViolation)
+            }
+            Self::Retired {
+                turn_id,
+                expected_prior_message_id,
+                message_id,
+                generation,
+            } => Ok(JournalState::Retired {
+                panel: BoundPanel {
+                    candidate: candidate(
+                        turn_id,
+                        Some(expected_prior_message_id),
+                        message_id,
+                        generation,
+                    ),
+                },
+                retired_message_id: expected_prior_message_id,
+            }),
+            Self::Quarantined if *replay == ReplayMetadata::Quarantined => {
+                Ok(JournalState::Quarantined {
+                    reason: QuarantineReason::UnknownState,
+                })
+            }
+            Self::Quarantined => Err(StoreError::InvariantViolation),
+        }
+    }
+}
+
+fn validate_snapshot_invariants(
+    state: &JournalState,
+    channel_generation: u64,
+    current_singleton_message_id: Option<u64>,
+) -> Result<(), StoreError> {
+    let candidate = match state {
+        JournalState::Prepared { plan, generation } => {
+            if !plan.is_valid() || *generation != channel_generation {
+                return Err(StoreError::InvariantViolation);
+            }
+            return Ok(());
+        }
+        JournalState::BindAuthorized { candidate, .. } => candidate,
+        JournalState::Bound { panel }
+        | JournalState::RetireAuthorized { panel, .. }
+        | JournalState::Retired { panel, .. } => &panel.candidate,
+        JournalState::Failed { .. } | JournalState::Quarantined { .. } => return Ok(()),
+    };
+    if !candidate.is_valid() || candidate.generation != channel_generation {
+        return Err(StoreError::InvariantViolation);
+    }
+    if matches!(
+        state,
+        JournalState::Bound { .. }
+            | JournalState::RetireAuthorized { .. }
+            | JournalState::Retired { .. }
+    ) && current_singleton_message_id != Some(candidate.message_id)
+    {
+        return Err(StoreError::InvariantViolation);
+    }
+    Ok(())
+}
+
+fn validate_replay(
+    state: &JournalState,
+    replay: &ReplayMetadata,
+    stamp: &OperationStamp,
+) -> Result<(), StoreError> {
+    let valid = match (state, replay) {
+        (JournalState::Prepared { plan, generation }, ReplayMetadata::Prepared) => {
+            stamp.digest
+                == prepare_digest(&stamp.operation_id, &stamp.owner_nonce, plan, *generation)
+        }
+        (
+            JournalState::BindAuthorized {
+                candidate,
+                authorization,
+            },
+            ReplayMetadata::BindAuthorized,
+        ) => {
+            authorization.matches_candidate(candidate)
+                && stamp.digest == bind_digest(&stamp.operation_id, &stamp.owner_nonce, candidate)
+        }
+        (JournalState::Bound { .. }, ReplayMetadata::Bound { bind_digest }) => {
+            valid_digest(bind_digest)
+                && stamp.digest
+                    == digest(&[
+                        b"bound",
+                        stamp.operation_id.as_bytes(),
+                        stamp.owner_nonce.as_bytes(),
+                        bind_digest.as_bytes(),
+                    ])
+        }
+        (
+            JournalState::RetireAuthorized {
+                panel,
+                authorization,
+            },
+            ReplayMetadata::RetireAuthorized,
+        ) => {
+            authorization.matches_panel(panel)
+                && stamp.digest
+                    == retire_digest(
+                        &stamp.operation_id,
+                        &stamp.owner_nonce,
+                        panel,
+                        authorization.delete_message_id,
+                    )
+        }
+        (
+            JournalState::Retired { .. },
+            ReplayMetadata::Retired {
+                retire_digest,
+                observation,
+            },
+        ) => {
+            valid_digest(retire_digest)
+                && stamp.digest
+                    == retired_digest(
+                        &stamp.operation_id,
+                        &stamp.owner_nonce,
+                        retire_digest,
+                        *observation,
+                    )
+        }
+        (JournalState::Quarantined { .. }, ReplayMetadata::Quarantined) => true,
+        _ => false,
+    };
+    valid.then_some(()).ok_or(StoreError::InvariantViolation)
+}
+
+fn digest(parts: &[&[u8]]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"agentdesk.status-panel-journal.v2\0");
+    for part in parts {
+        hasher.update(&(part.len() as u64).to_be_bytes());
+        hasher.update(part);
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+fn plan_parts(plan: &PanelPlan, generation: u64) -> Vec<Vec<u8>> {
+    vec![
+        plan.identity.provider().as_bytes().to_vec(),
+        plan.identity.canonical_token_hash().as_bytes().to_vec(),
+        plan.identity.channel_id().to_be_bytes().to_vec(),
+        plan.turn_id.to_be_bytes().to_vec(),
+        generation.to_be_bytes().to_vec(),
+        vec![u8::from(plan.expected_prior_message_id.is_some())],
+        plan.expected_prior_message_id
+            .unwrap_or(0)
+            .to_be_bytes()
+            .to_vec(),
+    ]
+}
+
+pub(super) fn prepare_digest(
+    operation_id: &str,
+    nonce: &str,
+    plan: &PanelPlan,
+    generation: u64,
+) -> String {
+    let mut owned = vec![
+        b"prepare".to_vec(),
+        operation_id.as_bytes().to_vec(),
+        nonce.as_bytes().to_vec(),
+    ];
+    owned.extend(plan_parts(plan, generation));
+    digest(&owned.iter().map(Vec::as_slice).collect::<Vec<_>>())
+}
+
+pub(super) fn bind_digest(operation_id: &str, nonce: &str, candidate: &Candidate) -> String {
+    let mut owned = vec![
+        b"bind_authorized".to_vec(),
+        operation_id.as_bytes().to_vec(),
+        nonce.as_bytes().to_vec(),
+    ];
+    owned.extend(plan_parts(&candidate.plan, candidate.generation));
+    owned.push(candidate.message_id.to_be_bytes().to_vec());
+    digest(&owned.iter().map(Vec::as_slice).collect::<Vec<_>>())
+}
+
+pub(super) fn commit_bind_digest(authorization: &JournalOwnedBind) -> String {
+    digest(&[
+        b"bound",
+        authorization.operation_id.as_bytes(),
+        authorization.owner_nonce.as_bytes(),
+        authorization.digest.as_bytes(),
+    ])
+}
+
+pub(super) fn retire_digest(
+    operation_id: &str,
+    nonce: &str,
+    panel: &BoundPanel,
+    delete_message_id: u64,
+) -> String {
+    digest(&[
+        b"retire_authorized",
+        operation_id.as_bytes(),
+        nonce.as_bytes(),
+        &panel.candidate.message_id.to_be_bytes(),
+        &delete_message_id.to_be_bytes(),
+        &panel.candidate.generation.to_be_bytes(),
+    ])
+}
+
+pub(super) fn delete_digest(
+    authorization: &JournalOwnedRetire,
+    observation: DeleteObservation,
+) -> String {
+    retired_digest(
+        &authorization.operation_id,
+        &authorization.owner_nonce,
+        &authorization.digest,
+        observation,
+    )
+}
+
+fn retired_digest(
+    operation_id: &str,
+    nonce: &str,
+    retire_digest: &str,
+    observation: DeleteObservation,
+) -> String {
+    let code = match observation {
+        DeleteObservation::Deleted => b"deleted".as_slice(),
+        DeleteObservation::NotFound404 => b"404",
+        DeleteObservation::UnknownMessage10008 => b"10008",
+        DeleteObservation::Forbidden403 => b"403",
+        DeleteObservation::Transient => b"transient",
+    };
+    digest(&[
+        b"retired",
+        operation_id.as_bytes(),
+        nonce.as_bytes(),
+        retire_digest.as_bytes(),
+        code,
+    ])
+}
+
+fn valid_id(value: &str) -> bool {
+    value.len() == 32
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn valid_digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}

--- a/src/services/discord/status_panel_transition_v2/journal/storage.rs
+++ b/src/services/discord/status_panel_transition_v2/journal/storage.rs
@@ -1,0 +1,231 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::Path;
+
+use uuid::Uuid;
+
+use super::StoreError;
+
+const CHANNEL_LOCK: &str = "channel.lock";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord::status_panel_transition_v2) enum WriteStage {
+    CreateTemp,
+    WriteAll,
+    SyncFile,
+    Rename,
+    SyncParent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WriteTarget {
+    Operation,
+    Channel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct Failpoint {
+    pub target: WriteTarget,
+    pub stage: WriteStage,
+}
+
+pub(super) struct ChannelLock {
+    file: File,
+}
+
+impl Drop for ChannelLock {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            let _ = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+        }
+    }
+}
+
+pub(super) fn ensure_directory(path: &Path) -> Result<(), StoreError> {
+    if !path.exists() {
+        fs::create_dir_all(path).map_err(|_| StoreError::WriteFailed(WriteStage::CreateTemp))?;
+    }
+    reject_directory(path)
+}
+
+pub(super) fn ensure_child_directory(root: &Path, path: &Path) -> Result<(), StoreError> {
+    if !path.starts_with(root) {
+        return Err(StoreError::InvalidPathComponent("root"));
+    }
+    if !path.exists() {
+        fs::create_dir(path).map_err(|_| StoreError::WriteFailed(WriteStage::CreateTemp))?;
+    }
+    reject_directory(path)
+}
+
+pub(super) fn lock_channel(channel_dir: &Path) -> Result<ChannelLock, StoreError> {
+    let path = channel_dir.join(CHANNEL_LOCK);
+    reject_symlink(&path)?;
+    let file = secure_open(&path, true, true).map_err(|_| StoreError::LockFailed)?;
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+            return Err(StoreError::LockFailed);
+        }
+    }
+    Ok(ChannelLock { file })
+}
+
+pub(super) fn read_nofollow(path: &Path) -> Result<Option<Vec<u8>>, StoreError> {
+    reject_symlink(path)?;
+    let mut file = match secure_open(path, false, false) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err(StoreError::ReadFailed),
+    };
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|_| StoreError::ReadFailed)?;
+    Ok(Some(bytes))
+}
+
+pub(super) fn atomic_write(
+    path: &Path,
+    body: &[u8],
+    target: WriteTarget,
+    failpoint: Option<Failpoint>,
+) -> Result<(), StoreError> {
+    let parent = path.parent().ok_or(StoreError::UnexpectedFileType)?;
+    reject_symlink(path)?;
+    let temp = parent.join(format!(
+        ".{}.{}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("record"),
+        Uuid::new_v4().simple()
+    ));
+    maybe_fail(failpoint, target, WriteStage::CreateTemp)?;
+    let result = (|| {
+        let mut file = secure_create_new(&temp)
+            .map_err(|_| StoreError::WriteFailed(WriteStage::CreateTemp))?;
+        maybe_fail(failpoint, target, WriteStage::WriteAll)?;
+        file.write_all(body)
+            .map_err(|_| StoreError::WriteFailed(WriteStage::WriteAll))?;
+        maybe_fail(failpoint, target, WriteStage::SyncFile)?;
+        file.sync_all()
+            .map_err(|_| StoreError::WriteFailed(WriteStage::SyncFile))?;
+        maybe_fail(failpoint, target, WriteStage::Rename)?;
+        fs::rename(&temp, path).map_err(|_| StoreError::WriteFailed(WriteStage::Rename))?;
+        maybe_fail(failpoint, target, WriteStage::SyncParent)?;
+        sync_directory(parent)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(temp);
+    }
+    result
+}
+
+pub(super) fn quarantine(channel_dir: &Path, path: &Path) -> Result<(), StoreError> {
+    let quarantine = channel_dir.join("quarantine").join(format!(
+        "{}-{}.json",
+        Uuid::new_v4().simple(),
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("record")
+    ));
+    fs::rename(path, quarantine).map_err(|_| StoreError::ReadFailed)?;
+    sync_directory(channel_dir)
+}
+
+pub(super) fn prune_directory(path: &Path, keep: usize) -> Result<(), StoreError> {
+    let mut files: Vec<_> = fs::read_dir(path)
+        .map_err(|_| StoreError::ReadFailed)?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_file()))
+        .collect();
+    files.sort_by_key(|entry| entry.file_name());
+    let remove_count = files.len().saturating_sub(keep);
+    for entry in files.into_iter().take(remove_count) {
+        fs::remove_file(entry.path())
+            .map_err(|_| StoreError::WriteFailed(WriteStage::SyncParent))?;
+    }
+    if remove_count > 0 {
+        sync_directory(path)?;
+    }
+    Ok(())
+}
+
+fn maybe_fail(
+    failpoint: Option<Failpoint>,
+    target: WriteTarget,
+    stage: WriteStage,
+) -> Result<(), StoreError> {
+    if failpoint == Some(Failpoint { target, stage }) {
+        Err(StoreError::WriteFailed(stage))
+    } else {
+        Ok(())
+    }
+}
+
+fn reject_directory(path: &Path) -> Result<(), StoreError> {
+    let metadata = fs::symlink_metadata(path).map_err(|_| StoreError::ReadFailed)?;
+    if metadata.file_type().is_symlink() {
+        Err(StoreError::SymlinkRejected)
+    } else if !metadata.is_dir() {
+        Err(StoreError::UnexpectedFileType)
+    } else {
+        Ok(())
+    }
+}
+
+fn reject_symlink(path: &Path) -> Result<(), StoreError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(StoreError::SymlinkRejected),
+        Ok(metadata) if !metadata.is_file() => Err(StoreError::UnexpectedFileType),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(_) => Err(StoreError::ReadFailed),
+    }
+}
+
+fn secure_open(path: &Path, create: bool, write: bool) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true).write(write).create(create);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW).mode(0o600);
+    }
+    options.open(path)
+}
+
+fn secure_create_new(path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW).mode(0o600);
+    }
+    options.open(path)
+}
+
+fn sync_directory(path: &Path) -> Result<(), StoreError> {
+    File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|_| StoreError::WriteFailed(WriteStage::SyncParent))
+}
+
+#[cfg(test)]
+pub(super) fn try_lock_for_test(channel_dir: &Path) -> Result<ChannelLock, StoreError> {
+    let path = channel_dir.join(CHANNEL_LOCK);
+    reject_symlink(&path)?;
+    let file = secure_open(&path, true, true).map_err(|_| StoreError::LockFailed)?;
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+            return Err(StoreError::LockFailed);
+        }
+    }
+    Ok(ChannelLock { file })
+}

--- a/src/services/discord/status_panel_transition_v2/journal/storage.rs
+++ b/src/services/discord/status_panel_transition_v2/journal/storage.rs
@@ -1,12 +1,18 @@
+use std::ffi::{CStr, CString};
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::Path;
+#[cfg(any(not(unix), test))]
+use std::path::PathBuf;
 
 use uuid::Uuid;
 
 use super::StoreError;
 
 const CHANNEL_LOCK: &str = "channel.lock";
+const CHANNEL_FILE: &str = "channel.json";
+const QUARANTINE_MARKER: &str = "channel.quarantined";
+const QUARANTINE_MARKER_PREFIX: &[u8] = b"agentdesk.status-panel-journal.v2\nquarantined\n";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::services::discord::status_panel_transition_v2) enum WriteStage {
@@ -43,115 +49,451 @@ impl Drop for ChannelLock {
     }
 }
 
-pub(super) fn ensure_directory(path: &Path) -> Result<(), StoreError> {
-    if !path.exists() {
-        fs::create_dir_all(path).map_err(|_| StoreError::WriteFailed(WriteStage::CreateTemp))?;
-    }
-    reject_directory(path)
-}
-
-pub(super) fn ensure_child_directory(root: &Path, path: &Path) -> Result<(), StoreError> {
-    if !path.starts_with(root) {
-        return Err(StoreError::InvalidPathComponent("root"));
-    }
-    if !path.exists() {
-        fs::create_dir(path).map_err(|_| StoreError::WriteFailed(WriteStage::CreateTemp))?;
-    }
-    reject_directory(path)
-}
-
-pub(super) fn lock_channel(channel_dir: &Path) -> Result<ChannelLock, StoreError> {
-    let path = channel_dir.join(CHANNEL_LOCK);
-    reject_symlink(&path)?;
-    let file = secure_open(&path, true, true).map_err(|_| StoreError::LockFailed)?;
+pub(super) struct ChannelStorage {
     #[cfg(unix)]
-    {
-        use std::os::fd::AsRawFd;
-        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
-            return Err(StoreError::LockFailed);
+    channel: File,
+    #[cfg(unix)]
+    operations: File,
+    #[cfg(unix)]
+    quarantine: File,
+    #[cfg(not(unix))]
+    channel_path: PathBuf,
+    #[cfg(test)]
+    initial_channel_path: PathBuf,
+}
+
+impl ChannelStorage {
+    pub(super) fn open(
+        root: &Path,
+        provider: &str,
+        canonical_token_hash: &str,
+        channel_id: u64,
+    ) -> Result<Self, StoreError> {
+        #[cfg(unix)]
+        {
+            let root_dir = open_or_create_root_directory(root)?;
+            let provider_dir = open_or_create_directory(&root_dir, provider)?;
+            let token_dir = open_or_create_directory(&provider_dir, canonical_token_hash)?;
+            let channel_name = channel_id.to_string();
+            let channel = open_or_create_directory(&token_dir, &channel_name)?;
+            let operations = open_or_create_directory(&channel, "operations")?;
+            let quarantine = open_or_create_directory(&channel, "quarantine")?;
+            return Ok(Self {
+                channel,
+                operations,
+                quarantine,
+                #[cfg(test)]
+                initial_channel_path: root
+                    .join(provider)
+                    .join(canonical_token_hash)
+                    .join(channel_name),
+            });
+        }
+
+        #[cfg(not(unix))]
+        {
+            let channel_path = root
+                .join(provider)
+                .join(canonical_token_hash)
+                .join(channel_id.to_string());
+            fs::create_dir_all(channel_path.join("operations"))
+                .map_err(|_| StoreError::WriteFailed(WriteStage::CreateTemp))?;
+            fs::create_dir_all(channel_path.join("quarantine"))
+                .map_err(|_| StoreError::WriteFailed(WriteStage::CreateTemp))?;
+            Ok(Self {
+                #[cfg(test)]
+                initial_channel_path: channel_path.clone(),
+                channel_path,
+            })
         }
     }
-    Ok(ChannelLock { file })
-}
 
-pub(super) fn read_nofollow(path: &Path) -> Result<Option<Vec<u8>>, StoreError> {
-    reject_symlink(path)?;
-    let mut file = match secure_open(path, false, false) {
-        Ok(file) => file,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(_) => return Err(StoreError::ReadFailed),
-    };
-    let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes)
-        .map_err(|_| StoreError::ReadFailed)?;
-    Ok(Some(bytes))
-}
-
-pub(super) fn atomic_write(
-    path: &Path,
-    body: &[u8],
-    target: WriteTarget,
-    failpoint: Option<Failpoint>,
-) -> Result<(), StoreError> {
-    let parent = path.parent().ok_or(StoreError::UnexpectedFileType)?;
-    reject_symlink(path)?;
-    let temp = parent.join(format!(
-        ".{}.{}.tmp",
-        path.file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("record"),
-        Uuid::new_v4().simple()
-    ));
-    maybe_fail(failpoint, target, WriteStage::CreateTemp)?;
-    let result = (|| {
-        let mut file = secure_create_new(&temp)
-            .map_err(|_| StoreError::WriteFailed(WriteStage::CreateTemp))?;
-        maybe_fail(failpoint, target, WriteStage::WriteAll)?;
-        file.write_all(body)
-            .map_err(|_| StoreError::WriteFailed(WriteStage::WriteAll))?;
-        maybe_fail(failpoint, target, WriteStage::SyncFile)?;
-        file.sync_all()
-            .map_err(|_| StoreError::WriteFailed(WriteStage::SyncFile))?;
-        maybe_fail(failpoint, target, WriteStage::Rename)?;
-        fs::rename(&temp, path).map_err(|_| StoreError::WriteFailed(WriteStage::Rename))?;
-        maybe_fail(failpoint, target, WriteStage::SyncParent)?;
-        sync_directory(parent)?;
-        Ok(())
-    })();
-    if result.is_err() {
-        let _ = fs::remove_file(temp);
+    pub(super) fn lock(&self) -> Result<ChannelLock, StoreError> {
+        self.lock_with_mode(false)
     }
-    result
+
+    pub(super) fn read_channel(&self) -> Result<Option<Vec<u8>>, StoreError> {
+        self.read_entry(Directory::Channel, CHANNEL_FILE)
+    }
+
+    pub(super) fn read_operation(&self, name: &str) -> Result<Option<Vec<u8>>, StoreError> {
+        self.read_entry(Directory::Operations, name)
+    }
+
+    pub(super) fn read_operation_records(&self) -> Result<Vec<(String, Vec<u8>)>, StoreError> {
+        #[cfg(unix)]
+        {
+            let mut records = Vec::new();
+            for name in list_regular_files(&self.operations)? {
+                let Some(bytes) = self.read_operation(&name)? else {
+                    continue;
+                };
+                records.push((name, bytes));
+            }
+            return Ok(records);
+        }
+
+        #[cfg(not(unix))]
+        {
+            let mut records = Vec::new();
+            for entry in fs::read_dir(self.directory_path(Directory::Operations))
+                .map_err(|_| StoreError::ReadFailed)?
+            {
+                let entry = entry.map_err(|_| StoreError::ReadFailed)?;
+                if !entry.file_type().is_ok_and(|kind| kind.is_file()) {
+                    continue;
+                }
+                let name = entry
+                    .file_name()
+                    .into_string()
+                    .map_err(|_| StoreError::UnexpectedFileType)?;
+                let Some(bytes) = self.read_operation(&name)? else {
+                    continue;
+                };
+                records.push((name, bytes));
+            }
+            Ok(records)
+        }
+    }
+
+    pub(super) fn read_quarantine_marker(&self) -> Result<Option<Vec<u8>>, StoreError> {
+        self.read_entry(Directory::Channel, QUARANTINE_MARKER)
+    }
+
+    #[cfg(test)]
+    pub(super) fn read_quarantine_records(&self) -> Result<Vec<Vec<u8>>, StoreError> {
+        #[cfg(unix)]
+        {
+            let mut records = Vec::new();
+            for name in list_regular_files(&self.quarantine)? {
+                if let Some(bytes) = self.read_entry(Directory::Quarantine, &name)? {
+                    records.push(bytes);
+                }
+            }
+            return Ok(records);
+        }
+
+        #[cfg(not(unix))]
+        {
+            let mut records = Vec::new();
+            for entry in fs::read_dir(self.directory_path(Directory::Quarantine))
+                .map_err(|_| StoreError::ReadFailed)?
+            {
+                let entry = entry.map_err(|_| StoreError::ReadFailed)?;
+                if entry.file_type().is_ok_and(|kind| kind.is_file()) {
+                    records.push(fs::read(entry.path()).map_err(|_| StoreError::ReadFailed)?);
+                }
+            }
+            Ok(records)
+        }
+    }
+
+    pub(super) fn write_operation(
+        &self,
+        name: &str,
+        body: &[u8],
+        failpoint: Option<Failpoint>,
+    ) -> Result<(), StoreError> {
+        self.atomic_write(
+            Directory::Operations,
+            name,
+            body,
+            WriteTarget::Operation,
+            failpoint,
+        )
+    }
+
+    pub(super) fn write_channel(
+        &self,
+        body: &[u8],
+        failpoint: Option<Failpoint>,
+    ) -> Result<(), StoreError> {
+        self.atomic_write(
+            Directory::Channel,
+            CHANNEL_FILE,
+            body,
+            WriteTarget::Channel,
+            failpoint,
+        )
+    }
+
+    pub(super) fn quarantine_marker_present(&self) -> Result<bool, StoreError> {
+        self.entry_exists(Directory::Channel, QUARANTINE_MARKER)
+    }
+
+    pub(super) fn quarantine_channel(
+        &self,
+        body: &[u8],
+        high_watermark: Option<(u64, u64)>,
+    ) -> Result<(), StoreError> {
+        if !self.quarantine_marker_present()? {
+            let mut marker = QUARANTINE_MARKER_PREFIX.to_vec();
+            if let Some((revision, generation)) = high_watermark {
+                marker.extend_from_slice(
+                    format!("revision={revision}\ngeneration={generation}\n").as_bytes(),
+                );
+            }
+            self.atomic_write(
+                Directory::Channel,
+                QUARANTINE_MARKER,
+                &marker,
+                WriteTarget::Channel,
+                None,
+            )?;
+        }
+        let archive_name = format!("{}-{CHANNEL_FILE}", Uuid::new_v4().simple());
+        self.atomic_write(
+            Directory::Quarantine,
+            &archive_name,
+            body,
+            WriteTarget::Channel,
+            None,
+        )
+    }
+
+    pub(super) fn prune(&self, directory: Directory, keep: usize) -> Result<(), StoreError> {
+        #[cfg(unix)]
+        {
+            let dir = self.directory(directory);
+            let mut names = list_regular_files(dir)?;
+            names.sort();
+            let remove_count = names.len().saturating_sub(keep);
+            for name in names.into_iter().take(remove_count) {
+                unlink_file_at(dir, &name)
+                    .map_err(|_| StoreError::WriteFailed(WriteStage::SyncParent))?;
+            }
+            if remove_count > 0 {
+                dir.sync_all()
+                    .map_err(|_| StoreError::WriteFailed(WriteStage::SyncParent))?;
+            }
+            return Ok(());
+        }
+
+        #[cfg(not(unix))]
+        {
+            let path = self.directory_path(directory);
+            let mut files: Vec<_> = fs::read_dir(path)
+                .map_err(|_| StoreError::ReadFailed)?
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_file()))
+                .collect();
+            files.sort_by_key(|entry| entry.file_name());
+            let remove_count = files.len().saturating_sub(keep);
+            for entry in files.into_iter().take(remove_count) {
+                fs::remove_file(entry.path())
+                    .map_err(|_| StoreError::WriteFailed(WriteStage::SyncParent))?;
+            }
+            if remove_count > 0 {
+                File::open(path)
+                    .and_then(|directory| directory.sync_all())
+                    .map_err(|_| StoreError::WriteFailed(WriteStage::SyncParent))?;
+            }
+            Ok(())
+        }
+    }
+
+    fn lock_with_mode(&self, nonblocking: bool) -> Result<ChannelLock, StoreError> {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            let file = open_file_at(
+                &self.channel,
+                CHANNEL_LOCK,
+                libc::O_RDWR | libc::O_CREAT,
+                0o600,
+            )
+            .map_err(|_| StoreError::LockFailed)?;
+            let operation = if nonblocking {
+                libc::LOCK_EX | libc::LOCK_NB
+            } else {
+                libc::LOCK_EX
+            };
+            if unsafe { libc::flock(file.as_raw_fd(), operation) } != 0 {
+                return Err(StoreError::LockFailed);
+            }
+            return Ok(ChannelLock { file });
+        }
+
+        #[cfg(not(unix))]
+        {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .open(self.channel_path.join(CHANNEL_LOCK))
+                .map_err(|_| StoreError::LockFailed)?;
+            let _ = nonblocking;
+            Ok(ChannelLock { file })
+        }
+    }
+
+    fn read_entry(&self, directory: Directory, name: &str) -> Result<Option<Vec<u8>>, StoreError> {
+        #[cfg(unix)]
+        let file = match open_file_at(self.directory(directory), name, libc::O_RDONLY, 0) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) if error.raw_os_error() == Some(libc::ELOOP) => {
+                return Err(StoreError::SymlinkRejected);
+            }
+            Err(_) => return Err(StoreError::ReadFailed),
+        };
+
+        #[cfg(not(unix))]
+        let file = match OpenOptions::new()
+            .read(true)
+            .open(self.directory_path(directory).join(name))
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(_) => return Err(StoreError::ReadFailed),
+        };
+
+        if !file.metadata().is_ok_and(|metadata| metadata.is_file()) {
+            return Err(StoreError::UnexpectedFileType);
+        }
+        let mut file = file;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)
+            .map_err(|_| StoreError::ReadFailed)?;
+        Ok(Some(bytes))
+    }
+
+    fn entry_exists(&self, directory: Directory, name: &str) -> Result<bool, StoreError> {
+        #[cfg(unix)]
+        {
+            match entry_kind_at(self.directory(directory), name)? {
+                EntryKind::Missing => Ok(false),
+                EntryKind::Regular => Ok(true),
+                EntryKind::Symlink => Err(StoreError::SymlinkRejected),
+                EntryKind::Other => Err(StoreError::UnexpectedFileType),
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            match fs::symlink_metadata(self.directory_path(directory).join(name)) {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    Err(StoreError::SymlinkRejected)
+                }
+                Ok(metadata) if metadata.is_file() => Ok(true),
+                Ok(_) => Err(StoreError::UnexpectedFileType),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+                Err(_) => Err(StoreError::ReadFailed),
+            }
+        }
+    }
+
+    fn atomic_write(
+        &self,
+        directory: Directory,
+        name: &str,
+        body: &[u8],
+        target: WriteTarget,
+        failpoint: Option<Failpoint>,
+    ) -> Result<(), StoreError> {
+        #[cfg(unix)]
+        {
+            let dir = self.directory(directory);
+            match entry_kind_at(dir, name)? {
+                EntryKind::Missing | EntryKind::Regular => {}
+                EntryKind::Symlink => return Err(StoreError::SymlinkRejected),
+                EntryKind::Other => return Err(StoreError::UnexpectedFileType),
+            }
+            let temp = format!(".{name}.{}.tmp", Uuid::new_v4().simple());
+            maybe_fail(failpoint, target, WriteStage::CreateTemp)?;
+            let result = (|| {
+                let mut file = open_file_at(
+                    dir,
+                    &temp,
+                    libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL,
+                    0o600,
+                )
+                .map_err(|_| StoreError::WriteFailed(WriteStage::CreateTemp))?;
+                maybe_fail(failpoint, target, WriteStage::WriteAll)?;
+                file.write_all(body)
+                    .map_err(|_| StoreError::WriteFailed(WriteStage::WriteAll))?;
+                maybe_fail(failpoint, target, WriteStage::SyncFile)?;
+                file.sync_all()
+                    .map_err(|_| StoreError::WriteFailed(WriteStage::SyncFile))?;
+                maybe_fail(failpoint, target, WriteStage::Rename)?;
+                rename_at(dir, &temp, dir, name)
+                    .map_err(|_| StoreError::WriteFailed(WriteStage::Rename))?;
+                maybe_fail(failpoint, target, WriteStage::SyncParent)?;
+                dir.sync_all()
+                    .map_err(|_| StoreError::WriteFailed(WriteStage::SyncParent))
+            })();
+            if result.is_err() {
+                let _ = unlink_file_at(dir, &temp);
+            }
+            return result;
+        }
+
+        #[cfg(not(unix))]
+        {
+            let parent = self.directory_path(directory);
+            let path = parent.join(name);
+            let temp = parent.join(format!(".{name}.{}.tmp", Uuid::new_v4().simple()));
+            maybe_fail(failpoint, target, WriteStage::CreateTemp)?;
+            let result = (|| {
+                let mut file = OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&temp)
+                    .map_err(|_| StoreError::WriteFailed(WriteStage::CreateTemp))?;
+                maybe_fail(failpoint, target, WriteStage::WriteAll)?;
+                file.write_all(body)
+                    .map_err(|_| StoreError::WriteFailed(WriteStage::WriteAll))?;
+                maybe_fail(failpoint, target, WriteStage::SyncFile)?;
+                file.sync_all()
+                    .map_err(|_| StoreError::WriteFailed(WriteStage::SyncFile))?;
+                maybe_fail(failpoint, target, WriteStage::Rename)?;
+                fs::rename(&temp, path).map_err(|_| StoreError::WriteFailed(WriteStage::Rename))?;
+                maybe_fail(failpoint, target, WriteStage::SyncParent)?;
+                File::open(parent)
+                    .and_then(|directory| directory.sync_all())
+                    .map_err(|_| StoreError::WriteFailed(WriteStage::SyncParent))
+            })();
+            if result.is_err() {
+                let _ = fs::remove_file(temp);
+            }
+            result
+        }
+    }
+
+    #[cfg(unix)]
+    fn directory(&self, directory: Directory) -> &File {
+        match directory {
+            Directory::Channel => &self.channel,
+            Directory::Operations => &self.operations,
+            Directory::Quarantine => &self.quarantine,
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn directory_path(&self, directory: Directory) -> PathBuf {
+        match directory {
+            Directory::Channel => self.channel_path.clone(),
+            Directory::Operations => self.channel_path.join("operations"),
+            Directory::Quarantine => self.channel_path.join("quarantine"),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn initial_channel_path(&self) -> &Path {
+        &self.initial_channel_path
+    }
+
+    #[cfg(test)]
+    pub(super) fn try_lock(&self) -> Result<ChannelLock, StoreError> {
+        self.lock_with_mode(true)
+    }
 }
 
-pub(super) fn quarantine(channel_dir: &Path, path: &Path) -> Result<(), StoreError> {
-    let quarantine = channel_dir.join("quarantine").join(format!(
-        "{}-{}.json",
-        Uuid::new_v4().simple(),
-        path.file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("record")
-    ));
-    fs::rename(path, quarantine).map_err(|_| StoreError::ReadFailed)?;
-    sync_directory(channel_dir)
-}
-
-pub(super) fn prune_directory(path: &Path, keep: usize) -> Result<(), StoreError> {
-    let mut files: Vec<_> = fs::read_dir(path)
-        .map_err(|_| StoreError::ReadFailed)?
-        .filter_map(Result::ok)
-        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_file()))
-        .collect();
-    files.sort_by_key(|entry| entry.file_name());
-    let remove_count = files.len().saturating_sub(keep);
-    for entry in files.into_iter().take(remove_count) {
-        fs::remove_file(entry.path())
-            .map_err(|_| StoreError::WriteFailed(WriteStage::SyncParent))?;
-    }
-    if remove_count > 0 {
-        sync_directory(path)?;
-    }
-    Ok(())
+#[derive(Debug, Clone, Copy)]
+pub(super) enum Directory {
+    Channel,
+    Operations,
+    Quarantine,
 }
 
 fn maybe_fail(
@@ -166,66 +508,249 @@ fn maybe_fail(
     }
 }
 
-fn reject_directory(path: &Path) -> Result<(), StoreError> {
-    let metadata = fs::symlink_metadata(path).map_err(|_| StoreError::ReadFailed)?;
-    if metadata.file_type().is_symlink() {
-        Err(StoreError::SymlinkRejected)
-    } else if !metadata.is_dir() {
-        Err(StoreError::UnexpectedFileType)
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EntryKind {
+    Missing,
+    Regular,
+    Symlink,
+    Other,
+}
+
+#[cfg(unix)]
+fn open_or_create_root_directory(path: &Path) -> Result<File, StoreError> {
+    use std::os::unix::ffi::OsStrExt;
+
+    let resolved_parent = path
+        .parent()
+        .ok_or(StoreError::InvalidPathComponent("root"))?
+        .canonicalize()
+        .map_err(|_| StoreError::ReadFailed)?;
+    let root_name = path
+        .file_name()
+        .ok_or(StoreError::InvalidPathComponent("root"))?;
+    let mut current = if resolved_parent.is_absolute() {
+        open_absolute_directory()?
     } else {
-        Ok(())
-    }
-}
+        open_current_directory()?
+    };
+    for component in resolved_parent.components() {
+        use std::path::Component;
 
-fn reject_symlink(path: &Path) -> Result<(), StoreError> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_symlink() => Err(StoreError::SymlinkRejected),
-        Ok(metadata) if !metadata.is_file() => Err(StoreError::UnexpectedFileType),
-        Ok(_) => Ok(()),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(_) => Err(StoreError::ReadFailed),
-    }
-}
-
-fn secure_open(path: &Path, create: bool, write: bool) -> io::Result<File> {
-    let mut options = OpenOptions::new();
-    options.read(true).write(write).create(create);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.custom_flags(libc::O_NOFOLLOW).mode(0o600);
-    }
-    options.open(path)
-}
-
-fn secure_create_new(path: &Path) -> io::Result<File> {
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.custom_flags(libc::O_NOFOLLOW).mode(0o600);
-    }
-    options.open(path)
-}
-
-fn sync_directory(path: &Path) -> Result<(), StoreError> {
-    File::open(path)
-        .and_then(|directory| directory.sync_all())
-        .map_err(|_| StoreError::WriteFailed(WriteStage::SyncParent))
-}
-
-#[cfg(test)]
-pub(super) fn try_lock_for_test(channel_dir: &Path) -> Result<ChannelLock, StoreError> {
-    let path = channel_dir.join(CHANNEL_LOCK);
-    reject_symlink(&path)?;
-    let file = secure_open(&path, true, true).map_err(|_| StoreError::LockFailed)?;
-    #[cfg(unix)]
-    {
-        use std::os::fd::AsRawFd;
-        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
-            return Err(StoreError::LockFailed);
+        match component {
+            Component::RootDir | Component::CurDir => continue,
+            Component::Normal(name) => {
+                let name = std::str::from_utf8(name.as_bytes())
+                    .map_err(|_| StoreError::InvalidPathComponent("root"))?;
+                current = open_or_create_directory(&current, name)?;
+            }
+            Component::ParentDir | Component::Prefix(_) => {
+                return Err(StoreError::InvalidPathComponent("root"));
+            }
         }
     }
-    Ok(ChannelLock { file })
+    let root_name = std::str::from_utf8(root_name.as_bytes())
+        .map_err(|_| StoreError::InvalidPathComponent("root"))?;
+    open_or_create_directory(&current, root_name)
+}
+
+#[cfg(unix)]
+fn open_absolute_directory() -> Result<File, StoreError> {
+    open_directory_path(Path::new("/"))
+}
+
+#[cfg(unix)]
+fn open_current_directory() -> Result<File, StoreError> {
+    open_directory_path(Path::new("."))
+}
+
+#[cfg(unix)]
+fn open_directory_path(path: &Path) -> Result<File, StoreError> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    options.open(path).map_err(|error| {
+        if error.raw_os_error() == Some(libc::ELOOP) {
+            StoreError::SymlinkRejected
+        } else {
+            StoreError::ReadFailed
+        }
+    })
+}
+
+#[cfg(unix)]
+fn open_or_create_directory(parent: &File, name: &str) -> Result<File, StoreError> {
+    use std::os::fd::AsRawFd;
+
+    let name = cstring(name)?;
+    let created = unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o700) };
+    if created != 0 {
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::AlreadyExists {
+            return Err(StoreError::WriteFailed(WriteStage::CreateTemp));
+        }
+    }
+    open_directory_at(parent, &name)
+}
+
+#[cfg(unix)]
+fn open_directory_at(parent: &File, name: &CStr) -> Result<File, StoreError> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        let error = io::Error::last_os_error();
+        return Err(
+            if matches!(
+                error.raw_os_error(),
+                Some(libc::ELOOP) | Some(libc::ENOTDIR)
+            ) {
+                StoreError::SymlinkRejected
+            } else {
+                StoreError::UnexpectedFileType
+            },
+        );
+    }
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn open_file_at(parent: &File, name: &str, flags: libc::c_int, mode: u32) -> io::Result<File> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let name = CString::new(name).map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            flags | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            mode as libc::c_int,
+        )
+    };
+    if fd < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(unsafe { File::from_raw_fd(fd) })
+    }
+}
+
+#[cfg(unix)]
+fn entry_kind_at(parent: &File, name: &str) -> Result<EntryKind, StoreError> {
+    use std::mem::MaybeUninit;
+    use std::os::fd::AsRawFd;
+
+    let name = cstring(name)?;
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    let result = unsafe {
+        libc::fstatat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result != 0 {
+        let error = io::Error::last_os_error();
+        return if error.kind() == io::ErrorKind::NotFound {
+            Ok(EntryKind::Missing)
+        } else {
+            Err(StoreError::ReadFailed)
+        };
+    }
+    let mode = unsafe { stat.assume_init() }.st_mode;
+    Ok(match mode & libc::S_IFMT {
+        libc::S_IFREG => EntryKind::Regular,
+        libc::S_IFLNK => EntryKind::Symlink,
+        _ => EntryKind::Other,
+    })
+}
+
+#[cfg(unix)]
+fn rename_at(from_dir: &File, from: &str, to_dir: &File, to: &str) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let from = CString::new(from).map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
+    let to = CString::new(to).map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
+    if unsafe {
+        libc::renameat(
+            from_dir.as_raw_fd(),
+            from.as_ptr(),
+            to_dir.as_raw_fd(),
+            to.as_ptr(),
+        )
+    } == 0
+    {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+fn unlink_file_at(parent: &File, name: &str) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let name = CString::new(name).map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
+    if unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), 0) } == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+fn list_regular_files(directory: &File) -> Result<Vec<String>, StoreError> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let duplicated = unsafe { libc::dup(directory.as_raw_fd()) };
+    if duplicated < 0 {
+        return Err(StoreError::ReadFailed);
+    }
+    if unsafe { libc::lseek(duplicated, 0, libc::SEEK_SET) } < 0 {
+        unsafe { libc::close(duplicated) };
+        return Err(StoreError::ReadFailed);
+    }
+    let cloned = unsafe { File::from_raw_fd(duplicated) };
+    let stream = unsafe { libc::fdopendir(std::os::fd::IntoRawFd::into_raw_fd(cloned)) };
+    if stream.is_null() {
+        return Err(StoreError::ReadFailed);
+    }
+    struct DirectoryStream(*mut libc::DIR);
+    impl Drop for DirectoryStream {
+        fn drop(&mut self) {
+            unsafe { libc::closedir(self.0) };
+        }
+    }
+    let stream = DirectoryStream(stream);
+    let mut names = Vec::new();
+    loop {
+        let entry = unsafe { libc::readdir(stream.0) };
+        if entry.is_null() {
+            break;
+        }
+        let name = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) };
+        let bytes = name.to_bytes();
+        if bytes == b"." || bytes == b".." {
+            continue;
+        }
+        let name = std::str::from_utf8(bytes).map_err(|_| StoreError::UnexpectedFileType)?;
+        if entry_kind_at(directory, name)? == EntryKind::Regular {
+            names.push(name.to_owned());
+        }
+    }
+    Ok(names)
+}
+
+#[cfg(unix)]
+fn cstring(value: &str) -> Result<CString, StoreError> {
+    CString::new(value).map_err(|_| StoreError::InvalidPathComponent("filesystem component"))
 }

--- a/src/services/discord/status_panel_transition_v2/journal/tests.rs
+++ b/src/services/discord/status_panel_transition_v2/journal/tests.rs
@@ -214,7 +214,7 @@ fn channel_lock_child_process() {
     let root = std::env::var_os("AGENTDESK_PANEL_JOURNAL_TEST_ROOT").unwrap();
     let journal = journal(Path::new(&root), 40);
     assert!(matches!(
-        storage::try_lock_for_test(&journal.channel_dir),
+        journal.storage.try_lock(),
         Err(StoreError::LockFailed)
     ));
 }
@@ -223,8 +223,8 @@ fn channel_lock_child_process() {
 fn operation_and_quarantine_gc_are_bounded() {
     let root = tempfile::tempdir().unwrap();
     let journal = journal(root.path(), 37);
-    let operations = journal.channel_dir.join("operations");
-    let quarantine = journal.channel_dir.join("quarantine");
+    let operations = journal.storage.initial_channel_path().join("operations");
+    let quarantine = journal.storage.initial_channel_path().join("quarantine");
     for index in 0..(MAX_OPERATION_RECORDS + 5) {
         fs::write(operations.join(format!("{index:020}.json")), b"{}").unwrap();
     }
@@ -251,9 +251,112 @@ fn symlinked_channel_file_is_rejected() {
     let journal = journal(root.path(), 38);
     let target = root.path().join("outside.json");
     fs::write(&target, b"{}").unwrap();
-    symlink(target, journal.channel_dir.join(CHANNEL_FILE)).unwrap();
+    symlink(
+        target,
+        journal.storage.initial_channel_path().join(CHANNEL_FILE),
+    )
+    .unwrap();
     assert_eq!(
         journal.load(),
         ReadOutcome::DurabilityFailure(StoreError::SymlinkRejected)
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn parent_swap_cannot_redirect_descriptor_relative_writes() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().unwrap();
+    let journal = journal(root.path(), 41);
+    let original_provider = root.path().join("claude");
+    let detached_provider = root.path().join("claude-detached");
+    let outside = tempfile::tempdir().unwrap();
+    fs::rename(&original_provider, &detached_provider).unwrap();
+    symlink(outside.path(), &original_provider).unwrap();
+
+    let prepared = applied(journal.prepare(plan(&journal, 1, None), 0));
+    assert_eq!(prepared.generation, 1);
+    assert!(
+        detached_provider
+            .join("discord_0123456789abcdef/41/channel.json")
+            .is_file()
+    );
+    assert!(!outside.path().join("discord_0123456789abcdef").exists());
+}
+
+#[test]
+fn malformed_channel_creates_durable_quarantine_barrier() {
+    let root = tempfile::tempdir().unwrap();
+    let channel_journal = journal(root.path(), 42);
+    let first = applied(channel_journal.prepare(plan(&channel_journal, 1, None), 0));
+    assert_eq!(first.generation, 1);
+    fs::write(
+        channel_journal
+            .storage
+            .initial_channel_path()
+            .join(CHANNEL_FILE),
+        b"{malformed",
+    )
+    .unwrap();
+
+    assert_eq!(
+        channel_journal.load(),
+        ReadOutcome::DurabilityFailure(StoreError::Quarantined)
+    );
+    assert!(channel_journal.storage.quarantine_marker_present().unwrap());
+    let marker = channel_journal
+        .storage
+        .read_quarantine_marker()
+        .unwrap()
+        .unwrap();
+    let marker = String::from_utf8(marker).unwrap();
+    assert!(marker.contains("revision=1\n"), "marker: {marker:?}");
+    assert!(marker.contains("generation=1\n"), "marker: {marker:?}");
+
+    let reopened = journal(root.path(), 42);
+    assert_eq!(
+        reopened.prepare(plan(&reopened, 2, None), 0),
+        Mutation::DurabilityFailure(StoreError::Quarantined)
+    );
+    assert_eq!(
+        reopened.prepare(plan(&reopened, 2, None), 1),
+        Mutation::DurabilityFailure(StoreError::Quarantined)
+    );
+}
+
+#[test]
+fn operation_mismatch_creates_durable_quarantine_barrier() {
+    let root = tempfile::tempdir().unwrap();
+    let channel_journal = journal(root.path(), 43);
+    let first = applied(channel_journal.prepare(plan(&channel_journal, 1, None), 0));
+    assert_eq!(first.generation, 1);
+    let channel = fs::read(
+        channel_journal
+            .storage
+            .initial_channel_path()
+            .join(CHANNEL_FILE),
+    )
+    .unwrap();
+    let wire: ChannelWire = serde_json::from_slice(&channel).unwrap();
+    fs::write(
+        channel_journal
+            .storage
+            .initial_channel_path()
+            .join("operations")
+            .join(ChannelJournal::operation_name(&wire.last_operation)),
+        b"{}",
+    )
+    .unwrap();
+
+    assert_eq!(
+        channel_journal.load(),
+        ReadOutcome::DurabilityFailure(StoreError::Quarantined)
+    );
+    let reopened = journal(root.path(), 43);
+    assert_eq!(
+        reopened.prepare(plan(&reopened, 2, None), 0),
+        Mutation::DurabilityFailure(StoreError::Quarantined)
+    );
+    assert_eq!(reopened.storage.read_quarantine_records().unwrap().len(), 1);
 }

--- a/src/services/discord/status_panel_transition_v2/journal/tests.rs
+++ b/src/services/discord/status_panel_transition_v2/journal/tests.rs
@@ -1,0 +1,259 @@
+use std::fs;
+
+use super::*;
+
+fn plan(journal: &ChannelJournal, turn_id: u64, prior: Option<u64>) -> PanelPlan {
+    PanelPlan {
+        identity: journal.identity().clone(),
+        turn_id,
+        expected_prior_message_id: prior,
+    }
+}
+
+fn applied<T: std::fmt::Debug>(mutation: Mutation<T>) -> T {
+    match mutation {
+        Mutation::Applied(value) => value,
+        other => panic!("expected applied mutation, got {other:?}"),
+    }
+}
+
+fn journal(root: &Path, channel_id: u64) -> ChannelJournal {
+    ChannelJournal::open(root, "claude", "discord_0123456789abcdef", channel_id).unwrap()
+}
+
+#[test]
+fn canonical_identity_rejects_noncanonical_path_components() {
+    let root = tempfile::tempdir().unwrap();
+    for provider in ["", "unsupported", "../claude", "Claude"] {
+        assert!(
+            ChannelJournal::open(root.path(), provider, "discord_0123456789abcdef", 1).is_err()
+        );
+    }
+    for token_hash in [
+        "",
+        "discord_0123456789abcde",
+        "discord_0123456789ABCDE",
+        "../discord_0123456789abcdef",
+    ] {
+        assert!(ChannelJournal::open(root.path(), "claude", token_hash, 1).is_err());
+    }
+    assert!(ChannelJournal::open(root.path(), "claude", "discord_0123456789abcdef", 0).is_err());
+}
+
+#[test]
+fn crash_reload_recovers_only_bind_authorized_state() {
+    let root = tempfile::tempdir().unwrap();
+    let channel_journal = journal(root.path(), 31);
+    let prepared = applied(channel_journal.prepare(plan(&channel_journal, 10, Some(90)), 0));
+    assert!(matches!(
+        channel_journal.recover_bind_authorization(),
+        ReadOutcome::Missing
+    ));
+    let authorization = applied(channel_journal.record_sent(&prepared, 91));
+
+    let reopened = journal(root.path(), 31);
+    assert_eq!(
+        reopened.recover_bind_authorization(),
+        ReadOutcome::Present(authorization.clone())
+    );
+    let bound = applied(reopened.commit_bind(&authorization));
+    assert!(matches!(
+        reopened.recover_bind_authorization(),
+        ReadOutcome::Missing
+    ));
+    let retire = applied(reopened.authorize_retire(&bound));
+    assert_eq!(retire.delete_message_id(), 90);
+}
+
+#[test]
+fn channel_generation_is_monotonic_across_equal_turn_observations() {
+    let root = tempfile::tempdir().unwrap();
+    let journal = journal(root.path(), 32);
+    let first = applied(journal.prepare(plan(&journal, 1, None), 0));
+    assert_eq!(first.generation, 1);
+    let first_auth = applied(journal.record_sent(&first, 100));
+    let _ = applied(journal.commit_bind(&first_auth));
+
+    let snapshot = match journal.load() {
+        ReadOutcome::Present(snapshot) => snapshot,
+        other => panic!("expected snapshot, got {other:?}"),
+    };
+    let second = applied(journal.prepare(plan(&journal, 2, Some(100)), snapshot.revision));
+    assert_eq!(second.generation, 2);
+}
+
+#[test]
+fn stale_cas_and_mutated_authorization_fail_closed() {
+    let root = tempfile::tempdir().unwrap();
+    let journal = journal(root.path(), 33);
+    let prepared = applied(journal.prepare(plan(&journal, 1, Some(7)), 0));
+    assert!(matches!(
+        journal.prepare(plan(&journal, 2, Some(7)), 0),
+        Mutation::Stale
+    ));
+    let authorization = applied(journal.record_sent(&prepared, 8));
+    let mut mutated = authorization.clone();
+    mutated.candidate.message_id = 9;
+    assert!(matches!(
+        journal.commit_bind(&mutated),
+        Mutation::DurabilityFailure(StoreError::InvariantViolation)
+    ));
+    assert!(matches!(
+        journal.commit_bind(&authorization),
+        Mutation::Applied(_)
+    ));
+}
+
+#[test]
+fn deletion_model_keeps_or_consumes_exact_authorization() {
+    for observation in [
+        DeleteObservation::Forbidden403,
+        DeleteObservation::Transient,
+    ] {
+        let root = tempfile::tempdir().unwrap();
+        let journal = journal(root.path(), 34);
+        let prepared = applied(journal.prepare(plan(&journal, 1, Some(20)), 0));
+        let bind = applied(journal.record_sent(&prepared, 21));
+        let bound = applied(journal.commit_bind(&bind));
+        let retire = applied(journal.authorize_retire(&bound));
+        assert_eq!(
+            journal.record_delete_observation(&retire, observation),
+            Mutation::Replayed(DeleteDisposition::RetainAuthorization)
+        );
+    }
+
+    for observation in [
+        DeleteObservation::Deleted,
+        DeleteObservation::NotFound404,
+        DeleteObservation::UnknownMessage10008,
+    ] {
+        let root = tempfile::tempdir().unwrap();
+        let journal = journal(root.path(), 35);
+        let prepared = applied(journal.prepare(plan(&journal, 1, Some(20)), 0));
+        let bind = applied(journal.record_sent(&prepared, 21));
+        let bound = applied(journal.commit_bind(&bind));
+        let retire = applied(journal.authorize_retire(&bound));
+        assert_eq!(
+            journal.record_delete_observation(&retire, observation),
+            Mutation::Applied(DeleteDisposition::Retired)
+        );
+    }
+}
+
+#[test]
+fn every_write_stage_failpoint_is_typed_and_reloadable() {
+    for target in [WriteTarget::Operation, WriteTarget::Channel] {
+        for stage in [
+            WriteStage::CreateTemp,
+            WriteStage::WriteAll,
+            WriteStage::SyncFile,
+            WriteStage::Rename,
+            WriteStage::SyncParent,
+        ] {
+            let root = tempfile::tempdir().unwrap();
+            let channel_journal = journal(root.path(), 36).with_failpoint(target, stage);
+            assert!(matches!(
+                channel_journal.prepare(plan(&channel_journal, 1, None), 0),
+                Mutation::DurabilityFailure(StoreError::WriteFailed(actual)) if actual == stage
+            ));
+            let reopened = journal(root.path(), 36);
+            assert!(matches!(
+                reopened.load(),
+                ReadOutcome::Missing | ReadOutcome::Present(_)
+            ));
+        }
+    }
+}
+
+#[test]
+fn exact_replay_tuple_accepts_only_identical_operation() {
+    let root = tempfile::tempdir().unwrap();
+    let journal = journal(root.path(), 39);
+    let prepared = applied(journal.prepare(plan(&journal, 1, Some(50)), 0));
+    let authorization = applied(journal.record_sent(&prepared, 51));
+    assert_eq!(
+        journal.record_sent(&prepared, 51),
+        Mutation::Replayed(authorization.clone())
+    );
+    assert_eq!(journal.record_sent(&prepared, 52), Mutation::Stale);
+    assert!(matches!(
+        journal.commit_bind(&authorization),
+        Mutation::Applied(_)
+    ));
+    assert!(matches!(
+        journal.commit_bind(&authorization),
+        Mutation::Replayed(_)
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn channel_lock_excludes_a_second_process() {
+    let root = tempfile::tempdir().unwrap();
+    let journal = journal(root.path(), 40);
+    let _held = journal.lock().unwrap();
+    let executable = std::env::current_exe().unwrap();
+    let helper =
+        "services::discord::status_panel_transition_v2::journal::tests::channel_lock_child_process";
+    let output = std::process::Command::new(executable)
+        .args(["--ignored", "--exact", helper])
+        .env("AGENTDESK_PANEL_JOURNAL_TEST_ROOT", root.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "child stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "helper subprocess for the channel-lock concurrency test"]
+fn channel_lock_child_process() {
+    let root = std::env::var_os("AGENTDESK_PANEL_JOURNAL_TEST_ROOT").unwrap();
+    let journal = journal(Path::new(&root), 40);
+    assert!(matches!(
+        storage::try_lock_for_test(&journal.channel_dir),
+        Err(StoreError::LockFailed)
+    ));
+}
+
+#[test]
+fn operation_and_quarantine_gc_are_bounded() {
+    let root = tempfile::tempdir().unwrap();
+    let journal = journal(root.path(), 37);
+    let operations = journal.channel_dir.join("operations");
+    let quarantine = journal.channel_dir.join("quarantine");
+    for index in 0..(MAX_OPERATION_RECORDS + 5) {
+        fs::write(operations.join(format!("{index:020}.json")), b"{}").unwrap();
+    }
+    for index in 0..(MAX_QUARANTINE_RECORDS + 5) {
+        fs::write(quarantine.join(format!("{index:020}.json")), b"{}").unwrap();
+    }
+    journal.gc_locked().unwrap();
+    assert_eq!(
+        fs::read_dir(operations).unwrap().count(),
+        MAX_OPERATION_RECORDS
+    );
+    assert_eq!(
+        fs::read_dir(quarantine).unwrap().count(),
+        MAX_QUARANTINE_RECORDS
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_channel_file_is_rejected() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().unwrap();
+    let journal = journal(root.path(), 38);
+    let target = root.path().join("outside.json");
+    fs::write(&target, b"{}").unwrap();
+    symlink(target, journal.channel_dir.join(CHANNEL_FILE)).unwrap();
+    assert_eq!(
+        journal.load(),
+        ReadOutcome::DurabilityFailure(StoreError::SymlinkRejected)
+    );
+}


### PR DESCRIPTION
## Summary
- replace caller-constructible bind evidence with adapter-sealed bind and retirement authorization handles tied to the exact panel identity
- add a dormant channel-wide filesystem journal with channel flocking, CAS revisions, monotonic channel generation, operation records, typed durability failures, quarantine, and bounded GC
- model exact recovery and deletion outcomes without adding a production caller, Discord I/O, legacy authority migration, or cutover

## Design boundaries
- Depends on merged #4934 and extends its dormant reducer.
- Tracks #4891 and the parent redesign in #4889.
- Does not make Discord send and journal persistence atomic and does not claim complete orphan discovery.
- Does not provide cryptographic protection against an attacker who can modify the local runtime tree.

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --lib`
- [x] `cargo test --lib services::discord::status_panel_transition_v2 -- --nocapture`
- [x] `python3 scripts/generate_inventory_docs.py`
- [x] `python3 scripts/check_agent_maintenance_docs.py`
- [x] subprocess channel-lock exclusion, operation/channel write-stage failpoints, crash reload, stale CAS, exact replay, generation monotonicity, authorization mutation, deletion disposition, symlink rejection, and GC-bound tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)