### PR TITLE
fix(auto-queue): align thread_group planner contract (#4878)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -379,7 +379,6 @@ src/
 │   │   ├── route_types.rs
 │   │   ├── runtime.rs
 │   │   ├── slot_routes.rs
-│   │   ├── thread_group_contract.rs
 │   │   ├── view.rs
 │   │   └── view_admin_routes.rs
 │   ├── automation_candidate_materializer/
@@ -1442,6 +1441,7 @@ src/
 ├── manual_intervention.rs
 ├── phase_gate.rs
 ├── pipeline.rs
+├── queue_contract.rs
 ├── receipt.rs
 └── reconcile.rs
 ```
@@ -1488,6 +1488,7 @@ This table is generated from the current `src/` root and fails CI when a new top
 | `src/manual_intervention.rs` | Manual intervention parsing and helpers shared by Discord reply/requeue flows. |
 | `src/phase_gate.rs` | Immutable typed phase-gate declarations and snapshot compatibility checks shared by HTTP, policy dispatch, and durable reducers. |
 | `src/pipeline.rs` | Pipeline stage loading, resolution, and transition helpers. |
+| `src/queue_contract.rs` | Queue field compatibility contracts shared by planner prompts, API documentation, and runtime-facing consumers. |
 | `src/receipt.rs` | Receipt parsing and workspace attribution helpers. |
 | `src/reconcile.rs` | Boot-time reconciliation for persisted state and dispatch-runtime drift. |
 <!-- END GENERATED: TOP LEVEL MODULE MAP -->

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -379,6 +379,7 @@ src/
 │   │   ├── route_types.rs
 │   │   ├── runtime.rs
 │   │   ├── slot_routes.rs
+│   │   ├── thread_group_contract.rs
 │   │   ├── view.rs
 │   │   └── view_admin_routes.rs
 │   ├── automation_candidate_materializer/

--- a/justfile
+++ b/justfile
@@ -28,6 +28,8 @@ test-active-usage-4631:
 # Stage 1 keeps the existing CI-safe subset. The broad non-PG sweep currently
 # fails legacy/full integration route tests; see docs/ci/rust-quality-gates.md.
 test-non-pg:
+    # #4878: keep the generated queue docs on the canonical thread-group contract.
+    cargo test --lib server::routes::docs::inventory::endpoints::part_0 -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib services::task_completion_v1::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib source_registry -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib task_notification -- --skip _pg --skip pg_ --skip postgres

--- a/scripts/generate_inventory_docs.py
+++ b/scripts/generate_inventory_docs.py
@@ -126,6 +126,7 @@ TOP_LEVEL_MODULE_PURPOSES = {
     "main.rs": "Binary entry point. Dispatches CLI commands or boots the server runtime.",
     "phase_gate.rs": "Immutable typed phase-gate declarations and snapshot compatibility checks shared by HTTP, policy dispatch, and durable reducers.",
     "pipeline.rs": "Pipeline stage loading, resolution, and transition helpers.",
+    "queue_contract.rs": "Queue field compatibility contracts shared by planner prompts, API documentation, and runtime-facing consumers.",
     "receipt.rs": "Receipt parsing and workspace attribution helpers.",
     "reconcile.rs": "Boot-time reconciliation for persisted state and dispatch-runtime drift.",
     "manual_intervention.rs": "Manual intervention parsing and helpers shared by Discord reply/requeue flows.",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,7 @@ pub(crate) mod manual_intervention;
 // compatibility across staged rollout paths.
 pub(crate) mod phase_gate;
 pub(crate) mod pipeline;
+pub(crate) mod queue_contract;
 pub(crate) mod receipt;
 // Reconciliation sweep jobs are invoked by maintenance scheduling, not by every
 // compile target.

--- a/src/queue_contract.rs
+++ b/src/queue_contract.rs
@@ -2,16 +2,3 @@
 /// field. Prompt and API documentation must reuse this sentence verbatim so
 /// callers cannot receive the runtime semantics in reverse.
 pub(crate) const THREAD_GROUP_SERIAL_LANE_CONTRACT: &str = "Within one `batch_phase`, entries with the same `thread_group` share a serial lane with at most one active entry; entries with different `thread_group` values may run in parallel up to available capacity, and dependency-related entries must share a serial lane or use separate `batch_phase` values.";
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn canonical_contract_states_runtime_direction_and_dependency_rule() {
-        assert_eq!(
-            THREAD_GROUP_SERIAL_LANE_CONTRACT,
-            "Within one `batch_phase`, entries with the same `thread_group` share a serial lane with at most one active entry; entries with different `thread_group` values may run in parallel up to available capacity, and dependency-related entries must share a serial lane or use separate `batch_phase` values."
-        );
-    }
-}

--- a/src/server/routes/docs/inventory/endpoints/part_06.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_06.rs
@@ -1,5 +1,7 @@
 use serde_json::json;
 
+use crate::services::auto_queue::thread_group_contract::THREAD_GROUP_SERIAL_LANE_CONTRACT;
+
 #[allow(unused_imports)]
 use super::super::{EndpointDoc, ParamDoc, body_param, ep, header_param, path_param, query_param};
 
@@ -759,6 +761,10 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
                 ),
             ),
             (
+                "entries[].thread_group",
+                body_param("integer", false, THREAD_GROUP_SERIAL_LANE_CONTRACT),
+            ),
+            (
                 "unified_thread",
                 body_param(
                     "boolean",
@@ -807,4 +813,23 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
         )
         .with_curl("curl -X POST http://localhost:8787/api/queue/generate -H 'Content-Type: application/json' -d '{\"repo\":\"test-repo\",\"issue_numbers\":[423,405]}'")
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn queue_generate_docs_use_canonical_thread_group_contract() {
+        let endpoint = endpoints()
+            .into_iter()
+            .find(|endpoint| endpoint.path == "/api/queue/generate")
+            .expect("queue generate endpoint");
+        let param = endpoint
+            .params
+            .get("entries[].thread_group")
+            .expect("entries[].thread_group parameter");
+
+        assert_eq!(param.description, THREAD_GROUP_SERIAL_LANE_CONTRACT);
+    }
 }

--- a/src/server/routes/docs/inventory/endpoints/part_06.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_06.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 
-use crate::services::auto_queue::thread_group_contract::THREAD_GROUP_SERIAL_LANE_CONTRACT;
+use crate::queue_contract::THREAD_GROUP_SERIAL_LANE_CONTRACT;
 
 #[allow(unused_imports)]
 use super::super::{EndpointDoc, ParamDoc, body_param, ep, header_param, path_param, query_param};

--- a/src/server/routes/docs/inventory/endpoints/part_08.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_08.rs
@@ -1,5 +1,7 @@
 use serde_json::json;
 
+use crate::services::auto_queue::thread_group_contract::THREAD_GROUP_SERIAL_LANE_CONTRACT;
+
 #[allow(unused_imports)]
 use super::super::{EndpointDoc, ParamDoc, body_param, ep, header_param, path_param, query_param};
 
@@ -672,7 +674,10 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
         .with_params([
             ("id", path_param("Auto-queue run id")),
             ("issue_number", body_param("integer", true, "GitHub issue number")),
-            ("thread_group", body_param("integer", false, "Optional thread-group override")),
+            (
+                "thread_group",
+                body_param("integer", false, THREAD_GROUP_SERIAL_LANE_CONTRACT),
+            ),
             ("batch_phase", body_param("integer", false, "Optional batch phase override")),
         ]),
         ep(
@@ -746,4 +751,23 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "Versioned operational health payload with bottleneck annotations.",
         )
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_run_entry_docs_use_canonical_thread_group_contract() {
+        let endpoint = endpoints()
+            .into_iter()
+            .find(|endpoint| endpoint.path == "/api/queue/runs/{id}/entries")
+            .expect("add run entry endpoint");
+        let param = endpoint
+            .params
+            .get("thread_group")
+            .expect("thread_group parameter");
+
+        assert_eq!(param.description, THREAD_GROUP_SERIAL_LANE_CONTRACT);
+    }
 }

--- a/src/server/routes/docs/inventory/endpoints/part_08.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_08.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 
-use crate::services::auto_queue::thread_group_contract::THREAD_GROUP_SERIAL_LANE_CONTRACT;
+use crate::queue_contract::THREAD_GROUP_SERIAL_LANE_CONTRACT;
 
 #[allow(unused_imports)]
 use super::super::{EndpointDoc, ParamDoc, body_param, ep, header_param, path_param, query_param};

--- a/src/services/auto_queue.rs
+++ b/src/services/auto_queue.rs
@@ -1,5 +1,6 @@
 pub(crate) mod cancel_run;
 pub(crate) mod route;
+pub(crate) mod thread_group_contract;
 pub mod runtime;
 
 use serde::Serialize;

--- a/src/services/auto_queue.rs
+++ b/src/services/auto_queue.rs
@@ -1,7 +1,7 @@
 pub(crate) mod cancel_run;
 pub(crate) mod route;
-pub(crate) mod thread_group_contract;
 pub mod runtime;
+pub(crate) mod thread_group_contract;
 
 use serde::Serialize;
 use serde_json::{Value, json};

--- a/src/services/auto_queue.rs
+++ b/src/services/auto_queue.rs
@@ -1,8 +1,6 @@
 pub(crate) mod cancel_run;
 pub(crate) mod route;
 pub mod runtime;
-pub(crate) mod thread_group_contract;
-
 use serde::Serialize;
 use serde_json::{Value, json};
 use sqlx::{PgPool, Row as SqlxRow};

--- a/src/services/auto_queue/route_request_generate.rs
+++ b/src/services/auto_queue/route_request_generate.rs
@@ -1,7 +1,7 @@
 use super::*;
 use serde::Deserialize;
 
-use crate::services::auto_queue::thread_group_contract::THREAD_GROUP_SERIAL_LANE_CONTRACT;
+use crate::queue_contract::THREAD_GROUP_SERIAL_LANE_CONTRACT;
 
 /// POST /api/queue/request-generate (#2126)
 ///
@@ -322,6 +322,10 @@ mod tests {
 
     #[test]
     fn instruction_uses_exact_thread_group_serial_lane_contract() {
+        assert_eq!(
+            THREAD_GROUP_SERIAL_LANE_CONTRACT,
+            "Within one `batch_phase`, entries with the same `thread_group` share a serial lane with at most one active entry; entries with different `thread_group` values may run in parallel up to available capacity, and dependency-related entries must share a serial lane or use separate `batch_phase` values."
+        );
         let issues = vec![1i64, 2];
         let text = build_request_generate_instruction(&RequestGenerateInput {
             repo: "r",

--- a/src/services/auto_queue/route_request_generate.rs
+++ b/src/services/auto_queue/route_request_generate.rs
@@ -1,6 +1,8 @@
 use super::*;
 use serde::Deserialize;
 
+use crate::services::auto_queue::thread_group_contract::THREAD_GROUP_SERIAL_LANE_CONTRACT;
+
 /// POST /api/queue/request-generate (#2126)
 ///
 /// Dashboard-facing convenience endpoint. The dashboard asks the backend to
@@ -237,7 +239,7 @@ pub(super) fn build_request_generate_instruction(input: &RequestGenerateInput<'_
          {allowed_kinds_line}\n\
          다음 절차로 처리:\n\
          1) 각 이슈를 gh로 직접 조회하여 본문/라벨/관련 의존성 파악\n\
-         2) 순서·thread_group(병렬 가능 단위)·batch_phase(직렬 페이즈)·phase_gate_kind 결정\n\
+         2) 순서·thread_group(serial lane)·batch_phase(실행 페이즈)·phase_gate_kind 결정\n\
          3) /api/queue/generate 호출 (스키마 아래)\n\n\
          호출 스키마:\n\
          POST /api/queue/generate\n\
@@ -253,7 +255,7 @@ pub(super) fn build_request_generate_instruction(input: &RequestGenerateInput<'_
          }}\n\n\
          가이드:\n\
          - entries는 실행 순서대로 정렬\n\
-         - thread_group: 동시 실행 가능한 카드는 같은 group, 직렬은 다른 group\n\
+         - {thread_group_contract}\n\
          - batch_phase: 페이즈 게이트 사이에 있는 카드는 같은 phase\n\
          {kind_guide_line}\n\
          - 자체 판단 후 즉시 호출, 완료 시 run_id를 본 채널에 보고",
@@ -264,6 +266,7 @@ pub(super) fn build_request_generate_instruction(input: &RequestGenerateInput<'_
         allowed_kinds_line = allowed_kinds_line,
         example_kind = example_kind,
         kind_guide_line = kind_guide_line,
+        thread_group_contract = THREAD_GROUP_SERIAL_LANE_CONTRACT,
     )
 }
 
@@ -315,6 +318,34 @@ mod tests {
             request_id: "r1",
         });
         assert!(!text.contains("allowed_gate_kinds:"));
+    }
+
+    #[test]
+    fn instruction_uses_exact_thread_group_serial_lane_contract() {
+        let issues = vec![1i64, 2];
+        let text = build_request_generate_instruction(&RequestGenerateInput {
+            repo: "r",
+            agent_id: "a",
+            issue_numbers: &issues,
+            allowed_gate_kinds: None,
+            request_id: "r1",
+        });
+
+        let expected_guide = format!("- {THREAD_GROUP_SERIAL_LANE_CONTRACT}");
+        assert!(
+            text.lines().any(|line| line.trim() == expected_guide),
+            "instruction must contain the canonical serial-lane contract exactly: {text}"
+        );
+        for reversed_wording in [
+            "thread_group(병렬 가능 단위)",
+            "동시 실행 가능한 카드는 같은 group",
+            "직렬은 다른 group",
+        ] {
+            assert!(
+                !text.contains(reversed_wording),
+                "instruction still contains reversed thread_group guidance `{reversed_wording}`: {text}"
+            );
+        }
     }
 
     /// Regression for codex review P1 on #2126: the synthesised call example

--- a/src/services/auto_queue/thread_group_contract.rs
+++ b/src/services/auto_queue/thread_group_contract.rs
@@ -1,5 +1,4 @@
 /// Canonical compatibility contract for the externally named `thread_group`
 /// field. Prompt and API documentation must reuse this sentence verbatim so
 /// callers cannot receive the runtime semantics in reverse.
-pub(crate) const THREAD_GROUP_SERIAL_LANE_CONTRACT: &str =
-    "Within one `batch_phase`, entries with the same `thread_group` share a serial lane with at most one active entry; entries with different `thread_group` values may run in parallel up to available capacity, and dependency-related entries must share a serial lane or use separate `batch_phase` values.";
+pub(crate) const THREAD_GROUP_SERIAL_LANE_CONTRACT: &str = "Within one `batch_phase`, entries with the same `thread_group` share a serial lane with at most one active entry; entries with different `thread_group` values may run in parallel up to available capacity, and dependency-related entries must share a serial lane or use separate `batch_phase` values.";

--- a/src/services/auto_queue/thread_group_contract.rs
+++ b/src/services/auto_queue/thread_group_contract.rs
@@ -1,0 +1,5 @@
+/// Canonical compatibility contract for the externally named `thread_group`
+/// field. Prompt and API documentation must reuse this sentence verbatim so
+/// callers cannot receive the runtime semantics in reverse.
+pub(crate) const THREAD_GROUP_SERIAL_LANE_CONTRACT: &str =
+    "Within one `batch_phase`, entries with the same `thread_group` share a serial lane with at most one active entry; entries with different `thread_group` values may run in parallel up to available capacity, and dependency-related entries must share a serial lane or use separate `batch_phase` values.";

--- a/src/services/auto_queue/thread_group_contract.rs
+++ b/src/services/auto_queue/thread_group_contract.rs
@@ -2,3 +2,16 @@
 /// field. Prompt and API documentation must reuse this sentence verbatim so
 /// callers cannot receive the runtime semantics in reverse.
 pub(crate) const THREAD_GROUP_SERIAL_LANE_CONTRACT: &str = "Within one `batch_phase`, entries with the same `thread_group` share a serial lane with at most one active entry; entries with different `thread_group` values may run in parallel up to available capacity, and dependency-related entries must share a serial lane or use separate `batch_phase` values.";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_contract_states_runtime_direction_and_dependency_rule() {
+        assert_eq!(
+            THREAD_GROUP_SERIAL_LANE_CONTRACT,
+            "Within one `batch_phase`, entries with the same `thread_group` share a serial lane with at most one active entry; entries with different `thread_group` values may run in parallel up to available capacity, and dependency-related entries must share a serial lane or use separate `batch_phase` values."
+        );
+    }
+}

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -22,6 +22,7 @@ BUSY_RETRY_4888_TEST_COMMAND = (
 # update this test deliberately. The duplication is a drift-prevention gate, not an
 # attempt to derive the expected coverage from the justfile under test.
 EXPECTED_TEST_NON_PG_COMMANDS = (
+    "cargo test --lib server::routes::docs::inventory::endpoints::part_0 -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib services::task_completion_v1::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib source_registry -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib task_notification -- --skip _pg --skip pg_ --skip postgres",


### PR DESCRIPTION
## Summary
- define one canonical `thread_group` compatibility contract
- reuse it in request-generation prompt and API documentation
- lock the runtime direction with exact semantic regression oracles
- refresh generated architecture inventory

Within one `batch_phase`, the same `thread_group` is a serial lane; different groups may run in parallel up to available capacity. Dependency-related entries must share a serial lane or use separate phases.

## Scope
This PR intentionally changes no runtime scheduling code. PR #4950 owns the adjacent runtime/failure lifecycle surface. Pair-level runtime acceptance remains for a later slice, so this PR references rather than closes #4878.

## Verification
- targeted contract/prompt/docs tests: PASS
- relevant Rust module tests: PASS
- `cargo fmt --check`: PASS
- inventory generation/check: PASS
- maintenance freshness gate: PASS
- reverse-direction, legacy prompt, and generic-doc mutations: all rejected
- fresh GPT-5.6 SOL adversarial review on exact `1b986ae4bbfc4fe61516a3d2badf19817b5a3ce3`: CLEAN

Refs #4878