### PR TITLE
fix(#4874): wake queued turns after local model controls

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -869,6 +869,7 @@ src/
 │   │   │   ├── idle_transcript_scan.rs
 │   │   │   ├── injected_prompt_policy.rs
 │   │   │   ├── launch_script.rs
+│   │   │   ├── local_model_queue_wake_e2e.rs
 │   │   │   ├── observed_prompt_decision.rs
 │   │   │   ├── rehydration.rs
 │   │   │   ├── relay_ownership.rs

--- a/justfile
+++ b/justfile
@@ -86,6 +86,8 @@ test-non-pg:
     # Run health first so a fail-fast relay_recovery failure cannot hide it.
     python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
     env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres
+    # #4874: keep the local-model durable-queue wake production E2E fully selected.
+    env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tui_prompt_relay::local_model_queue_wake_e2e -- --skip _pg --skip pg_ --skip postgres --test-threads=1
     # #4875: keep the Claude catalog and picker test modules fully selected.
     cargo test --lib services::discord::model_catalog -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib services::discord::commands::model_ui::tests -- --skip _pg --skip pg_ --skip postgres

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -499,8 +499,12 @@ async fn run_single_slow_idle_queue_backstop(
     provider: &ProviderKind,
     channel_id: ChannelId,
     reason: &'static str,
+    wake: &tokio::sync::Notify,
 ) -> Option<IdleQueueBackstopRearm> {
-    tokio::time::sleep(DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY).await;
+    let timed_out = tokio::select! {
+        _ = tokio::time::sleep(DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY) => true,
+        _ = wake.notified() => false,
+    };
     let snapshot = super::mailbox_snapshot(shared.as_ref(), channel_id).await;
     let backlog_units =
         idle_queue_backstop_backlog_units(shared.as_ref(), provider, channel_id, &snapshot);
@@ -508,13 +512,15 @@ async fn run_single_slow_idle_queue_backstop(
         return None;
     }
 
-    emit_idle_queue_backstop_warn(
-        provider,
-        Some(channel_id),
-        reason,
-        backlog_units,
-        "channel_backstop",
-    );
+    if timed_out {
+        emit_idle_queue_backstop_warn(
+            provider,
+            Some(channel_id),
+            reason,
+            backlog_units,
+            "channel_backstop",
+        );
+    }
     let _outcome =
         kick_idle_queue_channel_if_context_available(shared, provider, channel_id, reason).await;
 
@@ -547,7 +553,7 @@ fn schedule_single_slow_idle_queue_backstop(
     reason: &'static str,
     backlog_units: usize,
 ) -> bool {
-    match shared.restart.deferred_hook_channels.entry(channel_id) {
+    let wake = match shared.restart.deferred_hook_channels.entry(channel_id) {
         dashmap::mapref::entry::Entry::Occupied(_) => {
             tracing::debug!(
                 provider = provider.as_str(),
@@ -559,7 +565,9 @@ fn schedule_single_slow_idle_queue_backstop(
             return false;
         }
         dashmap::mapref::entry::Entry::Vacant(entry) => {
-            entry.insert(Arc::new(tokio::sync::Notify::new()));
+            let wake = Arc::new(tokio::sync::Notify::new());
+            entry.insert(wake.clone());
+            wake
         }
     };
     shared
@@ -573,7 +581,8 @@ fn schedule_single_slow_idle_queue_backstop(
             active: true,
         };
         let rearm =
-            run_single_slow_idle_queue_backstop(&shared, &provider, channel_id, reason).await;
+            run_single_slow_idle_queue_backstop(&shared, &provider, channel_id, reason, &wake)
+                .await;
         backlog_guard.release();
         if let Some(rearm) = rearm {
             schedule_single_slow_idle_queue_backstop(
@@ -724,7 +733,7 @@ fn schedule_deferred_idle_queue_kickoff_inner(
     reason: &'static str,
     profile: DeferredIdleQueueKickoffProfile,
 ) {
-    match shared.restart.deferred_hook_channels.entry(channel_id) {
+    let wake = match shared.restart.deferred_hook_channels.entry(channel_id) {
         dashmap::mapref::entry::Entry::Occupied(entry) => {
             if profile.wakes_existing_task() {
                 entry.get().notify_one();
@@ -740,7 +749,9 @@ fn schedule_deferred_idle_queue_kickoff_inner(
             return;
         }
         dashmap::mapref::entry::Entry::Vacant(entry) => {
-            entry.insert(Arc::new(tokio::sync::Notify::new()));
+            let wake = Arc::new(tokio::sync::Notify::new());
+            entry.insert(wake.clone());
+            wake
         }
     };
     shared
@@ -758,7 +769,10 @@ fn schedule_deferred_idle_queue_kickoff_inner(
 
         let initial_presleep = profile.initial_presleep();
         if !initial_presleep.is_zero() {
-            tokio::time::sleep(initial_presleep).await;
+            tokio::select! {
+                _ = tokio::time::sleep(initial_presleep) => {}
+                _ = wake.notified() => {}
+            }
         }
 
         let _ =
@@ -766,7 +780,8 @@ fn schedule_deferred_idle_queue_kickoff_inner(
                 .await;
 
         let rearm =
-            run_single_slow_idle_queue_backstop(&shared, &provider, channel_id, reason).await;
+            run_single_slow_idle_queue_backstop(&shared, &provider, channel_id, reason, &wake)
+                .await;
         backlog_guard.release();
         if let Some(rearm) = rearm {
             schedule_single_slow_idle_queue_backstop(

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -269,9 +269,11 @@ pub(super) fn spawn_tui_prompt_relay(shared: Arc<SharedData>, provider: Provider
         "tui_prompt_relay_observer",
         provider = %provider_name
     );
+    // Subscribe before spawning so callers can publish immediately after this
+    // function returns without racing the observer task's first poll.
+    let mut hook_rx = subscribe_hook_events();
+    let mut observed_rx = subscribe_observed_prompts();
     super::task_supervisor::spawn_observed("tui_prompt_relay_observer", async move {
-        let mut hook_rx = subscribe_hook_events();
-        let mut observed_rx = subscribe_observed_prompts();
         loop {
             tokio::select! {
                 hook_event = hook_rx.recv() => {
@@ -340,6 +342,13 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         return;
     };
     if let Some(control) = relay_prompt_decision.local_only_control.as_ref() {
+        let provider = ProviderKind::from_str_or_unsupported(&prompt.provider);
+        super::queue_io::schedule_deferred_idle_queue_kickoff_immediate(
+            shared.clone(),
+            provider,
+            channel_id,
+            "local_only_slash_command",
+        );
         let kind = control.kind.as_str();
         let Some(note) = prepare_local_only_slash_control_note(&prompt, kind) else {
             tracing::info!(
@@ -868,5 +877,8 @@ fn slash_command_control_turn_is_duplicate_external_replay(
     !slash_command_control_turn_is_first_sighting(tmux_session_name, kind)
 }
 
+#[cfg(all(test, unix))]
+#[path = "tui_prompt_relay/local_model_queue_wake_e2e.rs"]
+mod local_model_queue_wake_e2e;
 #[cfg(test)]
 mod tests;

--- a/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
+++ b/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
@@ -1,0 +1,598 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+use axum::Json;
+use axum::Router;
+use axum::body::Body;
+use axum::extract::{Path, State, WebSocketUpgrade};
+use axum::http::{Method, Request, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use futures::future::BoxFuture;
+use poise::serenity_prelude as serenity;
+use serde_json::{Value, json};
+use serenity::cache::{Cache, CacheUpdate};
+use serenity::{ChannelId, MessageId, UserId};
+use tokio::sync::Notify;
+
+use super::super::{Data, ProviderKind, mailbox_snapshot};
+
+const CHANNEL_ID: u64 = 940_487_400_000_001;
+const USER_ID: u64 = 940_487_400_000_002;
+const BOT_ID: u64 = 940_487_400_000_003;
+const A_MESSAGE_ID: u64 = 940_487_400_000_011;
+const B_MESSAGE_ID: u64 = 940_487_400_000_012;
+const FIRST_RESPONSE_MESSAGE_ID: u64 = 940_487_400_000_021;
+
+#[derive(Clone)]
+struct DiscordMockState {
+    placeholder_posts: Arc<AtomicUsize>,
+    local_note_posts: Arc<AtomicUsize>,
+    first_placeholder_arrived: Arc<Notify>,
+    release_first_placeholder: Arc<Notify>,
+    second_placeholder_arrived: Arc<Notify>,
+    next_response_id: Arc<AtomicU64>,
+}
+
+impl DiscordMockState {
+    fn new() -> Self {
+        Self {
+            placeholder_posts: Arc::new(AtomicUsize::new(0)),
+            local_note_posts: Arc::new(AtomicUsize::new(0)),
+            first_placeholder_arrived: Arc::new(Notify::new()),
+            release_first_placeholder: Arc::new(Notify::new()),
+            second_placeholder_arrived: Arc::new(Notify::new()),
+            next_response_id: Arc::new(AtomicU64::new(FIRST_RESPONSE_MESSAGE_ID)),
+        }
+    }
+}
+
+fn discord_user_json(id: u64, name: &str, bot: bool) -> Value {
+    json!({
+        "id": id.to_string(),
+        "username": name,
+        "discriminator": "0",
+        "global_name": null,
+        "avatar": null,
+        "bot": bot,
+        "system": false,
+        "mfa_enabled": false,
+        "banner": null,
+        "accent_color": null,
+        "locale": null,
+        "verified": null,
+        "email": null,
+        "flags": 0,
+        "premium_type": 0,
+        "public_flags": 0,
+        "member": null,
+        "primary_guild": null,
+        "avatar_decoration_data": null,
+        "collectibles": null
+    })
+}
+
+fn private_channel_json() -> Value {
+    json!({
+        "id": CHANNEL_ID.to_string(),
+        "last_message_id": null,
+        "last_pin_timestamp": null,
+        "type": 1,
+        "recipients": [discord_user_json(USER_ID, "queue-user", false)]
+    })
+}
+
+fn discord_message_json(id: u64, content: &str) -> Value {
+    json!({
+        "id": id.to_string(),
+        "channel_id": CHANNEL_ID.to_string(),
+        "author": discord_user_json(BOT_ID, "queue-bot", true),
+        "content": content,
+        "timestamp": "2026-07-26T00:00:00.000000+00:00",
+        "edited_timestamp": null,
+        "tts": false,
+        "mention_everyone": false,
+        "mentions": [],
+        "mention_roles": [],
+        "mention_channels": [],
+        "attachments": [],
+        "embeds": [],
+        "reactions": [],
+        "nonce": null,
+        "pinned": false,
+        "webhook_id": null,
+        "type": 0,
+        "activity": null,
+        "application": null,
+        "application_id": null,
+        "message_reference": null,
+        "flags": 0,
+        "referenced_message": null,
+        "message_snapshots": [],
+        "interaction": null,
+        "interaction_metadata": null,
+        "thread": null,
+        "components": [],
+        "sticker_items": [],
+        "position": null,
+        "role_subscription_data": null,
+        "guild_id": null,
+        "member": null,
+        "poll": null
+    })
+}
+
+async fn get_channel(Path(_channel_id): Path<u64>) -> Json<Value> {
+    Json(private_channel_json())
+}
+
+async fn discord_rest(State(state): State<DiscordMockState>, request: Request<Body>) -> Response {
+    let method = request.method().clone();
+    let path = request.uri().path().to_string();
+    if method == Method::GET && path == format!("/api/v10/channels/{CHANNEL_ID}") {
+        return Json(private_channel_json()).into_response();
+    }
+    if method == Method::POST && path == format!("/api/v10/channels/{CHANNEL_ID}/messages") {
+        let body = match axum::body::to_bytes(request.into_body(), 1024 * 1024).await {
+            Ok(body) => body,
+            Err(error) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"message": error.to_string(), "code": 0})),
+                )
+                    .into_response();
+            }
+        };
+        let payload: Value = serde_json::from_slice(&body).unwrap_or_else(|_| json!({}));
+        let content = payload
+            .get("content")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        if content == "..." {
+            let index = state.placeholder_posts.fetch_add(1, Ordering::SeqCst);
+            if index == 0 {
+                state.first_placeholder_arrived.notify_waiters();
+                state.release_first_placeholder.notified().await;
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"message": "release A", "code": 0})),
+                )
+                    .into_response();
+            }
+            state.second_placeholder_arrived.notify_waiters();
+        } else {
+            state.local_note_posts.fetch_add(1, Ordering::SeqCst);
+        }
+        let id = state.next_response_id.fetch_add(1, Ordering::SeqCst);
+        return (StatusCode::OK, Json(discord_message_json(id, &content))).into_response();
+    }
+
+    if (method == Method::PUT || method == Method::DELETE)
+        && path.starts_with(&format!("/api/v10/channels/{CHANNEL_ID}/messages/"))
+        && path.contains("/reactions/")
+    {
+        return StatusCode::NO_CONTENT.into_response();
+    }
+    if method == Method::DELETE
+        && path.starts_with(&format!("/api/v10/channels/{CHANNEL_ID}/messages/"))
+    {
+        return StatusCode::NO_CONTENT.into_response();
+    }
+    if method == Method::GET && path.starts_with("/api/v10/users/") {
+        return Json(discord_user_json(USER_ID, "queue-user", false)).into_response();
+    }
+
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({"message": format!("unhandled {method} {path}"), "code": 0})),
+    )
+        .into_response()
+}
+
+async fn gateway_socket(ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(|mut socket| async move { while socket.recv().await.is_some() {} })
+}
+
+async fn start_mock_discord(
+    state: DiscordMockState,
+) -> (String, String, tokio::task::JoinHandle<()>) {
+    let app = Router::new()
+        .route("/gateway", get(gateway_socket))
+        .route("/api/v10/channels/{channel_id}", get(get_channel))
+        .fallback(discord_rest)
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock Discord");
+    let address = listener.local_addr().expect("mock Discord address");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve mock Discord");
+    });
+    (
+        format!("http://{address}"),
+        format!("ws://{address}/gateway"),
+        server,
+    )
+}
+
+struct NoopFramework;
+
+#[async_trait::async_trait]
+impl serenity::framework::Framework for NoopFramework {
+    async fn dispatch(&self, _ctx: serenity::Context, _event: serenity::FullEvent) {}
+}
+
+async fn serenity_context(proxy: String, gateway_url: String) -> serenity::Context {
+    let http = Arc::new(
+        serenity::HttpBuilder::new("test-token")
+            .proxy(proxy)
+            .ratelimiter_disabled(true)
+            .build(),
+    );
+    let cache = Arc::new(Cache::new());
+    let mut ready: serenity::ReadyEvent = serde_json::from_value(json!({
+        "v": 10,
+        "user": discord_user_json(BOT_ID, "queue-bot", true),
+        "guilds": [],
+        "session_id": "queue-wake-e2e",
+        "resume_gateway_url": gateway_url,
+        "shard": [0, 1],
+        "application": {"id": BOT_ID.to_string(), "flags": 0}
+    }))
+    .expect("ready fixture");
+    cache.update(&mut ready);
+
+    let data = Arc::new(tokio::sync::RwLock::new(serenity::prelude::TypeMap::new()));
+    let ws_url = Arc::new(tokio::sync::Mutex::new(gateway_url));
+    let framework: Arc<dyn serenity::framework::Framework> = Arc::new(NoopFramework);
+    let (manager, _manager_result) =
+        serenity::gateway::ShardManager::new(serenity::gateway::ShardManagerOptions {
+            data: data.clone(),
+            event_handlers: vec![],
+            raw_event_handlers: vec![],
+            framework: Arc::new(std::sync::OnceLock::from(framework)),
+            shard_index: 0,
+            shard_init: 0,
+            shard_total: 1,
+            voice_manager: None,
+            ws_url: ws_url.clone(),
+            cache: cache.clone(),
+            http: http.clone(),
+            intents: serenity::GatewayIntents::DIRECT_MESSAGES
+                | serenity::GatewayIntents::MESSAGE_CONTENT,
+            presence: None,
+        });
+    let shard = serenity::gateway::Shard::new(
+        ws_url,
+        "test-token",
+        serenity::model::gateway::ShardInfo {
+            id: serenity::ShardId(0),
+            total: 1,
+        },
+        serenity::GatewayIntents::DIRECT_MESSAGES | serenity::GatewayIntents::MESSAGE_CONTENT,
+        None,
+    )
+    .await
+    .expect("test shard");
+    let runner = serenity::gateway::ShardRunner::new(serenity::gateway::ShardRunnerOptions {
+        data: data.clone(),
+        event_handlers: vec![],
+        raw_event_handlers: vec![],
+        framework: Some(Arc::new(NoopFramework)),
+        manager,
+        shard,
+        voice_manager: None,
+        cache: cache.clone(),
+        http: http.clone(),
+    });
+
+    serenity::Context {
+        data,
+        shard: serenity::ShardMessenger::new(&runner),
+        shard_id: serenity::ShardId(0),
+        http,
+        cache,
+    }
+}
+
+fn test_message(id: u64, text: &str) -> serenity::Message {
+    let mut message = serenity::Message::default();
+    message.id = MessageId::new(id);
+    message.channel_id = ChannelId::new(CHANNEL_ID);
+    message.author.id = UserId::new(USER_ID);
+    message.author.name = "queue-user".to_string();
+    message.content = text.to_string();
+    message.timestamp = message.id.created_at();
+    message
+}
+
+fn test_watcher_handle(
+    tmux_session_name: &str,
+    output_path: &std::path::Path,
+) -> super::super::TmuxWatcherHandle {
+    super::super::TmuxWatcherHandle {
+        tmux_session_name: tmux_session_name.to_string(),
+        output_path: output_path.display().to_string(),
+        paused: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        resume_offset: Arc::new(std::sync::Mutex::new(None)),
+        cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        pause_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        turn_delivered: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        last_heartbeat_ts_ms: Arc::new(std::sync::atomic::AtomicI64::new(
+            super::super::tmux_watcher_now_ms(),
+        )),
+    }
+}
+
+struct AbortOnDrop<T>(Option<tokio::task::JoinHandle<T>>);
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        if let Some(task) = self.0.take() {
+            task.abort();
+        }
+    }
+}
+
+async fn wait_until(
+    timeout: std::time::Duration,
+    mut predicate: impl FnMut() -> BoxFuture<'static, bool>,
+) -> bool {
+    tokio::time::timeout(timeout, async {
+        loop {
+            if predicate().await {
+                return;
+            }
+            tokio::task::yield_now().await;
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .is_ok()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn local_model_observation_wakes_idle_durable_queue_through_production_workers() {
+    let env_lock = crate::config::shared_test_env_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    let root = tempfile::tempdir().expect("isolated AgentDesk root");
+    let _root_guard = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+        "AGENTDESK_ROOT_DIR",
+        root.path(),
+    );
+    let _intake_mode_guard = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+        "ADK_INTAKE_ROUTING_MODE",
+        std::path::Path::new("disabled"),
+    );
+    let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+
+    let state = DiscordMockState::new();
+    let (proxy, gateway_url, server) = start_mock_discord(state.clone()).await;
+    let _server_guard = AbortOnDrop(Some(server));
+    let ctx = serenity_context(proxy, gateway_url).await;
+    let shared = super::super::make_shared_data_for_tests();
+    {
+        let mut settings = shared.settings.write().await;
+        settings.owner_user_id = Some(USER_ID);
+        settings.allow_all_users = true;
+    }
+    let voice_config = crate::voice::VoiceConfig::default();
+    let data = Data {
+        shared: shared.clone(),
+        token: "test-token".to_string(),
+        provider: ProviderKind::Claude,
+        voice_receiver: crate::voice::VoiceReceiver::from_voice_config(&voice_config),
+        voice_config,
+    };
+    let channel_id = ChannelId::new(CHANNEL_ID);
+    let cwd = root.path().to_str().expect("utf8 test root");
+    super::super::rebind_channel_session(
+        &shared,
+        &ProviderKind::Claude,
+        channel_id,
+        cwd,
+        "48740000-0000-0000-0000-000000000001",
+    )
+    .await;
+
+    let a_event = serenity::FullEvent::Message {
+        new_message: test_message(A_MESSAGE_ID, "A holds the active mailbox"),
+    };
+    let mut a_task = tokio::spawn({
+        let ctx = ctx.clone();
+        let data = Data {
+            shared: data.shared.clone(),
+            token: data.token.clone(),
+            provider: data.provider.clone(),
+            voice_config: data.voice_config.clone(),
+            voice_receiver: data.voice_receiver.clone(),
+        };
+        async move { super::super::router::handle_event(&ctx, &a_event, &data).await }
+    });
+    tokio::select! {
+        _ = state.first_placeholder_arrived.notified() => {}
+        result = &mut a_task => {
+            let snapshot = mailbox_snapshot(&shared, channel_id).await;
+            let checkpoint = shared.last_message_ids.get(&channel_id).map(|entry| *entry);
+            panic!(
+                "A exited before the placeholder POST: {result:?}; current_bot={}; active={:?}; queue_len={}; checkpoint={checkpoint:?}",
+                ctx.cache.current_user().id,
+                snapshot.active_user_message_id,
+                snapshot.intervention_queue.len()
+            )
+        }
+        _ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {
+            panic!("A did not reach the real placeholder POST")
+        }
+    }
+    let _a_guard = AbortOnDrop(Some(a_task));
+
+    let active_a = mailbox_snapshot(&shared, channel_id).await;
+    assert_eq!(
+        active_a.active_user_message_id,
+        Some(MessageId::new(A_MESSAGE_ID))
+    );
+
+    let b_event = serenity::FullEvent::Message {
+        new_message: test_message(B_MESSAGE_ID, "B must survive as durable pending intake"),
+    };
+    super::super::router::handle_event(&ctx, &b_event, &data)
+        .await
+        .expect("B traverses FullEvent intake");
+    let queued_b = mailbox_snapshot(&shared, channel_id).await;
+    assert_eq!(
+        queued_b.active_user_message_id,
+        Some(MessageId::new(A_MESSAGE_ID))
+    );
+    assert_eq!(queued_b.intervention_queue.len(), 1);
+    assert_eq!(
+        queued_b.intervention_queue[0].message_id,
+        MessageId::new(B_MESSAGE_ID)
+    );
+    let (durable_b, _) = crate::services::turn_orchestrator::load_channel_pending_queue_for_tests(
+        &ProviderKind::Claude,
+        &shared.token_hash,
+        channel_id,
+    );
+    assert_eq!(
+        durable_b.len(),
+        1,
+        "B must be durably persisted by BusyActiveTurn"
+    );
+    assert_eq!(durable_b[0].message_id, MessageId::new(B_MESSAGE_ID));
+
+    state.release_first_placeholder.notify_waiters();
+    assert!(
+        wait_until(std::time::Duration::from_secs(1), {
+            let shared = shared.clone();
+            move || {
+                let shared = shared.clone();
+                Box::pin(async move {
+                    let snapshot = mailbox_snapshot(&shared, ChannelId::new(CHANNEL_ID)).await;
+                    snapshot.active_user_message_id.is_none()
+                        && snapshot.intervention_queue.len() == 1
+                        && shared
+                            .restart
+                            .deferred_hook_channels
+                            .contains_key(&ChannelId::new(CHANNEL_ID))
+                })
+            }
+        })
+        .await,
+        "production placeholder-failure recovery must leave idle durable B behind an armed normal worker"
+    );
+
+    let before_model = mailbox_snapshot(&shared, channel_id).await;
+    assert!(before_model.active_user_message_id.is_none());
+    assert_eq!(
+        before_model.intervention_queue[0].message_id,
+        MessageId::new(B_MESSAGE_ID)
+    );
+
+    shared
+        .http
+        .cached_serenity_ctx
+        .set(ctx.clone())
+        .expect("cache test Serenity context");
+    shared
+        .http
+        .cached_bot_token
+        .set("test-token".to_string())
+        .expect("cache test bot token");
+    let transcript_path = root.path().join("claude-queue-wake.jsonl");
+    std::fs::write(&transcript_path, "").expect("write watcher transcript");
+    let tmux = "AgentDesk-claude-4874-local-model-wake";
+    shared
+        .tmux_watchers
+        .insert(channel_id, test_watcher_handle(tmux, &transcript_path));
+    super::spawn_tui_prompt_relay(shared.clone(), ProviderKind::Claude);
+
+    let mut completion_rx =
+        super::super::turn_completion_events::subscribe_turn_completion_events(&shared);
+    let command_half = "<command-message>x</command-message>\n<command-name>/model</command-name>";
+    let stdout_half = "<local-command-stdout>Set model to Fable 5</local-command-stdout>";
+    assert_eq!(
+        crate::services::tui_prompt_dedupe::observe_prompt_by_provider_session(
+            "claude",
+            tmux,
+            command_half,
+        ),
+        crate::services::tui_prompt_dedupe::PromptObservation::PublishedSshDirect
+    );
+    assert_eq!(
+        crate::services::tui_prompt_dedupe::observe_prompt_by_provider_session(
+            "claude",
+            tmux,
+            stdout_half,
+        ),
+        crate::services::tui_prompt_dedupe::PromptObservation::PublishedSshDirect
+    );
+
+    tokio::time::timeout(
+        std::time::Duration::from_millis(1500),
+        state.second_placeholder_arrived.notified(),
+    )
+    .await
+    .expect("local /model must wake the occupied two-second deferred worker");
+
+    let promoted_b = mailbox_snapshot(&shared, channel_id).await;
+    assert_eq!(
+        promoted_b.active_user_message_id,
+        Some(MessageId::new(B_MESSAGE_ID))
+    );
+    assert!(promoted_b.intervention_queue.is_empty());
+    let (durable_after, _) =
+        crate::services::turn_orchestrator::load_channel_pending_queue_for_tests(
+            &ProviderKind::Claude,
+            &shared.token_hash,
+            channel_id,
+        );
+    assert!(
+        durable_after.is_empty(),
+        "production kickoff must durably dequeue B"
+    );
+    assert_eq!(state.placeholder_posts.load(Ordering::SeqCst), 2);
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert_eq!(
+        state.placeholder_posts.load(Ordering::SeqCst),
+        2,
+        "coalesced two-half wake must not dispatch B twice"
+    );
+    assert_eq!(state.local_note_posts.load(Ordering::SeqCst), 2);
+
+    assert!(
+        !crate::services::tui_prompt_dedupe::external_input_relay_lease_present(
+            "claude", tmux, CHANNEL_ID,
+        )
+    );
+    assert!(
+        !crate::services::tui_prompt_dedupe::is_ssh_direct_observation_pending("claude", tmux,)
+    );
+    assert_eq!(
+        crate::services::tui_prompt_dedupe::prompt_anchor_for_response("claude", tmux, CHANNEL_ID,),
+        None,
+    );
+    let inflight =
+        super::super::inflight::load_inflight_state_read_only(&ProviderKind::Claude, CHANNEL_ID);
+    assert!(
+        !super::tui_direct_watcher_synthetic_inflight_matches(inflight.as_ref(), tmux, 1),
+        "local-only halves must not create synthetic inflight ownership"
+    );
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(100), completion_rx.recv())
+            .await
+            .is_err(),
+        "local-only halves must not publish completion events"
+    );
+
+    drop(_dedupe_guard);
+    drop(_intake_mode_guard);
+    drop(_root_guard);
+    drop(env_lock);
+}

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -484,6 +484,15 @@ pub(crate) struct HydratePendingQueueResult {
     pub(crate) persistence_error: Option<String>,
 }
 
+#[cfg(test)]
+pub(crate) fn load_channel_pending_queue_for_tests(
+    provider: &ProviderKind,
+    token_hash: &str,
+    channel_id: ChannelId,
+) -> (Vec<Intervention>, Option<ChannelId>) {
+    load_channel_pending_queue(provider, token_hash, channel_id)
+}
+
 #[derive(Debug)]
 pub(crate) struct DispatchLease;
 

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -75,6 +75,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres",
     "python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres",
     "env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres",
+    "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tui_prompt_relay::local_model_queue_wake_e2e -- --skip _pg --skip pg_ --skip postgres --test-threads=1",
     "cargo test --lib services::discord::model_catalog -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib services::discord::commands::model_ui::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib services::discord::runtime_bootstrap::shutdown::lifecycle_tests -- --skip _pg --skip pg_ --skip postgres",


### PR DESCRIPTION
## Summary
- request an immediate coalesced idle-queue wake for local-only model controls
- consume stored wake notifications in occupied deferred workers
- subscribe to observed prompts before relay task startup
- add production-path `/model` queue wake E2E coverage

## Validation
- production E2E repeated 3+ times
- mutation proofs for wake edge and Notify consumption
- `cargo check --lib`
- `cargo fmt --all --check`
- inventory/docs freshness gates
- cross-family dual review: GPT Sol CLEAN + Claude Opus CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)