### PR TITLE
fix(timeouts): harden shadow evidence gate (#3950)

### DIFF
--- a/scripts/__tests__/timeout-shadow-gate.test.mjs
+++ b/scripts/__tests__/timeout-shadow-gate.test.mjs
@@ -7,6 +7,7 @@ import { spawnSync } from "node:child_process";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { Readable } from "node:stream";
+import * as timeoutShadowGate from "../timeout-shadow-gate.mjs";
 
 import { aggregateFile, aggregateFiles, aggregateText, parseArgs, run, runFromReadable } from "../timeout-shadow-gate.mjs";
 
@@ -80,8 +81,8 @@ test("timestamp token parsing rejects partial offsets and accepts year zero leap
   const options = ["--stdin", "--since", "0000-02-29T00:00:00Z", "--min-a-samples", "0", "--min-j-samples", "0"];
   const result = run(options, [
     `0000-02-29T00:00:00Z INFO ${shadow("_section_A")}`,
-    `0000-02-29T00:00:00+09:000 INFO ${shadow("_section_A")}`,
-    `0000-02-29T00:00:00+09 INFO ${shadow("_section_A")}`
+    `0000-02-29T00:00:00+01:000 INFO ${shadow("_section_A")}`,
+    `0000-02-29T00:00:00+01 INFO ${shadow("_section_A")}`
   ].join("\n"));
   assert.equal(JSON.parse(result.output)._section_A.total, 1);
 });
@@ -130,6 +131,18 @@ test("J reducer errors are not successful minimum evidence and fail closed by de
   assert.equal(result.exitCode, 1);
   assert.match(result.failures.join(" "), /_section_J successful samples 0 < 1/);
   assert.match(result.failures.join(" "), /shadow errors 1 > 0/);
+});
+
+test("A derives agreement from decisions so forged agree cannot evade divergence gates", async () => {
+  const forgedTrue = shadow("_section_A", { reducer_decision: "exhaust", agree: true });
+  const forgedFalse = shadow("_section_A", { reducer_decision: "retry", agree: false });
+  const result = await runFromReadable([
+    "--stdin", "--min-a-samples", "2", "--min-j-samples", "0", "--max-divergence", "0", "--max-errors", "2"
+  ], Readable.from([Buffer.from(`${forgedTrue}\n${forgedFalse}\n`)]));
+  const a = JSON.parse(result.output)._section_A;
+  assert.deepEqual(a, { total: 2, comparable: 2, agreement: 0, divergence: 1, error: 2 });
+  assert.equal(result.exitCode, 1);
+  assert.match(result.failures.join(" "), /_section_A divergence 1 > 0/);
 });
 
 test("rejects decimal counts and invalid ISO-8601 calendar timestamps", () => {
@@ -355,18 +368,47 @@ test("streamed stdin rejects an unterminated line over the documented record cap
   assert.match(result.stderr, /log line exceeds 1048576 bytes/);
 });
 
-test("text and run library exports enforce the same bounded scanner cap", () => {
+test("raw-byte scanner accepts exactly capped LF and CRLF text records", () => {
+  const base = shadow("_section_A");
+  const padding = " ".repeat(1024 * 1024 - Buffer.byteLength(base));
+  assert.equal(aggregateText([`${base}${padding}\n`])._section_A.total, 1);
+  assert.equal(aggregateText([`${base}${padding}\r\n`])._section_A.total, 1);
+});
+
+test("raw invalid UTF-8 below the cap is malformed evidence, not inflated cap failure", async () => {
+  const invalidRecord = Buffer.concat([
+    Buffer.from("[timeout_shadow] "),
+    Buffer.alloc(400 * 1024, 0xff),
+    Buffer.from("\n")
+  ]);
+  const result = await runFromReadable([
+    "--stdin", "--min-a-samples", "0", "--min-j-samples", "0", "--max-errors", "1"
+  ], Readable.from([invalidRecord]));
+  assert.equal(result.exitCode, 0);
+  assert.equal(JSON.parse(result.output)._unclassified.malformed, 1);
+});
+
+test("text and run library exports enforce the same cap above one MiB", () => {
   const oversized = "x".repeat(1024 * 1024 + 1);
   assert.throws(() => aggregateText([oversized]), /log line exceeds 1048576 bytes/);
   assert.throws(() => run(["--min-a-samples", "0", "--min-j-samples", "0"], oversized), /log line exceeds 1048576 bytes/);
 });
 
-test("CLI readable input uses chunk iteration rather than a synchronous fd read", async () => {
+test("CLI readable input never reaches a synchronous fd0 EAGAIN path", async () => {
   const readable = Readable.from([
     Buffer.from(`prefix ${shadow("_section_A")}\n`),
     Buffer.from(shadow("_section_J", { reducer_decision: "incomparable", agree: false, incomparable: true }))
   ]);
-  const result = await runFromReadable(["--stdin"], readable);
+  const io = {
+    ...fs,
+    readSync() {
+      const error = new Error("simulated nonblocking fd");
+      error.code = "EAGAIN";
+      throw error;
+    }
+  };
+  assert.equal("runFromStdin" in timeoutShadowGate, false);
+  const result = await runFromReadable(["--stdin"], readable, io);
   assert.equal(result.exitCode, 0);
   assert.deepEqual(JSON.parse(result.output)._section_J, { total: 1, successful: 1, incomparable: 1, ratio: 1, error: 0 });
 });

--- a/scripts/__tests__/timeout-shadow-gate.test.mjs
+++ b/scripts/__tests__/timeout-shadow-gate.test.mjs
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { linkSync, mkdtempSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
-import { aggregateFile, aggregateText, parseArgs, run } from "../timeout-shadow-gate.mjs";
+import { aggregateFile, aggregateFiles, aggregateText, parseArgs, run } from "../timeout-shadow-gate.mjs";
 
 function record(section, overrides = {}) {
   return JSON.stringify({
@@ -55,6 +57,24 @@ test("time windows exclude both out-of-range and timestamp-less records", () => 
   });
 });
 
+test("time windows preserve microsecond boundaries and support zoned space timestamps", () => {
+  const precise = run([
+    "--stdin", "--since", "2026-07-28T00:00:00.000002Z", "--min-a-samples", "0", "--min-j-samples", "0"
+  ], [
+    `2026-07-28T00:00:00.000001Z INFO ${shadow("_section_A")}`,
+    `2026-07-28T00:00:00.000002Z INFO ${shadow("_section_A")}`
+  ].join("\n"));
+  assert.equal(JSON.parse(precise.output)._section_A.total, 1);
+
+  const zoned = run([
+    "--stdin", "--since", "2026-07-28T00:00:00Z", "--min-a-samples", "0", "--min-j-samples", "0"
+  ], [
+    `2026-07-28 00:00:00Z INFO ${shadow("_section_A")}`,
+    `2026-07-28 09:00:00+09:00 INFO ${shadow("_section_A")}`
+  ].join("\n"));
+  assert.equal(JSON.parse(zoned.output)._section_A.total, 2);
+});
+
 test("counts malformed shadow records but ignores unrelated log noise", () => {
   const report = aggregateText([
     "INFO ordinary log with { bad json",
@@ -100,7 +120,7 @@ test("rejects decimal counts and invalid ISO-8601 calendar timestamps", () => {
   assert.throws(() => parseArgs(["--since", "2026-07-28 00:00:00Z"]), /ISO-8601 calendar/);
 });
 
-test("streams a stable rotated file and retries a changed snapshot without double counting", () => {
+test("retries a changed opened-file snapshot without double counting", () => {
   const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
   try {
     const log = join(directory, "dcserver.stdout.log.1");
@@ -109,14 +129,44 @@ test("streams a stable rotated file and retries a changed snapshot without doubl
     let stats = 0;
     const io = {
       ...fs,
-      statSync(path) {
-        const stat = fs.statSync(path);
+      fstatSync(descriptor) {
+        const stat = fs.fstatSync(descriptor);
         return { ...stat, mtimeMs: signatureMtimes[stats++] };
       }
     };
     const report = aggregateFile(log, {}, io);
     assert.equal(report._section_A.total, 1);
     assert.equal(stats, 4);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("opens all rotated inputs before reading so a mid-scan rotation cannot drop or duplicate records", () => {
+  const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
+  try {
+    const current = join(directory, "dcserver.stdout.log");
+    const rotated = join(directory, "dcserver.stdout.log.1");
+    const archived = join(directory, "dcserver.stdout.log.2");
+    writeFileSync(current, `${shadow("_section_A")}\n`);
+    writeFileSync(rotated, `${shadow("_section_J", { reducer_decision: "incomparable", agree: false, incomparable: true })}\n`);
+    let rotatedDuringRead = false;
+    const io = {
+      ...fs,
+      readSync(...args) {
+        const bytes = fs.readSync(...args);
+        if (!rotatedDuringRead) {
+          rotatedDuringRead = true;
+          renameSync(rotated, archived);
+          renameSync(current, rotated);
+          writeFileSync(current, `${shadow("_section_A", { card_id: "new-current" })}\n`);
+        }
+        return bytes;
+      }
+    };
+    const report = aggregateFiles([current, rotated], {}, io);
+    assert.deepEqual(report._section_A, { total: 1, comparable: 1, agreement: 1, divergence: 0, error: 0 });
+    assert.deepEqual(report._section_J, { total: 1, incomparable: 1, ratio: 1, error: 0 });
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -131,6 +181,43 @@ test("rejects duplicate canonical log inputs", () => {
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
+});
+
+test("rejects duplicate opened inode inputs through hard links", () => {
+  const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
+  try {
+    const log = join(directory, "dcserver.stdout.log");
+    const alias = join(directory, "same-inode.log");
+    writeFileSync(log, `${shadow("_section_A")}\n`);
+    linkSync(log, alias);
+    assert.throws(() => run([log, alias], ""), /duplicate log input/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("main guard executes invalid CLI through a symlink alias", () => {
+  const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
+  try {
+    const script = fileURLToPath(new URL("../timeout-shadow-gate.mjs", import.meta.url));
+    const alias = join(directory, "timeout-shadow-gate-alias.mjs");
+    symlinkSync(script, alias);
+    const result = spawnSync(process.execPath, [alias, "--not-an-option"], { encoding: "utf8" });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /unknown option/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("streamed stdin rejects an unterminated line over the documented record cap", () => {
+  const script = fileURLToPath(new URL("../timeout-shadow-gate.mjs", import.meta.url));
+  const result = spawnSync(process.execPath, [script, "--min-a-samples", "0", "--min-j-samples", "0"], {
+    encoding: "utf8",
+    input: "x".repeat(1024 * 1024 + 1)
+  });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /log line exceeds 1048576 bytes/);
 });
 
 test("enforces pass and fail threshold combinations", () => {

--- a/scripts/__tests__/timeout-shadow-gate.test.mjs
+++ b/scripts/__tests__/timeout-shadow-gate.test.mjs
@@ -6,8 +6,9 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
+import { Readable } from "node:stream";
 
-import { aggregateFile, aggregateFiles, aggregateText, parseArgs, run } from "../timeout-shadow-gate.mjs";
+import { aggregateFile, aggregateFiles, aggregateText, parseArgs, run, runFromReadable } from "../timeout-shadow-gate.mjs";
 
 function record(section, overrides = {}) {
   return JSON.stringify({
@@ -218,6 +219,16 @@ test("streamed stdin rejects an unterminated line over the documented record cap
   });
   assert.equal(result.status, 2);
   assert.match(result.stderr, /log line exceeds 1048576 bytes/);
+});
+
+test("CLI readable input uses chunk iteration rather than a synchronous fd read", async () => {
+  const readable = Readable.from([
+    Buffer.from(`prefix ${shadow("_section_A")}\n`),
+    Buffer.from(shadow("_section_J", { reducer_decision: "incomparable", agree: false, incomparable: true }))
+  ]);
+  const result = await runFromReadable(["--stdin"], readable);
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(JSON.parse(result.output)._section_J, { total: 1, incomparable: 1, ratio: 1, error: 0 });
 });
 
 test("enforces pass and fail threshold combinations", () => {

--- a/scripts/__tests__/timeout-shadow-gate.test.mjs
+++ b/scripts/__tests__/timeout-shadow-gate.test.mjs
@@ -263,6 +263,7 @@ test("caller-order-independent rotation during open cannot erase divergence", ()
     const archived = join(directory, "dcserver.stdout.log.2");
     writeFileSync(current, `${shadow("_section_A")}\n`);
     writeFileSync(rotated, `${shadow("_section_J")}\n`);
+    const canonicalCurrent = fs.realpathSync(current);
     let rotatedOnce = false;
     const openedPaths = [];
     const io = {
@@ -280,7 +281,7 @@ test("caller-order-independent rotation during open cannot erase divergence", ()
       }
     };
     assert.throws(() => aggregateFiles([rotated, current], {}, io), /manifest|opened inode|changed while opening/);
-    assert.equal(openedPaths[0], current);
+    assert.equal(openedPaths[0], canonicalCurrent);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/scripts/__tests__/timeout-shadow-gate.test.mjs
+++ b/scripts/__tests__/timeout-shadow-gate.test.mjs
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
+import * as fs from "node:fs";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 
-import { aggregateText, run } from "../timeout-shadow-gate.mjs";
+import { aggregateFile, aggregateText, parseArgs, run } from "../timeout-shadow-gate.mjs";
 
 function record(section, overrides = {}) {
   return JSON.stringify({
@@ -42,15 +43,15 @@ test("aggregates current and rotated logs in deterministic section order", () =>
   }
 });
 
-test("reads stdin and filters only records carrying an out-of-range timestamp", () => {
+test("time windows exclude both out-of-range and timestamp-less records", () => {
   const input = [
     `2026-07-26T00:00:00Z INFO ${shadow("_section_A")}`,
     shadow("_section_A")
   ].join("\n");
-  const result = run(["--stdin", "--since", "2026-07-27T00:00:00Z"], input);
+  const result = run(["--stdin", "--since", "2026-07-27T00:00:00Z", "--min-a-samples", "0", "--min-j-samples", "0"], input);
   assert.equal(result.exitCode, 0);
   assert.deepEqual(JSON.parse(result.output)._section_A, {
-    total: 1, comparable: 1, agreement: 1, divergence: 0, error: 0
+    total: 0, comparable: 0, agreement: 0, divergence: 0, error: 0
   });
 });
 
@@ -84,11 +85,52 @@ test("reports J incomparable ratio and preserves zero-sample null ratio", () => 
   assert.equal(aggregateText([])._section_J.ratio, null);
 });
 
-test("positive sample thresholds fail on zero samples instead of passing as clean", () => {
-  const result = run(["--min-a-samples", "1", "--min-j-samples", "1"], "");
+test("default positive sample thresholds fail on zero samples instead of passing as clean", () => {
+  const result = run([], "");
   assert.equal(result.exitCode, 1);
   assert.match(result.failures.join(" "), /_section_A comparable samples 0 < 1/);
   assert.match(result.failures.join(" "), /_section_J samples 0 < 1/);
+});
+
+test("rejects decimal counts and invalid ISO-8601 calendar timestamps", () => {
+  assert.throws(() => parseArgs(["--min-a-samples", "1.5"]), /non-negative integer/);
+  assert.throws(() => parseArgs(["--max-errors", "01"]), /non-negative integer/);
+  assert.throws(() => parseArgs(["--since", "2026-02-30T00:00:00Z"]), /valid ISO-8601/);
+  assert.throws(() => parseArgs(["--until", "2026-07-28T24:00:00Z"]), /valid ISO-8601/);
+  assert.throws(() => parseArgs(["--since", "2026-07-28 00:00:00Z"]), /ISO-8601 calendar/);
+});
+
+test("streams a stable rotated file and retries a changed snapshot without double counting", () => {
+  const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
+  try {
+    const log = join(directory, "dcserver.stdout.log.1");
+    writeFileSync(log, `${shadow("_section_A")}\n`);
+    const signatureMtimes = [1, 2, 3, 3];
+    let stats = 0;
+    const io = {
+      ...fs,
+      statSync(path) {
+        const stat = fs.statSync(path);
+        return { ...stat, mtimeMs: signatureMtimes[stats++] };
+      }
+    };
+    const report = aggregateFile(log, {}, io);
+    assert.equal(report._section_A.total, 1);
+    assert.equal(stats, 4);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("rejects duplicate canonical log inputs", () => {
+  const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
+  try {
+    const log = join(directory, "dcserver.stdout.log");
+    writeFileSync(log, `${shadow("_section_A")}\n`);
+    assert.throws(() => run([log, log], ""), /duplicate log input/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("enforces pass and fail threshold combinations", () => {

--- a/scripts/__tests__/timeout-shadow-gate.test.mjs
+++ b/scripts/__tests__/timeout-shadow-gate.test.mjs
@@ -38,7 +38,7 @@ test("aggregates current and rotated logs in deterministic section order", () =>
     assert.equal(result.exitCode, 0);
     assert.equal(result.output, JSON.stringify({
       _section_A: { total: 1, comparable: 1, agreement: 1, divergence: 0, error: 0 },
-      _section_J: { total: 1, incomparable: 1, ratio: 1, error: 0 },
+      _section_J: { total: 1, successful: 1, incomparable: 1, ratio: 1, error: 0 },
       _unclassified: { malformed: 0 }
     }));
   } finally {
@@ -76,6 +76,16 @@ test("time windows preserve microsecond boundaries and support zoned space times
   assert.equal(JSON.parse(zoned.output)._section_A.total, 2);
 });
 
+test("timestamp token parsing rejects partial offsets and accepts year zero leap day", () => {
+  const options = ["--stdin", "--since", "0000-02-29T00:00:00Z", "--min-a-samples", "0", "--min-j-samples", "0"];
+  const result = run(options, [
+    `0000-02-29T00:00:00Z INFO ${shadow("_section_A")}`,
+    `0000-02-29T00:00:00+09:000 INFO ${shadow("_section_A")}`,
+    `0000-02-29T00:00:00+09 INFO ${shadow("_section_A")}`
+  ].join("\n"));
+  assert.equal(JSON.parse(result.output)._section_A.total, 1);
+});
+
 test("counts malformed shadow records but ignores unrelated log noise", () => {
   const report = aggregateText([
     "INFO ordinary log with { bad json",
@@ -102,7 +112,7 @@ test("reports J incomparable ratio and preserves zero-sample null ratio", () => 
     shadow("_section_J", { reducer_decision: "incomparable", agree: false, incomparable: true }),
     shadow("_section_J", { reducer_decision: "retry", agree: true })
   ]);
-  assert.deepEqual(report._section_J, { total: 2, incomparable: 1, ratio: 0.5, error: 0 });
+  assert.deepEqual(report._section_J, { total: 2, successful: 2, incomparable: 1, ratio: 0.5, error: 0 });
   assert.equal(aggregateText([])._section_J.ratio, null);
 });
 
@@ -110,7 +120,16 @@ test("default positive sample thresholds fail on zero samples instead of passing
   const result = run([], "");
   assert.equal(result.exitCode, 1);
   assert.match(result.failures.join(" "), /_section_A comparable samples 0 < 1/);
-  assert.match(result.failures.join(" "), /_section_J samples 0 < 1/);
+  assert.match(result.failures.join(" "), /_section_J successful samples 0 < 1/);
+});
+
+test("J reducer errors are not successful minimum evidence and fail closed by default", () => {
+  const result = run(["--stdin", "--min-a-samples", "0"], shadow("_section_J", {
+    reducer_decision: "error", agree: false, error: "preview failed"
+  }));
+  assert.equal(result.exitCode, 1);
+  assert.match(result.failures.join(" "), /_section_J successful samples 0 < 1/);
+  assert.match(result.failures.join(" "), /shadow errors 1 > 0/);
 });
 
 test("rejects decimal counts and invalid ISO-8601 calendar timestamps", () => {
@@ -131,13 +150,120 @@ test("retries a changed opened-file snapshot without double counting", () => {
     const io = {
       ...fs,
       fstatSync(descriptor) {
-        const stat = fs.fstatSync(descriptor);
-        return { ...stat, mtimeMs: signatureMtimes[stats++] };
+        const stat = fs.fstatSync(descriptor, { bigint: true });
+        const stamp = BigInt(signatureMtimes[stats++]);
+        return { ...stat, mtimeNs: stamp, ctimeNs: stamp };
       }
     };
     const report = aggregateFile(log, {}, io);
     assert.equal(report._section_A.total, 1);
     assert.equal(stats, 4);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("content recheck rejects same-inode rewrite with restored metadata and keeps only the fresh retry aggregate", () => {
+  const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
+  try {
+    const log = join(directory, "dcserver.stdout.log");
+    const oldRecord = `${shadow("_section_A")}\n`;
+    const newRecord = `${shadow("_section_J")}\n`;
+    assert.equal(Buffer.byteLength(oldRecord), Buffer.byteLength(newRecord));
+    writeFileSync(log, oldRecord);
+    const baseline = fs.statSync(log, { bigint: true });
+    let rewritten = false;
+    const io = {
+      ...fs,
+      fstatSync() { return { ...baseline }; },
+      readSync(...args) {
+        const bytes = fs.readSync(...args);
+        if (!rewritten) {
+          rewritten = true;
+          writeFileSync(log, newRecord);
+        }
+        return bytes;
+      }
+    };
+    const report = aggregateFile(log, {}, io);
+    assert.equal(report._section_A.total, 0);
+    assert.equal(report._section_J.total, 1);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("shrink during first scan retries with a fresh snapshot", () => {
+  const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
+  try {
+    const log = join(directory, "dcserver.stdout.log");
+    writeFileSync(log, `${shadow("_section_A")}\n`);
+    let shrunk = false;
+    const io = {
+      ...fs,
+      readSync(...args) {
+        const bytes = fs.readSync(...args);
+        if (!shrunk) {
+          shrunk = true;
+          writeFileSync(log, "");
+        }
+        return bytes;
+      }
+    };
+    assert.equal(aggregateFile(log, {}, io)._section_A.total, 0);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("opened-inode collision caused by rotation retries as one fresh all-file snapshot", () => {
+  const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
+  try {
+    const current = join(directory, "dcserver.stdout.log");
+    const rotated = join(directory, "dcserver.stdout.log.1");
+    const archived = join(directory, "dcserver.stdout.log.2");
+    writeFileSync(current, `${shadow("_section_A")}\n`);
+    writeFileSync(rotated, `${shadow("_section_J")}\n`);
+    let rotatedOnce = false;
+    const io = {
+      ...fs,
+      openSync(path, flags) {
+        const descriptor = fs.openSync(path, flags);
+        if (!rotatedOnce) {
+          rotatedOnce = true;
+          renameSync(rotated, archived);
+          renameSync(current, rotated);
+          writeFileSync(current, `${shadow("_section_J")}\n`);
+        }
+        return descriptor;
+      }
+    };
+    const report = aggregateFiles([current, rotated], {}, io);
+    assert.equal(report._section_A.total, 1);
+    assert.equal(report._section_J.total, 1);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("opened descriptors close on fstat and realpath failures", () => {
+  const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
+  try {
+    const log = join(directory, "dcserver.stdout.log");
+    writeFileSync(log, `${shadow("_section_A")}\n`);
+    for (const failedMethod of ["fstatSync", "realpathSync"]) {
+      let closes = 0;
+      const io = {
+        ...fs,
+        [failedMethod]() { throw new Error(`${failedMethod} injected failure`); },
+        closeSync(descriptor) {
+          closes += 1;
+          return fs.closeSync(descriptor);
+        }
+      };
+      assert.throws(() => aggregateFile(log, {}, io), /injected failure/);
+      assert.equal(closes, 2);
+    }
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -167,7 +293,7 @@ test("opens all rotated inputs before reading so a mid-scan rotation cannot drop
     };
     const report = aggregateFiles([current, rotated], {}, io);
     assert.deepEqual(report._section_A, { total: 1, comparable: 1, agreement: 1, divergence: 0, error: 0 });
-    assert.deepEqual(report._section_J, { total: 1, incomparable: 1, ratio: 1, error: 0 });
+    assert.deepEqual(report._section_J, { total: 1, successful: 1, incomparable: 1, ratio: 1, error: 0 });
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -221,6 +347,12 @@ test("streamed stdin rejects an unterminated line over the documented record cap
   assert.match(result.stderr, /log line exceeds 1048576 bytes/);
 });
 
+test("text and run library exports enforce the same bounded scanner cap", () => {
+  const oversized = "x".repeat(1024 * 1024 + 1);
+  assert.throws(() => aggregateText([oversized]), /log line exceeds 1048576 bytes/);
+  assert.throws(() => run(["--min-a-samples", "0", "--min-j-samples", "0"], oversized), /log line exceeds 1048576 bytes/);
+});
+
 test("CLI readable input uses chunk iteration rather than a synchronous fd read", async () => {
   const readable = Readable.from([
     Buffer.from(`prefix ${shadow("_section_A")}\n`),
@@ -228,7 +360,7 @@ test("CLI readable input uses chunk iteration rather than a synchronous fd read"
   ]);
   const result = await runFromReadable(["--stdin"], readable);
   assert.equal(result.exitCode, 0);
-  assert.deepEqual(JSON.parse(result.output)._section_J, { total: 1, incomparable: 1, ratio: 1, error: 0 });
+  assert.deepEqual(JSON.parse(result.output)._section_J, { total: 1, successful: 1, incomparable: 1, ratio: 1, error: 0 });
 });
 
 test("enforces pass and fail threshold combinations", () => {

--- a/scripts/__tests__/timeout-shadow-gate.test.mjs
+++ b/scripts/__tests__/timeout-shadow-gate.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { aggregateText, run } from "../timeout-shadow-gate.mjs";
+
+function record(section, overrides = {}) {
+  return JSON.stringify({
+    target: "agentdesk::timeout_shadow",
+    card_id: "card-1",
+    section,
+    js_decision: "retry",
+    reducer_decision: "retry",
+    agree: true,
+    ...overrides
+  });
+}
+
+function shadow(section, overrides) {
+  return `[timeout_shadow] ${record(section, overrides)}`;
+}
+
+test("aggregates current and rotated logs in deterministic section order", () => {
+  const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
+  try {
+    const current = join(directory, "dcserver.stdout.log");
+    const rotated = join(directory, "dcserver.stdout.log.1");
+    writeFileSync(current, `2026-07-28T00:00:00Z INFO ${shadow("_section_A")}\n`);
+    writeFileSync(rotated, `prefix ${shadow("_section_J", { reducer_decision: "incomparable", agree: false, incomparable: true })}\n`);
+
+    const result = run([current, rotated], "");
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.output, JSON.stringify({
+      _section_A: { total: 1, comparable: 1, agreement: 1, divergence: 0, error: 0 },
+      _section_J: { total: 1, incomparable: 1, ratio: 1, error: 0 },
+      _unclassified: { malformed: 0 }
+    }));
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("reads stdin and filters only records carrying an out-of-range timestamp", () => {
+  const input = [
+    `2026-07-26T00:00:00Z INFO ${shadow("_section_A")}`,
+    shadow("_section_A")
+  ].join("\n");
+  const result = run(["--stdin", "--since", "2026-07-27T00:00:00Z"], input);
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(JSON.parse(result.output)._section_A, {
+    total: 1, comparable: 1, agreement: 1, divergence: 0, error: 0
+  });
+});
+
+test("counts malformed shadow records but ignores unrelated log noise", () => {
+  const report = aggregateText([
+    "INFO ordinary log with { bad json",
+    '[timeout_shadow] {"target":"agentdesk::timeout_shadow","section":"_section_A",'
+  ]);
+  assert.deepEqual(report._section_A, {
+    total: 0, comparable: 0, agreement: 0, divergence: 0, error: 1
+  });
+  assert.equal(report._unclassified.malformed, 0);
+});
+
+test("reports A divergence separately from reducer errors", () => {
+  const report = aggregateText([
+    shadow("_section_A", { agree: false, reducer_decision: "exhaust" }),
+    shadow("_section_A", { agree: false, reducer_decision: "error", error: "preview unavailable" })
+  ]);
+  assert.deepEqual(report._section_A, {
+    total: 2, comparable: 1, agreement: 0, divergence: 1, error: 1
+  });
+});
+
+test("reports J incomparable ratio and preserves zero-sample null ratio", () => {
+  const report = aggregateText([
+    shadow("_section_J", { reducer_decision: "incomparable", agree: false, incomparable: true }),
+    shadow("_section_J", { reducer_decision: "retry", agree: true })
+  ]);
+  assert.deepEqual(report._section_J, { total: 2, incomparable: 1, ratio: 0.5, error: 0 });
+  assert.equal(aggregateText([])._section_J.ratio, null);
+});
+
+test("positive sample thresholds fail on zero samples instead of passing as clean", () => {
+  const result = run(["--min-a-samples", "1", "--min-j-samples", "1"], "");
+  assert.equal(result.exitCode, 1);
+  assert.match(result.failures.join(" "), /_section_A comparable samples 0 < 1/);
+  assert.match(result.failures.join(" "), /_section_J samples 0 < 1/);
+});
+
+test("enforces pass and fail threshold combinations", () => {
+  const input = [
+    shadow("_section_A"),
+    shadow("_section_J", { reducer_decision: "incomparable", agree: false, incomparable: true })
+  ].join("\n");
+  assert.equal(run(["--min-a-samples", "1", "--min-j-samples", "1", "--max-divergence", "0", "--max-errors", "0"], input).exitCode, 0);
+
+  const divergent = shadow("_section_A", { agree: false, reducer_decision: "exhaust" });
+  assert.equal(run(["--max-divergence", "0"], divergent).exitCode, 1);
+  const errored = shadow("_section_A", { agree: false, reducer_decision: "error", error: "boom" });
+  assert.equal(run(["--max-errors", "0"], errored).exitCode, 1);
+});

--- a/scripts/__tests__/timeout-shadow-gate.test.mjs
+++ b/scripts/__tests__/timeout-shadow-gate.test.mjs
@@ -112,11 +112,26 @@ test("reports A divergence separately from reducer errors", () => {
 
 test("reports J incomparable ratio and preserves zero-sample null ratio", () => {
   const report = aggregateText([
-    shadow("_section_J", { reducer_decision: "incomparable", agree: false, incomparable: true }),
-    shadow("_section_J", { reducer_decision: "retry", agree: true })
+    shadow("_section_J", { reducer_decision: "incomparable", agree: false, incomparable: true })
   ]);
-  assert.deepEqual(report._section_J, { total: 2, successful: 2, incomparable: 1, ratio: 0.5, error: 0 });
+  assert.deepEqual(report._section_J, { total: 1, successful: 1, incomparable: 1, ratio: 1, error: 0 });
   assert.equal(aggregateText([])._section_J.ratio, null);
+});
+
+test("J comparable output fails closed under the current producer contract", () => {
+  const result = run([
+    "--stdin", "--min-a-samples", "1", "--min-j-samples", "0",
+    "--max-divergence", "0", "--max-errors", "0"
+  ], [
+    shadow("_section_A", { js_decision: "retry", reducer_decision: "retry", agree: true }),
+    shadow("_section_J", { js_decision: "retry", reducer_decision: "exhaust", agree: false })
+  ].join("\n"));
+
+  assert.deepEqual(JSON.parse(result.output)._section_J, {
+    total: 1, successful: 0, incomparable: 0, ratio: null, error: 1
+  });
+  assert.equal(result.exitCode, 1);
+  assert.match(result.failures.join(" "), /shadow errors 1 > 0/);
 });
 
 test("default positive sample thresholds fail on zero samples instead of passing as clean", () => {
@@ -317,21 +332,24 @@ test("opened descriptors close on fstat failures while pre-open realpath failure
   }
 });
 
-test("close errors still attempt every descriptor and propagate the first failure", () => {
+test("close errors attempt every original descriptor once without closing a reused fd", () => {
   const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
+  let replacementDescriptor = null;
   try {
     const first = join(directory, "a.log");
     const second = join(directory, "b.log");
+    const replacement = join(directory, "replacement.log");
     writeFileSync(first, `${shadow("_section_A")}\n`);
     writeFileSync(second, `${shadow("_section_J")}\n`);
+    writeFileSync(replacement, "replacement");
     const closeCalls = [];
-    let injected = false;
     const io = {
       ...fs,
       closeSync(descriptor) {
         closeCalls.push(descriptor);
-        if (!injected) {
-          injected = true;
+        if (replacementDescriptor === null) {
+          fs.closeSync(descriptor);
+          replacementDescriptor = fs.openSync(replacement, "r");
           throw new Error("first close injected failure");
         }
         return fs.closeSync(descriptor);
@@ -339,8 +357,13 @@ test("close errors still attempt every descriptor and propagate the first failur
     };
     assert.throws(() => aggregateFiles([first, second], {}, io), /first close injected failure/);
     assert.equal(new Set(closeCalls).size, 2);
-    assert.equal(closeCalls.length, 3);
+    assert.equal(closeCalls.length, 2);
+    assert.equal(replacementDescriptor, closeCalls[0]);
+    assert.doesNotThrow(() => fs.fstatSync(replacementDescriptor));
   } finally {
+    if (replacementDescriptor !== null) {
+      try { fs.closeSync(replacementDescriptor); } catch (_) {}
+    }
     rmSync(directory, { recursive: true, force: true });
   }
 });

--- a/scripts/__tests__/timeout-shadow-gate.test.mjs
+++ b/scripts/__tests__/timeout-shadow-gate.test.mjs
@@ -278,8 +278,15 @@ test("opens all rotated inputs before reading so a mid-scan rotation cannot drop
     writeFileSync(current, `${shadow("_section_A")}\n`);
     writeFileSync(rotated, `${shadow("_section_J", { reducer_decision: "incomparable", agree: false, incomparable: true })}\n`);
     let rotatedDuringRead = false;
+    let ctimeChanged = false;
     const io = {
       ...fs,
+      fstatSync(descriptor, options) {
+        const stat = fs.fstatSync(descriptor, options);
+        if (!rotatedDuringRead) return stat;
+        ctimeChanged = true;
+        return { ...stat, ctimeNs: stat.ctimeNs + 1n };
+      },
       readSync(...args) {
         const bytes = fs.readSync(...args);
         if (!rotatedDuringRead) {
@@ -292,6 +299,7 @@ test("opens all rotated inputs before reading so a mid-scan rotation cannot drop
       }
     };
     const report = aggregateFiles([current, rotated], {}, io);
+    assert.equal(ctimeChanged, true);
     assert.deepEqual(report._section_A, { total: 1, comparable: 1, agreement: 1, divergence: 0, error: 0 });
     assert.deepEqual(report._section_J, { total: 1, successful: 1, incomparable: 1, ratio: 1, error: 0 });
   } finally {

--- a/scripts/__tests__/timeout-shadow-gate.test.mjs
+++ b/scripts/__tests__/timeout-shadow-gate.test.mjs
@@ -82,7 +82,9 @@ test("timestamp token parsing rejects partial offsets and accepts year zero leap
   const result = run(options, [
     `0000-02-29T00:00:00Z INFO ${shadow("_section_A")}`,
     `0000-02-29T00:00:00+01:000 INFO ${shadow("_section_A")}`,
-    `0000-02-29T00:00:00+01 INFO ${shadow("_section_A")}`
+    `0000-02-29T00:00:00+01 INFO ${shadow("_section_A")}`,
+    `12026-02-29T00:00:00Z INFO ${shadow("_section_A")}`,
+    `0000-02-29T00:00:00ZBAD INFO ${shadow("_section_A")}`
   ].join("\n"));
   assert.equal(JSON.parse(result.output)._section_A.total, 1);
 });
@@ -140,9 +142,36 @@ test("A derives agreement from decisions so forged agree cannot evade divergence
     "--stdin", "--min-a-samples", "2", "--min-j-samples", "0", "--max-divergence", "0", "--max-errors", "2"
   ], Readable.from([Buffer.from(`${forgedTrue}\n${forgedFalse}\n`)]));
   const a = JSON.parse(result.output)._section_A;
-  assert.deepEqual(a, { total: 2, comparable: 2, agreement: 0, divergence: 1, error: 2 });
+  assert.deepEqual(a, { total: 2, comparable: 2, agreement: 1, divergence: 1, error: 2 });
   assert.equal(result.exitCode, 1);
   assert.match(result.failures.join(" "), /_section_A divergence 1 > 0/);
+});
+
+test("A incomparable and agree diagnostics cannot hide decision-derived divergence", () => {
+  const result = run([
+    "--stdin", "--min-a-samples", "1", "--min-j-samples", "0", "--max-divergence", "0", "--max-errors", "1"
+  ], shadow("_section_A", { reducer_decision: "exhaust", agree: false, incomparable: true }));
+  assert.deepEqual(JSON.parse(result.output)._section_A, {
+    total: 1, comparable: 1, agreement: 0, divergence: 1, error: 1
+  });
+  assert.equal(result.exitCode, 1);
+});
+
+test("J unknown and missing preview labels are errors, never successful evidence", () => {
+  for (const reducerDecision of ["unknown", "missing", ""]) {
+    const result = run(["--stdin", "--min-a-samples", "0"], shadow("_section_J", {
+      reducer_decision: reducerDecision, agree: false
+    }));
+    const j = JSON.parse(result.output)._section_J;
+    assert.equal(j.successful, 0);
+    assert.equal(j.error, 1);
+    assert.equal(result.exitCode, 1);
+  }
+  const forgedDiagnostic = run(["--stdin", "--min-a-samples", "0"], shadow("_section_J", {
+    reducer_decision: "retry", agree: false
+  }));
+  assert.equal(JSON.parse(forgedDiagnostic.output)._section_J.successful, 0);
+  assert.equal(forgedDiagnostic.exitCode, 1);
 });
 
 test("rejects decimal counts and invalid ISO-8601 calendar timestamps", () => {
@@ -153,30 +182,28 @@ test("rejects decimal counts and invalid ISO-8601 calendar timestamps", () => {
   assert.throws(() => parseArgs(["--since", "2026-07-28 00:00:00Z"]), /ISO-8601 calendar/);
 });
 
-test("retries a changed opened-file snapshot without double counting", () => {
+test("fails closed when opened-file metadata changes during verification", () => {
   const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
   try {
     const log = join(directory, "dcserver.stdout.log.1");
     writeFileSync(log, `${shadow("_section_A")}\n`);
-    const signatureMtimes = [1, 2, 3, 3];
     let stats = 0;
     const io = {
       ...fs,
-      fstatSync(descriptor) {
+      fstatSync(descriptor, options) {
         const stat = fs.fstatSync(descriptor, { bigint: true });
-        const stamp = BigInt(signatureMtimes[stats++]);
-        return { ...stat, mtimeNs: stamp, ctimeNs: stamp };
+        stats += 1;
+        return stats % 2 === 0 ? { ...stat, mtimeNs: stat.mtimeNs + 1n } : stat;
       }
     };
-    const report = aggregateFile(log, {}, io);
-    assert.equal(report._section_A.total, 1);
+    assert.throws(() => aggregateFile(log, {}, io), /snapshot/);
     assert.equal(stats, 4);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
 });
 
-test("content recheck rejects same-inode rewrite with restored metadata and keeps only the fresh retry aggregate", () => {
+test("content recheck rejects same-inode rewrite even with restored metadata", () => {
   const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
   try {
     const log = join(directory, "dcserver.stdout.log");
@@ -188,6 +215,7 @@ test("content recheck rejects same-inode rewrite with restored metadata and keep
     let rewritten = false;
     const io = {
       ...fs,
+      statSync() { return { ...baseline }; },
       fstatSync() { return { ...baseline }; },
       readSync(...args) {
         const bytes = fs.readSync(...args);
@@ -198,15 +226,13 @@ test("content recheck rejects same-inode rewrite with restored metadata and keep
         return bytes;
       }
     };
-    const report = aggregateFile(log, {}, io);
-    assert.equal(report._section_A.total, 0);
-    assert.equal(report._section_J.total, 1);
+    assert.throws(() => aggregateFile(log, {}, io), /content changed|snapshot/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
 });
 
-test("shrink during first scan retries with a fresh snapshot", () => {
+test("shrink during first scan retries then fails closed", () => {
   const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
   try {
     const log = join(directory, "dcserver.stdout.log");
@@ -223,13 +249,13 @@ test("shrink during first scan retries with a fresh snapshot", () => {
         return bytes;
       }
     };
-    assert.equal(aggregateFile(log, {}, io)._section_A.total, 0);
+    assert.throws(() => aggregateFile(log, {}, io), /snapshot|shrank|manifest/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
 });
 
-test("opened-inode collision caused by rotation retries as one fresh all-file snapshot", () => {
+test("caller-order-independent rotation during open cannot erase divergence", () => {
   const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
   try {
     const current = join(directory, "dcserver.stdout.log");
@@ -238,9 +264,11 @@ test("opened-inode collision caused by rotation retries as one fresh all-file sn
     writeFileSync(current, `${shadow("_section_A")}\n`);
     writeFileSync(rotated, `${shadow("_section_J")}\n`);
     let rotatedOnce = false;
+    const openedPaths = [];
     const io = {
       ...fs,
       openSync(path, flags) {
+        openedPaths.push(path);
         const descriptor = fs.openSync(path, flags);
         if (!rotatedOnce) {
           rotatedOnce = true;
@@ -251,32 +279,66 @@ test("opened-inode collision caused by rotation retries as one fresh all-file sn
         return descriptor;
       }
     };
-    const report = aggregateFiles([current, rotated], {}, io);
-    assert.equal(report._section_A.total, 1);
-    assert.equal(report._section_J.total, 1);
+    assert.throws(() => aggregateFiles([rotated, current], {}, io), /manifest|opened inode|changed while opening/);
+    assert.equal(openedPaths[0], current);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
 });
 
-test("opened descriptors close on fstat and realpath failures", () => {
+test("opened descriptors close on fstat failures while pre-open realpath failure opens none", () => {
   const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
   try {
     const log = join(directory, "dcserver.stdout.log");
     writeFileSync(log, `${shadow("_section_A")}\n`);
-    for (const failedMethod of ["fstatSync", "realpathSync"]) {
-      let closes = 0;
-      const io = {
-        ...fs,
-        [failedMethod]() { throw new Error(`${failedMethod} injected failure`); },
-        closeSync(descriptor) {
-          closes += 1;
-          return fs.closeSync(descriptor);
+    let closes = 0;
+    const fstatIo = {
+      ...fs,
+      fstatSync() { throw new Error("fstatSync injected failure"); },
+      closeSync(descriptor) {
+        closes += 1;
+        return fs.closeSync(descriptor);
+      }
+    };
+    assert.throws(() => aggregateFile(log, {}, fstatIo), /injected failure/);
+    assert.equal(closes, 2);
+
+    let opens = 0;
+    const realpathIo = {
+      ...fs,
+      realpathSync() { throw new Error("realpathSync injected failure"); },
+      openSync(...args) { opens += 1; return fs.openSync(...args); }
+    };
+    assert.throws(() => aggregateFile(log, {}, realpathIo), /injected failure/);
+    assert.equal(opens, 0);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("close errors still attempt every descriptor and propagate the first failure", () => {
+  const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
+  try {
+    const first = join(directory, "a.log");
+    const second = join(directory, "b.log");
+    writeFileSync(first, `${shadow("_section_A")}\n`);
+    writeFileSync(second, `${shadow("_section_J")}\n`);
+    const closeCalls = [];
+    let injected = false;
+    const io = {
+      ...fs,
+      closeSync(descriptor) {
+        closeCalls.push(descriptor);
+        if (!injected) {
+          injected = true;
+          throw new Error("first close injected failure");
         }
-      };
-      assert.throws(() => aggregateFile(log, {}, io), /injected failure/);
-      assert.equal(closes, 2);
-    }
+        return fs.closeSync(descriptor);
+      }
+    };
+    assert.throws(() => aggregateFiles([first, second], {}, io), /first close injected failure/);
+    assert.equal(new Set(closeCalls).size, 2);
+    assert.equal(closeCalls.length, 3);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -373,19 +435,45 @@ test("raw-byte scanner accepts exactly capped LF and CRLF text records", () => {
   const padding = " ".repeat(1024 * 1024 - Buffer.byteLength(base));
   assert.equal(aggregateText([`${base}${padding}\n`])._section_A.total, 1);
   assert.equal(aggregateText([`${base}${padding}\r\n`])._section_A.total, 1);
+  assert.throws(() => aggregateText([Buffer.from(`${base}${padding}\r`)]), /log line exceeds 1048576 bytes/);
 });
 
-test("raw invalid UTF-8 below the cap is malformed evidence, not inflated cap failure", async () => {
+test("raw invalid UTF-8 is rejected identically by Buffer and Readable inputs", async () => {
   const invalidRecord = Buffer.concat([
     Buffer.from("[timeout_shadow] "),
     Buffer.alloc(400 * 1024, 0xff),
     Buffer.from("\n")
   ]);
-  const result = await runFromReadable([
-    "--stdin", "--min-a-samples", "0", "--min-j-samples", "0", "--max-errors", "1"
-  ], Readable.from([invalidRecord]));
-  assert.equal(result.exitCode, 0);
-  assert.equal(JSON.parse(result.output)._unclassified.malformed, 1);
+  assert.throws(() => aggregateText([invalidRecord]), /invalid UTF-8 log line/);
+  await assert.rejects(
+    runFromReadable(["--stdin"], Readable.from([invalidRecord])),
+    /invalid UTF-8 log line/
+  );
+  for (const section of ["_section_A", "_section_J"]) {
+    const corrupted = Buffer.concat([
+      Buffer.from(`[timeout_shadow] {"target":"agentdesk::timeout_shadow","section":"${section}","bad":"`),
+      Buffer.from([0xff]),
+      Buffer.from('"}\n')
+    ]);
+    await assert.rejects(runFromReadable(["--stdin"], Readable.from([corrupted])), /invalid UTF-8 log line/);
+  }
+});
+
+test("file snapshots reject invalid UTF-8 corruption in A and J records", () => {
+  const directory = mkdtempSync(join(tmpdir(), "timeout-shadow-gate-"));
+  try {
+    for (const section of ["_section_A", "_section_J"]) {
+      const log = join(directory, `${section}.log`);
+      writeFileSync(log, Buffer.concat([
+        Buffer.from(`[timeout_shadow] {"target":"agentdesk::timeout_shadow","section":"${section}","bad":"`),
+        Buffer.from([0xff]),
+        Buffer.from('"}\n')
+      ]));
+      assert.throws(() => aggregateFile(log), /invalid UTF-8 log line/);
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("text and run library exports enforce the same cap above one MiB", () => {

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -68,6 +68,9 @@ echo "=== Policy DB capability manifest guard (#3734) ==="
 echo "=== Merge automation policy tests (#4250) ==="
 node --test policies/__tests__/merge-automation.test.js
 
+echo "=== Timeout shadow aggregation gate tests (#3950) ==="
+node --test scripts/__tests__/timeout-shadow-gate.test.mjs
+
 echo "=== Daily log-digest routine tests (#4263) ==="
 node --test policies/__tests__/daily-log-digest.test.js
 "$PYTHON" -m unittest tests.test_daily_log_digest

--- a/scripts/timeout-shadow-gate.mjs
+++ b/scripts/timeout-shadow-gate.mjs
@@ -9,6 +9,7 @@
  */
 import fs from "node:fs";
 import process from "node:process";
+import { createHash } from "node:crypto";
 import { StringDecoder } from "node:string_decoder";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -28,7 +29,7 @@ function emptySection() {
 function emptyReport() {
   return {
     _section_A: emptySection(),
-    _section_J: { total: 0, incomparable: 0, ratio: null, error: 0 },
+    _section_J: { total: 0, successful: 0, incomparable: 0, ratio: null, error: 0 },
     // A malformed line without a readable `section` cannot honestly be
     // attributed to A or J.  Keep it visible and include it in max-errors.
     _unclassified: { malformed: 0 }
@@ -55,7 +56,8 @@ function parseTimestamp(value, optionName) {
   const hour = Number(hourText);
   const minute = Number(minuteText);
   const second = Number(secondText);
-  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
   const zoneValid = zone === "Z" || (Number(zone.slice(1, 3)) <= 23 && Number(zone.slice(4, 6)) <= 59);
   if (month < 1 || month > 12 || day < 1 || day > daysInMonth || hour > 23 || minute > 59 || second > 59 || !zoneValid) {
     throw new Error(`${optionName} requires a valid ISO-8601 calendar timestamp`);
@@ -84,7 +86,8 @@ export function parseArgs(argv) {
     minASamples: 1,
     minJSamples: 1,
     maxDivergence: Number.POSITIVE_INFINITY,
-    maxErrors: Number.POSITIVE_INFINITY
+    // Reducer/malformed errors are never clean shadow evidence by default.
+    maxErrors: 0
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -131,9 +134,13 @@ function timestampFromPrefix(prefix) {
   // tracing's usual RFC 3339 timestamps and the common space-separated form.
   // The final timestamp before the payload is the only one belonging to the
   // log line; timestamps in the JSON itself are deliberately ignored.
-  const matches = prefix.match(/\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?/g);
-  if (!matches || matches.length === 0) return null;
-  const raw = matches[matches.length - 1];
+  const matches = [...prefix.matchAll(/\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?/g)];
+  if (matches.length === 0) return null;
+  const match = matches[matches.length - 1];
+  const raw = match[0];
+  // Do not turn a partial offset such as +09 or +09:000 into UTC by matching
+  // only the timestamp prefix.  A valid tracing timestamp is token-bounded.
+  if (/^[0-9:+-]/.test(prefix.slice(match.index + raw.length))) return null;
   const normalizedBase = raw.replace(" ", "T");
   const normalized = /(?:Z|[+-]\d{2}:?\d{2})$/.test(normalizedBase)
     ? normalizedBase.replace(/([+-]\d{2})(\d{2})$/, "$1:$2")
@@ -190,6 +197,7 @@ function addRecord(report, record) {
     section.error += 1;
     return;
   }
+  if (record.section === "_section_J") section.successful += 1;
   if (record.section === "_section_A") {
     if (!isIncomparableRecord(record)) {
       section.comparable += 1;
@@ -203,7 +211,7 @@ function addRecord(report, record) {
 
 function finalizeReport(report) {
   const j = report._section_J;
-  j.ratio = j.total === 0 ? null : j.incomparable / j.total;
+  j.ratio = j.successful === 0 ? null : j.incomparable / j.successful;
   return report;
 }
 
@@ -221,7 +229,9 @@ export function aggregateText(inputs, options = {}) {
   const effectiveOptions = { since: null, until: null, ...options };
   const report = emptyReport();
   for (const input of inputs) {
-    for (const line of String(input).split(/\r?\n/)) processLine(report, line, effectiveOptions);
+    const scanner = createLineScanner((line) => processLine(report, line, effectiveOptions));
+    scanner.write(Buffer.from(String(input)));
+    scanner.end();
   }
   return finalizeReport(report);
 }
@@ -238,7 +248,7 @@ function processLine(report, line, options) {
 }
 
 function statSignature(stat) {
-  return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
+  return `${stat.dev}:${stat.ino}:${stat.size}:${stat.ctimeNs}:${stat.mtimeNs}`;
 }
 
 function createLineScanner(onLine) {
@@ -282,7 +292,7 @@ function createLineScanner(onLine) {
   };
 }
 
-function forEachDescriptorLine(descriptor, byteLimit, onLine, io) {
+function forEachDescriptorLine(descriptor, byteLimit, onLine, io, hash = null) {
   const buffer = Buffer.allocUnsafe(FILE_READ_CHUNK_BYTES);
   const scanner = createLineScanner(onLine);
   let remaining = byteLimit;
@@ -295,13 +305,30 @@ function forEachDescriptorLine(descriptor, byteLimit, onLine, io) {
       if (remaining !== null) throw new Error("log shrank while reading snapshot");
       break;
     }
-    scanner.write(buffer.subarray(0, bytesRead));
+    const chunk = buffer.subarray(0, bytesRead);
+    if (hash) hash.update(chunk);
+    scanner.write(chunk);
     if (remaining !== null) {
       remaining -= bytesRead;
       position += bytesRead;
     }
   }
   scanner.end();
+}
+
+function hashDescriptor(descriptor, byteLimit, io) {
+  const hash = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(FILE_READ_CHUNK_BYTES);
+  let remaining = byteLimit;
+  let position = 0;
+  while (remaining > 0) {
+    const bytesRead = io.readSync(descriptor, buffer, 0, Math.min(buffer.length, remaining), position);
+    if (bytesRead === 0) throw new Error("log shrank while re-reading snapshot");
+    hash.update(buffer.subarray(0, bytesRead));
+    remaining -= bytesRead;
+    position += bytesRead;
+  }
+  return hash.digest("hex");
 }
 
 function mergeReport(target, source) {
@@ -311,34 +338,34 @@ function mergeReport(target, source) {
   target._section_A.divergence += source._section_A.divergence;
   target._section_A.error += source._section_A.error;
   target._section_J.total += source._section_J.total;
+  target._section_J.successful += source._section_J.successful;
   target._section_J.incomparable += source._section_J.incomparable;
   target._section_J.error += source._section_J.error;
   target._unclassified.malformed += source._unclassified.malformed;
 }
 
-function openFileSnapshots(files, io) {
-  const snapshots = [];
+function openFileSnapshots(files, snapshots, io) {
   const canonicalPaths = new Set();
   const identities = new Set();
-  try {
-    for (const file of files) {
-      const descriptor = io.openSync(file, "r");
-      const stat = io.fstatSync(descriptor);
-      const canonical = io.realpathSync(file);
-      const identity = `${stat.dev}:${stat.ino}`;
-      if (canonicalPaths.has(canonical) || identities.has(identity)) {
-        io.closeSync(descriptor);
-        throw new Error(`duplicate log input: ${file}`);
-      }
-      canonicalPaths.add(canonical);
-      identities.add(identity);
-      snapshots.push({ descriptor, file, stat, signature: statSignature(stat) });
+  for (const file of files) {
+    const descriptor = io.openSync(file, "r");
+    // Push before every later failure so the enclosing attempt closes this fd.
+    const snapshot = { descriptor, file };
+    snapshots.push(snapshot);
+    const stat = io.fstatSync(descriptor, { bigint: true });
+    const canonical = io.realpathSync(file);
+    const identity = `${stat.dev}:${stat.ino}`;
+    if (canonicalPaths.has(canonical) || identities.has(identity)) {
+      throw new Error(`duplicate log input: ${file}`);
     }
-    return snapshots;
-  } catch (error) {
-    for (const snapshot of snapshots) io.closeSync(snapshot.descriptor);
-    throw error;
+    if (stat.size > BigInt(Number.MAX_SAFE_INTEGER)) throw new Error(`log too large for bounded scan: ${file}`);
+    canonicalPaths.add(canonical);
+    identities.add(identity);
+    snapshot.stat = stat;
+    snapshot.signature = statSignature(stat);
+    snapshot.size = Number(stat.size);
   }
+  return snapshots;
 }
 
 function closeSnapshots(snapshots, io) {
@@ -352,20 +379,32 @@ function closeSnapshots(snapshots, io) {
  */
 export function aggregateFiles(files, options = {}, io = fs) {
   const effectiveOptions = { since: null, until: null, ...options };
+  let lastError = null;
   for (let attempt = 0; attempt < STABLE_READ_ATTEMPTS; attempt += 1) {
-    const snapshots = openFileSnapshots(files, io);
+    const snapshots = [];
     const report = emptyReport();
     try {
+      openFileSnapshots(files, snapshots, io);
       for (const snapshot of snapshots) {
-        forEachDescriptorLine(snapshot.descriptor, snapshot.stat.size, (line) => processLine(report, line, effectiveOptions), io);
+        const hash = createHash("sha256");
+        forEachDescriptorLine(snapshot.descriptor, snapshot.size, (line) => processLine(report, line, effectiveOptions), io, hash);
+        snapshot.firstHash = hash.digest("hex");
       }
-      const stable = snapshots.every((snapshot) => statSignature(io.fstatSync(snapshot.descriptor)) === snapshot.signature);
+      let stable = true;
+      for (const snapshot of snapshots) {
+        const contentMatches = snapshot.firstHash === hashDescriptor(snapshot.descriptor, snapshot.size, io);
+        const metadataMatches = statSignature(io.fstatSync(snapshot.descriptor, { bigint: true })) === snapshot.signature;
+        if (!contentMatches || !metadataMatches) stable = false;
+      }
       if (stable) return finalizeReport(report);
+      lastError = new Error("log changed while reading snapshot");
+    } catch (error) {
+      lastError = error;
     } finally {
       closeSnapshots(snapshots, io);
     }
   }
-  throw new Error("log changed while reading snapshot");
+  throw lastError || new Error("log changed while reading snapshot");
 }
 
 export function aggregateFile(file, options = {}, io = fs) {
@@ -400,8 +439,8 @@ export function thresholdFailures(report, options) {
   if (report._section_A.comparable < options.minASamples) {
     failures.push(`_section_A comparable samples ${report._section_A.comparable} < ${options.minASamples}`);
   }
-  if (report._section_J.total < options.minJSamples) {
-    failures.push(`_section_J samples ${report._section_J.total} < ${options.minJSamples}`);
+  if (report._section_J.successful < options.minJSamples) {
+    failures.push(`_section_J successful samples ${report._section_J.successful} < ${options.minJSamples}`);
   }
   if (report._section_A.divergence > options.maxDivergence) {
     failures.push(`_section_A divergence ${report._section_A.divergence} > ${options.maxDivergence}`);
@@ -419,9 +458,9 @@ export function helpText() {
     `  --since <ISO-8601>         Include timestamped records at or after this time\n` +
     `  --until <ISO-8601>         Include timestamped records at or before this time\n` +
     `  --min-a-samples <count>    Minimum comparable _section_A records (default: 1)\n` +
-    `  --min-j-samples <count>    Minimum _section_J records (default: 1)\n` +
+    `  --min-j-samples <count>    Minimum successful _section_J records (default: 1)\n` +
     `  --max-divergence <count>   Maximum comparable _section_A disagreements\n` +
-    `  --max-errors <count>       Maximum malformed/reducer-error records\n\n` +
+    `  --max-errors <count>       Maximum malformed/reducer-error records (default: 0)\n\n` +
     `Input records are streamed; each log line is limited to ${MAX_RECORD_LINE_BYTES} bytes.\n`;
 }
 

--- a/scripts/timeout-shadow-gate.mjs
+++ b/scripts/timeout-shadow-gate.mjs
@@ -378,6 +378,21 @@ function aggregateDescriptor(descriptor, options, io = fs) {
   return finalizeReport(report);
 }
 
+/**
+ * Consume a Node Readable without touching its descriptor.  process.stdin is
+ * sometimes nonblocking under node:test; Readable owns readiness/EAGAIN
+ * handling, while this function keeps the existing bounded line scanner.
+ */
+async function aggregateReadable(readable, options) {
+  const report = emptyReport();
+  const scanner = createLineScanner((line) => processLine(report, line, options));
+  for await (const chunk of readable) {
+    scanner.write(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  scanner.end();
+  return finalizeReport(report);
+}
+
 export function thresholdFailures(report, options) {
   const failures = [];
   // A's meaningful evidence is comparable pairs.  J is intentionally
@@ -433,6 +448,16 @@ export function runFromStdin(argv, io = fs) {
   return { help: false, output: JSON.stringify(report), failures, exitCode: failures.length === 0 ? 0 : 1 };
 }
 
+export async function runFromReadable(argv, readable = process.stdin, io = fs) {
+  const options = parseArgs(argv);
+  if (options.help) return { help: true, output: helpText(), exitCode: 0 };
+  const report = aggregateFiles(options.files, options, io);
+  if (options.readStdin) mergeReport(report, await aggregateReadable(readable, options));
+  finalizeReport(report);
+  const failures = thresholdFailures(report, options);
+  return { help: false, output: JSON.stringify(report), failures, exitCode: failures.length === 0 ? 0 : 1 };
+}
+
 export function isMainModule(entry = process.argv[1], io = fs) {
   if (!entry) return false;
   try {
@@ -444,14 +469,13 @@ export function isMainModule(entry = process.argv[1], io = fs) {
 }
 
 if (isMainModule()) {
-  try {
-    const result = runFromStdin(process.argv.slice(2));
+  void runFromReadable(process.argv.slice(2)).then((result) => {
     if (result.help) process.stdout.write(result.output);
     else process.stdout.write(`${result.output}\n`);
     if (result.failures && result.failures.length > 0) process.stderr.write(`${result.failures.join("; ")}\n`);
     process.exitCode = result.exitCode;
-  } catch (error) {
+  }).catch((error) => {
     process.stderr.write(`timeout-shadow-gate: ${error.message}\n`);
     process.exitCode = 2;
-  }
+  });
 }

--- a/scripts/timeout-shadow-gate.mjs
+++ b/scripts/timeout-shadow-gate.mjs
@@ -10,12 +10,12 @@
 import fs from "node:fs";
 import process from "node:process";
 import { createHash } from "node:crypto";
-import { StringDecoder } from "node:string_decoder";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const SHADOW_PREFIX = "[timeout_shadow] ";
 const SHADOW_TARGET = "agentdesk::timeout_shadow";
 const SECTIONS = new Set(["_section_A", "_section_J"]);
+const COMPARABLE_A_DECISIONS = new Set(["retry", "exhaust"]);
 const FILE_READ_CHUNK_BYTES = 64 * 1024;
 const STABLE_READ_ATTEMPTS = 2;
 // A shadow record is one log line.  This cap prevents a malformed stdin/log
@@ -200,9 +200,23 @@ function addRecord(report, record) {
   if (record.section === "_section_J") section.successful += 1;
   if (record.section === "_section_A") {
     if (!isIncomparableRecord(record)) {
+      if (!COMPARABLE_A_DECISIONS.has(record.js_decision) || !COMPARABLE_A_DECISIONS.has(record.reducer_decision)) {
+        section.error += 1;
+        return;
+      }
       section.comparable += 1;
-      if (record.agree) section.agreement += 1;
-      else section.divergence += 1;
+      const derivedAgreement = record.js_decision === record.reducer_decision;
+      // `agree` is producer-controlled observability data, never gate
+      // authority. A forged true cannot hide a decision divergence; any
+      // mismatch is error evidence and a real divergence stays divergent.
+      if (record.agree !== derivedAgreement) {
+        section.error += 1;
+        if (!derivedAgreement) section.divergence += 1;
+      } else if (derivedAgreement) {
+        section.agreement += 1;
+      } else {
+        section.divergence += 1;
+      }
     }
   } else if (isIncomparableRecord(record)) {
     section.incomparable += 1;
@@ -255,42 +269,49 @@ function statSignature(stat) {
 }
 
 function createLineScanner(onLine) {
-  let remainder = "";
-  let remainderBytes = 0;
-  const decoder = new StringDecoder("utf8");
+  let segments = [];
+  let rawBytes = 0;
 
-  function appendPart(part, complete) {
-    const partBytes = Buffer.byteLength(part);
-    if (remainderBytes + partBytes > MAX_RECORD_LINE_BYTES) {
+  function append(segment) {
+    if (segment.length === 0) return;
+    // Allow one extra raw CR until the record terminator confirms CRLF.
+    // Anything larger cannot become a valid <= 1 MiB record.
+    if (rawBytes + segment.length > MAX_RECORD_LINE_BYTES + 1) {
       throw new Error(`log line exceeds ${MAX_RECORD_LINE_BYTES} bytes`);
     }
-    remainder += part;
-    remainderBytes += partBytes;
-    if (complete) {
-      onLine(remainder.endsWith("\r") ? remainder.slice(0, -1) : remainder);
-      remainder = "";
-      remainderBytes = 0;
-    }
+    segments.push(segment);
+    rawBytes += segment.length;
   }
 
-  function consume(text) {
-    let cursor = 0;
-    for (;;) {
-      const newline = text.indexOf("\n", cursor);
-      if (newline === -1) {
-        appendPart(text.slice(cursor), false);
-        return;
-      }
-      appendPart(text.slice(cursor, newline), true);
-      cursor = newline + 1;
+  function finishLine() {
+    const raw = Buffer.concat(segments, rawBytes);
+    const contentLength = rawBytes > 0 && raw[rawBytes - 1] === 0x0d ? rawBytes - 1 : rawBytes;
+    if (contentLength > MAX_RECORD_LINE_BYTES) {
+      throw new Error(`log line exceeds ${MAX_RECORD_LINE_BYTES} bytes`);
     }
+    // Decode only after raw-byte enforcement. Invalid UTF-8 consequently
+    // becomes malformed JSON evidence instead of inflating the cap.
+    onLine(raw.subarray(0, contentLength).toString("utf8"));
+    segments = [];
+    rawBytes = 0;
   }
 
   return {
-    write(buffer) { consume(decoder.write(buffer)); },
+    write(buffer) {
+      let cursor = 0;
+      for (;;) {
+        const newline = buffer.indexOf(0x0a, cursor);
+        if (newline === -1) {
+          append(buffer.subarray(cursor));
+          return;
+        }
+        append(buffer.subarray(cursor, newline));
+        finishLine();
+        cursor = newline + 1;
+      }
+    },
     end() {
-      consume(decoder.end());
-      if (remainderBytes > 0) appendPart("", true);
+      if (rawBytes > 0) finishLine();
     }
   };
 }
@@ -414,12 +435,6 @@ export function aggregateFile(file, options = {}, io = fs) {
   return aggregateFiles([file], options, io);
 }
 
-function aggregateDescriptor(descriptor, options, io = fs) {
-  const report = emptyReport();
-  forEachDescriptorLine(descriptor, null, (line) => processLine(report, line, options), io);
-  return finalizeReport(report);
-}
-
 /**
  * Consume a Node Readable without touching its descriptor.  process.stdin is
  * sometimes nonblocking under node:test; Readable owns readiness/EAGAIN
@@ -475,16 +490,6 @@ export function run(argv, stdinText) {
     const stdinReport = aggregateText([stdinText], options);
     mergeReport(report, stdinReport);
   }
-  finalizeReport(report);
-  const failures = thresholdFailures(report, options);
-  return { help: false, output: JSON.stringify(report), failures, exitCode: failures.length === 0 ? 0 : 1 };
-}
-
-export function runFromStdin(argv, io = fs) {
-  const options = parseArgs(argv);
-  if (options.help) return { help: true, output: helpText(), exitCode: 0 };
-  const report = aggregateFiles(options.files, options, io);
-  if (options.readStdin) mergeReport(report, aggregateDescriptor(0, options, io));
   finalizeReport(report);
   const failures = thresholdFailures(report, options);
   return { help: false, output: JSON.stringify(report), failures, exitCode: failures.length === 0 ? 0 : 1 };

--- a/scripts/timeout-shadow-gate.mjs
+++ b/scripts/timeout-shadow-gate.mjs
@@ -17,7 +17,7 @@ const SHADOW_PREFIX = "[timeout_shadow] ";
 const SHADOW_TARGET = "agentdesk::timeout_shadow";
 const SECTIONS = new Set(["_section_A", "_section_J"]);
 const COMPARABLE_A_DECISIONS = new Set(["retry", "exhaust"]);
-const VALID_J_REDUCER_DECISIONS = new Set(["retry", "exhaust", "incomparable"]);
+const EXPECTED_J_REDUCER_DECISION = "incomparable";
 const STRICT_UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 const FILE_READ_CHUNK_BYTES = 64 * 1024;
 const STABLE_READ_ATTEMPTS = 2;
@@ -218,19 +218,18 @@ function addRecord(report, record) {
       else section.divergence += 1;
     }
   } else {
-    const reducerValid = VALID_J_REDUCER_DECISIONS.has(record.reducer_decision);
-    if (record.js_decision !== "retry" || !reducerValid) {
+    // _section_J currently previews with null status/state, so the reducer can
+    // only produce incomparable or error.  A comparable label is not evidence
+    // of agreement; it violates the producer contract and must fail closed.
+    if (record.js_decision !== "retry" || record.reducer_decision !== EXPECTED_J_REDUCER_DECISION) {
       section.error += 1;
       return;
     }
-    const derivedIncomparable = record.reducer_decision === "incomparable";
-    const derivedAgreement = record.reducer_decision === record.js_decision && !derivedIncomparable;
-    const diagnosticMismatch = (record.incomparable === true) !== derivedIncomparable ||
-      record.agree !== derivedAgreement;
+    const diagnosticMismatch = record.incomparable !== true || record.agree !== false;
     if (diagnosticMismatch) section.error += 1;
     else {
       section.successful += 1;
-      if (derivedIncomparable) section.incomparable += 1;
+      section.incomparable += 1;
     }
   }
 }
@@ -454,9 +453,6 @@ function closeSnapshots(snapshots, io) {
       io.closeSync(snapshot.descriptor);
     } catch (error) {
       if (!firstError) firstError = error;
-      // Retry this fd once for transient close failures, while still moving on
-      // to every other descriptor regardless of either result.
-      try { io.closeSync(snapshot.descriptor); } catch (_) {}
     }
   }
   return firstError;

--- a/scripts/timeout-shadow-gate.mjs
+++ b/scripts/timeout-shadow-gate.mjs
@@ -248,7 +248,10 @@ function processLine(report, line, options) {
 }
 
 function statSignature(stat) {
-  return `${stat.dev}:${stat.ino}:${stat.size}:${stat.ctimeNs}:${stat.mtimeNs}`;
+  // ctime changes for a pure rename even though this opened inode's bytes are
+  // unchanged.  Preserve it on the snapshot for diagnostics, but let the
+  // content double-hash plus identity/size/mtime decide acceptance.
+  return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeNs}`;
 }
 
 function createLineScanner(onLine) {

--- a/scripts/timeout-shadow-gate.mjs
+++ b/scripts/timeout-shadow-gate.mjs
@@ -10,12 +10,16 @@
 import fs from "node:fs";
 import process from "node:process";
 import { StringDecoder } from "node:string_decoder";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const SHADOW_PREFIX = "[timeout_shadow] ";
 const SHADOW_TARGET = "agentdesk::timeout_shadow";
 const SECTIONS = new Set(["_section_A", "_section_J"]);
 const FILE_READ_CHUNK_BYTES = 64 * 1024;
 const STABLE_READ_ATTEMPTS = 2;
+// A shadow record is one log line.  This cap prevents a malformed stdin/log
+// stream from growing an unterminated line without bound.
+export const MAX_RECORD_LINE_BYTES = 1024 * 1024;
 
 function emptySection() {
   return { total: 0, comparable: 0, agreement: 0, divergence: 0, error: 0 };
@@ -56,9 +60,17 @@ function parseTimestamp(value, optionName) {
   if (month < 1 || month > 12 || day < 1 || day > daysInMonth || hour > 23 || minute > 59 || second > 59 || !zoneValid) {
     throw new Error(`${optionName} requires a valid ISO-8601 calendar timestamp`);
   }
-  const parsed = Date.parse(value);
-  if (Number.isNaN(parsed)) throw new Error(`${optionName} requires a valid ISO-8601 calendar timestamp`);
-  return parsed;
+  const fraction = (match[7] || "").padEnd(9, "0");
+  const monthForMarch = month + (month > 2 ? -3 : 9);
+  const adjustedYear = year - (month <= 2 ? 1 : 0);
+  const era = Math.floor(adjustedYear / 400);
+  const yearOfEra = adjustedYear - era * 400;
+  const dayOfYear = Math.floor((153 * monthForMarch + 2) / 5) + day - 1;
+  const dayOfEra = yearOfEra * 365 + Math.floor(yearOfEra / 4) - Math.floor(yearOfEra / 100) + dayOfYear;
+  const daysSinceEpoch = era * 146097 + dayOfEra - 719468;
+  const offsetSeconds = zone === "Z" ? 0 :
+    (Number(zone.slice(1, 3)) * 60 + Number(zone.slice(4, 6))) * 60 * (zone.startsWith("+") ? 1 : -1);
+  return (BigInt(daysSinceEpoch) * 86400n + BigInt(hour * 3600 + minute * 60 + second - offsetSeconds)) * 1000000000n + BigInt(fraction || "0");
 }
 
 export function parseArgs(argv) {
@@ -122,9 +134,10 @@ function timestampFromPrefix(prefix) {
   const matches = prefix.match(/\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?/g);
   if (!matches || matches.length === 0) return null;
   const raw = matches[matches.length - 1];
-  const normalized = /(?:Z|[+-]\d{2}:?\d{2})$/.test(raw)
-    ? raw.replace(/([+-]\d{2})(\d{2})$/, "$1:$2")
-    : raw.replace(" ", "T") + "Z";
+  const normalizedBase = raw.replace(" ", "T");
+  const normalized = /(?:Z|[+-]\d{2}:?\d{2})$/.test(normalizedBase)
+    ? normalizedBase.replace(/([+-]\d{2})(\d{2})$/, "$1:$2")
+    : normalizedBase + "Z";
   try {
     return parseTimestamp(normalized, "log timestamp");
   } catch {
@@ -228,25 +241,67 @@ function statSignature(stat) {
   return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
 }
 
-function forEachFileLine(file, onLine, io) {
-  const descriptor = io.openSync(file, "r");
+function createLineScanner(onLine) {
   let remainder = "";
-  const buffer = Buffer.allocUnsafe(FILE_READ_CHUNK_BYTES);
+  let remainderBytes = 0;
   const decoder = new StringDecoder("utf8");
-  try {
-    for (;;) {
-      const bytesRead = io.readSync(descriptor, buffer, 0, buffer.length, null);
-      if (bytesRead === 0) break;
-      const combined = remainder + decoder.write(buffer.subarray(0, bytesRead));
-      const lines = combined.split("\n");
-      remainder = lines.pop();
-      for (const line of lines) onLine(line.endsWith("\r") ? line.slice(0, -1) : line);
+
+  function appendPart(part, complete) {
+    const partBytes = Buffer.byteLength(part);
+    if (remainderBytes + partBytes > MAX_RECORD_LINE_BYTES) {
+      throw new Error(`log line exceeds ${MAX_RECORD_LINE_BYTES} bytes`);
     }
-    remainder += decoder.end();
-    if (remainder.length > 0) onLine(remainder.endsWith("\r") ? remainder.slice(0, -1) : remainder);
-  } finally {
-    io.closeSync(descriptor);
+    remainder += part;
+    remainderBytes += partBytes;
+    if (complete) {
+      onLine(remainder.endsWith("\r") ? remainder.slice(0, -1) : remainder);
+      remainder = "";
+      remainderBytes = 0;
+    }
   }
+
+  function consume(text) {
+    let cursor = 0;
+    for (;;) {
+      const newline = text.indexOf("\n", cursor);
+      if (newline === -1) {
+        appendPart(text.slice(cursor), false);
+        return;
+      }
+      appendPart(text.slice(cursor, newline), true);
+      cursor = newline + 1;
+    }
+  }
+
+  return {
+    write(buffer) { consume(decoder.write(buffer)); },
+    end() {
+      consume(decoder.end());
+      if (remainderBytes > 0) appendPart("", true);
+    }
+  };
+}
+
+function forEachDescriptorLine(descriptor, byteLimit, onLine, io) {
+  const buffer = Buffer.allocUnsafe(FILE_READ_CHUNK_BYTES);
+  const scanner = createLineScanner(onLine);
+  let remaining = byteLimit;
+  let position = 0;
+  for (;;) {
+    const length = remaining === null ? buffer.length : Math.min(buffer.length, remaining);
+    if (length === 0) break;
+    const bytesRead = io.readSync(descriptor, buffer, 0, length, remaining === null ? null : position);
+    if (bytesRead === 0) {
+      if (remaining !== null) throw new Error("log shrank while reading snapshot");
+      break;
+    }
+    scanner.write(buffer.subarray(0, bytesRead));
+    if (remaining !== null) {
+      remaining -= bytesRead;
+      position += bytesRead;
+    }
+  }
+  scanner.end();
 }
 
 function mergeReport(target, source) {
@@ -261,37 +316,66 @@ function mergeReport(target, source) {
   target._unclassified.malformed += source._unclassified.malformed;
 }
 
-/**
- * Read a regular/rotated log with bounded memory.  A changed stat signature
- * means the file may have been renamed or appended during the scan; retry the
- * whole file once and otherwise reject it instead of mixing two snapshots.
- */
-export function aggregateFile(file, options = {}, io = fs) {
-  const effectiveOptions = { since: null, until: null, ...options };
-  for (let attempt = 0; attempt < STABLE_READ_ATTEMPTS; attempt += 1) {
-    const before = io.statSync(file);
-    const report = emptyReport();
-    forEachFileLine(file, (line) => processLine(report, line, effectiveOptions), io);
-    const after = io.statSync(file);
-    if (statSignature(before) === statSignature(after)) return finalizeReport(report);
+function openFileSnapshots(files, io) {
+  const snapshots = [];
+  const canonicalPaths = new Set();
+  const identities = new Set();
+  try {
+    for (const file of files) {
+      const descriptor = io.openSync(file, "r");
+      const stat = io.fstatSync(descriptor);
+      const canonical = io.realpathSync(file);
+      const identity = `${stat.dev}:${stat.ino}`;
+      if (canonicalPaths.has(canonical) || identities.has(identity)) {
+        io.closeSync(descriptor);
+        throw new Error(`duplicate log input: ${file}`);
+      }
+      canonicalPaths.add(canonical);
+      identities.add(identity);
+      snapshots.push({ descriptor, file, stat, signature: statSignature(stat) });
+    }
+    return snapshots;
+  } catch (error) {
+    for (const snapshot of snapshots) io.closeSync(snapshot.descriptor);
+    throw error;
   }
-  throw new Error(`log changed while reading: ${file}`);
 }
 
-function uniqueFiles(files, io = fs) {
-  const seenCanonical = new Set();
-  const seenInodes = new Set();
-  return files.map((file) => {
-    const canonical = io.realpathSync(file);
-    const stat = io.statSync(canonical);
-    const inode = `${stat.dev}:${stat.ino}`;
-    if (seenCanonical.has(canonical) || seenInodes.has(inode)) {
-      throw new Error(`duplicate log input: ${file}`);
+function closeSnapshots(snapshots, io) {
+  for (const snapshot of snapshots) io.closeSync(snapshot.descriptor);
+}
+
+/**
+ * Open every input before reading any input.  Each descriptor is then read at
+ * its captured size, so a rotation between reads cannot mix old and new path
+ * contents.  Mutated opened files are retried once and then fail closed.
+ */
+export function aggregateFiles(files, options = {}, io = fs) {
+  const effectiveOptions = { since: null, until: null, ...options };
+  for (let attempt = 0; attempt < STABLE_READ_ATTEMPTS; attempt += 1) {
+    const snapshots = openFileSnapshots(files, io);
+    const report = emptyReport();
+    try {
+      for (const snapshot of snapshots) {
+        forEachDescriptorLine(snapshot.descriptor, snapshot.stat.size, (line) => processLine(report, line, effectiveOptions), io);
+      }
+      const stable = snapshots.every((snapshot) => statSignature(io.fstatSync(snapshot.descriptor)) === snapshot.signature);
+      if (stable) return finalizeReport(report);
+    } finally {
+      closeSnapshots(snapshots, io);
     }
-    seenCanonical.add(canonical);
-    seenInodes.add(inode);
-    return canonical;
-  });
+  }
+  throw new Error("log changed while reading snapshot");
+}
+
+export function aggregateFile(file, options = {}, io = fs) {
+  return aggregateFiles([file], options, io);
+}
+
+function aggregateDescriptor(descriptor, options, io = fs) {
+  const report = emptyReport();
+  forEachDescriptorLine(descriptor, null, (line) => processLine(report, line, options), io);
+  return finalizeReport(report);
 }
 
 export function thresholdFailures(report, options) {
@@ -322,14 +406,14 @@ export function helpText() {
     `  --min-a-samples <count>    Minimum comparable _section_A records (default: 1)\n` +
     `  --min-j-samples <count>    Minimum _section_J records (default: 1)\n` +
     `  --max-divergence <count>   Maximum comparable _section_A disagreements\n` +
-    `  --max-errors <count>       Maximum malformed/reducer-error records\n`;
+    `  --max-errors <count>       Maximum malformed/reducer-error records\n\n` +
+    `Input records are streamed; each log line is limited to ${MAX_RECORD_LINE_BYTES} bytes.\n`;
 }
 
 export function run(argv, stdinText) {
   const options = parseArgs(argv);
   if (options.help) return { help: true, output: helpText(), exitCode: 0 };
-  const report = emptyReport();
-  for (const file of uniqueFiles(options.files)) mergeReport(report, aggregateFile(file, options));
+  const report = aggregateFiles(options.files, options);
   if (options.readStdin) {
     const stdinReport = aggregateText([stdinText], options);
     mergeReport(report, stdinReport);
@@ -339,15 +423,29 @@ export function run(argv, stdinText) {
   return { help: false, output: JSON.stringify(report), failures, exitCode: failures.length === 0 ? 0 : 1 };
 }
 
-if (import.meta.url === new URL(process.argv[1], "file:").href) {
+export function runFromStdin(argv, io = fs) {
+  const options = parseArgs(argv);
+  if (options.help) return { help: true, output: helpText(), exitCode: 0 };
+  const report = aggregateFiles(options.files, options, io);
+  if (options.readStdin) mergeReport(report, aggregateDescriptor(0, options, io));
+  finalizeReport(report);
+  const failures = thresholdFailures(report, options);
+  return { help: false, output: JSON.stringify(report), failures, exitCode: failures.length === 0 ? 0 : 1 };
+}
+
+export function isMainModule(entry = process.argv[1], io = fs) {
+  if (!entry) return false;
   try {
-    // Do not consume a terminal's stdin merely because file paths were
-    // supplied.  Besides being surprising, that would make the gate hang in
-    // an operator shell.  stdin is consumed only for the explicit/default
-    // stdin modes parsed above.
-    const cliOptions = parseArgs(process.argv.slice(2));
-    const stdinText = !cliOptions.help && cliOptions.readStdin ? fs.readFileSync(0, "utf8") : "";
-    const result = run(process.argv.slice(2), stdinText);
+    return pathToFileURL(io.realpathSync(entry)).href ===
+      pathToFileURL(io.realpathSync(fileURLToPath(import.meta.url))).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  try {
+    const result = runFromStdin(process.argv.slice(2));
     if (result.help) process.stdout.write(result.output);
     else process.stdout.write(`${result.output}\n`);
     if (result.failures && result.failures.length > 0) process.stderr.write(`${result.failures.join("; ")}\n`);

--- a/scripts/timeout-shadow-gate.mjs
+++ b/scripts/timeout-shadow-gate.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * Aggregate the preview-only timeout reducer shadow logs used by #3950.
+ *
+ * The producer intentionally emits one JSON record per line prefixed with
+ * `[timeout_shadow] `.  dcserver/tracing may put arbitrary text in front of
+ * that prefix, so this reader finds the prefix instead of assuming a log
+ * format.  It never interprets ordinary log lines as shadow evidence.
+ */
+import fs from "node:fs";
+import process from "node:process";
+
+const SHADOW_PREFIX = "[timeout_shadow] ";
+const SHADOW_TARGET = "agentdesk::timeout_shadow";
+const SECTIONS = new Set(["_section_A", "_section_J"]);
+
+function emptySection() {
+  return { total: 0, comparable: 0, agreement: 0, divergence: 0, error: 0 };
+}
+
+function emptyReport() {
+  return {
+    _section_A: emptySection(),
+    _section_J: { total: 0, incomparable: 0, ratio: null, error: 0 },
+    // A malformed line without a readable `section` cannot honestly be
+    // attributed to A or J.  Keep it visible and include it in max-errors.
+    _unclassified: { malformed: 0 }
+  };
+}
+
+function parseNumber(name, value) {
+  if (value === undefined || value === "") {
+    throw new Error(`${name} requires a non-negative number`);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${name} requires a non-negative number`);
+  }
+  return parsed;
+}
+
+function parseTimestamp(value, optionName) {
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) throw new Error(`${optionName} requires an ISO-8601 timestamp`);
+  return parsed;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    files: [],
+    readStdin: false,
+    since: null,
+    until: null,
+    minASamples: 0,
+    minJSamples: 0,
+    maxDivergence: Number.POSITIVE_INFINITY,
+    maxErrors: Number.POSITIVE_INFINITY
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--stdin" || argument === "-") {
+      options.readStdin = true;
+      continue;
+    }
+    if (argument === "--help" || argument === "-h") {
+      options.help = true;
+      continue;
+    }
+
+    const equals = argument.indexOf("=");
+    const name = equals === -1 ? argument : argument.slice(0, equals);
+    const inlineValue = equals === -1 ? undefined : argument.slice(equals + 1);
+    const nextValue = () => {
+      if (inlineValue !== undefined) return inlineValue;
+      index += 1;
+      return argv[index];
+    };
+
+    switch (name) {
+      case "--since": options.since = parseTimestamp(nextValue(), name); break;
+      case "--until": options.until = parseTimestamp(nextValue(), name); break;
+      case "--min-a-samples": options.minASamples = parseNumber(name, nextValue()); break;
+      case "--min-j-samples": options.minJSamples = parseNumber(name, nextValue()); break;
+      case "--max-divergence": options.maxDivergence = parseNumber(name, nextValue()); break;
+      case "--max-errors": options.maxErrors = parseNumber(name, nextValue()); break;
+      default:
+        if (argument.startsWith("-")) throw new Error(`unknown option: ${argument}`);
+        options.files.push(argument);
+    }
+  }
+
+  if (options.since !== null && options.until !== null && options.since > options.until) {
+    throw new Error("--since must not be after --until");
+  }
+  if (options.files.length === 0) options.readStdin = true;
+  return options;
+}
+
+function timestampFromPrefix(prefix) {
+  // tracing's usual RFC 3339 timestamps and the common space-separated form.
+  // The final timestamp before the payload is the only one belonging to the
+  // log line; timestamps in the JSON itself are deliberately ignored.
+  const matches = prefix.match(/\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?/g);
+  if (!matches || matches.length === 0) return null;
+  const raw = matches[matches.length - 1];
+  const normalized = /(?:Z|[+-]\d{2}:?\d{2})$/.test(raw) ? raw : raw.replace(" ", "T") + "Z";
+  const timestamp = Date.parse(normalized);
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function sectionHint(payload) {
+  const match = /"section"\s*:\s*"(_section_[AJ])"/.exec(payload);
+  return match ? match[1] : null;
+}
+
+function isErrorRecord(record) {
+  return record.reducer_decision === "error" ||
+    (typeof record.error === "string" && record.error.length > 0);
+}
+
+function isIncomparableRecord(record) {
+  return record.incomparable === true || record.reducer_decision === "incomparable";
+}
+
+function validateRecord(record) {
+  if (!record || typeof record !== "object" || Array.isArray(record)) return "record is not an object";
+  if (record.target !== SHADOW_TARGET) return "unexpected target";
+  if (!SECTIONS.has(record.section)) return "unexpected section";
+  if (typeof record.js_decision !== "string") return "missing js_decision";
+  if (typeof record.reducer_decision !== "string") return "missing reducer_decision";
+  if (typeof record.agree !== "boolean") return "missing agree";
+  return null;
+}
+
+function addMalformed(report, payload) {
+  const hintedSection = sectionHint(payload);
+  if (hintedSection) report[hintedSection].error += 1;
+  else report._unclassified.malformed += 1;
+}
+
+function addRecord(report, record) {
+  const validationError = validateRecord(record);
+  if (validationError) {
+    const hintedSection = record && typeof record === "object" ? record.section : null;
+    if (SECTIONS.has(hintedSection)) report[hintedSection].error += 1;
+    else report._unclassified.malformed += 1;
+    return;
+  }
+
+  const section = report[record.section];
+  section.total += 1;
+  if (isErrorRecord(record)) {
+    section.error += 1;
+    return;
+  }
+  if (record.section === "_section_A") {
+    if (!isIncomparableRecord(record)) {
+      section.comparable += 1;
+      if (record.agree) section.agreement += 1;
+      else section.divergence += 1;
+    }
+  } else if (isIncomparableRecord(record)) {
+    section.incomparable += 1;
+  }
+}
+
+function finalizeReport(report) {
+  const j = report._section_J;
+  j.ratio = j.total === 0 ? null : j.incomparable / j.total;
+  return report;
+}
+
+function lineInRange(line, prefixIndex, options) {
+  if (options.since === null && options.until === null) return true;
+  const timestamp = timestampFromPrefix(line.slice(0, prefixIndex));
+  // A line without a timestamp remains eligible: the CLI promises filtering
+  // only where a timestamp is actually present.
+  if (timestamp === null) return true;
+  return (options.since === null || timestamp >= options.since) &&
+    (options.until === null || timestamp <= options.until);
+}
+
+export function aggregateText(inputs, options = {}) {
+  const effectiveOptions = { since: null, until: null, ...options };
+  const report = emptyReport();
+  for (const input of inputs) {
+    for (const line of String(input).split(/\r?\n/)) {
+      const prefixIndex = line.indexOf(SHADOW_PREFIX);
+      if (prefixIndex === -1 || !lineInRange(line, prefixIndex, effectiveOptions)) continue;
+      const payload = line.slice(prefixIndex + SHADOW_PREFIX.length).trim();
+      try {
+        addRecord(report, JSON.parse(payload));
+      } catch {
+        addMalformed(report, payload);
+      }
+    }
+  }
+  return finalizeReport(report);
+}
+
+export function thresholdFailures(report, options) {
+  const failures = [];
+  // A's meaningful evidence is comparable pairs.  J is intentionally
+  // incomparable today, so all valid J records are useful evidence there.
+  if (report._section_A.comparable < options.minASamples) {
+    failures.push(`_section_A comparable samples ${report._section_A.comparable} < ${options.minASamples}`);
+  }
+  if (report._section_J.total < options.minJSamples) {
+    failures.push(`_section_J samples ${report._section_J.total} < ${options.minJSamples}`);
+  }
+  if (report._section_A.divergence > options.maxDivergence) {
+    failures.push(`_section_A divergence ${report._section_A.divergence} > ${options.maxDivergence}`);
+  }
+  const errors = report._section_A.error + report._section_J.error + report._unclassified.malformed;
+  if (errors > options.maxErrors) failures.push(`shadow errors ${errors} > ${options.maxErrors}`);
+  return failures;
+}
+
+export function helpText() {
+  return `Usage: node scripts/timeout-shadow-gate.mjs [options] [log-file ...]\n\n` +
+    `Read timeout shadow records from files and/or --stdin, then print JSON.\n\n` +
+    `Options:\n` +
+    `  --stdin                    Read stdin in addition to log files\n` +
+    `  --since <ISO-8601>         Include timestamped records at or after this time\n` +
+    `  --until <ISO-8601>         Include timestamped records at or before this time\n` +
+    `  --min-a-samples <count>    Minimum comparable _section_A records\n` +
+    `  --min-j-samples <count>    Minimum _section_J records\n` +
+    `  --max-divergence <count>   Maximum comparable _section_A disagreements\n` +
+    `  --max-errors <count>       Maximum malformed/reducer-error records\n`;
+}
+
+export function run(argv, stdinText) {
+  const options = parseArgs(argv);
+  if (options.help) return { help: true, output: helpText(), exitCode: 0 };
+  const inputs = options.files.map((file) => fs.readFileSync(file, "utf8"));
+  if (options.readStdin) inputs.push(stdinText);
+  const report = aggregateText(inputs, options);
+  const failures = thresholdFailures(report, options);
+  return { help: false, output: JSON.stringify(report), failures, exitCode: failures.length === 0 ? 0 : 1 };
+}
+
+if (import.meta.url === new URL(process.argv[1], "file:").href) {
+  try {
+    // Do not consume a terminal's stdin merely because file paths were
+    // supplied.  Besides being surprising, that would make the gate hang in
+    // an operator shell.  stdin is consumed only for the explicit/default
+    // stdin modes parsed above.
+    const cliOptions = parseArgs(process.argv.slice(2));
+    const stdinText = !cliOptions.help && cliOptions.readStdin ? fs.readFileSync(0, "utf8") : "";
+    const result = run(process.argv.slice(2), stdinText);
+    if (result.help) process.stdout.write(result.output);
+    else process.stdout.write(`${result.output}\n`);
+    if (result.failures && result.failures.length > 0) process.stderr.write(`${result.failures.join("; ")}\n`);
+    process.exitCode = result.exitCode;
+  } catch (error) {
+    process.stderr.write(`timeout-shadow-gate: ${error.message}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/scripts/timeout-shadow-gate.mjs
+++ b/scripts/timeout-shadow-gate.mjs
@@ -11,11 +11,14 @@ import fs from "node:fs";
 import process from "node:process";
 import { createHash } from "node:crypto";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { TextDecoder } from "node:util";
 
 const SHADOW_PREFIX = "[timeout_shadow] ";
 const SHADOW_TARGET = "agentdesk::timeout_shadow";
 const SECTIONS = new Set(["_section_A", "_section_J"]);
 const COMPARABLE_A_DECISIONS = new Set(["retry", "exhaust"]);
+const VALID_J_REDUCER_DECISIONS = new Set(["retry", "exhaust", "incomparable"]);
+const STRICT_UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 const FILE_READ_CHUNK_BYTES = 64 * 1024;
 const STABLE_READ_ATTEMPTS = 2;
 // A shadow record is one log line.  This cap prevents a malformed stdin/log
@@ -138,9 +141,11 @@ function timestampFromPrefix(prefix) {
   if (matches.length === 0) return null;
   const match = matches[matches.length - 1];
   const raw = match[0];
-  // Do not turn a partial offset such as +09 or +09:000 into UTC by matching
-  // only the timestamp prefix.  A valid tracing timestamp is token-bounded.
-  if (/^[0-9:+-]/.test(prefix.slice(match.index + raw.length))) return null;
+  const before = match.index > 0 ? prefix[match.index - 1] : "";
+  const after = prefix.slice(match.index + raw.length, match.index + raw.length + 1);
+  // Only standalone timestamp tokens are eligible. This rejects a timestamp
+  // embedded in 12026-... and suffixes such as ZBAD, plus partial offsets.
+  if ((before && /[0-9A-Za-z_]/.test(before)) || (after && /[0-9A-Za-z_:+-]/.test(after))) return null;
   const normalizedBase = raw.replace(" ", "T");
   const normalized = /(?:Z|[+-]\d{2}:?\d{2})$/.test(normalizedBase)
     ? normalizedBase.replace(/([+-]\d{2})(\d{2})$/, "$1:$2")
@@ -162,10 +167,6 @@ function isErrorRecord(record) {
     (typeof record.error === "string" && record.error.length > 0);
 }
 
-function isIncomparableRecord(record) {
-  return record.incomparable === true || record.reducer_decision === "incomparable";
-}
-
 function validateRecord(record) {
   if (!record || typeof record !== "object" || Array.isArray(record)) return "record is not an object";
   if (record.target !== SHADOW_TARGET) return "unexpected target";
@@ -173,6 +174,9 @@ function validateRecord(record) {
   if (typeof record.js_decision !== "string") return "missing js_decision";
   if (typeof record.reducer_decision !== "string") return "missing reducer_decision";
   if (typeof record.agree !== "boolean") return "missing agree";
+  if (Object.prototype.hasOwnProperty.call(record, "incomparable") && typeof record.incomparable !== "boolean") {
+    return "invalid incomparable";
+  }
   return null;
 }
 
@@ -197,29 +201,37 @@ function addRecord(report, record) {
     section.error += 1;
     return;
   }
-  if (record.section === "_section_J") section.successful += 1;
   if (record.section === "_section_A") {
-    if (!isIncomparableRecord(record)) {
-      if (!COMPARABLE_A_DECISIONS.has(record.js_decision) || !COMPARABLE_A_DECISIONS.has(record.reducer_decision)) {
-        section.error += 1;
-        return;
-      }
-      section.comparable += 1;
-      const derivedAgreement = record.js_decision === record.reducer_decision;
-      // `agree` is producer-controlled observability data, never gate
-      // authority. A forged true cannot hide a decision divergence; any
-      // mismatch is error evidence and a real divergence stays divergent.
-      if (record.agree !== derivedAgreement) {
-        section.error += 1;
-        if (!derivedAgreement) section.divergence += 1;
-      } else if (derivedAgreement) {
-        section.agreement += 1;
-      } else {
-        section.divergence += 1;
-      }
+    const reducerComparable = COMPARABLE_A_DECISIONS.has(record.reducer_decision);
+    const derivedIncomparable = record.reducer_decision === "incomparable";
+    if (!COMPARABLE_A_DECISIONS.has(record.js_decision) || (!reducerComparable && !derivedIncomparable)) {
+      section.error += 1;
+      return;
     }
-  } else if (isIncomparableRecord(record)) {
-    section.incomparable += 1;
+    const derivedAgreement = reducerComparable && record.js_decision === record.reducer_decision;
+    const diagnosticMismatch = (record.incomparable === true) !== derivedIncomparable ||
+      record.agree !== derivedAgreement;
+    if (diagnosticMismatch) section.error += 1;
+    if (reducerComparable) {
+      section.comparable += 1;
+      if (derivedAgreement) section.agreement += 1;
+      else section.divergence += 1;
+    }
+  } else {
+    const reducerValid = VALID_J_REDUCER_DECISIONS.has(record.reducer_decision);
+    if (record.js_decision !== "retry" || !reducerValid) {
+      section.error += 1;
+      return;
+    }
+    const derivedIncomparable = record.reducer_decision === "incomparable";
+    const derivedAgreement = record.reducer_decision === record.js_decision && !derivedIncomparable;
+    const diagnosticMismatch = (record.incomparable === true) !== derivedIncomparable ||
+      record.agree !== derivedAgreement;
+    if (diagnosticMismatch) section.error += 1;
+    else {
+      section.successful += 1;
+      if (derivedIncomparable) section.incomparable += 1;
+    }
   }
 }
 
@@ -244,7 +256,9 @@ export function aggregateText(inputs, options = {}) {
   const report = emptyReport();
   for (const input of inputs) {
     const scanner = createLineScanner((line) => processLine(report, line, effectiveOptions));
-    scanner.write(Buffer.from(String(input)));
+    if (typeof input === "string") scanner.write(Buffer.from(input));
+    else if (Buffer.isBuffer(input)) scanner.write(input);
+    else throw new TypeError("aggregateText inputs must be strings or Buffers");
     scanner.end();
   }
   return finalizeReport(report);
@@ -279,19 +293,24 @@ function createLineScanner(onLine) {
     if (rawBytes + segment.length > MAX_RECORD_LINE_BYTES + 1) {
       throw new Error(`log line exceeds ${MAX_RECORD_LINE_BYTES} bytes`);
     }
-    segments.push(segment);
+    // File reads reuse their 64 KiB buffer, so retain an owned bounded copy.
+    segments.push(Buffer.from(segment));
     rawBytes += segment.length;
   }
 
-  function finishLine() {
+  function finishLine(terminatedByLf) {
     const raw = Buffer.concat(segments, rawBytes);
-    const contentLength = rawBytes > 0 && raw[rawBytes - 1] === 0x0d ? rawBytes - 1 : rawBytes;
+    const contentLength = terminatedByLf && rawBytes > 0 && raw[rawBytes - 1] === 0x0d ? rawBytes - 1 : rawBytes;
     if (contentLength > MAX_RECORD_LINE_BYTES) {
       throw new Error(`log line exceeds ${MAX_RECORD_LINE_BYTES} bytes`);
     }
-    // Decode only after raw-byte enforcement. Invalid UTF-8 consequently
-    // becomes malformed JSON evidence instead of inflating the cap.
-    onLine(raw.subarray(0, contentLength).toString("utf8"));
+    let decoded;
+    try {
+      decoded = STRICT_UTF8_DECODER.decode(raw.subarray(0, contentLength));
+    } catch {
+      throw new Error("invalid UTF-8 log line");
+    }
+    onLine(decoded);
     segments = [];
     rawBytes = 0;
   }
@@ -306,12 +325,12 @@ function createLineScanner(onLine) {
           return;
         }
         append(buffer.subarray(cursor, newline));
-        finishLine();
+        finishLine(true);
         cursor = newline + 1;
       }
     },
     end() {
-      if (rawBytes > 0) finishLine();
+      if (rawBytes > 0) finishLine(false);
     }
   };
 }
@@ -368,22 +387,58 @@ function mergeReport(target, source) {
   target._unclassified.malformed += source._unclassified.malformed;
 }
 
-function openFileSnapshots(files, snapshots, io) {
-  const canonicalPaths = new Set();
+function rotationOrder(canonical) {
+  const match = /^(.*)\.(\d+)$/.exec(canonical);
+  return match ? { family: match[1], generation: BigInt(match[2]) } : { family: canonical, generation: 0n };
+}
+
+function canonicalizeFiles(files, io) {
+  const seen = new Set();
+  const entries = files.map((input) => {
+    const canonical = io.realpathSync(input);
+    if (seen.has(canonical)) throw new Error(`duplicate log input: ${input}`);
+    seen.add(canonical);
+    return { input, canonical, order: rotationOrder(canonical) };
+  });
+  entries.sort((left, right) => {
+    if (left.order.family !== right.order.family) return left.order.family < right.order.family ? -1 : 1;
+    if (left.order.generation !== right.order.generation) return left.order.generation < right.order.generation ? -1 : 1;
+    return left.canonical < right.canonical ? -1 : left.canonical > right.canonical ? 1 : 0;
+  });
+  return entries;
+}
+
+function capturePathManifest(entries, io) {
+  const manifest = [];
   const identities = new Set();
-  for (const file of files) {
-    const descriptor = io.openSync(file, "r");
+  for (const entry of entries) {
+    const stat = io.statSync(entry.canonical, { bigint: true });
+    const identity = `${stat.dev}:${stat.ino}`;
+    if (identities.has(identity)) throw new Error(`duplicate log input (opened inode): ${entry.input}`);
+    identities.add(identity);
+    manifest.push({ ...entry, identity, signature: statSignature(stat), stat });
+  }
+  return manifest;
+}
+
+function manifestSignature(manifest) {
+  return manifest.map((entry) => `${entry.canonical}=${entry.signature}`).join("\n");
+}
+
+function openFileSnapshots(manifest, snapshots, io) {
+  const identities = new Set();
+  for (const expected of manifest) {
+    const descriptor = io.openSync(expected.canonical, "r");
     // Push before every later failure so the enclosing attempt closes this fd.
-    const snapshot = { descriptor, file };
+    const snapshot = { descriptor, file: expected.canonical };
     snapshots.push(snapshot);
     const stat = io.fstatSync(descriptor, { bigint: true });
-    const canonical = io.realpathSync(file);
     const identity = `${stat.dev}:${stat.ino}`;
-    if (canonicalPaths.has(canonical) || identities.has(identity)) {
-      throw new Error(`duplicate log input: ${file}`);
+    if (identities.has(identity)) throw new Error(`duplicate log input (opened inode): ${expected.input}`);
+    if (identity !== expected.identity || statSignature(stat) !== expected.signature) {
+      throw new Error(`log path changed while opening snapshot: ${expected.input}`);
     }
-    if (stat.size > BigInt(Number.MAX_SAFE_INTEGER)) throw new Error(`log too large for bounded scan: ${file}`);
-    canonicalPaths.add(canonical);
+    if (stat.size > BigInt(Number.MAX_SAFE_INTEGER)) throw new Error(`log too large for bounded scan: ${expected.input}`);
     identities.add(identity);
     snapshot.stat = stat;
     snapshot.signature = statSignature(stat);
@@ -393,7 +448,18 @@ function openFileSnapshots(files, snapshots, io) {
 }
 
 function closeSnapshots(snapshots, io) {
-  for (const snapshot of snapshots) io.closeSync(snapshot.descriptor);
+  let firstError = null;
+  for (const snapshot of snapshots) {
+    try {
+      io.closeSync(snapshot.descriptor);
+    } catch (error) {
+      if (!firstError) firstError = error;
+      // Retry this fd once for transient close failures, while still moving on
+      // to every other descriptor regardless of either result.
+      try { io.closeSync(snapshot.descriptor); } catch (_) {}
+    }
+  }
+  return firstError;
 }
 
 /**
@@ -403,30 +469,57 @@ function closeSnapshots(snapshots, io) {
  */
 export function aggregateFiles(files, options = {}, io = fs) {
   const effectiveOptions = { since: null, until: null, ...options };
+  const entries = canonicalizeFiles(files, io);
   let lastError = null;
+  let baselineManifest = null;
+  let baselineContent = null;
+  let coherenceLost = false;
   for (let attempt = 0; attempt < STABLE_READ_ATTEMPTS; attempt += 1) {
     const snapshots = [];
     const report = emptyReport();
+    let attemptError = null;
+    let stable = false;
     try {
-      openFileSnapshots(files, snapshots, io);
+      const manifest = capturePathManifest(entries, io);
+      const currentManifest = manifestSignature(manifest);
+      if (baselineManifest === null) baselineManifest = currentManifest;
+      else if (baselineManifest !== currentManifest) throw new Error("log path manifest changed between snapshot attempts");
+      openFileSnapshots(manifest, snapshots, io);
+      if (manifestSignature(capturePathManifest(entries, io)) !== currentManifest) {
+        throw new Error("log path manifest changed while opening snapshot");
+      }
+      const attemptContent = new Map();
       for (const snapshot of snapshots) {
         const hash = createHash("sha256");
         forEachDescriptorLine(snapshot.descriptor, snapshot.size, (line) => processLine(report, line, effectiveOptions), io, hash);
         snapshot.firstHash = hash.digest("hex");
+        attemptContent.set(snapshot.file, snapshot.firstHash);
       }
-      let stable = true;
+      if (baselineContent === null) baselineContent = attemptContent;
+      else {
+        for (const [file, digest] of attemptContent) {
+          if (baselineContent.get(file) !== digest) throw new Error(`log content changed between snapshot attempts: ${file}`);
+        }
+      }
+      stable = true;
       for (const snapshot of snapshots) {
         const contentMatches = snapshot.firstHash === hashDescriptor(snapshot.descriptor, snapshot.size, io);
         const metadataMatches = statSignature(io.fstatSync(snapshot.descriptor, { bigint: true })) === snapshot.signature;
         if (!contentMatches || !metadataMatches) stable = false;
       }
-      if (stable) return finalizeReport(report);
-      lastError = new Error("log changed while reading snapshot");
+      if (!stable) throw new Error("log changed while reading snapshot");
     } catch (error) {
-      lastError = error;
-    } finally {
-      closeSnapshots(snapshots, io);
+      attemptError = error;
+      coherenceLost = true;
     }
+    const closeError = closeSnapshots(snapshots, io);
+    if (!attemptError && closeError) attemptError = closeError;
+    if (closeError) {
+      lastError = attemptError;
+      break;
+    }
+    if (stable && !attemptError && !coherenceLost) return finalizeReport(report);
+    lastError = attemptError || new Error("log snapshot coherence could not be proven");
   }
   throw lastError || new Error("log changed while reading snapshot");
 }

--- a/scripts/timeout-shadow-gate.mjs
+++ b/scripts/timeout-shadow-gate.mjs
@@ -9,10 +9,13 @@
  */
 import fs from "node:fs";
 import process from "node:process";
+import { StringDecoder } from "node:string_decoder";
 
 const SHADOW_PREFIX = "[timeout_shadow] ";
 const SHADOW_TARGET = "agentdesk::timeout_shadow";
 const SECTIONS = new Set(["_section_A", "_section_J"]);
+const FILE_READ_CHUNK_BYTES = 64 * 1024;
+const STABLE_READ_ATTEMPTS = 2;
 
 function emptySection() {
   return { total: 0, comparable: 0, agreement: 0, divergence: 0, error: 0 };
@@ -29,19 +32,32 @@ function emptyReport() {
 }
 
 function parseNumber(name, value) {
-  if (value === undefined || value === "") {
-    throw new Error(`${name} requires a non-negative number`);
+  if (typeof value !== "string" || !/^(?:0|[1-9]\d*)$/.test(value)) {
+    throw new Error(`${name} requires a non-negative integer`);
   }
   const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    throw new Error(`${name} requires a non-negative number`);
-  }
+  if (!Number.isSafeInteger(parsed)) throw new Error(`${name} requires a safe non-negative integer`);
   return parsed;
 }
 
 function parseTimestamp(value, optionName) {
+  if (typeof value !== "string") throw new Error(`${optionName} requires an ISO-8601 calendar timestamp`);
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|[+-]\d{2}:\d{2})$/.exec(value);
+  if (!match) throw new Error(`${optionName} requires an ISO-8601 calendar timestamp`);
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, , zone] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const zoneValid = zone === "Z" || (Number(zone.slice(1, 3)) <= 23 && Number(zone.slice(4, 6)) <= 59);
+  if (month < 1 || month > 12 || day < 1 || day > daysInMonth || hour > 23 || minute > 59 || second > 59 || !zoneValid) {
+    throw new Error(`${optionName} requires a valid ISO-8601 calendar timestamp`);
+  }
   const parsed = Date.parse(value);
-  if (Number.isNaN(parsed)) throw new Error(`${optionName} requires an ISO-8601 timestamp`);
+  if (Number.isNaN(parsed)) throw new Error(`${optionName} requires a valid ISO-8601 calendar timestamp`);
   return parsed;
 }
 
@@ -51,8 +67,10 @@ export function parseArgs(argv) {
     readStdin: false,
     since: null,
     until: null,
-    minASamples: 0,
-    minJSamples: 0,
+    // A no-evidence report is never a deployment GO by default.  Operators
+    // may explicitly lower these to zero when they only need an inventory.
+    minASamples: 1,
+    minJSamples: 1,
     maxDivergence: Number.POSITIVE_INFINITY,
     maxErrors: Number.POSITIVE_INFINITY
   };
@@ -104,9 +122,14 @@ function timestampFromPrefix(prefix) {
   const matches = prefix.match(/\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?/g);
   if (!matches || matches.length === 0) return null;
   const raw = matches[matches.length - 1];
-  const normalized = /(?:Z|[+-]\d{2}:?\d{2})$/.test(raw) ? raw : raw.replace(" ", "T") + "Z";
-  const timestamp = Date.parse(normalized);
-  return Number.isNaN(timestamp) ? null : timestamp;
+  const normalized = /(?:Z|[+-]\d{2}:?\d{2})$/.test(raw)
+    ? raw.replace(/([+-]\d{2})(\d{2})$/, "$1:$2")
+    : raw.replace(" ", "T") + "Z";
+  try {
+    return parseTimestamp(normalized, "log timestamp");
+  } catch {
+    return null;
+  }
 }
 
 function sectionHint(payload) {
@@ -174,9 +197,9 @@ function finalizeReport(report) {
 function lineInRange(line, prefixIndex, options) {
   if (options.since === null && options.until === null) return true;
   const timestamp = timestampFromPrefix(line.slice(0, prefixIndex));
-  // A line without a timestamp remains eligible: the CLI promises filtering
-  // only where a timestamp is actually present.
-  if (timestamp === null) return true;
+  // Filtering must fail closed.  A timestamp-less record cannot be placed in
+  // the requested window, so treating it as evidence would defeat the gate.
+  if (timestamp === null) return false;
   return (options.since === null || timestamp >= options.since) &&
     (options.until === null || timestamp <= options.until);
 }
@@ -185,18 +208,90 @@ export function aggregateText(inputs, options = {}) {
   const effectiveOptions = { since: null, until: null, ...options };
   const report = emptyReport();
   for (const input of inputs) {
-    for (const line of String(input).split(/\r?\n/)) {
-      const prefixIndex = line.indexOf(SHADOW_PREFIX);
-      if (prefixIndex === -1 || !lineInRange(line, prefixIndex, effectiveOptions)) continue;
-      const payload = line.slice(prefixIndex + SHADOW_PREFIX.length).trim();
-      try {
-        addRecord(report, JSON.parse(payload));
-      } catch {
-        addMalformed(report, payload);
-      }
-    }
+    for (const line of String(input).split(/\r?\n/)) processLine(report, line, effectiveOptions);
   }
   return finalizeReport(report);
+}
+
+function processLine(report, line, options) {
+  const prefixIndex = line.indexOf(SHADOW_PREFIX);
+  if (prefixIndex === -1 || !lineInRange(line, prefixIndex, options)) return;
+  const payload = line.slice(prefixIndex + SHADOW_PREFIX.length).trim();
+  try {
+    addRecord(report, JSON.parse(payload));
+  } catch {
+    addMalformed(report, payload);
+  }
+}
+
+function statSignature(stat) {
+  return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
+}
+
+function forEachFileLine(file, onLine, io) {
+  const descriptor = io.openSync(file, "r");
+  let remainder = "";
+  const buffer = Buffer.allocUnsafe(FILE_READ_CHUNK_BYTES);
+  const decoder = new StringDecoder("utf8");
+  try {
+    for (;;) {
+      const bytesRead = io.readSync(descriptor, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      const combined = remainder + decoder.write(buffer.subarray(0, bytesRead));
+      const lines = combined.split("\n");
+      remainder = lines.pop();
+      for (const line of lines) onLine(line.endsWith("\r") ? line.slice(0, -1) : line);
+    }
+    remainder += decoder.end();
+    if (remainder.length > 0) onLine(remainder.endsWith("\r") ? remainder.slice(0, -1) : remainder);
+  } finally {
+    io.closeSync(descriptor);
+  }
+}
+
+function mergeReport(target, source) {
+  target._section_A.total += source._section_A.total;
+  target._section_A.comparable += source._section_A.comparable;
+  target._section_A.agreement += source._section_A.agreement;
+  target._section_A.divergence += source._section_A.divergence;
+  target._section_A.error += source._section_A.error;
+  target._section_J.total += source._section_J.total;
+  target._section_J.incomparable += source._section_J.incomparable;
+  target._section_J.error += source._section_J.error;
+  target._unclassified.malformed += source._unclassified.malformed;
+}
+
+/**
+ * Read a regular/rotated log with bounded memory.  A changed stat signature
+ * means the file may have been renamed or appended during the scan; retry the
+ * whole file once and otherwise reject it instead of mixing two snapshots.
+ */
+export function aggregateFile(file, options = {}, io = fs) {
+  const effectiveOptions = { since: null, until: null, ...options };
+  for (let attempt = 0; attempt < STABLE_READ_ATTEMPTS; attempt += 1) {
+    const before = io.statSync(file);
+    const report = emptyReport();
+    forEachFileLine(file, (line) => processLine(report, line, effectiveOptions), io);
+    const after = io.statSync(file);
+    if (statSignature(before) === statSignature(after)) return finalizeReport(report);
+  }
+  throw new Error(`log changed while reading: ${file}`);
+}
+
+function uniqueFiles(files, io = fs) {
+  const seenCanonical = new Set();
+  const seenInodes = new Set();
+  return files.map((file) => {
+    const canonical = io.realpathSync(file);
+    const stat = io.statSync(canonical);
+    const inode = `${stat.dev}:${stat.ino}`;
+    if (seenCanonical.has(canonical) || seenInodes.has(inode)) {
+      throw new Error(`duplicate log input: ${file}`);
+    }
+    seenCanonical.add(canonical);
+    seenInodes.add(inode);
+    return canonical;
+  });
 }
 
 export function thresholdFailures(report, options) {
@@ -224,8 +319,8 @@ export function helpText() {
     `  --stdin                    Read stdin in addition to log files\n` +
     `  --since <ISO-8601>         Include timestamped records at or after this time\n` +
     `  --until <ISO-8601>         Include timestamped records at or before this time\n` +
-    `  --min-a-samples <count>    Minimum comparable _section_A records\n` +
-    `  --min-j-samples <count>    Minimum _section_J records\n` +
+    `  --min-a-samples <count>    Minimum comparable _section_A records (default: 1)\n` +
+    `  --min-j-samples <count>    Minimum _section_J records (default: 1)\n` +
     `  --max-divergence <count>   Maximum comparable _section_A disagreements\n` +
     `  --max-errors <count>       Maximum malformed/reducer-error records\n`;
 }
@@ -233,9 +328,13 @@ export function helpText() {
 export function run(argv, stdinText) {
   const options = parseArgs(argv);
   if (options.help) return { help: true, output: helpText(), exitCode: 0 };
-  const inputs = options.files.map((file) => fs.readFileSync(file, "utf8"));
-  if (options.readStdin) inputs.push(stdinText);
-  const report = aggregateText(inputs, options);
+  const report = emptyReport();
+  for (const file of uniqueFiles(options.files)) mergeReport(report, aggregateFile(file, options));
+  if (options.readStdin) {
+    const stdinReport = aggregateText([stdinText], options);
+    mergeReport(report, stdinReport);
+  }
+  finalizeReport(report);
   const failures = thresholdFailures(report, options);
   return { help: false, output: JSON.stringify(report), failures, exitCode: failures.length === 0 ? 0 : 1 };
 }


### PR DESCRIPTION
## Summary
- add a streamed, bounded timeout-shadow evidence gate for A/J producer logs
- fail closed on forged diagnostics, invalid decision domains, malformed UTF-8, incoherent rotations, timestamp ambiguity, and descriptor errors
- validate coherent current/.1/.2 snapshots and preserve strict raw-byte caps
- wire the gate and its regression suite into script CI

## Safety properties
- zero or insufficient evidence cannot GO
- J non-incomparable outcomes are producer-contract errors
- A comparability is derived from decisions, not producer booleans
- rotation generations and opened inode identities cannot be mixed silently
- each original descriptor is closed at most once while remaining closes continue

## Verification
- shadow gate tests: 31/31 PASS
- existing timeout policy tests: 37/37 PASS
- full scripts/ci-script-checks.sh: PASS
- repeated real mutants for forged A/J, invalid UTF-8, mixed rotation, timestamp substring, raw cap/CR, and fd reuse: rejected
- fresh GPT-5.6 SOL adversarial review on exact 3d2dbbd6028f18a1db9806313f27b2e7ddc583bd: CLEAN

This PR delivers the evidence aggregation gate only. Live shadow samples are still zero and production wiring remains a later acceptance step, so it references rather than closes #3950.

Refs #3950