### PR TITLE
fix(ci): classify auto-queue PostgreSQL tests

### DIFF
--- a/scripts/check_test_lane_coverage.py
+++ b/scripts/check_test_lane_coverage.py
@@ -92,11 +92,11 @@ class LaneFilter:
 
     def selects_test(self, test_name: str) -> bool:
         """Whether libtest selects one fully qualified test name."""
-        positive_match = not self.positives or any(
-            positive == test_name if self.exact else positive in test_name
-            for positive in self.positives
-        )
-        return positive_match and not any(skip in test_name for skip in self.skips)
+        def matches(pattern: str) -> bool:
+            return pattern == test_name if self.exact else pattern in test_name
+
+        positive_match = not self.positives or any(map(matches, self.positives))
+        return positive_match and not any(map(matches, self.skips))
 
     def fully_selects(self, module: str, test_names: Iterable[str]) -> bool:
         """Whether this command selects every discovered test in the module.

--- a/scripts/check_test_lane_coverage.py
+++ b/scripts/check_test_lane_coverage.py
@@ -90,6 +90,14 @@ class LaneFilter:
     skips: tuple[str, ...]
     exact: bool = False
 
+    def selects_test(self, test_name: str) -> bool:
+        """Whether libtest selects one fully qualified test name."""
+        positive_match = not self.positives or any(
+            positive == test_name if self.exact else positive in test_name
+            for positive in self.positives
+        )
+        return positive_match and not any(skip in test_name for skip in self.skips)
+
     def fully_selects(self, module: str, test_names: Iterable[str]) -> bool:
         """Whether this command selects every discovered test in the module.
 
@@ -102,15 +110,9 @@ class LaneFilter:
         positive_match = not self.positives or any(
             positive in module for positive in self.positives
         )
-        if not positive_match:
+        if not positive_match or any(skip in module for skip in self.skips):
             return False
-        if any(skip in module for skip in self.skips):
-            return False
-        return not any(
-            skip in test_name
-            for test_name in test_names
-            for skip in self.skips
-        )
+        return all(self.selects_test(test_name) for test_name in test_names)
 
 
 class StripState:

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -1906,232 +1906,241 @@ mod auto_queue_phase_gate_finalize_wrapper_tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn normal_finalize_infers_legacy_default_only_from_persisted_null_kind() {
-        let pg_db = TestPostgresDb::create().await;
-        let pool = pg_db.connect_and_migrate().await;
-        seed_legacy_gate_dispatch(&pool, "run-finalize-legacy", "dsp-finalize-legacy", None).await;
+    #[cfg(test)]
+    mod postgres_tests {
+        use super::*;
 
-        let injected = maybe_inject_phase_gate_verdict_pg(
-            &pool,
-            "dsp-finalize-legacy",
-            &json!({"checks": passing_checks()}),
-        )
-        .await;
-        assert_eq!(
-            injected
-                .as_ref()
-                .and_then(|value| value.get("verdict"))
-                .and_then(Value::as_str),
-            Some("phase_gate_passed")
-        );
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn normal_finalize_infers_legacy_default_only_from_persisted_null_kind() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate().await;
+            seed_legacy_gate_dispatch(&pool, "run-finalize-legacy", "dsp-finalize-legacy", None)
+                .await;
 
-        pool.close().await;
-        pg_db.drop().await;
-    }
+            let injected = maybe_inject_phase_gate_verdict_pg(
+                &pool,
+                "dsp-finalize-legacy",
+                &json!({"checks": passing_checks()}),
+            )
+            .await;
+            assert_eq!(
+                injected
+                    .as_ref()
+                    .and_then(|value| value.get("verdict"))
+                    .and_then(Value::as_str),
+                Some("phase_gate_passed")
+            );
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn patch_completion_reconstructs_legacy_default_and_clears_gate() {
-        let pg_db = TestPostgresDb::create().await;
-        let pool = pg_db.connect_and_migrate().await;
-        seed_legacy_gate_dispatch(&pool, "run-patch-legacy", "dsp-patch-legacy", Some("   ")).await;
+            pool.close().await;
+            pg_db.drop().await;
+        }
 
-        let changed = set_dispatch_status_on_pg_async(
-            &pool,
-            "dsp-patch-legacy",
-            "completed",
-            Some(&json!({"checks": passing_checks()})),
-            "test_patch",
-            Some(&["dispatched"]),
-            true,
-        )
-        .await
-        .expect("complete legacy PATCH dispatch"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
-        assert_eq!(changed, 1);
-        let row =
-            sqlx::query("SELECT status, result::TEXT AS result FROM task_dispatches WHERE id = $1")
-                .bind("dsp-patch-legacy")
-                .fetch_one(&pool)
-                .await
-                .expect("load completed PATCH dispatch"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
-        assert_eq!(row.get::<String, _>("status"), "completed");
-        let result: Value = serde_json::from_str(&row.get::<String, _>("result"))
-            .expect("decode completed PATCH result"); // agentdesk-audit: allow-unwrap — persisted result must remain valid JSON
-        assert_eq!(result["verdict"], "phase_gate_passed");
-        let gate_count = sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM auto_queue_phase_gates
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn patch_completion_reconstructs_legacy_default_and_clears_gate() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate().await;
+            seed_legacy_gate_dispatch(&pool, "run-patch-legacy", "dsp-patch-legacy", Some("   "))
+                .await;
+
+            let changed = set_dispatch_status_on_pg_async(
+                &pool,
+                "dsp-patch-legacy",
+                "completed",
+                Some(&json!({"checks": passing_checks()})),
+                "test_patch",
+                Some(&["dispatched"]),
+                true,
+            )
+            .await
+            .expect("complete legacy PATCH dispatch"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
+            assert_eq!(changed, 1);
+            let row = sqlx::query(
+                "SELECT status, result::TEXT AS result FROM task_dispatches WHERE id = $1",
+            )
+            .bind("dsp-patch-legacy")
+            .fetch_one(&pool)
+            .await
+            .expect("load completed PATCH dispatch"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
+            assert_eq!(row.get::<String, _>("status"), "completed");
+            let result: Value = serde_json::from_str(&row.get::<String, _>("result"))
+                .expect("decode completed PATCH result"); // agentdesk-audit: allow-unwrap — persisted result must remain valid JSON
+            assert_eq!(result["verdict"], "phase_gate_passed");
+            let gate_count = sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM auto_queue_phase_gates
              WHERE run_id = 'run-patch-legacy' AND phase = 0",
-        )
-        .fetch_one(&pool)
-        .await
-        .expect("count cleared PATCH gate"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
-        assert_eq!(gate_count, 0);
+            )
+            .fetch_one(&pool)
+            .await
+            .expect("count cleared PATCH gate"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
+            assert_eq!(gate_count, 0);
 
-        pool.close().await;
-        pg_db.drop().await;
-    }
+            pool.close().await;
+            pg_db.drop().await;
+        }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn finalize_and_patch_accept_ascii_control_whitespace_legacy_provenance() {
-        let pg_db = TestPostgresDb::create().await;
-        let pool = pg_db.connect_and_migrate().await;
-        seed_legacy_gate_dispatch(
-            &pool,
-            "run-whitespace-legacy",
-            "dsp-whitespace-legacy",
-            Some(" \t\n\r"),
-        )
-        .await;
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn finalize_and_patch_accept_ascii_control_whitespace_legacy_provenance() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate().await;
+            seed_legacy_gate_dispatch(
+                &pool,
+                "run-whitespace-legacy",
+                "dsp-whitespace-legacy",
+                Some(" \t\n\r"),
+            )
+            .await;
 
-        let injected = maybe_inject_phase_gate_verdict_pg(
-            &pool,
-            "dsp-whitespace-legacy",
-            &json!({"checks": passing_checks()}),
-        )
-        .await;
-        assert_eq!(
-            injected
-                .as_ref()
-                .and_then(|value| value.get("verdict"))
-                .and_then(Value::as_str),
-            Some("phase_gate_passed")
-        );
-        let changed = set_dispatch_status_on_pg_async(
-            &pool,
-            "dsp-whitespace-legacy",
-            "completed",
-            Some(&json!({"checks": passing_checks()})),
-            "test_patch",
-            Some(&["dispatched"]),
-            true,
-        )
-        .await
-        .expect("complete whitespace PATCH dispatch"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
-        assert_eq!(changed, 1);
-        let gate_count = sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM auto_queue_phase_gates
+            let injected = maybe_inject_phase_gate_verdict_pg(
+                &pool,
+                "dsp-whitespace-legacy",
+                &json!({"checks": passing_checks()}),
+            )
+            .await;
+            assert_eq!(
+                injected
+                    .as_ref()
+                    .and_then(|value| value.get("verdict"))
+                    .and_then(Value::as_str),
+                Some("phase_gate_passed")
+            );
+            let changed = set_dispatch_status_on_pg_async(
+                &pool,
+                "dsp-whitespace-legacy",
+                "completed",
+                Some(&json!({"checks": passing_checks()})),
+                "test_patch",
+                Some(&["dispatched"]),
+                true,
+            )
+            .await
+            .expect("complete whitespace PATCH dispatch"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
+            assert_eq!(changed, 1);
+            let gate_count = sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM auto_queue_phase_gates
              WHERE run_id = 'run-whitespace-legacy' AND phase = 0",
-        )
-        .fetch_one(&pool)
-        .await
-        .expect("count cleared whitespace gate"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
-        assert_eq!(gate_count, 0);
+            )
+            .fetch_one(&pool)
+            .await
+            .expect("count cleared whitespace gate"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
+            assert_eq!(gate_count, 0);
 
-        pool.close().await;
-        pg_db.drop().await;
-    }
+            pool.close().await;
+            pg_db.drop().await;
+        }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn finalize_and_patch_reject_mixed_null_and_nonblank_legacy_provenance() {
-        let pg_db = TestPostgresDb::create().await;
-        let pool = pg_db.connect_and_migrate().await;
-        TestPostgresDb::emulate_pre_0100_deploy_gate_rows(&pool).await;
-        seed_legacy_gate_dispatch_with_kinds(
-            &pool,
-            "run-mixed-legacy",
-            "dsp-mixed-legacy",
-            &[None, Some("deploy-gate")],
-        )
-        .await;
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn finalize_and_patch_reject_mixed_null_and_nonblank_legacy_provenance() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate().await;
+            TestPostgresDb::emulate_pre_0100_deploy_gate_rows(&pool).await;
+            seed_legacy_gate_dispatch_with_kinds(
+                &pool,
+                "run-mixed-legacy",
+                "dsp-mixed-legacy",
+                &[None, Some("deploy-gate")],
+            )
+            .await;
 
-        assert!(
-            maybe_inject_phase_gate_verdict_pg(
+            assert!(
+                maybe_inject_phase_gate_verdict_pg(
+                    &pool,
+                    "dsp-mixed-legacy",
+                    &json!({"checks": passing_checks()}),
+                )
+                .await
+                .is_none()
+            );
+            set_dispatch_status_on_pg_async(
                 &pool,
                 "dsp-mixed-legacy",
-                &json!({"checks": passing_checks()}),
+                "completed",
+                Some(&json!({"checks": passing_checks()})),
+                "test_patch",
+                Some(&["dispatched"]),
+                true,
             )
             .await
-            .is_none()
-        );
-        set_dispatch_status_on_pg_async(
-            &pool,
-            "dsp-mixed-legacy",
-            "completed",
-            Some(&json!({"checks": passing_checks()})),
-            "test_patch",
-            Some(&["dispatched"]),
-            true,
-        )
-        .await
-        .expect("complete mixed-provenance PATCH dispatch"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
-        let result = sqlx::query_scalar::<_, Option<String>>(
-            "SELECT result::TEXT FROM task_dispatches WHERE id = $1",
-        )
-        .bind("dsp-mixed-legacy")
-        .fetch_one(&pool)
-        .await
-        .expect("load mixed-provenance PATCH result") // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
-        .expect("mixed-provenance PATCH result exists"); // agentdesk-audit: allow-unwrap — completion writes the supplied result
-        let result: Value =
-            serde_json::from_str(&result).expect("decode mixed-provenance PATCH result"); // agentdesk-audit: allow-unwrap — persisted result must remain valid JSON
-        assert!(result.get("verdict").is_none());
-        let gate_status = sqlx::query_scalar::<_, String>(
-            "SELECT status FROM auto_queue_phase_gates
+            .expect("complete mixed-provenance PATCH dispatch"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
+            let result = sqlx::query_scalar::<_, Option<String>>(
+                "SELECT result::TEXT FROM task_dispatches WHERE id = $1",
+            )
+            .bind("dsp-mixed-legacy")
+            .fetch_one(&pool)
+            .await
+            .expect("load mixed-provenance PATCH result") // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
+            .expect("mixed-provenance PATCH result exists"); // agentdesk-audit: allow-unwrap — completion writes the supplied result
+            let result: Value =
+                serde_json::from_str(&result).expect("decode mixed-provenance PATCH result"); // agentdesk-audit: allow-unwrap — persisted result must remain valid JSON
+            assert!(result.get("verdict").is_none());
+            let gate_status = sqlx::query_scalar::<_, String>(
+                "SELECT status FROM auto_queue_phase_gates
              WHERE run_id = 'run-mixed-legacy' AND phase = 0",
-        )
-        .fetch_one(&pool)
-        .await
-        .expect("load failed mixed-provenance gate"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
-        assert_eq!(gate_status, "failed");
+            )
+            .fetch_one(&pool)
+            .await
+            .expect("load failed mixed-provenance gate"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
+            assert_eq!(gate_status, "failed");
 
-        pool.close().await;
-        pg_db.drop().await;
-    }
+            pool.close().await;
+            pg_db.drop().await;
+        }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn finalize_and_patch_reject_nonblank_legacy_provenance() {
-        let pg_db = TestPostgresDb::create().await;
-        let pool = pg_db.connect_and_migrate().await;
-        TestPostgresDb::emulate_pre_0100_deploy_gate_rows(&pool).await;
-        seed_legacy_gate_dispatch(
-            &pool,
-            "run-nonblank-legacy",
-            "dsp-nonblank-legacy",
-            Some("deploy-gate"),
-        )
-        .await;
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn finalize_and_patch_reject_nonblank_legacy_provenance() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate().await;
+            TestPostgresDb::emulate_pre_0100_deploy_gate_rows(&pool).await;
+            seed_legacy_gate_dispatch(
+                &pool,
+                "run-nonblank-legacy",
+                "dsp-nonblank-legacy",
+                Some("deploy-gate"),
+            )
+            .await;
 
-        assert!(
-            maybe_inject_phase_gate_verdict_pg(
+            assert!(
+                maybe_inject_phase_gate_verdict_pg(
+                    &pool,
+                    "dsp-nonblank-legacy",
+                    &json!({"checks": passing_checks()}),
+                )
+                .await
+                .is_none()
+            );
+            set_dispatch_status_on_pg_async(
                 &pool,
                 "dsp-nonblank-legacy",
-                &json!({"checks": passing_checks()}),
+                "completed",
+                Some(&json!({"checks": passing_checks()})),
+                "test_patch",
+                Some(&["dispatched"]),
+                true,
             )
             .await
-            .is_none()
-        );
-        set_dispatch_status_on_pg_async(
-            &pool,
-            "dsp-nonblank-legacy",
-            "completed",
-            Some(&json!({"checks": passing_checks()})),
-            "test_patch",
-            Some(&["dispatched"]),
-            true,
-        )
-        .await
-        .expect("complete nonblank PATCH dispatch"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
-        let result = sqlx::query_scalar::<_, Option<String>>(
-            "SELECT result::TEXT FROM task_dispatches WHERE id = $1",
-        )
-        .bind("dsp-nonblank-legacy")
-        .fetch_one(&pool)
-        .await
-        .expect("load nonblank PATCH result") // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
-        .expect("nonblank PATCH result exists"); // agentdesk-audit: allow-unwrap — completion writes the supplied result
-        let result: Value = serde_json::from_str(&result).expect("decode nonblank PATCH result"); // agentdesk-audit: allow-unwrap — persisted result must remain valid JSON
-        assert!(result.get("verdict").is_none());
-        let gate_status = sqlx::query_scalar::<_, String>(
-            "SELECT status FROM auto_queue_phase_gates
+            .expect("complete nonblank PATCH dispatch"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
+            let result = sqlx::query_scalar::<_, Option<String>>(
+                "SELECT result::TEXT FROM task_dispatches WHERE id = $1",
+            )
+            .bind("dsp-nonblank-legacy")
+            .fetch_one(&pool)
+            .await
+            .expect("load nonblank PATCH result") // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
+            .expect("nonblank PATCH result exists"); // agentdesk-audit: allow-unwrap — completion writes the supplied result
+            let result: Value =
+                serde_json::from_str(&result).expect("decode nonblank PATCH result"); // agentdesk-audit: allow-unwrap — persisted result must remain valid JSON
+            assert!(result.get("verdict").is_none());
+            let gate_status = sqlx::query_scalar::<_, String>(
+                "SELECT status FROM auto_queue_phase_gates
              WHERE run_id = 'run-nonblank-legacy' AND phase = 0",
-        )
-        .fetch_one(&pool)
-        .await
-        .expect("load failed nonblank gate"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
-        assert_eq!(gate_status, "failed");
+            )
+            .fetch_one(&pool)
+            .await
+            .expect("load failed nonblank gate"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
+            assert_eq!(gate_status, "failed");
 
-        pool.close().await;
-        pg_db.drop().await;
+            pool.close().await;
+            pg_db.drop().await;
+        }
     }
 
     #[test]

--- a/src/services/auto_queue/route_generate.rs
+++ b/src/services/auto_queue/route_generate.rs
@@ -774,44 +774,49 @@ mod deploy_gate_request_rejection_tests {
         );
     }
 
-    #[tokio::test]
-    async fn unavailable_deploy_gate_creates_no_database_rows() {
-        let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
-        let pool = pg_db.connect_and_migrate().await;
-        let runs_before =
-            sqlx::query_scalar::<_, i64>("SELECT COUNT(*)::BIGINT FROM auto_queue_runs")
-                .fetch_one(&pool)
-                .await
-                .expect("count auto-queue runs before request"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL fixture
-        let entries_before =
-            sqlx::query_scalar::<_, i64>("SELECT COUNT(*)::BIGINT FROM auto_queue_entries")
-                .fetch_one(&pool)
-                .await
-                .expect("count auto-queue entries before request"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL fixture
+    #[cfg(test)]
+    mod postgres_tests {
+        use super::*;
 
-        let error = generate(
-            State(state_with_postgres(Some(pool.clone()))),
-            Json(body("deploy-gate")),
-        )
-        .await
-        .expect_err("unavailable deploy-gate must be rejected");
-        assert_eq!(error.status(), StatusCode::BAD_REQUEST);
-        assert_eq!(
-            sqlx::query_scalar::<_, i64>("SELECT COUNT(*)::BIGINT FROM auto_queue_runs")
-                .fetch_one(&pool)
-                .await
-                .expect("count auto-queue runs after request"), // agentdesk-audit: allow-unwrap — test-only PostgreSQL fixture
-            runs_before
-        );
-        assert_eq!(
-            sqlx::query_scalar::<_, i64>("SELECT COUNT(*)::BIGINT FROM auto_queue_entries")
-                .fetch_one(&pool)
-                .await
-                .expect("count auto-queue entries after request"), // agentdesk-audit: allow-unwrap — test-only PostgreSQL fixture
-            entries_before
-        );
+        #[tokio::test]
+        async fn unavailable_deploy_gate_creates_no_database_rows() {
+            let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate().await;
+            let runs_before =
+                sqlx::query_scalar::<_, i64>("SELECT COUNT(*)::BIGINT FROM auto_queue_runs")
+                    .fetch_one(&pool)
+                    .await
+                    .expect("count auto-queue runs before request"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL fixture
+            let entries_before =
+                sqlx::query_scalar::<_, i64>("SELECT COUNT(*)::BIGINT FROM auto_queue_entries")
+                    .fetch_one(&pool)
+                    .await
+                    .expect("count auto-queue entries before request"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL fixture
 
-        pool.close().await;
-        pg_db.drop().await;
+            let error = generate(
+                State(state_with_postgres(Some(pool.clone()))),
+                Json(body("deploy-gate")),
+            )
+            .await
+            .expect_err("unavailable deploy-gate must be rejected");
+            assert_eq!(error.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(
+                sqlx::query_scalar::<_, i64>("SELECT COUNT(*)::BIGINT FROM auto_queue_runs")
+                    .fetch_one(&pool)
+                    .await
+                    .expect("count auto-queue runs after request"), // agentdesk-audit: allow-unwrap — test-only PostgreSQL fixture
+                runs_before
+            );
+            assert_eq!(
+                sqlx::query_scalar::<_, i64>("SELECT COUNT(*)::BIGINT FROM auto_queue_entries")
+                    .fetch_one(&pool)
+                    .await
+                    .expect("count auto-queue entries after request"), // agentdesk-audit: allow-unwrap — test-only PostgreSQL fixture
+                entries_before
+            );
+
+            pool.close().await;
+            pg_db.drop().await;
+        }
     }
 }

--- a/tests/test_test_lane_coverage.py
+++ b/tests/test_test_lane_coverage.py
@@ -153,6 +153,39 @@ class LaneFilterTests(unittest.TestCase):
             )
         )
 
+    def test_exact_skip_matching_agrees_with_libtest(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source = root / "exact_skip.rs"
+            binary = root / "exact_skip"
+            source.write_text("#[test] fn deploy_gate_case() {}\n", encoding="utf-8")
+            subprocess.run(
+                ["rustc", "--test", source, "-o", binary],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            cases = (
+                ("deploy_gate", True, "1 passed"),
+                ("deploy_gate_case", False, "0 passed"),
+            )
+            for skip, expected_selected, libtest_summary in cases:
+                with self.subTest(skip=skip):
+                    lane = coverage.LaneFilter(
+                        ("deploy_gate_case",), (skip,), exact=True
+                    )
+                    result = subprocess.run(
+                        [binary, "deploy_gate_case", "--exact", "--skip", skip],
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(
+                        lane.selects_test("deploy_gate_case"), expected_selected
+                    )
+                    self.assertIn(libtest_summary, result.stdout)
+
     def test_single_test_filter_does_not_cover_parent_module(self) -> None:
         modules = {"service::tests", "other::tests"}
         lanes = (coverage.LaneFilter(("service::tests::one_case",), ()),)

--- a/tests/test_test_lane_coverage.py
+++ b/tests/test_test_lane_coverage.py
@@ -15,6 +15,14 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "check_test_lane_coverage.py"
+AUTO_QUEUE_POSTGRES_TESTS = {
+    "dispatch::dispatch_status::auto_queue_phase_gate_finalize_wrapper_tests::postgres_tests::finalize_and_patch_accept_ascii_control_whitespace_legacy_provenance",
+    "dispatch::dispatch_status::auto_queue_phase_gate_finalize_wrapper_tests::postgres_tests::finalize_and_patch_reject_mixed_null_and_nonblank_legacy_provenance",
+    "dispatch::dispatch_status::auto_queue_phase_gate_finalize_wrapper_tests::postgres_tests::finalize_and_patch_reject_nonblank_legacy_provenance",
+    "dispatch::dispatch_status::auto_queue_phase_gate_finalize_wrapper_tests::postgres_tests::normal_finalize_infers_legacy_default_only_from_persisted_null_kind",
+    "dispatch::dispatch_status::auto_queue_phase_gate_finalize_wrapper_tests::postgres_tests::patch_completion_reconstructs_legacy_default_and_clears_gate",
+    "services::auto_queue::route::route_generate::deploy_gate_request_rejection_tests::postgres_tests::unavailable_deploy_gate_creates_no_database_rows",
+}
 _spec = importlib.util.spec_from_file_location("check_test_lane_coverage", SCRIPT)
 assert _spec and _spec.loader
 coverage = importlib.util.module_from_spec(_spec)
@@ -212,6 +220,40 @@ class LaneFilterTests(unittest.TestCase):
                 inventory["services::auto_queue::tests"],
             )
         )
+
+    def test_auto_queue_postgres_authority_lane_owns_all_six_regressions(self) -> None:
+        inventory = coverage.discover_test_inventory(REPO_ROOT)
+        discovered = set().union(*inventory.values())
+        self.assertEqual(AUTO_QUEUE_POSTGRES_TESTS & discovered, AUTO_QUEUE_POSTGRES_TESTS)
+
+        non_pg = coverage.LaneFilter(
+            ("auto_queue",), ("_pg", "pg_", "postgres")
+        )
+        postgres = coverage.LaneFilter(("_pg", "pg_", "postgres"), ())
+        for test_name in AUTO_QUEUE_POSTGRES_TESTS:
+            with self.subTest(test=test_name):
+                self.assertFalse(non_pg.selects_test(test_name))
+                self.assertTrue(postgres.selects_test(test_name))
+
+    def test_auto_queue_postgres_authority_lane_inventory_match_is_fail_closed(self) -> None:
+        def assert_expected_tests_exist(
+            expected: set[str], discovered: set[str]
+        ) -> None:
+            missing = expected - discovered
+            if missing:
+                raise AssertionError(f"missing expected tests: {sorted(missing)}")
+
+        inventory = coverage.discover_test_inventory(REPO_ROOT)
+        discovered = set().union(*inventory.values())
+        assert_expected_tests_exist(AUTO_QUEUE_POSTGRES_TESTS, discovered)
+        with self.assertRaisesRegex(AssertionError, "missing_regression"):
+            assert_expected_tests_exist(
+                AUTO_QUEUE_POSTGRES_TESTS
+                | {
+                    "dispatch::dispatch_status::auto_queue_phase_gate_finalize_wrapper_tests::postgres_tests::missing_regression"
+                },
+                discovered,
+            )
 
 
 class RatchetTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- classify six DB-dependent auto-queue tests under `postgres_tests` so the non-PG lane no longer opens PostgreSQL connections
- preserve all six tests in the PostgreSQL authority lane
- model libtest `--exact` semantics for both positive and skip filters, with a real rustc/libtest comparison regression

## Validation
- exact non-PG CI command: 83 passed, 0 failed, 1 ignored
- PostgreSQL lane: 505 passed, 0 failed; all six moved tests executed
- lane coverage tests: 31 passed; baseline unchanged
- fast CI wiring: 21 passed
- cargo check/fmt, ci-script-checks, docs/inventory, diff-check: passed
- independent exact-head GPT reviews: CLEAN + CLEAN on `a29c825e3cb3a3e669b71d68eeea5eaba6b12657`

Closes #4923

🤖 Generated with [Claude Code](https://claude.com/claude-code)