### PR TITLE
fix(#4909): resolve fenced zero-delivery ACKs

### DIFF
--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -30,6 +30,13 @@ use crate::services::cluster::watcher_supervisor::{SupervisorConfig, run_watcher
 use crate::services::provider::ProviderKind;
 use tracing::Instrument;
 
+#[cfg(test)]
+pub(in crate::services::discord) const PURE_SUBAGENT_ZERO_DELIVERY_PAYLOAD: &str = concat!(
+    "{\"type\":\"system\",\"subtype\":\"task_started\",\"task_id\":\"sub-1\",\"task_type\":\"local_agent\"}\n",
+    "{\"type\":\"system\",\"subtype\":\"task_notification\",\"task_id\":\"sub-1\",\"status\":\"completed\",\"summary\":\"Subagent finished\"}\n",
+    "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"done\"}\n"
+);
+
 mod delivery_outcome_classify;
 mod idle_jsonl;
 // #3960: orphaned `SessionBoundRelay` TUI-direct reclaim (producer-liveness TOCTOU).
@@ -1343,6 +1350,11 @@ impl RelaySink for SessionBoundDiscordRelaySink {
         // handled by the per-sequence ACK. The fence still ONLY gates the OFFSET ADVANCE
         // (inline in `deliver_response`) — outcome and advance are decoupled.
         let deliveries = self.ingest_frame(frame);
+        let fenced_terminal_without_delivery = deliveries.is_empty()
+            && matches!(
+                (frame.turn_start_offset, frame.terminal_consumed_end),
+                (Some(start), Some(end)) if end > start
+            );
         let mut terminal_delivered = false;
         let mut terminal_fresh_delivered = None;
         let mut terminal_not_delivered = false;
@@ -1370,7 +1382,10 @@ impl RelaySink for SessionBoundDiscordRelaySink {
         }
         // #3041 P1-3 R5: surface the outcome on THIS frame's sequence (the watcher
         // resolves its own terminal ACK on its exact seq, so a co-chunked tail can't
-        // satisfy another turn's ACK); no result-bearing delivery → `FrameAccepted`.
+        // satisfy another turn's ACK). A valid terminal commit fence proves this exact
+        // sequence needs a terminal resolution even when parser visibility policy emits
+        // no delivery; resolve it as NotDelivered so the watcher reconciles immediately.
+        // An unfenced frame with no result-bearing delivery remains `FrameAccepted`.
         // #3041 P1-5: NO `TerminalUnknown` (the sink always KNOWS its result).
         if terminal_delivered {
             Ok(RelaySinkOutcome::TerminalDelivered)
@@ -1379,7 +1394,7 @@ impl RelaySink for SessionBoundDiscordRelaySink {
                 committed_to,
                 persistence_recorded,
             })
-        } else if terminal_not_delivered {
+        } else if terminal_not_delivered || fenced_terminal_without_delivery {
             Ok(RelaySinkOutcome::TerminalNotDelivered)
         } else {
             Ok(RelaySinkOutcome::FrameAccepted)
@@ -4529,14 +4544,9 @@ mod tests {
         let binding = matched("42");
         let mut parser = SessionRelayParser::default();
 
-        let pure_subagent = concat!(
-            "{\"type\":\"system\",\"subtype\":\"task_started\",\"task_id\":\"sub-1\",\"task_type\":\"local_agent\"}\n",
-            "{\"type\":\"system\",\"subtype\":\"task_notification\",\"task_id\":\"sub-1\",\"status\":\"completed\",\"summary\":\"Subagent finished\"}\n",
-            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"done\"}\n"
-        );
         assert!(
             parser
-                .ingest_frame(&frame(&binding, pure_subagent, 1))
+                .ingest_frame(&frame(&binding, PURE_SUBAGENT_ZERO_DELIVERY_PAYLOAD, 1,))
                 .is_empty()
         );
 

--- a/src/services/discord/tmux_watcher/session_bound_ack_tests.rs
+++ b/src/services/discord/tmux_watcher/session_bound_ack_tests.rs
@@ -128,6 +128,69 @@ fn resolve_time_drop_span_ignores_prior_turn_drops() {
     );
 }
 
+#[tokio::test]
+async fn fenced_zero_delivery_resolves_exact_not_delivered_without_timeout_4909() {
+    use crate::services::cluster::session_matcher::{MatchedChannel, expected_rollout_path_for};
+    use crate::services::cluster::stream_relay::{
+        RelaySink, TerminalCommitFence, spawn_stream_relay,
+    };
+    use crate::services::discord::health::HealthRegistry;
+    use crate::services::discord::session_relay_sink::{
+        PURE_SUBAGENT_ZERO_DELIVERY_PAYLOAD, SessionBoundDiscordRelaySink,
+    };
+    use crate::services::provider::ProviderKind;
+    use std::sync::Arc;
+
+    let channel_id = "4909";
+    let session = ProviderKind::Claude.build_tmux_session_name(channel_id);
+    let binding = MatchedChannel {
+        channel_id: channel_id.to_string(),
+        agent_id: format!("agent-{channel_id}"),
+        provider: ProviderKind::Claude,
+        expected_session_name: session.clone(),
+        expected_rollout_path: expected_rollout_path_for(&session),
+    };
+    let sink: Arc<dyn RelaySink> = Arc::new(SessionBoundDiscordRelaySink::new(Arc::new(
+        HealthRegistry::new(),
+    )));
+    let handle = spawn_stream_relay(binding, sink);
+    let producer = handle.producer();
+    let sent = producer.try_send_terminal_frame_with_sequence(
+        PURE_SUBAGENT_ZERO_DELIVERY_PAYLOAD.to_string(),
+        TerminalCommitFence {
+            consumed_end: 256,
+            turn_user_msg_id: 49_090,
+            turn_started_at: "2026-07-27T00:00:00Z".to_string(),
+            turn_start_offset: Some(64),
+        },
+    );
+    let sequence = sent.sequence.expect("terminal frame enqueued");
+    let metrics = producer.metrics().clone();
+    let target = SessionBoundRelayAckTarget {
+        metrics: metrics.clone(),
+        sequence,
+        turn_start_offset: Some(64),
+    };
+
+    let ack = wait_for_session_bound_relay_delivery_ack(
+        Some(&target),
+        std::time::Duration::from_millis(250),
+    )
+    .await;
+
+    assert_eq!(
+        ack,
+        SessionBoundRelayAckOutcome::NotDelivered,
+        "the real parser and sink must resolve the exact ACK instead of timing out"
+    );
+    assert_ne!(ack, SessionBoundRelayAckOutcome::TimedOut);
+    let snapshot = metrics.snapshot();
+    assert_eq!(snapshot.last_terminal_skipped_sequence, Some(sequence));
+    assert_eq!(snapshot.last_terminal_committed_sequence, None);
+    assert_eq!(snapshot.last_sink_error_sequence, None);
+    handle.shutdown().await;
+}
+
 /// #3579: the `NotAttempted` vs `MissingTarget` sentinel split. `NotAttempted`
 /// is the watcher-owned NON-attempt (the ack-wait block was skipped); it must
 /// stay DISTINCT from the genuine `MissingTarget` failure (the ack-wait ran but


### PR DESCRIPTION
## Summary
- resolve terminal-fenced zero-delivery frames as typed `TerminalNotDelivered`
- preserve `FrameAccepted` for unfenced zero-delivery frames
- add production-equivalent sink/parser/relay/ACK regression coverage

## Validation
- focused production-equivalent ACK test
- session relay sink tests (71)
- stream relay tests (22)
- session-bound ACK tests (23)
- `cargo check --lib`
- `cargo fmt --all -- --check`
- inventory/docs/CI script gates
- mutation proof
- two fresh exact-head GPT reviews: CLEAN / CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)