### PR TITLE
fix(#4946): defer relay gap issues while dcserver is unreachable

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -133,6 +133,11 @@ LAST_PENDING_TRANSCRIPT_RETIREMENT_ALERT_KEY = (
 GAP_TRANSCRIPT_KEY = "gap_transcript"
 GAP_OWNER_TRANSCRIPTS_KEY = "gap_owner_transcripts"
 RECOVERED_GAP_GUARDS_KEY = "recovered_gap_replay_guards"
+ISSUE_FILING_SUPPRESSION_REASON_KEY = "issue_filing_suppression_reason"
+ISSUE_FILING_SUPPRESSION_SINCE_KEY = "issue_filing_suppression_since"
+ISSUE_FILING_REACHABLE_TICKS_KEY = "issue_filing_reachable_ticks"
+ISSUE_FILING_REACHABLE_TICKS_REQUIRED = 2
+ISSUE_FILING_DC_UNREACHABLE_REASON = "dcserver_transport_unreachable"
 MAX_TRANSCRIPT_HISTORY = 64
 MAX_KNOWN_TRANSCRIPTS = 256
 MAX_PENDING_TRANSCRIPTS = 32
@@ -1470,6 +1475,7 @@ class WatcherStateProbe:
     # Local-time bridge heartbeat copied from the watcher-state snapshot. Missing
     # or malformed values remain None so coverage corroboration fails closed.
     inflight_updated_at: float | None = None
+    response_malformed: bool = False
 
 
 def canonical_session_uuid(value: object) -> str | None:
@@ -1490,7 +1496,7 @@ def parse_watcher_state_probe(
     if status != 200:
         return WatcherStateProbe(status)
     if not isinstance(payload, Mapping):
-        return WatcherStateProbe(200)
+        return WatcherStateProbe(200, response_malformed=True)
 
     attached_raw = payload.get("attached")
     desynced_raw = payload.get("desynced")
@@ -1498,6 +1504,9 @@ def parse_watcher_state_probe(
     bound_session_id_raw = payload.get("bound_session_id")
     attached = attached_raw if isinstance(attached_raw, bool) else None
     desynced = desynced_raw if isinstance(desynced_raw, bool) else None
+    response_malformed = not isinstance(attached_raw, bool) or not isinstance(
+        desynced_raw, bool
+    )
     bound = bound_output_path if isinstance(bound_output_path, str) else None
     bound_session_id = canonical_session_uuid(bound_session_id_raw)
     inflight_updated_at = parse_local_timestamp(payload.get("inflight_updated_at"))
@@ -1513,6 +1522,7 @@ def parse_watcher_state_probe(
             bound,
             bound_session_id=bound_session_id,
             inflight_updated_at=inflight_updated_at,
+            response_malformed=response_malformed,
         )
 
     malformed = False
@@ -1538,6 +1548,7 @@ def parse_watcher_state_probe(
             ),
             bound_session_id,
             inflight_updated_at,
+            True,
         )
 
     def string_field(key: str) -> tuple[str | None, bool]:
@@ -1622,6 +1633,7 @@ def parse_watcher_state_probe(
         ),
         bound_session_id,
         inflight_updated_at,
+        response_malformed or malformed,
     )
 
 
@@ -2257,7 +2269,7 @@ class Runtime:
         try:
             payload = json.loads(body)
         except json.JSONDecodeError:
-            return WatcherStateProbe(200)
+            return WatcherStateProbe(200, response_malformed=True)
         return parse_watcher_state_probe(200, payload)
 
     def discord_haystack(self, channel_id: str) -> str | None:
@@ -3037,6 +3049,58 @@ def _alert_pending_retirement(
     return True
 
 
+def _reset_issue_filing_suppression(channel_state: dict[str, Any]) -> None:
+    channel_state.pop(ISSUE_FILING_SUPPRESSION_REASON_KEY, None)
+    channel_state.pop(ISSUE_FILING_SUPPRESSION_SINCE_KEY, None)
+    channel_state.pop(ISSUE_FILING_REACHABLE_TICKS_KEY, None)
+
+
+def _issue_filing_stable(
+    channel_state: dict[str, Any], probe: WatcherStateProbe, now: float
+) -> bool:
+    """Defer filing only for transport-level dcserver unreachability."""
+    suppression_active = (
+        channel_state.get(ISSUE_FILING_SUPPRESSION_REASON_KEY)
+        == ISSUE_FILING_DC_UNREACHABLE_REASON
+        and _is_finite_nonnegative_number(
+            channel_state.get(ISSUE_FILING_SUPPRESSION_SINCE_KEY)
+        )
+    )
+    if not suppression_active:
+        _reset_issue_filing_suppression(channel_state)
+
+    if probe.status is None:
+        if not suppression_active:
+            channel_state[ISSUE_FILING_SUPPRESSION_REASON_KEY] = (
+                ISSUE_FILING_DC_UNREACHABLE_REASON
+            )
+            channel_state[ISSUE_FILING_SUPPRESSION_SINCE_KEY] = now
+        channel_state[ISSUE_FILING_REACHABLE_TICKS_KEY] = 0
+        return False
+
+    if probe.status in (200, 404) and not probe.response_malformed:
+        if not suppression_active:
+            return True
+        raw_ticks = channel_state.get(ISSUE_FILING_REACHABLE_TICKS_KEY, 0)
+        ticks = (
+            raw_ticks
+            if isinstance(raw_ticks, int)
+            and not isinstance(raw_ticks, bool)
+            and raw_ticks >= 0
+            else 0
+        )
+        ticks += 1
+        channel_state[ISSUE_FILING_REACHABLE_TICKS_KEY] = ticks
+        if ticks < ISSUE_FILING_REACHABLE_TICKS_REQUIRED:
+            return False
+        _reset_issue_filing_suppression(channel_state)
+        return True
+
+    if suppression_active:
+        channel_state[ISSUE_FILING_REACHABLE_TICKS_KEY] = 0
+    return True
+
+
 def _clear_gap_alert_without_recovery(
     rt: Runtime,
     channel_state: dict[str, Any],
@@ -3084,6 +3148,7 @@ def _clear_gap_alert_without_recovery(
     channel_state.pop("alerting", None)
     channel_state.pop("gap_since", None)
     channel_state.pop("issue_url", None)
+    _reset_issue_filing_suppression(channel_state)
     channel_state.pop(GAP_TRANSCRIPT_KEY, None)
     channel_state.pop(GAP_OWNER_TRANSCRIPTS_KEY, None)
     return True
@@ -3924,6 +3989,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             chs.pop("alerting", None)
             chs.pop("gap_since", None)
             chs.pop("issue_url", None)
+            _reset_issue_filing_suppression(chs)
             chs.pop(GAP_TRANSCRIPT_KEY, None)
             chs.pop(GAP_OWNER_TRANSCRIPTS_KEY, None)
         rt.log(
@@ -3946,17 +4012,25 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 f"(marker < {cfg.deploy_quiet_secs}s old)"
             )
             return
+        issue_filing_stable = _issue_filing_stable(chs, selected_probe, now)
         gap_min = int(v.gap_secs // 60) if v.delivered_ts else 999
         if not chs.get("gap_since"):
             chs["gap_since"] = now
-        if (
-            cfg.github_repo
+        issue_due = (
+            bool(cfg.github_repo)
             and not chs.get("issue_url")
             and now - float(chs["gap_since"]) >= cfg.issue_after_secs
-        ):
+        )
+        if issue_due and issue_filing_stable:
             url = rt.file_github_issue(ch, gap_min, v.lost)
             if url:
                 chs["issue_url"] = url
+        elif issue_due:
+            rt.log(
+                f"[{cid}] issue filing deferred "
+                f"reason={chs.get(ISSUE_FILING_SUPPRESSION_REASON_KEY)} "
+                f"reachable_ticks={chs.get(ISSUE_FILING_REACHABLE_TICKS_KEY, 0)}"
+            )
         if now - float(chs.get("last_alert", 0)) >= cfg.realert_secs:
             issue_line = (
                 f"\n자동 등록 이슈: {chs['issue_url']}" if chs.get("issue_url") else ""
@@ -4006,6 +4080,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         chs.pop("alerting", None)
         chs.pop("gap_since", None)
         chs.pop("issue_url", None)
+        _reset_issue_filing_suppression(chs)
         chs.pop(GAP_TRANSCRIPT_KEY, None)
         chs.pop(GAP_OWNER_TRANSCRIPTS_KEY, None)
         rt.log(

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -3098,6 +3098,7 @@ def _issue_filing_stable(
 
     if suppression_active:
         channel_state[ISSUE_FILING_REACHABLE_TICKS_KEY] = 0
+        return False
     return True
 
 
@@ -3820,7 +3821,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         ),
         None,
     )
-    selected_probe = rt.watcher_state(cid) if selected_path else WatcherStateProbe(None)
+    selected_probe = rt.watcher_state(cid)
     selected_session_id = (
         canonical_session_uuid(selected.path.stem) if selected is not None else None
     )

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -1360,7 +1360,10 @@ class WatcherStateParserTests(unittest.TestCase):
         self.assertTrue(verdict.confirmed)
 
     def test_non_mapping_and_non_200_never_invent_activity(self):
-        self.assertEqual(parse_watcher_state_probe(200, []), WatcherStateProbe(200))
+        self.assertEqual(
+            parse_watcher_state_probe(200, []),
+            WatcherStateProbe(200, response_malformed=True),
+        )
         self.assertEqual(
             parse_watcher_state_probe(404, self.payload()), WatcherStateProbe(404)
         )
@@ -2151,7 +2154,9 @@ class RuntimeCoverageProbeTests(unittest.TestCase):
         )
         with mock.patch.object(relay_watchdog.subprocess, "run", return_value=completed):
             probe = self.make_rt().watcher_state("999")
-        self.assertEqual(probe, WatcherStateProbe(200, None, None))
+        self.assertEqual(
+            probe, WatcherStateProbe(200, None, None, response_malformed=True)
+        )
 
     def test_direct_node_snapshot_does_not_report_tunnel_closed(self):
         calls: list[list[str]] = []
@@ -6098,6 +6103,7 @@ class TickChannelTests(unittest.TestCase):
     # (d) persistent-gap issue auto-filing is deduplicated
     def test_persistent_gap_files_issue_exactly_once(self):
         rt = self.gap_rt(github_repo="owner/repo")
+        rt.watcher_probe = WatcherStateProbe(200, True, False)
         state = {"999": {"gap_since": self.now - rt.cfg.issue_after_secs - 1}}
         tick_channel(rt, TICK_CHANNEL, state, self.now)
         self.assertEqual(rt.issue_calls, 1)
@@ -6113,6 +6119,218 @@ class TickChannelTests(unittest.TestCase):
         state = {"999": {"gap_since": self.now - rt.cfg.issue_after_secs - 1}}
         tick_channel(rt, TICK_CHANNEL, state, self.now)
         self.assertEqual(rt.issue_calls, 0)
+
+    def test_unreachable_gap_defers_issue_but_preserves_alert_and_evidence(self):
+        rt = self.gap_rt(github_repo="owner/repo")
+        rt.watcher_probe = WatcherStateProbe(None)
+        incident_age = rt.cfg.issue_after_secs + 60
+        transcript = self.proj_dir / "s.jsonl"
+        recovered_guard = {
+            "size": transcript.stat().st_size,
+            "confirmed_at": self.now - 120,
+            "last_seen_at": self.now - 60,
+            "absent_since": None,
+        }
+        state = {
+            "999": {
+                "gap_since": self.now - incident_age,
+                relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY: [str(transcript)],
+                relay_watchdog.RECOVERED_GAP_GUARDS_KEY: {
+                    str(transcript): recovered_guard
+                },
+            }
+        }
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        chs = state["999"]
+        self.assertEqual(rt.issue_calls, 0)
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("릴레이 갭 감지", rt.alerts[0][0])
+        self.assertEqual(chs["gap_since"], self.now - incident_age)
+        self.assertEqual(
+            chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY],
+            [str(self.proj_dir / "s.jsonl")],
+        )
+        self.assertEqual(
+            chs[relay_watchdog.RECOVERED_GAP_GUARDS_KEY][str(transcript)][
+                "confirmed_at"
+            ],
+            recovered_guard["confirmed_at"],
+        )
+        self.assertTrue(chs.get("alerting"))
+        self.assertEqual(
+            chs[relay_watchdog.ISSUE_FILING_SUPPRESSION_REASON_KEY],
+            relay_watchdog.ISSUE_FILING_DC_UNREACHABLE_REASON,
+        )
+        self.assertEqual(
+            chs[relay_watchdog.ISSUE_FILING_SUPPRESSION_SINCE_KEY], self.now
+        )
+        self.assertEqual(chs[relay_watchdog.ISSUE_FILING_REACHABLE_TICKS_KEY], 0)
+
+    def test_repeated_unreachable_ticks_preserve_incident_clock(self):
+        rt = self.gap_rt(github_repo="owner/repo", realert_secs=1)
+        rt.watcher_probe = WatcherStateProbe(None)
+        original_gap_since = self.now - rt.cfg.issue_after_secs - 600
+        state = {"999": {"gap_since": original_gap_since}}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        chs = state["999"]
+        self.assertEqual(rt.issue_calls, 0)
+        self.assertEqual(len(rt.alerts), 2)
+        self.assertEqual(chs["gap_since"], original_gap_since)
+        self.assertEqual(
+            chs[relay_watchdog.ISSUE_FILING_SUPPRESSION_SINCE_KEY], self.now
+        )
+        self.assertEqual(chs[relay_watchdog.ISSUE_FILING_REACHABLE_TICKS_KEY], 0)
+
+    def test_two_reachable_ticks_resume_old_incident_exactly_once(self):
+        rt = self.gap_rt(github_repo="owner/repo")
+        rt.watcher_probe = WatcherStateProbe(None)
+        original_gap_since = self.now - rt.cfg.issue_after_secs - 300
+        state = {"999": {"gap_since": original_gap_since}}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        rt.watcher_probe = WatcherStateProbe(200, True, False)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        self.assertEqual(rt.issue_calls, 0)
+        self.assertEqual(
+            state["999"][relay_watchdog.ISSUE_FILING_REACHABLE_TICKS_KEY], 1
+        )
+        self.assertEqual(state["999"]["gap_since"], original_gap_since)
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        self.assertEqual(rt.issue_calls, 1)
+        self.assertEqual(
+            state["999"]["issue_url"], "https://example.test/issues/1"
+        )
+        self.assertEqual(state["999"]["gap_since"], original_gap_since)
+        self.assertNotIn(
+            relay_watchdog.ISSUE_FILING_SUPPRESSION_REASON_KEY, state["999"]
+        )
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+        self.assertEqual(rt.issue_calls, 1)
+
+    def test_reachable_flap_resets_two_tick_counter(self):
+        rt = self.gap_rt(github_repo="owner/repo")
+        state = {
+            "999": {
+                "gap_since": self.now - rt.cfg.issue_after_secs - 1,
+                relay_watchdog.ISSUE_FILING_SUPPRESSION_REASON_KEY: (
+                    relay_watchdog.ISSUE_FILING_DC_UNREACHABLE_REASON
+                ),
+                relay_watchdog.ISSUE_FILING_SUPPRESSION_SINCE_KEY: self.now - 10,
+                relay_watchdog.ISSUE_FILING_REACHABLE_TICKS_KEY: 0,
+            }
+        }
+
+        rt.watcher_probe = WatcherStateProbe(200, True, False)
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        rt.watcher_probe = WatcherStateProbe(None)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        rt.watcher_probe = WatcherStateProbe(404)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        self.assertEqual(rt.issue_calls, 0)
+        self.assertEqual(
+            state["999"][relay_watchdog.ISSUE_FILING_REACHABLE_TICKS_KEY], 1
+        )
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+        self.assertEqual(rt.issue_calls, 1)
+
+    def test_404_counts_as_reachable_for_issue_resume(self):
+        rt = self.gap_rt(github_repo="owner/repo")
+        state = {
+            "999": {
+                "gap_since": self.now - rt.cfg.issue_after_secs - 1,
+                relay_watchdog.ISSUE_FILING_SUPPRESSION_REASON_KEY: (
+                    relay_watchdog.ISSUE_FILING_DC_UNREACHABLE_REASON
+                ),
+                relay_watchdog.ISSUE_FILING_SUPPRESSION_SINCE_KEY: self.now - 10,
+                relay_watchdog.ISSUE_FILING_REACHABLE_TICKS_KEY: 0,
+            }
+        }
+        rt.watcher_probe = WatcherStateProbe(404)
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+
+        self.assertEqual(rt.issue_calls, 1)
+
+    def test_5xx_and_malformed_200_are_not_unreachable_suppression_authority(self):
+        probes = (
+            WatcherStateProbe(503),
+            parse_watcher_state_probe(200, {"attached": "malformed"}),
+        )
+        for probe in probes:
+            with self.subTest(probe=probe):
+                rt = self.gap_rt(github_repo="owner/repo")
+                rt.watcher_probe = probe
+                state = {
+                    "999": {
+                        "gap_since": self.now - rt.cfg.issue_after_secs - 1
+                    }
+                }
+
+                tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+                self.assertEqual(rt.issue_calls, 1)
+                self.assertNotIn(
+                    relay_watchdog.ISSUE_FILING_SUPPRESSION_REASON_KEY,
+                    state["999"],
+                )
+
+    def test_bad_responses_reset_reachable_counter(self):
+        probes = (
+            WatcherStateProbe(503),
+            parse_watcher_state_probe(200, {"attached": "malformed"}),
+        )
+        for probe in probes:
+            with self.subTest(probe=probe):
+                rt = self.gap_rt(github_repo="owner/repo")
+                rt.watcher_probe = probe
+                original_since = self.now - 10
+                state = {
+                    "999": {
+                        "gap_since": self.now - rt.cfg.issue_after_secs + 100,
+                        relay_watchdog.ISSUE_FILING_SUPPRESSION_REASON_KEY: (
+                            relay_watchdog.ISSUE_FILING_DC_UNREACHABLE_REASON
+                        ),
+                        relay_watchdog.ISSUE_FILING_SUPPRESSION_SINCE_KEY: original_since,
+                        relay_watchdog.ISSUE_FILING_REACHABLE_TICKS_KEY: 1,
+                    }
+                }
+
+                tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+                self.assertEqual(rt.issue_calls, 0)
+                self.assertEqual(
+                    state["999"][relay_watchdog.ISSUE_FILING_REACHABLE_TICKS_KEY],
+                    0,
+                )
+                self.assertEqual(
+                    state["999"][relay_watchdog.ISSUE_FILING_SUPPRESSION_SINCE_KEY],
+                    original_since,
+                )
+
+    def test_planned_deploy_still_returns_before_gap_incident_state(self):
+        rt = self.gap_rt(github_repo="owner/repo")
+        rt.watcher_probe = WatcherStateProbe(None)
+        rt.deploy_marker.touch()
+        state: dict = {}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        chs = state["999"]
+        self.assertEqual(rt.alerts, [])
+        self.assertEqual(rt.issue_calls, 0)
+        self.assertNotIn("gap_since", chs)
+        self.assertNotIn(
+            relay_watchdog.ISSUE_FILING_SUPPRESSION_REASON_KEY, chs
+        )
 
     # (e) consecutive discord-read failures escalate to an alert
     def test_read_failure_threshold_escalates(self):

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -6260,6 +6260,40 @@ class TickChannelTests(unittest.TestCase):
 
         self.assertEqual(rt.issue_calls, 1)
 
+    def test_gap_owner_without_selected_transcript_still_probes_recovery(self):
+        rt = self.gap_rt(github_repo="owner/repo")
+        transcript = self.proj_dir / "s.jsonl"
+        original_gap_since = self.now - rt.cfg.issue_after_secs - 60
+        state = {
+            "999": {
+                "gap_since": original_gap_since,
+                relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY: [str(transcript)],
+                relay_watchdog.ISSUE_FILING_SUPPRESSION_REASON_KEY: (
+                    relay_watchdog.ISSUE_FILING_DC_UNREACHABLE_REASON
+                ),
+                relay_watchdog.ISSUE_FILING_SUPPRESSION_SINCE_KEY: self.now - 10,
+                relay_watchdog.ISSUE_FILING_REACHABLE_TICKS_KEY: 0,
+            }
+        }
+        rt.watcher_probe = WatcherStateProbe(200, True, False)
+
+        with mock.patch.object(
+            relay_watchdog,
+            "select_watch_transcript_with_reason",
+            return_value=(None, "no_candidates"),
+        ):
+            tick_channel(rt, TICK_CHANNEL, state, self.now)
+            self.assertEqual(rt.issue_calls, 0)
+            self.assertEqual(
+                state["999"][relay_watchdog.ISSUE_FILING_REACHABLE_TICKS_KEY], 1
+            )
+            tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+            tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        self.assertGreaterEqual(rt.watcher_calls, 2)
+        self.assertEqual(rt.issue_calls, 1)
+        self.assertEqual(state["999"]["gap_since"], original_gap_since)
+
     def test_5xx_and_malformed_200_are_not_unreachable_suppression_authority(self):
         probes = (
             WatcherStateProbe(503),
@@ -6283,7 +6317,7 @@ class TickChannelTests(unittest.TestCase):
                     state["999"],
                 )
 
-    def test_bad_responses_reset_reachable_counter(self):
+    def test_bad_responses_keep_aged_incident_suppressed_until_two_healthy_ticks(self):
         probes = (
             WatcherStateProbe(503),
             parse_watcher_state_probe(200, {"attached": "malformed"}),
@@ -6291,30 +6325,30 @@ class TickChannelTests(unittest.TestCase):
         for probe in probes:
             with self.subTest(probe=probe):
                 rt = self.gap_rt(github_repo="owner/repo")
-                rt.watcher_probe = probe
-                original_since = self.now - 10
-                state = {
-                    "999": {
-                        "gap_since": self.now - rt.cfg.issue_after_secs + 100,
-                        relay_watchdog.ISSUE_FILING_SUPPRESSION_REASON_KEY: (
-                            relay_watchdog.ISSUE_FILING_DC_UNREACHABLE_REASON
-                        ),
-                        relay_watchdog.ISSUE_FILING_SUPPRESSION_SINCE_KEY: original_since,
-                        relay_watchdog.ISSUE_FILING_REACHABLE_TICKS_KEY: 1,
-                    }
-                }
+                original_gap_since = self.now - rt.cfg.issue_after_secs - 100
+                state = {"999": {"gap_since": original_gap_since}}
 
+                rt.watcher_probe = WatcherStateProbe(None)
                 tick_channel(rt, TICK_CHANNEL, state, self.now)
+                rt.watcher_probe = WatcherStateProbe(200, True, False)
+                tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+                rt.watcher_probe = probe
+                tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
 
                 self.assertEqual(rt.issue_calls, 0)
                 self.assertEqual(
                     state["999"][relay_watchdog.ISSUE_FILING_REACHABLE_TICKS_KEY],
                     0,
                 )
-                self.assertEqual(
-                    state["999"][relay_watchdog.ISSUE_FILING_SUPPRESSION_SINCE_KEY],
-                    original_since,
-                )
+                self.assertEqual(state["999"]["gap_since"], original_gap_since)
+
+                rt.watcher_probe = WatcherStateProbe(200, True, False)
+                tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+                self.assertEqual(rt.issue_calls, 0)
+                tick_channel(rt, TICK_CHANNEL, state, self.now + 4)
+                self.assertEqual(rt.issue_calls, 1)
+                tick_channel(rt, TICK_CHANNEL, state, self.now + 5)
+                self.assertEqual(rt.issue_calls, 1)
 
     def test_planned_deploy_still_returns_before_gap_incident_state(self):
         rt = self.gap_rt(github_repo="owner/repo")


### PR DESCRIPTION
## Summary
- defer only GitHub gap issue filing while the dcserver watcher endpoint is transport-unreachable
- preserve gap evidence and out-of-band alerts
- require two consecutive healthy 200/404 probes before filing resumes
- distinguish no-selected-transcript from real transport failure

## Verification
- watchdog suite: 252 passed
- watchdog + PostgreSQL CI lane: 301 passed
- Python portability/policy: 10 passed
- 8 initial contract tests plus 3 repaired-blocker regressions
- mutation proofs killed for transport narrowing, recovery hysteresis, gap-age/alert preservation, synthetic-none regression, and bad-response release
- GPT Sol exact-head review: CLEAN
- Claude Opus exact-head review: CLEAN

Related to #4946 (closed point-in-time artifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)