### PR TITLE
fix: harden relay watchdog loss detection

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -2413,7 +2413,10 @@ def advance_delivered_watermark(
 
 
 def _forget_reclaimed_recovered_gap_lifecycles(
-    channel_state: dict[str, Any], paths: list[str]
+    channel_state: dict[str, Any],
+    paths: list[str],
+    *,
+    loss_state_corrupted: bool,
 ) -> None:
     """Drop all replay identity for guards proven absent for one full TTL."""
     reclaimed = set(paths)
@@ -2466,17 +2469,18 @@ def _forget_reclaimed_recovered_gap_lifecycles(
     else:
         channel_state.pop(DELIVERED_WATERMARKS_KEY, None)
 
-    observations = {
-        block_id: entry
-        for block_id, entry in _validated_loss_observations(channel_state).items()
-        if entry["path"] not in reclaimed
-    }
-    tombstones = {
-        block_id: entry
-        for block_id, entry in permanent_loss_tombstones(channel_state).items()
-        if entry["path"] not in reclaimed
-    }
-    _store_loss_state(channel_state, observations, tombstones)
+    if not loss_state_corrupted:
+        observations = {
+            block_id: entry
+            for block_id, entry in _validated_loss_observations(channel_state).items()
+            if entry["path"] not in reclaimed
+        }
+        tombstones = {
+            block_id: entry
+            for block_id, entry in permanent_loss_tombstones(channel_state).items()
+            if entry["path"] not in reclaimed
+        }
+        _store_loss_state(channel_state, observations, tombstones)
     raw_actual = channel_state.get(LAST_ACTUAL_DELIVERY_BY_PATH_KEY)
     if isinstance(raw_actual, dict):
         retained_actual = {
@@ -3553,11 +3557,23 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     )
     _store_recovered_gap_guards(chs, recovered_gap_guards)
     if reclaimed_guard_paths:
-        _forget_reclaimed_recovered_gap_lifecycles(chs, reclaimed_guard_paths)
+        _, observations_corrupted = _validated_loss_observations_with_status(chs)
+        _, tombstones_corrupted = _permanent_loss_tombstones_with_status(chs)
+        loss_state_corrupted = observations_corrupted or tombstones_corrupted
+        _forget_reclaimed_recovered_gap_lifecycles(
+            chs,
+            reclaimed_guard_paths,
+            loss_state_corrupted=loss_state_corrupted,
+        )
         rt.log(
             f"[{cid}] recovered-gap-guard-reclaimed "
             f"count={len(reclaimed_guard_paths)}"
         )
+        if loss_state_corrupted:
+            rt.log(
+                f"[{cid}] permanent-loss-state-corrupt during lifecycle reclaim; "
+                "preserving raw state"
+            )
     previous_sizes = _validated_transcript_sizes(chs)
     previous_seen_at = _validated_transcript_seen_at(chs, previous_sizes, now)
     known_state_persisted = isinstance(chs.get(TRANSCRIPT_KNOWN_AT_KEY), dict)

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -146,6 +146,7 @@ PERMANENT_LOSS_TOTAL_KEY = "permanent_loss_total"
 PERMANENT_LOSS_SUSPECTED_KEY = "permanent_loss_suspected"
 PERMANENT_LOSS_OVERFLOW_TOTAL_KEY = "permanent_loss_overflow_total"
 PERMANENT_LOSS_IDENTITY_WARNING_KEY = "permanent_loss_identity_warnings"
+PERMANENT_LOSS_CORRUPTION_WARNING_KEY = "permanent_loss_corruption_warnings"
 LAST_ACTUAL_DELIVERY_AT_KEY = "last_actual_delivery_at"
 LAST_ACTUAL_DELIVERY_BY_PATH_KEY = "last_actual_delivery_by_path"
 # Permanent loss requires two different delivered-frontier advances beyond the
@@ -4188,11 +4189,47 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             chs[PERMANENT_LOSS_IDENTITY_WARNING_KEY] = identity_warnings
         else:
             chs.pop(PERMANENT_LOSS_IDENTITY_WARNING_KEY, None)
+        raw_corruption_warnings = chs.get(
+            PERMANENT_LOSS_CORRUPTION_WARNING_KEY, {}
+        )
+        corruption_warnings = (
+            {
+                warning_path: fingerprint
+                for warning_path, fingerprint in raw_corruption_warnings.items()
+                if isinstance(warning_path, str)
+                and isinstance(fingerprint, str)
+                and fingerprint
+            }
+            if isinstance(raw_corruption_warnings, dict)
+            else {}
+        )
+        prior_corruption = corruption_warnings.get(path)
         if tombstone_update.corrupted:
-            rt.log(
-                f"[{cid}] permanent-loss-state-corrupt path={path}; "
-                "preserving raw state"
-            )
+            corruption_fingerprint = hashlib.sha256(
+                json.dumps(
+                    {
+                        LOSS_OBSERVATIONS_KEY: chs.get(LOSS_OBSERVATIONS_KEY),
+                        PERMANENT_LOSS_TOMBSTONES_KEY: chs.get(
+                            PERMANENT_LOSS_TOMBSTONES_KEY
+                        ),
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=repr,
+                ).encode("utf-8")
+            ).hexdigest()
+            corruption_warnings[path] = corruption_fingerprint
+            if prior_corruption != corruption_fingerprint:
+                rt.log(
+                    f"[{cid}] permanent-loss-state-corrupt path={path}; "
+                    "preserving raw state"
+                )
+        else:
+            corruption_warnings.pop(path, None)
+        if corruption_warnings:
+            chs[PERMANENT_LOSS_CORRUPTION_WARNING_KEY] = corruption_warnings
+        else:
+            chs.pop(PERMANENT_LOSS_CORRUPTION_WARNING_KEY, None)
         if tombstone_update.overflowed and not tombstone_update.corrupted:
             rt.log(
                 f"[{cid}] permanent-loss-state-overflow path={path} "

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -2129,7 +2129,6 @@ def evaluate(
     grace_secs: int,
     gap_alert_secs: int,
     prior_delivered_ts: float = 0.0,
-    last_actual_delivery_ts: float | None = None,
 ) -> Verdict:
     """Core relay-gap judgment descended from the 07-09 logic and subsequently
     extended through the #4140→#4178→#4181 lineage. The health watermark is the
@@ -2153,15 +2152,7 @@ def evaluate(
     delivered_ts = max(prior, current_delivered_ts)
     stale = [(e, t) for e, t in blocks if now - e > grace_secs]
     lost = [(e, t) for e, t in stale if e > delivered_ts and not delivered(t, hay)]
-    if last_actual_delivery_ts is None:
-        actual_delivery_ts = delivered_ts
-    else:
-        actual_delivery_ts = (
-            float(last_actual_delivery_ts)
-            if _is_finite_nonnegative_number(last_actual_delivery_ts)
-            else 0.0
-        )
-    gap_secs = (now - actual_delivery_ts) if actual_delivery_ts else float("inf")
+    gap_secs = (now - delivered_ts) if delivered_ts else float("inf")
     if lost and gap_secs > gap_alert_secs:
         state = STATE_GAP
     elif lost:
@@ -2259,13 +2250,6 @@ def delivered_watermark_for_path(
 ) -> float:
     entry = delivered_watermarks(channel_state).get(str(transcript))
     return entry[0] if entry is not None else 0.0
-
-
-def last_delivery_observed_at_for_path(
-    channel_state: Mapping[str, Any], transcript: str | Path
-) -> float:
-    entry = delivered_watermarks(channel_state).get(str(transcript))
-    return entry[1] if entry is not None else 0.0
 
 
 def advance_delivered_watermark(
@@ -3941,9 +3925,6 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             continue
         pending_failures.pop(path, None)
         prior_delivered_ts = delivered_watermark_for_path(chs, candidate.path)
-        prior_delivery_observed_at = last_delivery_observed_at_for_path(
-            chs, candidate.path
-        )
         # Advance the health watermark from the unfiltered source before removing
         # permanent-loss tombstones. Elapsed time must describe real transport
         # progress, never the age of an unmatched block.
@@ -3976,9 +3957,6 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             cfg.grace_secs,
             cfg.gap_alert_secs,
             prior_delivered_ts,
-            now
-            if observed_verdict.delivered_ts > prior_delivered_ts
-            else prior_delivery_observed_at,
         )
         fresh_undelivered = sum(
             1

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -4255,7 +4255,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 f"[{cid}] permanent-loss-state-corrupt path={path}; "
                 f"quarantined={tombstone_update.quarantined}"
             )
-        if tombstone_update.overflowed:
+        if tombstone_update.overflowed and not tombstone_update.corrupted:
             rt.log(
                 f"[{cid}] permanent-loss-state-overflow path={path} "
                 f"dropped={tombstone_update.overflowed} "

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -145,6 +145,7 @@ PERMANENT_LOSS_UNANNOUNCED_KEY = "permanent_loss_unannounced"
 PERMANENT_LOSS_TOTAL_KEY = "permanent_loss_total"
 PERMANENT_LOSS_SUSPECTED_KEY = "permanent_loss_suspected"
 PERMANENT_LOSS_OVERFLOW_TOTAL_KEY = "permanent_loss_overflow_total"
+PERMANENT_LOSS_IDENTITY_WARNING_KEY = "permanent_loss_identity_warnings"
 LAST_ACTUAL_DELIVERY_AT_KEY = "last_actual_delivery_at"
 LAST_ACTUAL_DELIVERY_BY_PATH_KEY = "last_actual_delivery_by_path"
 # Permanent loss requires two different delivered-frontier advances beyond the
@@ -4190,7 +4191,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         if tombstone_update.corrupted:
             rt.log(
                 f"[{cid}] permanent-loss-state-corrupt path={path}; "
-                f"quarantined={tombstone_update.quarantined}"
+                "preserving raw state"
             )
         if tombstone_update.overflowed and not tombstone_update.corrupted:
             rt.log(

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -1704,6 +1704,9 @@ def update_permanent_loss_tombstones(
     if not corrupted:
         _store_loss_state(channel_state, observations, tombstones)
         channel_state[PERMANENT_LOSS_TOTAL_KEY] = len(tombstones)
+    else:
+        newly_tombstoned.clear()
+        retracted.clear()
     if overflowed:
         previous_overflow = channel_state.get(PERMANENT_LOSS_OVERFLOW_TOTAL_KEY, 0)
         if not isinstance(previous_overflow, int) or isinstance(previous_overflow, bool):

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -4222,16 +4222,38 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         )
         suspected_permanent_losses += tombstone_update.suspected
         new_permanent_losses += len(tombstone_update.newly_tombstoned)
+        raw_identity_warnings = chs.get(PERMANENT_LOSS_IDENTITY_WARNING_KEY, {})
+        identity_warnings = (
+            {
+                warning_path: int(count)
+                for warning_path, count in raw_identity_warnings.items()
+                if isinstance(warning_path, str)
+                and isinstance(count, int)
+                and not isinstance(count, bool)
+                and count > 0
+            }
+            if isinstance(raw_identity_warnings, dict)
+            else {}
+        )
+        prior_fallbacks = identity_warnings.get(path)
         if read_result.identity_fallbacks:
-            rt.log(
-                f"[{cid}] permanent-loss-identity-offset-fallback path={path} "
-                f"blocks={read_result.identity_fallbacks}; identity may change "
-                "after head truncation"
-            )
+            identity_warnings[path] = read_result.identity_fallbacks
+            if prior_fallbacks != read_result.identity_fallbacks:
+                rt.log(
+                    f"[{cid}] permanent-loss-identity-offset-fallback path={path} "
+                    f"blocks={read_result.identity_fallbacks}; identity may change "
+                    "after head truncation"
+                )
+        else:
+            identity_warnings.pop(path, None)
+        if identity_warnings:
+            chs[PERMANENT_LOSS_IDENTITY_WARNING_KEY] = identity_warnings
+        else:
+            chs.pop(PERMANENT_LOSS_IDENTITY_WARNING_KEY, None)
         if tombstone_update.corrupted:
             rt.log(
                 f"[{cid}] permanent-loss-state-corrupt path={path}; "
-                "preserving raw state"
+                f"quarantined={tombstone_update.quarantined}"
             )
         if tombstone_update.overflowed:
             rt.log(

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -1642,6 +1642,7 @@ def update_permanent_loss_tombstones(
         channel_state, now
     )
     corrupted = tombstones_corrupted or observations_corrupted
+    durable_tombstone_ids = set(tombstones)
     if len(block_source_ids) != len(blocks):
         raise ValueError("block_source_ids must identify every source block")
     block_ids = [
@@ -1705,6 +1706,11 @@ def update_permanent_loss_tombstones(
         _store_loss_state(channel_state, observations, tombstones)
         channel_state[PERMANENT_LOSS_TOTAL_KEY] = len(tombstones)
     else:
+        active_blocks = [
+            block
+            for block, identity in zip(blocks, block_ids)
+            if identity not in durable_tombstone_ids
+        ]
         newly_tombstoned.clear()
         retracted.clear()
     if overflowed:

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -4208,10 +4208,14 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             corruption_fingerprint = hashlib.sha256(
                 json.dumps(
                     {
-                        LOSS_OBSERVATIONS_KEY: chs.get(LOSS_OBSERVATIONS_KEY),
-                        PERMANENT_LOSS_TOMBSTONES_KEY: chs.get(
-                            PERMANENT_LOSS_TOMBSTONES_KEY
-                        ),
+                        LOSS_OBSERVATIONS_KEY: {
+                            "present": LOSS_OBSERVATIONS_KEY in chs,
+                            "value": chs.get(LOSS_OBSERVATIONS_KEY),
+                        },
+                        PERMANENT_LOSS_TOMBSTONES_KEY: {
+                            "present": PERMANENT_LOSS_TOMBSTONES_KEY in chs,
+                            "value": chs.get(PERMANENT_LOSS_TOMBSTONES_KEY),
+                        },
                     },
                     sort_keys=True,
                     separators=(",", ":"),

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -145,9 +145,6 @@ PERMANENT_LOSS_UNANNOUNCED_KEY = "permanent_loss_unannounced"
 PERMANENT_LOSS_TOTAL_KEY = "permanent_loss_total"
 PERMANENT_LOSS_SUSPECTED_KEY = "permanent_loss_suspected"
 PERMANENT_LOSS_OVERFLOW_TOTAL_KEY = "permanent_loss_overflow_total"
-PERMANENT_LOSS_QUARANTINE_KEY = "permanent_loss_quarantine"
-PERMANENT_LOSS_QUARANTINE_TOTAL_KEY = "permanent_loss_quarantine_total"
-PERMANENT_LOSS_IDENTITY_WARNING_KEY = "permanent_loss_identity_warnings"
 LAST_ACTUAL_DELIVERY_AT_KEY = "last_actual_delivery_at"
 LAST_ACTUAL_DELIVERY_BY_PATH_KEY = "last_actual_delivery_by_path"
 # Permanent loss requires two different delivered-frontier advances beyond the
@@ -1482,7 +1479,6 @@ class PermanentLossUpdate:
     retracted: tuple[str, ...]
     suspected: int = 0
     overflowed: int = 0
-    quarantined: int = 0
     corrupted: bool = False
 
 
@@ -1588,60 +1584,6 @@ def _permanent_loss_tombstones_with_status(
     return bounded, corrupted
 
 
-def _quarantine_corrupt_loss_state(
-    channel_state: dict[str, Any],
-    *,
-    observations_corrupted: bool,
-    tombstones_corrupted: bool,
-    now: float,
-) -> int:
-    """Move malformed loss state out of the authoritative state machine."""
-    quarantined: dict[str, dict[str, Any]] = {}
-    for key, corrupted, validator in (
-        (
-            LOSS_OBSERVATIONS_KEY,
-            observations_corrupted,
-            _validated_loss_observations_with_status,
-        ),
-        (
-            PERMANENT_LOSS_TOMBSTONES_KEY,
-            tombstones_corrupted,
-            _permanent_loss_tombstones_with_status,
-        ),
-    ):
-        if not corrupted:
-            continue
-        raw = channel_state.get(key)
-        valid = validator(channel_state, now)[0]
-        if isinstance(raw, dict):
-            invalid = {
-                str(entry_id): entry
-                for entry_id, entry in raw.items()
-                if entry_id not in valid
-            }
-        else:
-            invalid = {"<root>": raw}
-        if invalid:
-            quarantined[key] = invalid
-        if valid:
-            channel_state[key] = valid
-        else:
-            channel_state.pop(key, None)
-
-    if not quarantined:
-        return 0
-    existing = channel_state.get(PERMANENT_LOSS_QUARANTINE_KEY, [])
-    bucket = list(existing) if isinstance(existing, list) else []
-    bucket.append({"quarantined_at": now, "entries": quarantined})
-    channel_state[PERMANENT_LOSS_QUARANTINE_KEY] = bucket[-MAX_LOSS_OBSERVATIONS:]
-    count = sum(len(entries) for entries in quarantined.values())
-    previous = channel_state.get(PERMANENT_LOSS_QUARANTINE_TOTAL_KEY, 0)
-    if not isinstance(previous, int) or isinstance(previous, bool) or previous < 0:
-        previous = 0
-    channel_state[PERMANENT_LOSS_QUARANTINE_TOTAL_KEY] = previous + count
-    return count
-
-
 def permanent_loss_tombstones(
     channel_state: Mapping[str, Any], now: float | None = None
 ) -> dict[str, dict[str, Any]]:
@@ -1700,12 +1642,6 @@ def update_permanent_loss_tombstones(
         channel_state, now
     )
     corrupted = tombstones_corrupted or observations_corrupted
-    quarantined = _quarantine_corrupt_loss_state(
-        channel_state,
-        observations_corrupted=observations_corrupted,
-        tombstones_corrupted=tombstones_corrupted,
-        now=now,
-    )
     durable_tombstone_ids = set(tombstones)
     if len(block_source_ids) != len(blocks):
         raise ValueError("block_source_ids must identify every source block")
@@ -1766,15 +1702,17 @@ def update_permanent_loss_tombstones(
     active_blocks = [
         block for block, identity in zip(blocks, block_ids) if identity not in tombstones
     ]
-    if corrupted:
+    if not corrupted:
+        _store_loss_state(channel_state, observations, tombstones)
+        channel_state[PERMANENT_LOSS_TOTAL_KEY] = len(tombstones)
+    else:
         active_blocks = [
             block
             for block, identity in zip(blocks, block_ids)
             if identity not in durable_tombstone_ids
         ]
         newly_tombstoned.clear()
-    _store_loss_state(channel_state, observations, tombstones)
-    channel_state[PERMANENT_LOSS_TOTAL_KEY] = len(tombstones)
+        retracted.clear()
     if overflowed and not corrupted:
         previous_overflow = channel_state.get(PERMANENT_LOSS_OVERFLOW_TOTAL_KEY, 0)
         if not isinstance(previous_overflow, int) or isinstance(previous_overflow, bool):
@@ -1786,7 +1724,6 @@ def update_permanent_loss_tombstones(
         retracted=tuple(retracted),
         suspected=suspected,
         overflowed=overflowed,
-        quarantined=quarantined,
         corrupted=corrupted,
     )
 

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -143,6 +143,9 @@ LOSS_OBSERVATIONS_KEY = "permanent_loss_observations"
 PERMANENT_LOSS_TOMBSTONES_KEY = "permanent_loss_tombstones"
 PERMANENT_LOSS_UNANNOUNCED_KEY = "permanent_loss_unannounced"
 PERMANENT_LOSS_TOTAL_KEY = "permanent_loss_total"
+PERMANENT_LOSS_SUSPECTED_KEY = "permanent_loss_suspected"
+PERMANENT_LOSS_OVERFLOW_TOTAL_KEY = "permanent_loss_overflow_total"
+LAST_ACTUAL_DELIVERY_AT_KEY = "last_actual_delivery_at"
 LAST_ACTUAL_DELIVERY_BY_PATH_KEY = "last_actual_delivery_by_path"
 # Permanent loss requires two different delivered-frontier advances beyond the
 # candidate. Re-reading the same bounded Discord window never adds evidence.
@@ -583,6 +586,7 @@ class TranscriptReadResult:
     incomplete_tail: bool = False
     semantic_end_offset: int = 0
     observed_size: int = 0
+    block_offsets: list[int] = field(default_factory=list)
 
 
 def transcript_candidates(dirs: list[Path]) -> list[TranscriptCandidate]:
@@ -1357,11 +1361,16 @@ def assistant_blocks(
                 except (json.JSONDecodeError, TypeError):
                     incomplete_tail = True
             blocks: list[tuple[float, str]] = []
+            block_offsets: list[int] = []
             semantic_end_offset = 0
             byte_offset = 0
             for raw_line, line in zip(raw_lines, lines):
+                line_start_offset = byte_offset
                 line_blocks = assistant_blocks_from_lines([line])
                 blocks.extend(line_blocks)
+                block_offsets.extend(
+                    line_start_offset + index for index in range(len(line_blocks))
+                )
                 byte_offset += len(raw_line)
                 if line_blocks:
                     semantic_end_offset = byte_offset
@@ -1370,6 +1379,7 @@ def assistant_blocks(
                 incomplete_tail=incomplete_tail,
                 semantic_end_offset=semantic_end_offset,
                 observed_size=byte_offset,
+                block_offsets=block_offsets,
             )
     except (OSError, UnicodeError, ValueError) as exc:
         return TranscriptReadResult([], type(exc).__name__)
@@ -1443,12 +1453,17 @@ class PermanentLossUpdate:
     active_blocks: list[tuple[float, str]]
     newly_tombstoned: tuple[str, ...]
     retracted: tuple[str, ...]
+    suspected: int = 0
+    overflowed: int = 0
+    corrupted: bool = False
 
 
-def _assistant_block_id(transcript: str | Path, epoch: float, text: str) -> str:
-    """Stable content identity; independent of compacted occurrence numbering."""
+def _assistant_block_id(
+    transcript: str | Path, epoch: float, text: str, source_offset: int
+) -> str:
+    """Stable source identity based on the transcript byte position."""
     digest = hashlib.sha256(norm(text).encode("utf-8")).hexdigest()
-    identity = f"{transcript}\0{epoch:.6f}\0{digest}"
+    identity = f"{transcript}\0{source_offset}\0{epoch:.6f}\0{digest}"
     return hashlib.sha256(identity.encode("utf-8")).hexdigest()
 
 
@@ -1465,13 +1480,14 @@ def _bounded_loss_entries(
     return dict(ordered[:limit])
 
 
-def _validated_loss_observations(
+def _validated_loss_observations_with_status(
     channel_state: Mapping[str, Any], now: float | None = None
-) -> dict[str, dict[str, Any]]:
+) -> tuple[dict[str, dict[str, Any]], bool]:
     raw = channel_state.get(LOSS_OBSERVATIONS_KEY, {})
     if not isinstance(raw, dict):
-        return {}
+        return {}, LOSS_OBSERVATIONS_KEY in channel_state
     valid: dict[str, dict[str, Any]] = {}
+    corrupted = False
     for block_id, entry in raw.items():
         advances = entry.get("evidence_frontiers") if isinstance(entry, dict) else None
         if not (
@@ -1485,12 +1501,14 @@ def _validated_loss_observations(
             and isinstance(advances, list)
             and all(_is_finite_nonnegative_number(value) for value in advances)
         ):
+            corrupted = True
             continue
         last_observed_at = float(entry["last_observed_at"])
         if now is not None and now - last_observed_at > TRANSCRIPT_HISTORY_TTL_SECS:
             continue
         distinct = sorted({float(value) for value in advances})[-PERMANENT_LOSS_CONFIRM_ADVANCES:]
         if not distinct:
+            corrupted = True
             continue
         valid[block_id] = {
             "path": entry["path"],
@@ -1498,17 +1516,23 @@ def _validated_loss_observations(
             "evidence_frontiers": distinct,
             "last_observed_at": last_observed_at,
         }
-    return _bounded_loss_entries(valid, MAX_LOSS_OBSERVATIONS)
+    return _bounded_loss_entries(valid, MAX_LOSS_OBSERVATIONS), corrupted
 
 
-def permanent_loss_tombstones(
+def _validated_loss_observations(
     channel_state: Mapping[str, Any], now: float | None = None
 ) -> dict[str, dict[str, Any]]:
-    """Return bounded durable loss identities; malformed state fails open."""
+    return _validated_loss_observations_with_status(channel_state, now)[0]
+
+
+def _permanent_loss_tombstones_with_status(
+    channel_state: Mapping[str, Any], now: float | None = None
+) -> tuple[dict[str, dict[str, Any]], bool]:
     raw = channel_state.get(PERMANENT_LOSS_TOMBSTONES_KEY, {})
     if not isinstance(raw, dict):
-        return {}
+        return {}, PERMANENT_LOSS_TOMBSTONES_KEY in channel_state
     valid: dict[str, dict[str, Any]] = {}
+    corrupted = False
     for block_id, entry in raw.items():
         if not (
             isinstance(block_id, str)
@@ -1519,6 +1543,7 @@ def permanent_loss_tombstones(
             and _is_finite_nonnegative_number(entry.get("epoch"))
             and _is_finite_nonnegative_number(entry.get("confirmed_at"))
         ):
+            corrupted = True
             continue
         confirmed_at = float(entry["confirmed_at"])
         if now is not None and now - confirmed_at > TRANSCRIPT_HISTORY_TTL_SECS:
@@ -1532,12 +1557,24 @@ def permanent_loss_tombstones(
     bounded = _bounded_loss_entries(valid, MAX_PERMANENT_LOSS_TOMBSTONES)
     for entry in bounded.values():
         entry.pop("last_observed_at", None)
-    return bounded
+    return bounded, corrupted
+
+
+def permanent_loss_tombstones(
+    channel_state: Mapping[str, Any], now: float | None = None
+) -> dict[str, dict[str, Any]]:
+    """Return bounded durable loss identities; malformed state fails open."""
+    return _permanent_loss_tombstones_with_status(channel_state, now)[0]
 
 
 def permanent_loss_total(channel_state: Mapping[str, Any]) -> int:
-    """Current retained permanent losses; derived map prevents split-key drift."""
-    return len(permanent_loss_tombstones(channel_state))
+    """Current retained losses, retaining the last projection on corruption."""
+    tombstones, corrupted = _permanent_loss_tombstones_with_status(channel_state)
+    if corrupted:
+        projected = channel_state.get(PERMANENT_LOSS_TOTAL_KEY, 0)
+        if isinstance(projected, int) and not isinstance(projected, bool) and projected >= 0:
+            return projected
+    return len(tombstones)
 
 
 def _store_loss_state(
@@ -1559,6 +1596,7 @@ def update_permanent_loss_tombstones(
     channel_state: dict[str, Any],
     transcript: str | Path,
     blocks: list[tuple[float, str]],
+    block_offsets: list[int],
     hay: str,
     now: float,
     grace_secs: int,
@@ -1573,25 +1611,31 @@ def update_permanent_loss_tombstones(
     match retracts a tombstone and decrements the cumulative total.
     """
     path = str(transcript)
-    tombstones = permanent_loss_tombstones(channel_state, now)
-    observations = _validated_loss_observations(channel_state, now)
-    total = len(tombstones)
-    block_ids = [_assistant_block_id(path, epoch, text) for epoch, text in blocks]
+    tombstones, tombstones_corrupted = _permanent_loss_tombstones_with_status(
+        channel_state, now
+    )
+    observations, observations_corrupted = _validated_loss_observations_with_status(
+        channel_state, now
+    )
+    corrupted = tombstones_corrupted or observations_corrupted
+    if len(block_offsets) != len(blocks):
+        raise ValueError("block_offsets must identify every source block")
+    block_ids = [
+        _assistant_block_id(path, epoch, text, source_offset)
+        for (epoch, text), source_offset in zip(blocks, block_offsets)
+    ]
     matched = delivered_flags(blocks, hay)
 
     retracted: list[str] = []
-    active_blocks: list[tuple[float, str]] = []
-    for (epoch, text), block_id, is_matched in zip(blocks, block_ids, matched):
+    for block_id, is_matched in zip(block_ids, matched):
         if block_id in tombstones and is_matched:
             tombstones.pop(block_id, None)
             observations.pop(block_id, None)
             retracted.append(block_id)
-            total = len(tombstones)
-        if block_id not in tombstones:
-            active_blocks.append((epoch, text))
 
     frontier_advanced = current_delivered_ts > prior_delivered_ts
     newly_tombstoned: list[str] = []
+    suspected = 0
     for index, ((epoch, _), block_id) in enumerate(zip(blocks, block_ids)):
         if block_id in tombstones or matched[index]:
             observations.pop(block_id, None)
@@ -1602,6 +1646,8 @@ def update_permanent_loss_tombstones(
         )
         later_advance = frontier_advanced and current_delivered_ts > epoch
         if not (eligible and later_advance):
+            if prior is not None and now - epoch > grace_secs:
+                suspected += 1
             continue
         frontiers = set(prior.get("evidence_frontiers", [])) if prior else set()
         frontiers.add(current_delivered_ts)
@@ -1614,10 +1660,6 @@ def update_permanent_loss_tombstones(
             }
             observations.pop(block_id, None)
             newly_tombstoned.append(block_id)
-            total = len(tombstones)
-            active_blocks = [
-                block for block, identity in zip(blocks, block_ids) if identity != block_id
-            ]
         else:
             observations[block_id] = {
                 "path": path,
@@ -1625,16 +1667,31 @@ def update_permanent_loss_tombstones(
                 "evidence_frontiers": evidence,
                 "last_observed_at": now,
             }
+            suspected += 1
 
+    observation_overflow = max(0, len(observations) - MAX_LOSS_OBSERVATIONS)
+    tombstone_overflow = max(0, len(tombstones) - MAX_PERMANENT_LOSS_TOMBSTONES)
+    overflowed = observation_overflow + tombstone_overflow
     observations = _bounded_loss_entries(observations, MAX_LOSS_OBSERVATIONS)
     tombstones = _bounded_loss_entries(tombstones, MAX_PERMANENT_LOSS_TOMBSTONES)
-    total = len(tombstones)
-    _store_loss_state(channel_state, observations, tombstones)
-    channel_state[PERMANENT_LOSS_TOTAL_KEY] = total
+    active_blocks = [
+        block for block, identity in zip(blocks, block_ids) if identity not in tombstones
+    ]
+    if not corrupted:
+        _store_loss_state(channel_state, observations, tombstones)
+        channel_state[PERMANENT_LOSS_TOTAL_KEY] = len(tombstones)
+    if overflowed:
+        previous_overflow = channel_state.get(PERMANENT_LOSS_OVERFLOW_TOTAL_KEY, 0)
+        if not isinstance(previous_overflow, int) or isinstance(previous_overflow, bool):
+            previous_overflow = 0
+        channel_state[PERMANENT_LOSS_OVERFLOW_TOTAL_KEY] = previous_overflow + overflowed
     return PermanentLossUpdate(
         active_blocks=active_blocks,
         newly_tombstoned=tuple(newly_tombstoned),
         retracted=tuple(retracted),
+        suspected=suspected,
+        overflowed=overflowed,
+        corrupted=corrupted,
     )
 
 
@@ -3955,6 +4012,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
 
     evaluated: list[tuple[TranscriptCandidate, Verdict]] = []
     fresh_undelivered_by_path: dict[str, int] = {}
+    suspected_permanent_losses = 0
     new_permanent_losses = 0
     raw_delivery_by_path = chs.get(LAST_ACTUAL_DELIVERY_BY_PATH_KEY, {})
     last_actual_delivery_by_path = (
@@ -3968,6 +4026,20 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         if isinstance(raw_delivery_by_path, dict)
         else {}
     )
+    legacy_actual_delivery = chs.get(LAST_ACTUAL_DELIVERY_AT_KEY)
+    if not last_actual_delivery_by_path:
+        if _is_finite_nonnegative_number(legacy_actual_delivery):
+            migrated_at = min(float(legacy_actual_delivery), now)
+        else:
+            migrated_at = now
+        for candidate in active_candidates:
+            last_actual_delivery_by_path[str(candidate.path)] = migrated_at
+        rt.log(
+            f"[{cid}] initialized last actual delivery timestamps "
+            f"paths={len(active_candidates)} source="
+            f"{'legacy' if _is_finite_nonnegative_number(legacy_actual_delivery) else 'now'}"
+        )
+    chs.pop(LAST_ACTUAL_DELIVERY_AT_KEY, None)
     unreadable_paths: list[str] = []
     escalated_pending_paths: list[str] = []
     remaining_pending = list(pending_paths)
@@ -4029,13 +4101,26 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             chs,
             candidate.path,
             read_result.blocks,
+            read_result.block_offsets,
             hay,
             now,
             cfg.grace_secs,
             prior_delivered_ts,
             observed_verdict.delivered_ts,
         )
+        suspected_permanent_losses += tombstone_update.suspected
         new_permanent_losses += len(tombstone_update.newly_tombstoned)
+        if tombstone_update.corrupted:
+            rt.log(
+                f"[{cid}] permanent-loss-state-corrupt path={path}; "
+                "preserving raw state"
+            )
+        if tombstone_update.overflowed:
+            rt.log(
+                f"[{cid}] permanent-loss-state-overflow path={path} "
+                f"dropped={tombstone_update.overflowed} "
+                f"total={chs[PERMANENT_LOSS_OVERFLOW_TOTAL_KEY]}"
+            )
         verdict = evaluate(
             tombstone_update.active_blocks,
             hay,
@@ -4281,9 +4366,16 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             f"[{cid}] PERMANENT LOSS ALERT new={unannounced} "
             f"cumulative={cumulative_losses} delivered={delivered_notice}"
         )
+    if suspected_permanent_losses:
+        chs[PERMANENT_LOSS_SUSPECTED_KEY] = suspected_permanent_losses
+        rt.log(
+            f"[{cid}] permanent-loss-suspected count={suspected_permanent_losses} "
+            "awaiting independent frontier evidence"
+        )
+    else:
+        chs.pop(PERMANENT_LOSS_SUSPECTED_KEY, None)
     preserve_gap_incident = (
         selected_probe.status is None
-        and new_permanent_losses > 0
         and chs.get(ISSUE_FILING_SUPPRESSION_REASON_KEY)
         == ISSUE_FILING_DC_UNREACHABLE_REASON
         and bool(

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -140,16 +140,15 @@ ISSUE_FILING_REACHABLE_TICKS_KEY = "issue_filing_reachable_ticks"
 ISSUE_FILING_REACHABLE_TICKS_REQUIRED = 2
 ISSUE_FILING_DC_UNREACHABLE_REASON = "dcserver_transport_unreachable"
 LOSS_OBSERVATIONS_KEY = "permanent_loss_observations"
-LOSS_SCAN_SEQUENCE_KEY = "permanent_loss_scan_sequence"
 PERMANENT_LOSS_TOMBSTONES_KEY = "permanent_loss_tombstones"
+PERMANENT_LOSS_UNANNOUNCED_KEY = "permanent_loss_unannounced"
 PERMANENT_LOSS_TOTAL_KEY = "permanent_loss_total"
-LAST_ACTUAL_DELIVERY_AT_KEY = "last_actual_delivery_at"
-# A source block becomes unrecoverable only after two independent ordering
-# observations: it stays unmatched in consecutive successful Discord reads while
-# a later source block is actually matched on both reads. A wall-clock threshold
-# cannot prove a skip; repeated overtaking can, and two observations reject one
-# bounded-read/transient-edit snapshot without coupling the rule to poll_secs.
-PERMANENT_LOSS_CONFIRM_TICKS = 2
+LAST_ACTUAL_DELIVERY_BY_PATH_KEY = "last_actual_delivery_by_path"
+# Permanent loss requires two different delivered-frontier advances beyond the
+# candidate. Re-reading the same bounded Discord window never adds evidence.
+PERMANENT_LOSS_CONFIRM_ADVANCES = 2
+MAX_LOSS_OBSERVATIONS = 256
+MAX_PERMANENT_LOSS_TOMBSTONES = 256
 MAX_TRANSCRIPT_HISTORY = 64
 MAX_KNOWN_TRANSCRIPTS = 256
 MAX_PENDING_TRANSCRIPTS = 32
@@ -1390,13 +1389,43 @@ def norm(s: str) -> str:
 
 
 def delivered(text: str, hay: str) -> bool:
-    """3 probes (head/middle/tail); ≥1 hit counts as delivered, because the
-    relay chunks long blocks across messages and edits messages in place."""
+    """Whether at least one delivery probe is present in the bounded haystack."""
     n = norm(text)
     if len(n) < 60:
         return n in hay
     probes = [n[:60], n[len(n) // 2 : len(n) // 2 + 50], n[-60:]]
     return any(p and p in hay for p in probes)
+
+
+def delivered_flags(blocks: list[tuple[float, str]], hay: str) -> list[bool]:
+    """Cardinality-aware matching for duplicate source text.
+
+    Identical source blocks consume distinct occurrences of their strongest
+    delivery probe. This prevents one Discord copy from satisfying two source
+    obligations. Ambiguous duplicates remain active and are never tombstoned.
+    """
+    capacities: dict[str, int] = {}
+    consumed: dict[str, int] = {}
+    flags: list[bool] = []
+    for _, text in blocks:
+        normalized = norm(text)
+        if normalized not in capacities:
+            probes = (
+                [normalized]
+                if len(normalized) < 60
+                else [
+                    normalized[:60],
+                    normalized[len(normalized) // 2 : len(normalized) // 2 + 50],
+                    normalized[-60:],
+                ]
+            )
+            capacities[normalized] = max(
+                (hay.count(probe) for probe in probes if probe), default=0
+            )
+        used = consumed.get(normalized, 0)
+        flags.append(used < capacities[normalized])
+        consumed[normalized] = used + 1
+    return flags
 
 
 @dataclass(frozen=True)
@@ -1413,56 +1442,69 @@ class Verdict:
 class PermanentLossUpdate:
     active_blocks: list[tuple[float, str]]
     newly_tombstoned: tuple[str, ...]
-    tombstoned_in_scan: int
+    retracted: tuple[str, ...]
 
 
-def _assistant_block_id(
-    transcript: str | Path, epoch: float, text: str, occurrence: int
-) -> str:
-    """Stable identity for one source block across append-only transcript scans."""
+def _assistant_block_id(transcript: str | Path, epoch: float, text: str) -> str:
+    """Stable content identity; independent of compacted occurrence numbering."""
     digest = hashlib.sha256(norm(text).encode("utf-8")).hexdigest()
-    identity = f"{transcript}\0{epoch:.6f}\0{digest}\0{occurrence}"
+    identity = f"{transcript}\0{epoch:.6f}\0{digest}"
     return hashlib.sha256(identity.encode("utf-8")).hexdigest()
 
 
+def _bounded_loss_entries(
+    entries: Mapping[str, dict[str, Any]], limit: int
+) -> dict[str, dict[str, Any]]:
+    ordered = sorted(
+        entries.items(),
+        key=lambda item: (
+            -float(item[1].get("last_observed_at", item[1].get("confirmed_at", 0.0))),
+            item[0],
+        ),
+    )
+    return dict(ordered[:limit])
+
+
 def _validated_loss_observations(
-    channel_state: Mapping[str, Any],
+    channel_state: Mapping[str, Any], now: float | None = None
 ) -> dict[str, dict[str, Any]]:
     raw = channel_state.get(LOSS_OBSERVATIONS_KEY, {})
     if not isinstance(raw, dict):
         return {}
     valid: dict[str, dict[str, Any]] = {}
     for block_id, entry in raw.items():
+        advances = entry.get("evidence_frontiers") if isinstance(entry, dict) else None
         if not (
             isinstance(block_id, str)
             and len(block_id) == 64
             and isinstance(entry, dict)
             and isinstance(entry.get("path"), str)
             and entry.get("path")
-            and isinstance(entry.get("count"), int)
-            and not isinstance(entry.get("count"), bool)
-            and 0 < entry["count"] < PERMANENT_LOSS_CONFIRM_TICKS
             and _is_finite_nonnegative_number(entry.get("epoch"))
             and _is_finite_nonnegative_number(entry.get("last_observed_at"))
-            and isinstance(entry.get("last_scan"), int)
-            and not isinstance(entry.get("last_scan"), bool)
-            and entry["last_scan"] >= 0
+            and isinstance(advances, list)
+            and all(_is_finite_nonnegative_number(value) for value in advances)
         ):
+            continue
+        last_observed_at = float(entry["last_observed_at"])
+        if now is not None and now - last_observed_at > TRANSCRIPT_HISTORY_TTL_SECS:
+            continue
+        distinct = sorted({float(value) for value in advances})[-PERMANENT_LOSS_CONFIRM_ADVANCES:]
+        if not distinct:
             continue
         valid[block_id] = {
             "path": entry["path"],
             "epoch": float(entry["epoch"]),
-            "count": entry["count"],
-            "last_observed_at": float(entry["last_observed_at"]),
-            "last_scan": entry["last_scan"],
+            "evidence_frontiers": distinct,
+            "last_observed_at": last_observed_at,
         }
-    return valid
+    return _bounded_loss_entries(valid, MAX_LOSS_OBSERVATIONS)
 
 
 def permanent_loss_tombstones(
-    channel_state: Mapping[str, Any],
+    channel_state: Mapping[str, Any], now: float | None = None
 ) -> dict[str, dict[str, Any]]:
-    """Return durable confirmed-loss identities; malformed state fails open."""
+    """Return bounded durable loss identities; malformed state fails open."""
     raw = channel_state.get(PERMANENT_LOSS_TOMBSTONES_KEY, {})
     if not isinstance(raw, dict):
         return {}
@@ -1478,34 +1520,39 @@ def permanent_loss_tombstones(
             and _is_finite_nonnegative_number(entry.get("confirmed_at"))
         ):
             continue
+        confirmed_at = float(entry["confirmed_at"])
+        if now is not None and now - confirmed_at > TRANSCRIPT_HISTORY_TTL_SECS:
+            continue
         valid[block_id] = {
             "path": entry["path"],
             "epoch": float(entry["epoch"]),
-            "confirmed_at": float(entry["confirmed_at"]),
+            "confirmed_at": confirmed_at,
+            "last_observed_at": confirmed_at,
         }
-    return valid
+    bounded = _bounded_loss_entries(valid, MAX_PERMANENT_LOSS_TOMBSTONES)
+    for entry in bounded.values():
+        entry.pop("last_observed_at", None)
+    return bounded
 
 
 def permanent_loss_total(channel_state: Mapping[str, Any]) -> int:
-    raw = channel_state.get(PERMANENT_LOSS_TOTAL_KEY, 0)
-    persisted = (
-        raw
-        if isinstance(raw, int) and not isinstance(raw, bool) and raw >= 0
-        else 0
-    )
-    return max(persisted, len(permanent_loss_tombstones(channel_state)))
+    """Current retained permanent losses; derived map prevents split-key drift."""
+    return len(permanent_loss_tombstones(channel_state))
 
 
-def next_permanent_loss_scan(channel_state: dict[str, Any]) -> int:
-    raw = channel_state.get(LOSS_SCAN_SEQUENCE_KEY, 0)
-    prior = (
-        raw
-        if isinstance(raw, int) and not isinstance(raw, bool) and raw >= 0
-        else 0
-    )
-    current = prior + 1
-    channel_state[LOSS_SCAN_SEQUENCE_KEY] = current
-    return current
+def _store_loss_state(
+    channel_state: dict[str, Any],
+    observations: Mapping[str, dict[str, Any]],
+    tombstones: Mapping[str, dict[str, Any]],
+) -> None:
+    if observations:
+        channel_state[LOSS_OBSERVATIONS_KEY] = dict(observations)
+    else:
+        channel_state.pop(LOSS_OBSERVATIONS_KEY, None)
+    if tombstones:
+        channel_state[PERMANENT_LOSS_TOMBSTONES_KEY] = dict(tombstones)
+    else:
+        channel_state.pop(PERMANENT_LOSS_TOMBSTONES_KEY, None)
 
 
 def update_permanent_loss_tombstones(
@@ -1515,94 +1562,79 @@ def update_permanent_loss_tombstones(
     hay: str,
     now: float,
     grace_secs: int,
-    scan_sequence: int,
+    prior_delivered_ts: float,
+    current_delivered_ts: float,
 ) -> PermanentLossUpdate:
-    """Confirm source-order skips and remove confirmed losses from active gaps.
+    """Confirm only skips proven by distinct delivered-frontier advances.
 
-    Confirmation is ordering-based rather than age-based: the same stale source
-    block must remain unmatched on two consecutive successful Discord reads, and
-    each read must match a later block from the same transcript. Relay delivery is
-    ordered and frame_ack=false drops have no replay path, so repeated overtaking
-    proves that the earlier block was skipped. One observation remains retryable.
+    A candidate must be newer than the already-confirmed frontier. Each evidence
+    point is a different later source timestamp that newly advances that frontier;
+    repeated reads of one bounded Discord window cannot confirm a loss. A later
+    match retracts a tombstone and decrements the cumulative total.
     """
     path = str(transcript)
-    tombstones = permanent_loss_tombstones(channel_state)
-    total_before = permanent_loss_total(channel_state)
-    observations = _validated_loss_observations(channel_state)
-    identities: list[str] = []
-    duplicate_occurrences: dict[tuple[float, str], int] = {}
-    matched: list[bool] = []
-    for epoch, text in blocks:
-        digest = hashlib.sha256(norm(text).encode("utf-8")).hexdigest()
-        duplicate_key = (epoch, digest)
-        occurrence = duplicate_occurrences.get(duplicate_key, 0)
-        duplicate_occurrences[duplicate_key] = occurrence + 1
-        identities.append(_assistant_block_id(path, epoch, text, occurrence))
-        matched.append(delivered(text, hay))
+    tombstones = permanent_loss_tombstones(channel_state, now)
+    observations = _validated_loss_observations(channel_state, now)
+    total = len(tombstones)
+    block_ids = [_assistant_block_id(path, epoch, text) for epoch, text in blocks]
+    matched = delivered_flags(blocks, hay)
 
-    later_match: list[bool] = [False] * len(blocks)
-    seen_match = False
-    for index in range(len(blocks) - 1, -1, -1):
-        later_match[index] = seen_match
-        seen_match = seen_match or matched[index]
-
-    observed_ids: set[str] = set()
-    newly_tombstoned: list[str] = []
+    retracted: list[str] = []
     active_blocks: list[tuple[float, str]] = []
-    tombstoned_in_scan = 0
-    for index, ((epoch, text), block_id) in enumerate(zip(blocks, identities)):
-        if block_id in tombstones:
-            tombstoned_in_scan += 1
+    for (epoch, text), block_id, is_matched in zip(blocks, block_ids, matched):
+        if block_id in tombstones and is_matched:
+            tombstones.pop(block_id, None)
+            observations.pop(block_id, None)
+            retracted.append(block_id)
+            total = len(tombstones)
+        if block_id not in tombstones:
+            active_blocks.append((epoch, text))
+
+    frontier_advanced = current_delivered_ts > prior_delivered_ts
+    newly_tombstoned: list[str] = []
+    for index, ((epoch, _), block_id) in enumerate(zip(blocks, block_ids)):
+        if block_id in tombstones or matched[index]:
+            observations.pop(block_id, None)
             continue
-        overtaken = now - epoch > grace_secs and not matched[index] and later_match[index]
-        if overtaken:
-            observed_ids.add(block_id)
-            prior = observations.get(block_id)
-            consecutive = bool(
-                prior
-                and prior["path"] == path
-                and prior["last_scan"] == scan_sequence - 1
-            )
-            count = prior["count"] + 1 if consecutive else 1
-            if count >= PERMANENT_LOSS_CONFIRM_TICKS:
-                tombstones[block_id] = {
-                    "path": path,
-                    "epoch": epoch,
-                    "confirmed_at": now,
-                }
-                observations.pop(block_id, None)
-                newly_tombstoned.append(block_id)
-                tombstoned_in_scan += 1
-                continue
+        prior = observations.get(block_id)
+        eligible = now - epoch > grace_secs and (
+            epoch > prior_delivered_ts or prior is not None
+        )
+        later_advance = frontier_advanced and current_delivered_ts > epoch
+        if not (eligible and later_advance):
+            continue
+        frontiers = set(prior.get("evidence_frontiers", [])) if prior else set()
+        frontiers.add(current_delivered_ts)
+        evidence = sorted(frontiers)[-PERMANENT_LOSS_CONFIRM_ADVANCES:]
+        if len(evidence) >= PERMANENT_LOSS_CONFIRM_ADVANCES:
+            tombstones[block_id] = {
+                "path": path,
+                "epoch": epoch,
+                "confirmed_at": now,
+            }
+            observations.pop(block_id, None)
+            newly_tombstoned.append(block_id)
+            total = len(tombstones)
+            active_blocks = [
+                block for block, identity in zip(blocks, block_ids) if identity != block_id
+            ]
+        else:
             observations[block_id] = {
                 "path": path,
                 "epoch": epoch,
-                "count": count,
+                "evidence_frontiers": evidence,
                 "last_observed_at": now,
-                "last_scan": scan_sequence,
             }
-        active_blocks.append((epoch, text))
 
-    observations = {
-        block_id: entry
-        for block_id, entry in observations.items()
-        if entry["path"] != path or block_id in observed_ids
-    }
-    if observations:
-        channel_state[LOSS_OBSERVATIONS_KEY] = observations
-    else:
-        channel_state.pop(LOSS_OBSERVATIONS_KEY, None)
-    if tombstones:
-        channel_state[PERMANENT_LOSS_TOMBSTONES_KEY] = tombstones
-    else:
-        channel_state.pop(PERMANENT_LOSS_TOMBSTONES_KEY, None)
-    channel_state[PERMANENT_LOSS_TOTAL_KEY] = total_before + len(
-        newly_tombstoned
-    )
+    observations = _bounded_loss_entries(observations, MAX_LOSS_OBSERVATIONS)
+    tombstones = _bounded_loss_entries(tombstones, MAX_PERMANENT_LOSS_TOMBSTONES)
+    total = len(tombstones)
+    _store_loss_state(channel_state, observations, tombstones)
+    channel_state[PERMANENT_LOSS_TOTAL_KEY] = total
     return PermanentLossUpdate(
         active_blocks=active_blocks,
         newly_tombstoned=tuple(newly_tombstoned),
-        tombstoned_in_scan=tombstoned_in_scan,
+        retracted=tuple(retracted),
     )
 
 
@@ -2144,15 +2176,25 @@ def evaluate(
         if _is_finite_nonnegative_number(prior_delivered_ts)
         else 0.0
     )
+    matches = delivered_flags(blocks, hay)
     current_delivered_ts = max(
-        (e for e, t in blocks if delivered(t, hay)), default=0.0
+        (epoch for (epoch, _), matched in zip(blocks, matches) if matched),
+        default=0.0,
     )
     # Discord reads are bounded. Absence from today's haystack cannot erase the
     # health watermark, but source classification remains independent: an older
     # unmatched block is ignored only after durable skip/tombstone confirmation.
     delivered_ts = max(prior, current_delivered_ts)
-    stale = [(e, t) for e, t in blocks if now - e > grace_secs]
-    lost = [(e, t) for e, t in stale if e > delivered_ts and not delivered(t, hay)]
+    stale = [
+        ((epoch, text), matched)
+        for (epoch, text), matched in zip(blocks, matches)
+        if now - epoch > grace_secs
+    ]
+    lost = [
+        block
+        for block, matched in stale
+        if block[0] > delivered_ts and not matched
+    ]
     gap_secs = (now - delivered_ts) if delivered_ts else float("inf")
     if lost and gap_secs > gap_alert_secs:
         state = STATE_GAP
@@ -2339,6 +2381,29 @@ def _forget_reclaimed_recovered_gap_lifecycles(
         }
     else:
         channel_state.pop(DELIVERED_WATERMARKS_KEY, None)
+
+    observations = {
+        block_id: entry
+        for block_id, entry in _validated_loss_observations(channel_state).items()
+        if entry["path"] not in reclaimed
+    }
+    tombstones = {
+        block_id: entry
+        for block_id, entry in permanent_loss_tombstones(channel_state).items()
+        if entry["path"] not in reclaimed
+    }
+    _store_loss_state(channel_state, observations, tombstones)
+    raw_actual = channel_state.get(LAST_ACTUAL_DELIVERY_BY_PATH_KEY)
+    if isinstance(raw_actual, dict):
+        retained_actual = {
+            path: observed_at
+            for path, observed_at in raw_actual.items()
+            if path not in reclaimed
+        }
+        if retained_actual:
+            channel_state[LAST_ACTUAL_DELIVERY_BY_PATH_KEY] = retained_actual
+        else:
+            channel_state.pop(LAST_ACTUAL_DELIVERY_BY_PATH_KEY, None)
 
 
 def load_state(path: Path) -> dict[str, Any]:
@@ -2654,7 +2719,7 @@ class Runtime:
             bits.append("dcserver UNKNOWN")
         return " | ".join(bits)
 
-    def alert(self, ch: ChannelConfig, body: str, trigger_turn: bool = True) -> None:
+    def alert(self, ch: ChannelConfig, body: str, trigger_turn: bool = True) -> bool:
         """Deliver an alert OUT OF BAND (never through the watched turn relay).
 
         Primary: announce bot (`send-to-agent --from system`). Trips the target
@@ -2696,7 +2761,7 @@ class Runtime:
                 )
                 if p.returncode == 0:
                     self.log("alert delivered via announce bot (turn trigger)")
-                    return
+                    return True
                 self.log(
                     f"announce bot failed rc={p.returncode}: "
                     f"{(p.stderr or p.stdout)[:160]!r}; falling back"
@@ -2719,9 +2784,16 @@ class Runtime:
                 text=True,
                 timeout=45,
             )
-            self.log(f"alert delivered via discord-sendmessage rc={p.returncode}")
+            if p.returncode == 0:
+                self.log("alert delivered via discord-sendmessage rc=0")
+                return True
+            self.log(
+                f"discord-sendmessage failed rc={p.returncode}: "
+                f"{(p.stderr or p.stdout)[:160]!r}"
+            )
         except (OSError, subprocess.SubprocessError) as e:
             self.log(f"discord-sendmessage error: {e}")
+        return False
 
     def file_github_issue(self, ch: ChannelConfig, gap_min: int, lost: int) -> str:
         """Auto-file a GitHub issue for a persistent gap (06-29 relay-gap-watch
@@ -3884,12 +3956,18 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     evaluated: list[tuple[TranscriptCandidate, Verdict]] = []
     fresh_undelivered_by_path: dict[str, int] = {}
     new_permanent_losses = 0
-    last_actual_delivery_at = (
-        float(chs.get(LAST_ACTUAL_DELIVERY_AT_KEY))
-        if _is_finite_nonnegative_number(chs.get(LAST_ACTUAL_DELIVERY_AT_KEY))
-        else 0.0
+    raw_delivery_by_path = chs.get(LAST_ACTUAL_DELIVERY_BY_PATH_KEY, {})
+    last_actual_delivery_by_path = (
+        {
+            path: float(observed_at)
+            for path, observed_at in raw_delivery_by_path.items()
+            if isinstance(path, str)
+            and path
+            and _is_finite_nonnegative_number(observed_at)
+        }
+        if isinstance(raw_delivery_by_path, dict)
+        else {}
     )
-    loss_scan_sequence = next_permanent_loss_scan(chs)
     unreadable_paths: list[str] = []
     escalated_pending_paths: list[str] = []
     remaining_pending = list(pending_paths)
@@ -3946,8 +4024,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             advance_delivered_watermark(
                 chs, candidate.path, observed_verdict.delivered_ts, now
             )
-            last_actual_delivery_at = max(last_actual_delivery_at, now)
-            chs[LAST_ACTUAL_DELIVERY_AT_KEY] = last_actual_delivery_at
+            last_actual_delivery_by_path[path] = now
         tombstone_update = update_permanent_loss_tombstones(
             chs,
             candidate.path,
@@ -3955,7 +4032,8 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             hay,
             now,
             cfg.grace_secs,
-            loss_scan_sequence,
+            prior_delivered_ts,
+            observed_verdict.delivered_ts,
         )
         new_permanent_losses += len(tombstone_update.newly_tombstoned)
         verdict = evaluate(
@@ -3966,18 +4044,27 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             cfg.gap_alert_secs,
             prior_delivered_ts,
         )
+        active_matches = delivered_flags(tombstone_update.active_blocks, hay)
         fresh_undelivered = sum(
             1
-            for epoch, text in tombstone_update.active_blocks
+            for (epoch, _), matched in zip(
+                tombstone_update.active_blocks, active_matches
+            )
             if now - epoch <= cfg.grace_secs
             and epoch > verdict.delivered_ts
-            and not delivered(text, hay)
+            and not matched
         )
         fresh_undelivered_by_path[path] = fresh_undelivered
         if tombstone_update.newly_tombstoned:
             rt.log(
                 f"[{cid}] permanent-loss-confirmed path={path} "
                 f"new={len(tombstone_update.newly_tombstoned)} "
+                f"total={permanent_loss_total(chs)}"
+            )
+        if tombstone_update.retracted:
+            rt.log(
+                f"[{cid}] permanent-loss-retracted path={path} "
+                f"count={len(tombstone_update.retracted)} "
                 f"total={permanent_loss_total(chs)}"
             )
         if path in pending_set:
@@ -4017,6 +4104,12 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         chs[PENDING_TRANSCRIPT_SINCE_KEY] = pending_since
     else:
         chs.pop(PENDING_TRANSCRIPT_SINCE_KEY, None)
+    if last_actual_delivery_by_path:
+        chs[LAST_ACTUAL_DELIVERY_BY_PATH_KEY] = dict(
+            sorted(last_actual_delivery_by_path.items())[-MAX_KNOWN_TRANSCRIPTS:]
+        )
+    else:
+        chs.pop(LAST_ACTUAL_DELIVERY_BY_PATH_KEY, None)
     if escalated_pending_paths:
         retired_pending_paths.extend(escalated_pending_paths)
         escalated = set(escalated_pending_paths)
@@ -4161,22 +4254,45 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         else None
     )
     observe_coverage(coverage_transcript_probe)
-    if new_permanent_losses:
+    raw_unannounced = chs.get(PERMANENT_LOSS_UNANNOUNCED_KEY, 0)
+    unannounced = (
+        raw_unannounced
+        if isinstance(raw_unannounced, int)
+        and not isinstance(raw_unannounced, bool)
+        and raw_unannounced >= 0
+        else 0
+    ) + new_permanent_losses
+    if unannounced:
         cumulative_losses = permanent_loss_total(chs)
-        rt.alert(
+        delivered_notice = rt.alert(
             ch,
             "🚨 **새 영구 릴레이 유실 확정 (out-of-band 워치독)**\n\n"
-            f"후속 assistant 블록의 실제 Discord 도착이 반복 확인된 뒤에도 "
-            f"미매칭으로 남은 블록 **{new_permanent_losses}건**을 재전송 불가 "
-            "tombstone으로 전환했습니다.\n"
+            f"서로 다른 후속 delivery frontier 전진 뒤에도 미매칭으로 남은 "
+            f"블록 **{unannounced}건**을 재전송 불가 tombstone으로 전환했습니다.\n"
             f"현재 미도달 **{sum(verdict.lost for _, verdict in evaluated)}건**, "
             f"영구 유실 **{cumulative_losses}건 누적**.\n\n"
             f"런타임: {rt.dcserver_snapshot()}",
         )
+        if delivered_notice:
+            chs.pop(PERMANENT_LOSS_UNANNOUNCED_KEY, None)
+        else:
+            chs[PERMANENT_LOSS_UNANNOUNCED_KEY] = unannounced
         rt.log(
-            f"[{cid}] PERMANENT LOSS ALERT new={new_permanent_losses} "
-            f"cumulative={cumulative_losses}"
+            f"[{cid}] PERMANENT LOSS ALERT new={unannounced} "
+            f"cumulative={cumulative_losses} delivered={delivered_notice}"
         )
+    preserve_gap_incident = (
+        selected_probe.status is None
+        and new_permanent_losses > 0
+        and chs.get(ISSUE_FILING_SUPPRESSION_REASON_KEY)
+        == ISSUE_FILING_DC_UNREACHABLE_REASON
+        and bool(
+            _validated_gap_owner_transcripts(chs)
+            or chs.get("alerting")
+            or chs.get("gap_since")
+            or chs.get("issue_url")
+        )
+    )
     previous_gap_owners = _validated_gap_owner_transcripts(chs)
     evaluated_paths = {str(candidate.path) for candidate, _ in evaluated}
     incident_open = bool(
@@ -4214,7 +4330,11 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     next_gap_owners = [
         path
         for path in previous_gap_owners
-        if path not in evaluated_paths and path not in superseded_gap_owners
+        if (
+            path not in evaluated_paths
+            or (preserve_gap_incident and path in evaluated_paths)
+        )
+        and path not in superseded_gap_owners
     ]
     for candidate, verdict in evaluated:
         path = str(candidate.path)
@@ -4276,6 +4396,9 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             )
             return
         issue_filing_stable = _issue_filing_stable(chs, selected_probe, now)
+        last_actual_delivery_at = last_actual_delivery_by_path.get(
+            verdict_path, 0.0
+        )
         gap_min = (
             int(max(0.0, now - last_actual_delivery_at) // 60)
             if last_actual_delivery_at
@@ -4329,6 +4452,12 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             f"(< {cfg.gap_alert_secs}s alert threshold — relay batching, not down)"
         )
     else:
+        if preserve_gap_incident:
+            rt.log(
+                f"[{cid}] dcserver transport unreachable — preserving gap "
+                "incident state across permanent-loss transition"
+            )
+            return
         if chs.get("alerting") and new_permanent_losses:
             # Tombstoning closes the retryable incident but does not prove that
             # the skipped blocks arrived; the dedicated permanent-loss alert is

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -586,7 +586,8 @@ class TranscriptReadResult:
     incomplete_tail: bool = False
     semantic_end_offset: int = 0
     observed_size: int = 0
-    block_offsets: list[int] = field(default_factory=list)
+    block_source_ids: list[str] = field(default_factory=list)
+    identity_fallbacks: int = 0
 
 
 def transcript_candidates(dirs: list[Path]) -> list[TranscriptCandidate]:
@@ -1291,31 +1292,39 @@ def is_harness_control_assistant_record(record: object) -> bool:
     return isinstance(message, dict) and message.get("model") == "<synthetic>"
 
 
+def _assistant_blocks_from_record(
+    record: object,
+) -> list[tuple[float, str]]:
+    if (
+        not isinstance(record, dict)
+        or record.get("type") != "assistant"
+        or is_harness_control_assistant_record(record)
+    ):
+        return []
+    epoch = parse_transcript_ts(record.get("timestamp", ""))
+    if epoch is None:
+        return []
+    message = record.get("message")
+    if not isinstance(message, dict):
+        return []
+    out: list[tuple[float, str]] = []
+    for content in message.get("content") or []:
+        if isinstance(content, dict) and content.get("type") == "text":
+            text = (content.get("text") or "").strip()
+            if text:
+                out.append((epoch, text))
+    return out
+
+
 def assistant_blocks_from_lines(lines) -> list[tuple[float, str]]:
     """(epoch, text) for every assistant text block in a transcript's lines."""
     out: list[tuple[float, str]] = []
     for line in lines:
         try:
-            r = json.loads(line)
+            record = json.loads(line)
         except (json.JSONDecodeError, TypeError):
             continue
-        if (
-            not isinstance(r, dict)
-            or r.get("type") != "assistant"
-            or is_harness_control_assistant_record(r)
-        ):
-            continue
-        epoch = parse_transcript_ts(r.get("timestamp", ""))
-        if epoch is None:
-            continue
-        message = r.get("message")
-        if not isinstance(message, dict):
-            continue
-        for c in message.get("content") or []:
-            if isinstance(c, dict) and c.get("type") == "text":
-                t = (c.get("text") or "").strip()
-                if t:
-                    out.append((epoch, t))
+        out.extend(_assistant_blocks_from_record(record))
     return out
 
 
@@ -1361,16 +1370,30 @@ def assistant_blocks(
                 except (json.JSONDecodeError, TypeError):
                     incomplete_tail = True
             blocks: list[tuple[float, str]] = []
-            block_offsets: list[int] = []
+            block_source_ids: list[str] = []
+            identity_fallbacks = 0
             semantic_end_offset = 0
             byte_offset = 0
             for raw_line, line in zip(raw_lines, lines):
                 line_start_offset = byte_offset
-                line_blocks = assistant_blocks_from_lines([line])
+                try:
+                    record = json.loads(line)
+                except (json.JSONDecodeError, TypeError):
+                    record = None
+                line_blocks = _assistant_blocks_from_record(record)
                 blocks.extend(line_blocks)
-                block_offsets.extend(
-                    line_start_offset + index for index in range(len(line_blocks))
-                )
+                record_uuid = record.get("uuid") if isinstance(record, dict) else None
+                if isinstance(record_uuid, str) and record_uuid:
+                    block_source_ids.extend(
+                        f"uuid:{record_uuid}:{index}"
+                        for index in range(len(line_blocks))
+                    )
+                else:
+                    block_source_ids.extend(
+                        f"offset:{line_start_offset + index}"
+                        for index in range(len(line_blocks))
+                    )
+                    identity_fallbacks += len(line_blocks)
                 byte_offset += len(raw_line)
                 if line_blocks:
                     semantic_end_offset = byte_offset
@@ -1379,7 +1402,8 @@ def assistant_blocks(
                 incomplete_tail=incomplete_tail,
                 semantic_end_offset=semantic_end_offset,
                 observed_size=byte_offset,
-                block_offsets=block_offsets,
+                block_source_ids=block_source_ids,
+                identity_fallbacks=identity_fallbacks,
             )
     except (OSError, UnicodeError, ValueError) as exc:
         return TranscriptReadResult([], type(exc).__name__)
@@ -1459,11 +1483,11 @@ class PermanentLossUpdate:
 
 
 def _assistant_block_id(
-    transcript: str | Path, epoch: float, text: str, source_offset: int
+    transcript: str | Path, epoch: float, text: str, source_id: str
 ) -> str:
-    """Stable source identity based on the transcript byte position."""
+    """Stable identity from a record UUID plus its text-block index."""
     digest = hashlib.sha256(norm(text).encode("utf-8")).hexdigest()
-    identity = f"{transcript}\0{source_offset}\0{epoch:.6f}\0{digest}"
+    identity = f"{transcript}\0{source_id}\0{epoch:.6f}\0{digest}"
     return hashlib.sha256(identity.encode("utf-8")).hexdigest()
 
 
@@ -1596,7 +1620,7 @@ def update_permanent_loss_tombstones(
     channel_state: dict[str, Any],
     transcript: str | Path,
     blocks: list[tuple[float, str]],
-    block_offsets: list[int],
+    block_source_ids: list[str],
     hay: str,
     now: float,
     grace_secs: int,
@@ -1618,11 +1642,11 @@ def update_permanent_loss_tombstones(
         channel_state, now
     )
     corrupted = tombstones_corrupted or observations_corrupted
-    if len(block_offsets) != len(blocks):
-        raise ValueError("block_offsets must identify every source block")
+    if len(block_source_ids) != len(blocks):
+        raise ValueError("block_source_ids must identify every source block")
     block_ids = [
-        _assistant_block_id(path, epoch, text, source_offset)
-        for (epoch, text), source_offset in zip(blocks, block_offsets)
+        _assistant_block_id(path, epoch, text, source_id)
+        for (epoch, text), source_id in zip(blocks, block_source_ids)
     ]
     matched = delivered_flags(blocks, hay)
 
@@ -4101,7 +4125,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             chs,
             candidate.path,
             read_result.blocks,
-            read_result.block_offsets,
+            read_result.block_source_ids,
             hay,
             now,
             cfg.grace_secs,
@@ -4110,6 +4134,12 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         )
         suspected_permanent_losses += tombstone_update.suspected
         new_permanent_losses += len(tombstone_update.newly_tombstoned)
+        if read_result.identity_fallbacks:
+            rt.log(
+                f"[{cid}] permanent-loss-identity-offset-fallback path={path} "
+                f"blocks={read_result.identity_fallbacks}; identity may change "
+                "after head truncation"
+            )
         if tombstone_update.corrupted:
             rt.log(
                 f"[{cid}] permanent-loss-state-corrupt path={path}; "

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -143,6 +143,7 @@ LOSS_OBSERVATIONS_KEY = "permanent_loss_observations"
 LOSS_SCAN_SEQUENCE_KEY = "permanent_loss_scan_sequence"
 PERMANENT_LOSS_TOMBSTONES_KEY = "permanent_loss_tombstones"
 PERMANENT_LOSS_TOTAL_KEY = "permanent_loss_total"
+LAST_ACTUAL_DELIVERY_AT_KEY = "last_actual_delivery_at"
 # A source block becomes unrecoverable only after two independent ordering
 # observations: it stays unmatched in consecutive successful Discord reads while
 # a later source block is actually matched on both reads. A wall-clock threshold
@@ -3883,6 +3884,11 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     evaluated: list[tuple[TranscriptCandidate, Verdict]] = []
     fresh_undelivered_by_path: dict[str, int] = {}
     new_permanent_losses = 0
+    last_actual_delivery_at = (
+        float(chs.get(LAST_ACTUAL_DELIVERY_AT_KEY))
+        if _is_finite_nonnegative_number(chs.get(LAST_ACTUAL_DELIVERY_AT_KEY))
+        else 0.0
+    )
     loss_scan_sequence = next_permanent_loss_scan(chs)
     unreadable_paths: list[str] = []
     escalated_pending_paths: list[str] = []
@@ -3940,6 +3946,8 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             advance_delivered_watermark(
                 chs, candidate.path, observed_verdict.delivered_ts, now
             )
+            last_actual_delivery_at = max(last_actual_delivery_at, now)
+            chs[LAST_ACTUAL_DELIVERY_AT_KEY] = last_actual_delivery_at
         tombstone_update = update_permanent_loss_tombstones(
             chs,
             candidate.path,
@@ -4268,7 +4276,11 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             )
             return
         issue_filing_stable = _issue_filing_stable(chs, selected_probe, now)
-        gap_min = int(v.gap_secs // 60) if v.delivered_ts else 999
+        gap_min = (
+            int(max(0.0, now - last_actual_delivery_at) // 60)
+            if last_actual_delivery_at
+            else (int(v.gap_secs // 60) if v.delivered_ts else 999)
+        )
         if not chs.get("gap_since"):
             chs["gap_since"] = now
         issue_due = (

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -145,6 +145,9 @@ PERMANENT_LOSS_UNANNOUNCED_KEY = "permanent_loss_unannounced"
 PERMANENT_LOSS_TOTAL_KEY = "permanent_loss_total"
 PERMANENT_LOSS_SUSPECTED_KEY = "permanent_loss_suspected"
 PERMANENT_LOSS_OVERFLOW_TOTAL_KEY = "permanent_loss_overflow_total"
+PERMANENT_LOSS_QUARANTINE_KEY = "permanent_loss_quarantine"
+PERMANENT_LOSS_QUARANTINE_TOTAL_KEY = "permanent_loss_quarantine_total"
+PERMANENT_LOSS_IDENTITY_WARNING_KEY = "permanent_loss_identity_warnings"
 LAST_ACTUAL_DELIVERY_AT_KEY = "last_actual_delivery_at"
 LAST_ACTUAL_DELIVERY_BY_PATH_KEY = "last_actual_delivery_by_path"
 # Permanent loss requires two different delivered-frontier advances beyond the
@@ -1479,6 +1482,7 @@ class PermanentLossUpdate:
     retracted: tuple[str, ...]
     suspected: int = 0
     overflowed: int = 0
+    quarantined: int = 0
     corrupted: bool = False
 
 
@@ -1584,6 +1588,60 @@ def _permanent_loss_tombstones_with_status(
     return bounded, corrupted
 
 
+def _quarantine_corrupt_loss_state(
+    channel_state: dict[str, Any],
+    *,
+    observations_corrupted: bool,
+    tombstones_corrupted: bool,
+    now: float,
+) -> int:
+    """Move malformed loss state out of the authoritative state machine."""
+    quarantined: dict[str, dict[str, Any]] = {}
+    for key, corrupted, validator in (
+        (
+            LOSS_OBSERVATIONS_KEY,
+            observations_corrupted,
+            _validated_loss_observations_with_status,
+        ),
+        (
+            PERMANENT_LOSS_TOMBSTONES_KEY,
+            tombstones_corrupted,
+            _permanent_loss_tombstones_with_status,
+        ),
+    ):
+        if not corrupted:
+            continue
+        raw = channel_state.get(key)
+        valid = validator(channel_state, now)[0]
+        if isinstance(raw, dict):
+            invalid = {
+                str(entry_id): entry
+                for entry_id, entry in raw.items()
+                if entry_id not in valid
+            }
+        else:
+            invalid = {"<root>": raw}
+        if invalid:
+            quarantined[key] = invalid
+        if valid:
+            channel_state[key] = valid
+        else:
+            channel_state.pop(key, None)
+
+    if not quarantined:
+        return 0
+    existing = channel_state.get(PERMANENT_LOSS_QUARANTINE_KEY, [])
+    bucket = list(existing) if isinstance(existing, list) else []
+    bucket.append({"quarantined_at": now, "entries": quarantined})
+    channel_state[PERMANENT_LOSS_QUARANTINE_KEY] = bucket[-MAX_LOSS_OBSERVATIONS:]
+    count = sum(len(entries) for entries in quarantined.values())
+    previous = channel_state.get(PERMANENT_LOSS_QUARANTINE_TOTAL_KEY, 0)
+    if not isinstance(previous, int) or isinstance(previous, bool) or previous < 0:
+        previous = 0
+    channel_state[PERMANENT_LOSS_QUARANTINE_TOTAL_KEY] = previous + count
+    return count
+
+
 def permanent_loss_tombstones(
     channel_state: Mapping[str, Any], now: float | None = None
 ) -> dict[str, dict[str, Any]]:
@@ -1642,6 +1700,12 @@ def update_permanent_loss_tombstones(
         channel_state, now
     )
     corrupted = tombstones_corrupted or observations_corrupted
+    quarantined = _quarantine_corrupt_loss_state(
+        channel_state,
+        observations_corrupted=observations_corrupted,
+        tombstones_corrupted=tombstones_corrupted,
+        now=now,
+    )
     durable_tombstone_ids = set(tombstones)
     if len(block_source_ids) != len(blocks):
         raise ValueError("block_source_ids must identify every source block")
@@ -1702,18 +1766,16 @@ def update_permanent_loss_tombstones(
     active_blocks = [
         block for block, identity in zip(blocks, block_ids) if identity not in tombstones
     ]
-    if not corrupted:
-        _store_loss_state(channel_state, observations, tombstones)
-        channel_state[PERMANENT_LOSS_TOTAL_KEY] = len(tombstones)
-    else:
+    if corrupted:
         active_blocks = [
             block
             for block, identity in zip(blocks, block_ids)
             if identity not in durable_tombstone_ids
         ]
         newly_tombstoned.clear()
-        retracted.clear()
-    if overflowed:
+    _store_loss_state(channel_state, observations, tombstones)
+    channel_state[PERMANENT_LOSS_TOTAL_KEY] = len(tombstones)
+    if overflowed and not corrupted:
         previous_overflow = channel_state.get(PERMANENT_LOSS_OVERFLOW_TOTAL_KEY, 0)
         if not isinstance(previous_overflow, int) or isinstance(previous_overflow, bool):
             previous_overflow = 0
@@ -1724,6 +1786,7 @@ def update_permanent_loss_tombstones(
         retracted=tuple(retracted),
         suspected=suspected,
         overflowed=overflowed,
+        quarantined=quarantined,
         corrupted=corrupted,
     )
 

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -48,6 +48,7 @@ if sys.version_info < MIN_PYTHON:  # pragma: no cover - trivial guard
     raise SystemExit(1)
 
 import calendar
+import hashlib
 import json
 import math
 import os
@@ -138,6 +139,16 @@ ISSUE_FILING_SUPPRESSION_SINCE_KEY = "issue_filing_suppression_since"
 ISSUE_FILING_REACHABLE_TICKS_KEY = "issue_filing_reachable_ticks"
 ISSUE_FILING_REACHABLE_TICKS_REQUIRED = 2
 ISSUE_FILING_DC_UNREACHABLE_REASON = "dcserver_transport_unreachable"
+LOSS_OBSERVATIONS_KEY = "permanent_loss_observations"
+LOSS_SCAN_SEQUENCE_KEY = "permanent_loss_scan_sequence"
+PERMANENT_LOSS_TOMBSTONES_KEY = "permanent_loss_tombstones"
+PERMANENT_LOSS_TOTAL_KEY = "permanent_loss_total"
+# A source block becomes unrecoverable only after two independent ordering
+# observations: it stays unmatched in consecutive successful Discord reads while
+# a later source block is actually matched on both reads. A wall-clock threshold
+# cannot prove a skip; repeated overtaking can, and two observations reject one
+# bounded-read/transient-edit snapshot without coupling the rule to poll_secs.
+PERMANENT_LOSS_CONFIRM_TICKS = 2
 MAX_TRANSCRIPT_HISTORY = 64
 MAX_KNOWN_TRANSCRIPTS = 256
 MAX_PENDING_TRANSCRIPTS = 32
@@ -1398,6 +1409,203 @@ class Verdict:
 
 
 @dataclass(frozen=True)
+class PermanentLossUpdate:
+    active_blocks: list[tuple[float, str]]
+    newly_tombstoned: tuple[str, ...]
+    tombstoned_in_scan: int
+
+
+def _assistant_block_id(
+    transcript: str | Path, epoch: float, text: str, occurrence: int
+) -> str:
+    """Stable identity for one source block across append-only transcript scans."""
+    digest = hashlib.sha256(norm(text).encode("utf-8")).hexdigest()
+    identity = f"{transcript}\0{epoch:.6f}\0{digest}\0{occurrence}"
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()
+
+
+def _validated_loss_observations(
+    channel_state: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    raw = channel_state.get(LOSS_OBSERVATIONS_KEY, {})
+    if not isinstance(raw, dict):
+        return {}
+    valid: dict[str, dict[str, Any]] = {}
+    for block_id, entry in raw.items():
+        if not (
+            isinstance(block_id, str)
+            and len(block_id) == 64
+            and isinstance(entry, dict)
+            and isinstance(entry.get("path"), str)
+            and entry.get("path")
+            and isinstance(entry.get("count"), int)
+            and not isinstance(entry.get("count"), bool)
+            and 0 < entry["count"] < PERMANENT_LOSS_CONFIRM_TICKS
+            and _is_finite_nonnegative_number(entry.get("epoch"))
+            and _is_finite_nonnegative_number(entry.get("last_observed_at"))
+            and isinstance(entry.get("last_scan"), int)
+            and not isinstance(entry.get("last_scan"), bool)
+            and entry["last_scan"] >= 0
+        ):
+            continue
+        valid[block_id] = {
+            "path": entry["path"],
+            "epoch": float(entry["epoch"]),
+            "count": entry["count"],
+            "last_observed_at": float(entry["last_observed_at"]),
+            "last_scan": entry["last_scan"],
+        }
+    return valid
+
+
+def permanent_loss_tombstones(
+    channel_state: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Return durable confirmed-loss identities; malformed state fails open."""
+    raw = channel_state.get(PERMANENT_LOSS_TOMBSTONES_KEY, {})
+    if not isinstance(raw, dict):
+        return {}
+    valid: dict[str, dict[str, Any]] = {}
+    for block_id, entry in raw.items():
+        if not (
+            isinstance(block_id, str)
+            and len(block_id) == 64
+            and isinstance(entry, dict)
+            and isinstance(entry.get("path"), str)
+            and entry.get("path")
+            and _is_finite_nonnegative_number(entry.get("epoch"))
+            and _is_finite_nonnegative_number(entry.get("confirmed_at"))
+        ):
+            continue
+        valid[block_id] = {
+            "path": entry["path"],
+            "epoch": float(entry["epoch"]),
+            "confirmed_at": float(entry["confirmed_at"]),
+        }
+    return valid
+
+
+def permanent_loss_total(channel_state: Mapping[str, Any]) -> int:
+    raw = channel_state.get(PERMANENT_LOSS_TOTAL_KEY, 0)
+    persisted = (
+        raw
+        if isinstance(raw, int) and not isinstance(raw, bool) and raw >= 0
+        else 0
+    )
+    return max(persisted, len(permanent_loss_tombstones(channel_state)))
+
+
+def next_permanent_loss_scan(channel_state: dict[str, Any]) -> int:
+    raw = channel_state.get(LOSS_SCAN_SEQUENCE_KEY, 0)
+    prior = (
+        raw
+        if isinstance(raw, int) and not isinstance(raw, bool) and raw >= 0
+        else 0
+    )
+    current = prior + 1
+    channel_state[LOSS_SCAN_SEQUENCE_KEY] = current
+    return current
+
+
+def update_permanent_loss_tombstones(
+    channel_state: dict[str, Any],
+    transcript: str | Path,
+    blocks: list[tuple[float, str]],
+    hay: str,
+    now: float,
+    grace_secs: int,
+    scan_sequence: int,
+) -> PermanentLossUpdate:
+    """Confirm source-order skips and remove confirmed losses from active gaps.
+
+    Confirmation is ordering-based rather than age-based: the same stale source
+    block must remain unmatched on two consecutive successful Discord reads, and
+    each read must match a later block from the same transcript. Relay delivery is
+    ordered and frame_ack=false drops have no replay path, so repeated overtaking
+    proves that the earlier block was skipped. One observation remains retryable.
+    """
+    path = str(transcript)
+    tombstones = permanent_loss_tombstones(channel_state)
+    total_before = permanent_loss_total(channel_state)
+    observations = _validated_loss_observations(channel_state)
+    identities: list[str] = []
+    duplicate_occurrences: dict[tuple[float, str], int] = {}
+    matched: list[bool] = []
+    for epoch, text in blocks:
+        digest = hashlib.sha256(norm(text).encode("utf-8")).hexdigest()
+        duplicate_key = (epoch, digest)
+        occurrence = duplicate_occurrences.get(duplicate_key, 0)
+        duplicate_occurrences[duplicate_key] = occurrence + 1
+        identities.append(_assistant_block_id(path, epoch, text, occurrence))
+        matched.append(delivered(text, hay))
+
+    later_match: list[bool] = [False] * len(blocks)
+    seen_match = False
+    for index in range(len(blocks) - 1, -1, -1):
+        later_match[index] = seen_match
+        seen_match = seen_match or matched[index]
+
+    observed_ids: set[str] = set()
+    newly_tombstoned: list[str] = []
+    active_blocks: list[tuple[float, str]] = []
+    tombstoned_in_scan = 0
+    for index, ((epoch, text), block_id) in enumerate(zip(blocks, identities)):
+        if block_id in tombstones:
+            tombstoned_in_scan += 1
+            continue
+        overtaken = now - epoch > grace_secs and not matched[index] and later_match[index]
+        if overtaken:
+            observed_ids.add(block_id)
+            prior = observations.get(block_id)
+            consecutive = bool(
+                prior
+                and prior["path"] == path
+                and prior["last_scan"] == scan_sequence - 1
+            )
+            count = prior["count"] + 1 if consecutive else 1
+            if count >= PERMANENT_LOSS_CONFIRM_TICKS:
+                tombstones[block_id] = {
+                    "path": path,
+                    "epoch": epoch,
+                    "confirmed_at": now,
+                }
+                observations.pop(block_id, None)
+                newly_tombstoned.append(block_id)
+                tombstoned_in_scan += 1
+                continue
+            observations[block_id] = {
+                "path": path,
+                "epoch": epoch,
+                "count": count,
+                "last_observed_at": now,
+                "last_scan": scan_sequence,
+            }
+        active_blocks.append((epoch, text))
+
+    observations = {
+        block_id: entry
+        for block_id, entry in observations.items()
+        if entry["path"] != path or block_id in observed_ids
+    }
+    if observations:
+        channel_state[LOSS_OBSERVATIONS_KEY] = observations
+    else:
+        channel_state.pop(LOSS_OBSERVATIONS_KEY, None)
+    if tombstones:
+        channel_state[PERMANENT_LOSS_TOMBSTONES_KEY] = tombstones
+    else:
+        channel_state.pop(PERMANENT_LOSS_TOMBSTONES_KEY, None)
+    channel_state[PERMANENT_LOSS_TOTAL_KEY] = total_before + len(
+        newly_tombstoned
+    )
+    return PermanentLossUpdate(
+        active_blocks=active_blocks,
+        newly_tombstoned=tuple(newly_tombstoned),
+        tombstoned_in_scan=tombstoned_in_scan,
+    )
+
+
+@dataclass(frozen=True)
 class PgHealthVerdict:
     """End-to-end PG health plus the listener-only cause discriminator."""
 
@@ -1921,6 +2129,7 @@ def evaluate(
     grace_secs: int,
     gap_alert_secs: int,
     prior_delivered_ts: float = 0.0,
+    last_actual_delivery_ts: float | None = None,
 ) -> Verdict:
     """Core relay-gap judgment descended from the 07-09 logic and subsequently
     extended through the #4140→#4178→#4181 lineage. The health watermark is the
@@ -1938,12 +2147,21 @@ def evaluate(
     current_delivered_ts = max(
         (e for e, t in blocks if delivered(t, hay)), default=0.0
     )
-    # Discord reads are bounded.  Absence from today's haystack cannot erase a
-    # delivery confirmed by an earlier tick or process lifetime.
+    # Discord reads are bounded. Absence from today's haystack cannot erase the
+    # health watermark, but source classification remains independent: an older
+    # unmatched block is ignored only after durable skip/tombstone confirmation.
     delivered_ts = max(prior, current_delivered_ts)
     stale = [(e, t) for e, t in blocks if now - e > grace_secs]
     lost = [(e, t) for e, t in stale if e > delivered_ts and not delivered(t, hay)]
-    gap_secs = (now - delivered_ts) if delivered_ts else float("inf")
+    if last_actual_delivery_ts is None:
+        actual_delivery_ts = delivered_ts
+    else:
+        actual_delivery_ts = (
+            float(last_actual_delivery_ts)
+            if _is_finite_nonnegative_number(last_actual_delivery_ts)
+            else 0.0
+        )
+    gap_secs = (now - actual_delivery_ts) if actual_delivery_ts else float("inf")
     if lost and gap_secs > gap_alert_secs:
         state = STATE_GAP
     elif lost:
@@ -2041,6 +2259,13 @@ def delivered_watermark_for_path(
 ) -> float:
     entry = delivered_watermarks(channel_state).get(str(transcript))
     return entry[0] if entry is not None else 0.0
+
+
+def last_delivery_observed_at_for_path(
+    channel_state: Mapping[str, Any], transcript: str | Path
+) -> float:
+    entry = delivered_watermarks(channel_state).get(str(transcript))
+    return entry[1] if entry is not None else 0.0
 
 
 def advance_delivered_watermark(
@@ -3673,6 +3898,8 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
 
     evaluated: list[tuple[TranscriptCandidate, Verdict]] = []
     fresh_undelivered_by_path: dict[str, int] = {}
+    new_permanent_losses = 0
+    loss_scan_sequence = next_permanent_loss_scan(chs)
     unreadable_paths: list[str] = []
     escalated_pending_paths: list[str] = []
     remaining_pending = list(pending_paths)
@@ -3714,7 +3941,13 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             continue
         pending_failures.pop(path, None)
         prior_delivered_ts = delivered_watermark_for_path(chs, candidate.path)
-        verdict = evaluate(
+        prior_delivery_observed_at = last_delivery_observed_at_for_path(
+            chs, candidate.path
+        )
+        # Advance the health watermark from the unfiltered source before removing
+        # permanent-loss tombstones. Elapsed time must describe real transport
+        # progress, never the age of an unmatched block.
+        observed_verdict = evaluate(
             read_result.blocks,
             hay,
             now,
@@ -3722,18 +3955,45 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             cfg.gap_alert_secs,
             prior_delivered_ts,
         )
-        if verdict.delivered_ts > prior_delivered_ts:
+        if observed_verdict.delivered_ts > prior_delivered_ts:
             advance_delivered_watermark(
-                chs, candidate.path, verdict.delivered_ts, now
+                chs, candidate.path, observed_verdict.delivered_ts, now
             )
+        tombstone_update = update_permanent_loss_tombstones(
+            chs,
+            candidate.path,
+            read_result.blocks,
+            hay,
+            now,
+            cfg.grace_secs,
+            loss_scan_sequence,
+        )
+        new_permanent_losses += len(tombstone_update.newly_tombstoned)
+        verdict = evaluate(
+            tombstone_update.active_blocks,
+            hay,
+            now,
+            cfg.grace_secs,
+            cfg.gap_alert_secs,
+            prior_delivered_ts,
+            now
+            if observed_verdict.delivered_ts > prior_delivered_ts
+            else prior_delivery_observed_at,
+        )
         fresh_undelivered = sum(
             1
-            for epoch, text in read_result.blocks
+            for epoch, text in tombstone_update.active_blocks
             if now - epoch <= cfg.grace_secs
             and epoch > verdict.delivered_ts
             and not delivered(text, hay)
         )
         fresh_undelivered_by_path[path] = fresh_undelivered
+        if tombstone_update.newly_tombstoned:
+            rt.log(
+                f"[{cid}] permanent-loss-confirmed path={path} "
+                f"new={len(tombstone_update.newly_tombstoned)} "
+                f"total={permanent_loss_total(chs)}"
+            )
         if path in pending_set:
             rt.log(
                 f"[{cid}] transcript-debut-eval path={path} "
@@ -3915,6 +4175,22 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         else None
     )
     observe_coverage(coverage_transcript_probe)
+    if new_permanent_losses:
+        cumulative_losses = permanent_loss_total(chs)
+        rt.alert(
+            ch,
+            "🚨 **새 영구 릴레이 유실 확정 (out-of-band 워치독)**\n\n"
+            f"후속 assistant 블록의 실제 Discord 도착이 반복 확인된 뒤에도 "
+            f"미매칭으로 남은 블록 **{new_permanent_losses}건**을 재전송 불가 "
+            "tombstone으로 전환했습니다.\n"
+            f"현재 미도달 **{sum(verdict.lost for _, verdict in evaluated)}건**, "
+            f"영구 유실 **{cumulative_losses}건 누적**.\n\n"
+            f"런타임: {rt.dcserver_snapshot()}",
+        )
+        rt.log(
+            f"[{cid}] PERMANENT LOSS ALERT new={new_permanent_losses} "
+            f"cumulative={cumulative_losses}"
+        )
     previous_gap_owners = _validated_gap_owner_transcripts(chs)
     evaluated_paths = {str(candidate.path) for candidate, _ in evaluated}
     incident_open = bool(
@@ -4063,7 +4339,15 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             f"(< {cfg.gap_alert_secs}s alert threshold — relay batching, not down)"
         )
     else:
-        if chs.get("alerting"):
+        if chs.get("alerting") and new_permanent_losses:
+            # Tombstoning closes the retryable incident but does not prove that
+            # the skipped blocks arrived; the dedicated permanent-loss alert is
+            # the only transition notice.
+            rt.log(
+                f"[{cid}] gap transitioned to permanent loss — "
+                "alert state cleared without recovery claim"
+            )
+        elif chs.get("alerting"):
             # Auto-clear: tell the same audience the gap resolved, then reset.
             rt.alert(
                 ch,

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -6163,6 +6163,10 @@ class TickChannelTests(unittest.TestCase):
         self.assertEqual(len(rt.alerts), 1)
         self.assertIn("마지막 정상 도달 이후 **51분**", rt.alerts[0][0])
         self.assertNotIn("92분", rt.alerts[0][0])
+        self.assertEqual(
+            state["999"][relay_watchdog.LAST_ACTUAL_DELIVERY_AT_KEY],
+            last_actual_delivery,
+        )
 
     def test_new_permanent_loss_after_prior_tombstone_alerts_again(self):
         first_missing = (self.now - 4000, "first skipped response")

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -6512,6 +6512,34 @@ class TickChannelTests(unittest.TestCase):
             any("permanent-loss-state-corrupt" in line for line in rt.log_lines)
         )
 
+    def test_corruption_warning_is_edge_triggered_by_content(self):
+        chs = {
+            relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY: {"bad": "shape"},
+            relay_watchdog.PERMANENT_LOSS_TOTAL_KEY: 9,
+        }
+        state = {"999": chs}
+        self.write_transcript([(self.now - 2000, "corrupt warning candidate")])
+        rt = self.make_rt()
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+
+        warnings = [
+            line
+            for line in rt.log_lines
+            if "permanent-loss-state-corrupt" in line
+        ]
+        self.assertEqual(len(warnings), 1)
+        chs[relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY] = {"changed": "shape"}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        warnings = [
+            line
+            for line in rt.log_lines
+            if "permanent-loss-state-corrupt" in line
+        ]
+        self.assertEqual(len(warnings), 2)
 
     def test_corrupt_tick_does_not_increment_overflow_projection(self):
         path = str(self.proj_dir / "s.jsonl")

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -57,6 +57,7 @@ from scripts.relay_watchdog import (
     assistant_blocks_from_lines,
     channel_project_dirs,
     delivered,
+    delivered_flags,
     delivered_watermark_for_path,
     delivered_watermarks,
     evaluate,
@@ -73,6 +74,8 @@ from scripts.relay_watchdog import (
     parse_config,
     parse_watcher_state_probe,
     parse_transcript_ts,
+    permanent_loss_tombstones,
+    permanent_loss_total,
     project_slug,
     recheck_selected_transcript,
     save_state,
@@ -2207,6 +2210,7 @@ class FakeRuntime(Runtime):
         self.log_lines: list[str] = []
         self.haystack: str | None = ""
         self.issue_calls = 0
+        self.alert_succeeds = True
         self.live_sessions: set[str] | None = set()
         self.watcher_probe = WatcherStateProbe(None)
         self.watcher_calls = 0
@@ -2227,8 +2231,9 @@ class FakeRuntime(Runtime):
     def dcserver_snapshot(self) -> str:
         return "stub-snapshot"
 
-    def alert(self, ch, body: str, trigger_turn: bool = True) -> None:
+    def alert(self, ch, body: str, trigger_turn: bool = True) -> bool:
         self.alerts.append((body, trigger_turn))
+        return self.alert_succeeds
 
     def file_github_issue(self, ch, gap_min: int, lost: int) -> str:
         self.issue_calls += 1
@@ -2269,8 +2274,9 @@ class FakePgRuntime(Runtime):
     def dcserver_snapshot(self) -> str:
         return "stub-pg-snapshot"
 
-    def alert(self, ch, body: str, trigger_turn: bool = True) -> None:
+    def alert(self, ch, body: str, trigger_turn: bool = True) -> bool:
         self.alerts.append((body, trigger_turn))
+        return True
 
     def log(self, msg: str) -> None:
         self.log_lines.append(msg)
@@ -6100,153 +6106,264 @@ class TickChannelTests(unittest.TestCase):
         tick_channel(rt, TICK_CHANNEL, {}, self.now)
         self.assertEqual(rt.alerts, [])
 
-    def test_permanent_loss_tombstone_stops_repeat_gap_alarm(self):
-        missing = (self.now - 2000, "permanently skipped response")
-        delivered_later = (self.now - 1200, "later response reached discord")
-        self.write_transcript([missing, delivered_later])
-        rt = self.make_rt(realert_secs=1)
-        rt.haystack = norm(delivered_later[1])
+    def append_transcript_block(self, epoch: float, text: str) -> None:
+        transcript = self.proj_dir / "s.jsonl"
+        ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch))
+        with transcript.open("a", encoding="utf-8") as stream:
+            stream.write(
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "timestamp": ts,
+                        "message": {"content": [{"type": "text", "text": text}]},
+                    }
+                )
+                + "\n"
+            )
+
+    def drive_distinct_delivery_advances(
+        self,
+        rt: FakeRuntime,
+        state: dict,
+        missing: tuple[float, str],
+        first: tuple[float, str],
+        second: tuple[float, str],
+    ) -> None:
+        self.write_transcript([missing, first])
+        rt.haystack = norm(first[1])
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.append_transcript_block(*second)
+        rt.haystack = norm(f"{first[1]} {second[1]}")
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+
+    def test_bounded_window_rolloff_never_creates_tombstone_evidence(self):
+        old = (self.now - 3000, "delivered response rolled out of limit 100")
+        newer = (self.now - 2000, "newer delivered response still in window")
+        self.write_transcript([old, newer])
+        rt = self.make_rt()
+        state: dict = {}
+
+        rt.haystack = norm(f"{old[1]} {newer[1]}")
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        rt.haystack = norm(newer[1])
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        chs = state["999"]
+        self.assertEqual(permanent_loss_total(chs), 0)
+        self.assertNotIn(relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY, chs)
+        self.assertEqual(rt.alerts, [])
+
+    def test_same_delivery_snapshot_twice_does_not_confirm_loss(self):
+        missing = (self.now - 3000, "missing response needs new evidence")
+        successor = (self.now - 2000, "only delivered successor")
+        self.write_transcript([missing, successor])
+        rt = self.make_rt()
+        rt.haystack = norm(successor[1])
         state: dict = {}
 
         tick_channel(rt, TICK_CHANNEL, state, self.now)
-        self.assertEqual(rt.alerts, [])
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        chs = state["999"]
+        self.assertEqual(permanent_loss_total(chs), 0)
+        observations = relay_watchdog._validated_loss_observations(chs)
+        self.assertEqual(len(observations), 1)
         self.assertEqual(
-            state["999"][relay_watchdog.PERMANENT_LOSS_TOTAL_KEY], 0
+            next(iter(observations.values()))["evidence_frontiers"],
+            [float(int(successor[0]))],
         )
 
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+    def test_permanent_loss_requires_two_distinct_frontier_advances(self):
+        missing = (self.now - 4000, "permanently skipped response")
+        first = (self.now - 3000, "first delivered successor")
+        second = (self.now - 2000, "second delivered successor")
+        rt = self.make_rt(realert_secs=1)
+        state: dict = {}
+
+        self.drive_distinct_delivery_advances(rt, state, missing, first, second)
+
         self.assertEqual(len(rt.alerts), 1)
         self.assertIn("새 영구 릴레이 유실 확정", rt.alerts[0][0])
         self.assertIn("현재 미도달 **0건**", rt.alerts[0][0])
         self.assertIn("영구 유실 **1건 누적**", rt.alerts[0][0])
-        self.assertNotIn("alerting", state["999"])
-
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 4)
-        self.assertEqual(
-            len(rt.alerts),
-            1,
-            "an existing tombstone must not re-alert while delivery continues",
-        )
-        self.assertEqual(
-            state["999"][relay_watchdog.PERMANENT_LOSS_TOTAL_KEY], 1
-        )
-
-    def test_gap_elapsed_uses_last_actual_delivery_not_missing_block_age(self):
-        prior_delivery = (self.now - 2400, "prior delivered response")
-        missing = (self.now - 1200, "new skipped response")
-        later_missing = (self.now - 800, "still retryable response")
-        self.write_transcript([prior_delivery, missing, later_missing])
-        rt = self.make_rt(gap_alert_secs=3000)
-        rt.haystack = norm(prior_delivery[1])
-        state: dict = {}
-
-        tick_channel(rt, TICK_CHANNEL, state, self.now)
-        self.assertEqual(rt.alerts, [])
-
-        last_actual_delivery = self.now + 60
-        new_delivery = (self.now + 30, "newly observed real delivery")
-        final_missing = (self.now + 40, "newly retryable response")
-        self.write_transcript(
-            [prior_delivery, missing, later_missing, new_delivery, final_missing]
-        )
-        rt.haystack = norm(f"{prior_delivery[1]} {new_delivery[1]}")
-        tick_channel(rt, TICK_CHANNEL, state, last_actual_delivery)
-
-        rt.haystack = norm(prior_delivery[1])
-        tick_channel(
-            rt,
-            TICK_CHANNEL,
-            state,
-            last_actual_delivery + rt.cfg.gap_alert_secs + 60,
-        )
-
-        self.assertEqual(len(rt.alerts), 1)
-        self.assertIn("마지막 정상 도달 이후 **51분**", rt.alerts[0][0])
-        self.assertNotIn("92분", rt.alerts[0][0])
-        self.assertEqual(
-            state["999"][relay_watchdog.LAST_ACTUAL_DELIVERY_AT_KEY],
-            last_actual_delivery,
-        )
-
-    def test_new_permanent_loss_after_prior_tombstone_alerts_again(self):
-        first_missing = (self.now - 4000, "first skipped response")
-        first_success = (self.now - 3000, "first delivered successor")
-        self.write_transcript([first_missing, first_success])
-        rt = self.make_rt(realert_secs=1)
-        rt.haystack = norm(first_success[1])
-        state: dict = {}
-        tick_channel(rt, TICK_CHANNEL, state, self.now)
         tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
         self.assertEqual(len(rt.alerts), 1)
 
-        second_missing = (self.now - 2000, "second skipped response")
-        second_success = (self.now - 1000, "second delivered successor")
-        self.write_transcript(
-            [first_missing, first_success, second_missing, second_success]
+    def test_late_delivery_retracts_tombstone_and_total(self):
+        missing = (self.now - 4000, "late response")
+        first = (self.now - 3000, "first successor")
+        second = (self.now - 2000, "second successor")
+        rt = self.make_rt()
+        state: dict = {}
+        self.drive_distinct_delivery_advances(rt, state, missing, first, second)
+        self.assertEqual(permanent_loss_total(state["999"]), 1)
+
+        rt.haystack = norm(f"{missing[1]} {first[1]} {second[1]}")
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        self.assertEqual(permanent_loss_total(state["999"]), 0)
+        self.assertNotIn(relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY, state["999"])
+        self.assertTrue(any("permanent-loss-retracted" in line for line in rt.log_lines))
+
+    def test_new_permanent_loss_after_prior_tombstone_alerts_again(self):
+        first_missing = (self.now - 6000, "first skipped response")
+        first_success = (self.now - 5000, "first delivered successor")
+        second_success = (self.now - 4000, "second delivered successor")
+        rt = self.make_rt(realert_secs=1)
+        state: dict = {}
+        self.drive_distinct_delivery_advances(
+            rt, state, first_missing, first_success, second_success
         )
-        rt.haystack = norm(f"{first_success[1]} {second_success[1]}")
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 4)
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 6)
+
+        next_missing = (self.now - 3000, "second skipped response")
+        third_success = (self.now - 2000, "third delivered successor")
+        fourth_success = (self.now - 1000, "fourth delivered successor")
+        self.append_transcript_block(*next_missing)
+        self.append_transcript_block(*third_success)
+        rt.haystack = norm(
+            f"{first_success[1]} {second_success[1]} {third_success[1]}"
+        )
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        self.append_transcript_block(*fourth_success)
+        rt.haystack = norm(
+            f"{first_success[1]} {second_success[1]} {third_success[1]} {fourth_success[1]}"
+        )
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
 
         permanent_alerts = [
             body for body, _ in rt.alerts if "새 영구 릴레이 유실 확정" in body
         ]
         self.assertEqual(len(permanent_alerts), 2)
         self.assertIn("영구 유실 **2건 누적**", permanent_alerts[-1])
-        self.assertEqual(
-            state["999"][relay_watchdog.PERMANENT_LOSS_TOTAL_KEY], 2
-        )
 
     def test_tombstone_survives_state_round_trip_and_restart(self):
-        missing = (self.now - 2000, "restart-persistent skipped response")
-        delivered_later = (self.now - 1200, "restart-persistent successor")
-        self.write_transcript([missing, delivered_later])
-        rt = self.make_rt(realert_secs=1)
-        rt.haystack = norm(delivered_later[1])
+        missing = (self.now - 4000, "restart-persistent skipped response")
+        first = (self.now - 3000, "restart first successor")
+        second = (self.now - 2000, "restart second successor")
+        rt = self.make_rt()
         state: dict = {}
-        tick_channel(rt, TICK_CHANNEL, state, self.now)
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
-        self.assertEqual(len(rt.alerts), 1)
+        self.drive_distinct_delivery_advances(rt, state, missing, first, second)
         save_state(rt.state_path, state)
 
         restarted_state = load_state(rt.state_path)
-        restarted = self.make_rt(realert_secs=1)
-        restarted.haystack = norm(delivered_later[1])
-        tick_channel(restarted, TICK_CHANNEL, restarted_state, self.now + 4)
+        restarted = self.make_rt()
+        restarted.haystack = norm(f"{first[1]} {second[1]}")
+        tick_channel(restarted, TICK_CHANNEL, restarted_state, self.now + 2)
 
         self.assertEqual(restarted.alerts, [])
+        self.assertEqual(permanent_loss_total(restarted_state["999"]), 1)
         self.assertEqual(
-            restarted_state["999"][relay_watchdog.PERMANENT_LOSS_TOTAL_KEY], 1
-        )
-        self.assertEqual(
-            len(
-                restarted_state["999"][
-                    relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY
-                ]
-            ),
+            len(restarted_state["999"][relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY]),
             1,
         )
 
-    def test_nonconsecutive_overtaking_observation_does_not_tombstone(self):
-        missing = (self.now - 2000, "intermittently observed missing response")
-        delivered_later = (self.now - 1200, "intermittent delivered successor")
-        self.write_transcript([missing, delivered_later])
-        rt = self.make_rt()
-        rt.haystack = norm(delivered_later[1])
-        state: dict = {}
-        tick_channel(rt, TICK_CHANNEL, state, self.now)
+    def test_duplicate_delivery_is_cardinality_aware(self):
+        ts = self.now - 2000
+        blocks = [(ts, "same response"), (ts + 1, "same response")]
+        verdict = evaluate(blocks, norm("same response"), self.now, 600, 900)
+        self.assertEqual(verdict.delivered_ts, ts)
+        self.assertEqual(delivered_flags(blocks, norm("same response")), [True, False])
 
-        rt.haystack = norm(f"{missing[1]} {delivered_later[1]}")
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
-        rt.haystack = norm(delivered_later[1])
+    def test_failed_permanent_loss_alert_retries_next_tick(self):
+        missing = (self.now - 4000, "alert retry skipped response")
+        first = (self.now - 3000, "alert retry first successor")
+        second = (self.now - 2000, "alert retry second successor")
+        rt = self.make_rt()
+        rt.alert_succeeds = False
+        state: dict = {}
+        self.drive_distinct_delivery_advances(rt, state, missing, first, second)
+        self.assertEqual(
+            state["999"][relay_watchdog.PERMANENT_LOSS_UNANNOUNCED_KEY], 1
+        )
+
+        rt.alert_succeeds = True
         tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
 
-        self.assertEqual(
-            state["999"][relay_watchdog.PERMANENT_LOSS_TOTAL_KEY], 0
-        )
         self.assertNotIn(
-            relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY, state["999"]
+            relay_watchdog.PERMANENT_LOSS_UNANNOUNCED_KEY, state["999"]
         )
+        permanent_alerts = [
+            body for body, _ in rt.alerts if "새 영구 릴레이 유실 확정" in body
+        ]
+        self.assertEqual(len(permanent_alerts), 2)
+
+    def test_transport_unreachable_tombstone_preserves_gap_incident(self):
+        missing = (self.now - 4000, "transport skipped response")
+        first = (self.now - 3000, "transport first successor")
+        second = (self.now - 2000, "transport second successor")
+        rt = self.make_rt(github_repo="owner/repo")
+        rt.watcher_probe = WatcherStateProbe(None)
+        state: dict = {}
+        self.write_transcript([missing, first])
+        rt.haystack = norm(first[1])
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        chs = state["999"]
+        # Seed the exact #4947 incident established by a prior GAP tick.
+        chs["alerting"] = True
+        chs["gap_since"] = self.now - 3600
+        chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY] = [
+            str(self.proj_dir / "s.jsonl")
+        ]
+        chs[relay_watchdog.ISSUE_FILING_SUPPRESSION_REASON_KEY] = (
+            relay_watchdog.ISSUE_FILING_DC_UNREACHABLE_REASON
+        )
+        chs[relay_watchdog.ISSUE_FILING_SUPPRESSION_SINCE_KEY] = self.now
+        chs[relay_watchdog.ISSUE_FILING_REACHABLE_TICKS_KEY] = 0
+        self.append_transcript_block(*second)
+        rt.haystack = norm(f"{first[1]} {second[1]}")
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+
+        chs = state["999"]
+        self.assertTrue(chs["alerting"])
+        self.assertEqual(chs["gap_since"], self.now - 3600)
+        self.assertEqual(
+            chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY],
+            [str(self.proj_dir / "s.jsonl")],
+        )
+        self.assertEqual(
+            chs[relay_watchdog.ISSUE_FILING_SUPPRESSION_REASON_KEY],
+            relay_watchdog.ISSUE_FILING_DC_UNREACHABLE_REASON,
+        )
+
+    def test_corrupt_tombstone_map_cannot_double_count_total(self):
+        state = {
+            relay_watchdog.PERMANENT_LOSS_TOTAL_KEY: 9,
+            relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY: {"bad": "shape"},
+        }
+        self.assertEqual(permanent_loss_total(state), 0)
+
+    def test_loss_state_is_bounded_ttl_pruned_and_lifecycle_cleaned(self):
+        path = str(self.proj_dir / "s.jsonl")
+        old = self.now - relay_watchdog.TRANSCRIPT_HISTORY_TTL_SECS - 1
+        state = {
+            relay_watchdog.LOSS_OBSERVATIONS_KEY: {
+                f"{index:064x}": {
+                    "path": path,
+                    "epoch": old,
+                    "evidence_frontiers": [old + 1],
+                    "last_observed_at": old,
+                }
+                for index in range(relay_watchdog.MAX_LOSS_OBSERVATIONS + 10)
+            },
+            relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY: {
+                f"{index + 1000:064x}": {
+                    "path": path,
+                    "epoch": old,
+                    "confirmed_at": old,
+                }
+                for index in range(relay_watchdog.MAX_PERMANENT_LOSS_TOMBSTONES + 10)
+            },
+            relay_watchdog.LAST_ACTUAL_DELIVERY_BY_PATH_KEY: {path: self.now},
+        }
+        self.assertEqual(
+            relay_watchdog._validated_loss_observations(state, self.now), {}
+        )
+        self.assertEqual(permanent_loss_tombstones(state, self.now), {})
+        relay_watchdog._forget_reclaimed_recovered_gap_lifecycles(state, [path])
+        self.assertNotIn(relay_watchdog.LAST_ACTUAL_DELIVERY_BY_PATH_KEY, state)
 
     # (d) persistent-gap issue auto-filing is deduplicated
     def test_persistent_gap_files_issue_exactly_once(self):
@@ -6623,6 +6740,18 @@ class AlertFallbackTests(unittest.TestCase):
         calls = self._run_alert(announce_rc=0)
         self.assertEqual(len(calls), 1)
         self.assertIn("send-to-agent", calls[0])
+
+    def test_direct_fallback_nonzero_returns_failure(self):
+        ch = ChannelConfig(
+            channel_id="999", sendmessage_key="key123", worktree_root=WORKTREE_ROOT
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            rt = Runtime(Config(channels=(ch,)), Path(tmp))
+            failed = subprocess.CompletedProcess(
+                ["discord-sendmessage"], 1, stdout="", stderr="delivery failed"
+            )
+            with mock.patch.object(relay_watchdog.subprocess, "run", return_value=failed):
+                self.assertFalse(rt.alert(ch, "alert body"))
 
     def test_no_announce_target_goes_straight_to_sendmessage(self):
         ch = ChannelConfig(

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -2413,12 +2413,13 @@ class TickChannelTests(unittest.TestCase):
 
     def write_transcript(self, blocks: list[tuple[float, str]]) -> None:
         lines = []
-        for epoch, text in blocks:
+        for index, (epoch, text) in enumerate(blocks):
             ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch))
             lines.append(
                 json.dumps(
                     {
                         "type": "assistant",
+                        "uuid": f"00000000-0000-4000-8000-{index:012d}",
                         "timestamp": ts,
                         "message": {"content": [{"type": "text", "text": text}]},
                     }
@@ -6110,11 +6111,13 @@ class TickChannelTests(unittest.TestCase):
     def append_transcript_block(self, epoch: float, text: str) -> None:
         transcript = self.proj_dir / "s.jsonl"
         ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch))
+        record_uuid = f"00000000-0000-4000-9000-{transcript.stat().st_size:012d}"
         with transcript.open("a", encoding="utf-8") as stream:
             stream.write(
                 json.dumps(
                     {
                         "type": "assistant",
+                        "uuid": record_uuid,
                         "timestamp": ts,
                         "message": {"content": [{"type": "text", "text": text}]},
                     }
@@ -6361,7 +6364,7 @@ class TickChannelTests(unittest.TestCase):
             relay_watchdog.ISSUE_FILING_DC_UNREACHABLE_REASON,
         )
 
-    def test_duplicate_same_timestamp_text_uses_stable_source_offsets(self):
+    def test_duplicate_same_timestamp_text_uses_stable_record_identities(self):
         duplicate = (self.now - 4000, "same duplicate obligation")
         first = (self.now - 3000, "duplicate first successor")
         second = (self.now - 2000, "duplicate second successor")
@@ -6377,6 +6380,31 @@ class TickChannelTests(unittest.TestCase):
         tombstones = permanent_loss_tombstones(state["999"])
         self.assertEqual(len(tombstones), 1)
         self.assertEqual(permanent_loss_total(state["999"]), 1)
+
+    def test_record_uuid_identity_survives_actual_head_truncation(self):
+        prefix = (self.now - 5000, "truncated delivered prefix")
+        missing = (self.now - 4000, "late block retained after truncation")
+        first = (self.now - 3000, "truncate first successor")
+        second = (self.now - 2000, "truncate second successor")
+        self.write_transcript([prefix, missing, first])
+        rt = self.make_rt()
+        state: dict = {}
+        rt.haystack = norm(f"{prefix[1]} {first[1]}")
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.append_transcript_block(*second)
+        rt.haystack = norm(f"{prefix[1]} {first[1]} {second[1]}")
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+
+        before = set(permanent_loss_tombstones(state["999"]))
+        self.assertEqual(len(before), 1)
+        transcript = self.proj_dir / "s.jsonl"
+        raw_lines = transcript.read_bytes().splitlines(keepends=True)
+        transcript.write_bytes(b"".join(raw_lines[1:]))
+        rt.haystack = norm(f"{missing[1]} {first[1]} {second[1]}")
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        self.assertEqual(permanent_loss_total(state["999"]), 0)
+        self.assertTrue(any("permanent-loss-retracted" in line for line in rt.log_lines))
 
     def test_legacy_actual_delivery_scalar_migrates_to_selected_path(self):
         missing = (self.now - 4000, "legacy migration missing response")

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -6381,6 +6381,35 @@ class TickChannelTests(unittest.TestCase):
         self.assertEqual(len(tombstones), 1)
         self.assertEqual(permanent_loss_total(state["999"]), 1)
 
+    def test_offset_fallback_warning_is_edge_triggered(self):
+        transcript = self.proj_dir / "s.jsonl"
+        ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(self.now - 2000))
+        transcript.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": ts,
+                    "message": {
+                        "content": [{"type": "text", "text": "uuid-less fallback"}]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        rt = self.make_rt()
+        state: dict = {}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+
+        warnings = [
+            line
+            for line in rt.log_lines
+            if "permanent-loss-identity-offset-fallback" in line
+        ]
+        self.assertEqual(len(warnings), 1)
+
     def test_record_uuid_identity_survives_actual_head_truncation(self):
         prefix = (self.now - 5000, "truncated delivered prefix")
         missing = (self.now - 4000, "late block retained after truncation")
@@ -6486,8 +6515,12 @@ class TickChannelTests(unittest.TestCase):
             ],
             corrupt,
         )
-        self.assertTrue(
-            any("permanent-loss-state-corrupt" in line for line in rt.log_lines)
+        self.assertEqual(
+            sum("permanent-loss-state-corrupt" in line for line in rt.log_lines), 1
+        )
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        self.assertEqual(
+            sum("permanent-loss-state-corrupt" in line for line in rt.log_lines), 1
         )
         self.assertFalse(any("PERMANENT LOSS ALERT" in line for line in rt.log_lines))
         self.assertFalse(any("영구 릴레이 유실" in body for body, _ in rt.alerts))

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -5687,6 +5687,7 @@ class TickChannelTests(unittest.TestCase):
         self.assertTrue(chs.get("alerting"))
 
         rt.haystack = norm("new missing B")
+        rt.watcher_probe = WatcherStateProbe(200, True, False)
         tick_channel(rt, TICK_CHANNEL, state, stale_tick + 1)
         chs = state["999"]
         self.assertFalse(chs.get("alerting", False))
@@ -6154,7 +6155,7 @@ class TickChannelTests(unittest.TestCase):
         self.assertNotIn(relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY, chs)
         self.assertEqual(rt.alerts, [])
 
-    def test_same_delivery_snapshot_twice_does_not_confirm_loss(self):
+    def test_single_frontier_skip_surfaces_suspected_loss_without_confirming(self):
         missing = (self.now - 3000, "missing response needs new evidence")
         successor = (self.now - 2000, "only delivered successor")
         self.write_transcript([missing, successor])
@@ -6168,11 +6169,34 @@ class TickChannelTests(unittest.TestCase):
 
         chs = state["999"]
         self.assertEqual(permanent_loss_total(chs), 0)
+        self.assertEqual(chs[relay_watchdog.PERMANENT_LOSS_SUSPECTED_KEY], 1)
+        self.assertTrue(
+            any("permanent-loss-suspected count=1" in line for line in rt.log_lines)
+        )
         observations = relay_watchdog._validated_loss_observations(chs)
         self.assertEqual(len(observations), 1)
         self.assertEqual(
             next(iter(observations.values()))["evidence_frontiers"],
             [float(int(successor[0]))],
+        )
+
+    def test_bounded_rolloff_does_not_surface_suspected_loss(self):
+        old = (self.now - 3000, "delivered response rolled out of limit 100")
+        newer = (self.now - 2000, "newer delivered response still in window")
+        self.write_transcript([old, newer])
+        rt = self.make_rt()
+        state: dict = {}
+
+        rt.haystack = norm(f"{old[1]} {newer[1]}")
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        rt.haystack = norm(newer[1])
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+
+        self.assertNotIn(
+            relay_watchdog.PERMANENT_LOSS_SUSPECTED_KEY, state["999"]
+        )
+        self.assertFalse(
+            any("permanent-loss-suspected" in line for line in rt.log_lines)
         )
 
     def test_permanent_loss_requires_two_distinct_frontier_advances(self):
@@ -6328,12 +6352,115 @@ class TickChannelTests(unittest.TestCase):
             relay_watchdog.ISSUE_FILING_DC_UNREACHABLE_REASON,
         )
 
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        chs = state["999"]
+        self.assertTrue(chs["alerting"])
+        self.assertEqual(chs["gap_since"], self.now - 3600)
+        self.assertEqual(
+            chs[relay_watchdog.ISSUE_FILING_SUPPRESSION_REASON_KEY],
+            relay_watchdog.ISSUE_FILING_DC_UNREACHABLE_REASON,
+        )
+
+    def test_duplicate_same_timestamp_text_uses_stable_source_offsets(self):
+        duplicate = (self.now - 4000, "same duplicate obligation")
+        first = (self.now - 3000, "duplicate first successor")
+        second = (self.now - 2000, "duplicate second successor")
+        self.write_transcript([duplicate, duplicate, first])
+        rt = self.make_rt()
+        state: dict = {}
+        rt.haystack = norm(f"{duplicate[1]} {first[1]}")
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.append_transcript_block(*second)
+        rt.haystack = norm(f"{duplicate[1]} {first[1]} {second[1]}")
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+
+        tombstones = permanent_loss_tombstones(state["999"])
+        self.assertEqual(len(tombstones), 1)
+        self.assertEqual(permanent_loss_total(state["999"]), 1)
+
+    def test_legacy_actual_delivery_scalar_migrates_to_selected_path(self):
+        missing = (self.now - 4000, "legacy migration missing response")
+        successor = (self.now - 3000, "legacy migration delivered successor")
+        self.write_transcript([missing, successor])
+        rt = self.make_rt(realert_secs=1)
+        rt.haystack = norm(successor[1])
+        legacy_observed_at = self.now - 120
+        state = {
+            "999": {
+                relay_watchdog.LAST_ACTUAL_DELIVERY_AT_KEY: legacy_observed_at,
+                DELIVERED_WATERMARKS_KEY: {
+                    str(self.proj_dir / "s.jsonl"): {
+                        "delivered_ts": successor[0],
+                        "updated_at": self.now - 3000,
+                    }
+                },
+            }
+        }
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        chs = state["999"]
+        self.assertNotIn(relay_watchdog.LAST_ACTUAL_DELIVERY_AT_KEY, chs)
+        self.assertEqual(
+            chs[relay_watchdog.LAST_ACTUAL_DELIVERY_BY_PATH_KEY][
+                str(self.proj_dir / "s.jsonl")
+            ],
+            legacy_observed_at,
+        )
+
+    def test_loss_state_overflow_is_logged_and_counted(self):
+        path = str(self.proj_dir / "s.jsonl")
+        state = {
+            relay_watchdog.LOSS_OBSERVATIONS_KEY: {
+                f"{index:064x}": {
+                    "path": path,
+                    "epoch": self.now - 4000,
+                    "evidence_frontiers": [self.now - 3000],
+                    "last_observed_at": self.now - index,
+                }
+                for index in range(relay_watchdog.MAX_LOSS_OBSERVATIONS)
+            }
+        }
+        missing = (self.now - 2000, "overflow missing response")
+        successor = (self.now - 1000, "overflow delivered successor")
+        self.write_transcript([missing, successor])
+        rt = self.make_rt()
+        rt.haystack = norm(successor[1])
+
+        tick_channel(rt, TICK_CHANNEL, {"999": state}, self.now)
+
+        self.assertEqual(state[relay_watchdog.PERMANENT_LOSS_OVERFLOW_TOTAL_KEY], 1)
+        self.assertTrue(
+            any("permanent-loss-state-overflow" in line for line in rt.log_lines)
+        )
+
+    def test_corrupt_loss_state_logs_and_preserves_raw_evidence(self):
+        path = str(self.proj_dir / "s.jsonl")
+        corrupt = {"bad": "shape"}
+        state = {
+            "999": {
+                relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY: corrupt.copy(),
+                relay_watchdog.PERMANENT_LOSS_TOTAL_KEY: 9,
+            }
+        }
+        self.write_transcript([(self.now - 2000, "corrupt state candidate")])
+        rt = self.make_rt()
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        chs = state["999"]
+        self.assertEqual(chs[relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY], corrupt)
+        self.assertEqual(permanent_loss_total(chs), 9)
+        self.assertTrue(
+            any("permanent-loss-state-corrupt" in line for line in rt.log_lines)
+        )
+
     def test_corrupt_tombstone_map_cannot_double_count_total(self):
         state = {
             relay_watchdog.PERMANENT_LOSS_TOTAL_KEY: 9,
             relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY: {"bad": "shape"},
         }
-        self.assertEqual(permanent_loss_total(state), 0)
+        self.assertEqual(permanent_loss_total(state), 9)
 
     def test_loss_state_is_bounded_ttl_pruned_and_lifecycle_cleaned(self):
         path = str(self.proj_dir / "s.jsonl")

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -6462,8 +6462,7 @@ class TickChannelTests(unittest.TestCase):
             any("permanent-loss-state-overflow" in line for line in rt.log_lines)
         )
 
-    def test_corrupt_loss_state_logs_and_preserves_raw_evidence(self):
-        path = str(self.proj_dir / "s.jsonl")
+    def test_corrupt_loss_state_is_quarantined_and_projection_recovers(self):
         corrupt = {"bad": "shape"}
         state = {
             "999": {
@@ -6477,13 +6476,23 @@ class TickChannelTests(unittest.TestCase):
         tick_channel(rt, TICK_CHANNEL, state, self.now)
 
         chs = state["999"]
-        self.assertEqual(chs[relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY], corrupt)
-        self.assertEqual(permanent_loss_total(chs), 9)
+        self.assertNotIn(relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY, chs)
+        self.assertEqual(permanent_loss_total(chs), 0)
+        self.assertEqual(chs[relay_watchdog.PERMANENT_LOSS_QUARANTINE_TOTAL_KEY], 1)
+        quarantine = chs[relay_watchdog.PERMANENT_LOSS_QUARANTINE_KEY]
+        self.assertEqual(
+            quarantine[-1]["entries"][
+                relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY
+            ],
+            corrupt,
+        )
         self.assertTrue(
             any("permanent-loss-state-corrupt" in line for line in rt.log_lines)
         )
+        self.assertFalse(any("PERMANENT LOSS ALERT" in line for line in rt.log_lines))
+        self.assertFalse(any("영구 릴레이 유실" in body for body, _ in rt.alerts))
 
-    def test_corrupt_state_suppresses_unpersisted_loss_confirmation(self):
+    def test_corrupt_state_suppresses_same_tick_loss_confirmation(self):
         missing = (self.now - 4000, "corrupt unpersisted skipped response")
         first = (self.now - 3000, "corrupt first successor")
         second = (self.now - 2000, "corrupt second successor")
@@ -6500,8 +6509,12 @@ class TickChannelTests(unittest.TestCase):
 
         tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
 
+        self.assertNotIn("bad", chs[relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY])
         self.assertEqual(
-            chs[relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY], raw_tombstones
+            chs[relay_watchdog.PERMANENT_LOSS_QUARANTINE_KEY][-1]["entries"][
+                relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY
+            ],
+            raw_tombstones,
         )
         self.assertFalse(
             any("permanent-loss-confirmed" in line for line in rt.log_lines)
@@ -6518,6 +6531,62 @@ class TickChannelTests(unittest.TestCase):
             relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY: {"bad": "shape"},
         }
         self.assertEqual(permanent_loss_total(state), 9)
+
+    def test_corrupt_observation_does_not_block_valid_tombstone_retraction(self):
+        delivered = (self.now - 2000, "valid tombstone delivered late")
+        self.write_transcript([delivered])
+        path = str(self.proj_dir / "s.jsonl")
+        source_id = "uuid:00000000-0000-4000-8000-000000000000:0"
+        block_id = relay_watchdog._assistant_block_id(
+            path, float(int(delivered[0])), delivered[1], source_id
+        )
+        state = {
+            "999": {
+                relay_watchdog.LOSS_OBSERVATIONS_KEY: {"bad": "shape"},
+                relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY: {
+                    block_id: {
+                        "path": path,
+                        "epoch": float(int(delivered[0])),
+                        "confirmed_at": self.now - 1,
+                    }
+                },
+                relay_watchdog.PERMANENT_LOSS_TOTAL_KEY: 1,
+            }
+        }
+        rt = self.make_rt()
+        rt.haystack = norm(delivered[1])
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        chs = state["999"]
+        self.assertEqual(permanent_loss_total(chs), 0)
+        self.assertNotIn(relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY, chs)
+        self.assertEqual(chs[relay_watchdog.PERMANENT_LOSS_QUARANTINE_TOTAL_KEY], 1)
+        self.assertTrue(any("permanent-loss-retracted" in line for line in rt.log_lines))
+        self.assertFalse(any("PERMANENT LOSS ALERT" in line for line in rt.log_lines))
+
+    def test_quarantined_corruption_allows_next_tick_state_progress(self):
+        missing = (self.now - 4000, "progress after corrupt entry")
+        first = (self.now - 3000, "first frontier after corrupt entry")
+        second = (self.now - 2000, "second frontier after corrupt entry")
+        rt = self.make_rt()
+        state = {
+            "999": {
+                relay_watchdog.LOSS_OBSERVATIONS_KEY: {"bad": "shape"},
+            }
+        }
+
+        self.drive_distinct_delivery_advances(rt, state, missing, first, second)
+        self.append_transcript_block(self.now - 1000, "third frontier after quarantine")
+        rt.haystack = norm(
+            f"{first[1]} {second[1]} third frontier after quarantine"
+        )
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        chs = state["999"]
+        self.assertEqual(permanent_loss_total(chs), 1)
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertEqual(chs[relay_watchdog.PERMANENT_LOSS_QUARANTINE_TOTAL_KEY], 1)
 
     def test_lifecycle_reclaim_preserves_and_escalates_corrupt_loss_state(self):
         target = self.proj_dir / "corrupt-reclaim.jsonl"

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -6525,6 +6525,41 @@ class TickChannelTests(unittest.TestCase):
         self.assertFalse(any("PERMANENT LOSS ALERT" in line for line in rt.log_lines))
         self.assertFalse(any("영구 릴레이 유실" in body for body, _ in rt.alerts))
 
+    def test_corrupt_tick_does_not_increment_overflow_projection(self):
+        path = str(self.proj_dir / "s.jsonl")
+        observations = {
+            f"{index:064x}": {
+                "path": path,
+                "epoch": self.now - 4000,
+                "evidence_frontiers": [self.now - 3000],
+                "last_observed_at": self.now - index,
+            }
+            for index in range(relay_watchdog.MAX_LOSS_OBSERVATIONS)
+        }
+        observations["bad"] = "shape"
+        state = {
+            "999": {
+                relay_watchdog.LOSS_OBSERVATIONS_KEY: observations,
+                relay_watchdog.PERMANENT_LOSS_OVERFLOW_TOTAL_KEY: 7,
+            }
+        }
+        self.write_transcript(
+            [
+                (self.now - 2000, "corrupt overflow candidate"),
+                (self.now - 1000, "corrupt overflow successor"),
+            ]
+        )
+        rt = self.make_rt()
+        rt.haystack = norm("corrupt overflow successor")
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        chs = state["999"]
+        self.assertEqual(chs[relay_watchdog.PERMANENT_LOSS_OVERFLOW_TOTAL_KEY], 7)
+        self.assertFalse(
+            any("permanent-loss-state-overflow" in line for line in rt.log_lines)
+        )
+
     def test_corrupt_state_suppresses_same_tick_loss_confirmation(self):
         missing = (self.now - 4000, "corrupt unpersisted skipped response")
         first = (self.now - 3000, "corrupt first successor")

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -6491,7 +6491,8 @@ class TickChannelTests(unittest.TestCase):
             any("permanent-loss-state-overflow" in line for line in rt.log_lines)
         )
 
-    def test_corrupt_loss_state_is_quarantined_and_projection_recovers(self):
+    def test_corrupt_loss_state_logs_and_preserves_raw_evidence(self):
+        path = str(self.proj_dir / "s.jsonl")
         corrupt = {"bad": "shape"}
         state = {
             "999": {
@@ -6505,25 +6506,12 @@ class TickChannelTests(unittest.TestCase):
         tick_channel(rt, TICK_CHANNEL, state, self.now)
 
         chs = state["999"]
-        self.assertNotIn(relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY, chs)
-        self.assertEqual(permanent_loss_total(chs), 0)
-        self.assertEqual(chs[relay_watchdog.PERMANENT_LOSS_QUARANTINE_TOTAL_KEY], 1)
-        quarantine = chs[relay_watchdog.PERMANENT_LOSS_QUARANTINE_KEY]
-        self.assertEqual(
-            quarantine[-1]["entries"][
-                relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY
-            ],
-            corrupt,
+        self.assertEqual(chs[relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY], corrupt)
+        self.assertEqual(permanent_loss_total(chs), 9)
+        self.assertTrue(
+            any("permanent-loss-state-corrupt" in line for line in rt.log_lines)
         )
-        self.assertEqual(
-            sum("permanent-loss-state-corrupt" in line for line in rt.log_lines), 1
-        )
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
-        self.assertEqual(
-            sum("permanent-loss-state-corrupt" in line for line in rt.log_lines), 1
-        )
-        self.assertFalse(any("PERMANENT LOSS ALERT" in line for line in rt.log_lines))
-        self.assertFalse(any("영구 릴레이 유실" in body for body, _ in rt.alerts))
+
 
     def test_corrupt_tick_does_not_increment_overflow_projection(self):
         path = str(self.proj_dir / "s.jsonl")
@@ -6560,7 +6548,7 @@ class TickChannelTests(unittest.TestCase):
             any("permanent-loss-state-overflow" in line for line in rt.log_lines)
         )
 
-    def test_corrupt_state_suppresses_same_tick_loss_confirmation(self):
+    def test_corrupt_state_suppresses_unpersisted_loss_confirmation(self):
         missing = (self.now - 4000, "corrupt unpersisted skipped response")
         first = (self.now - 3000, "corrupt first successor")
         second = (self.now - 2000, "corrupt second successor")
@@ -6577,12 +6565,8 @@ class TickChannelTests(unittest.TestCase):
 
         tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
 
-        self.assertNotIn("bad", chs[relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY])
         self.assertEqual(
-            chs[relay_watchdog.PERMANENT_LOSS_QUARANTINE_KEY][-1]["entries"][
-                relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY
-            ],
-            raw_tombstones,
+            chs[relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY], raw_tombstones
         )
         self.assertFalse(
             any("permanent-loss-confirmed" in line for line in rt.log_lines)
@@ -6599,62 +6583,6 @@ class TickChannelTests(unittest.TestCase):
             relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY: {"bad": "shape"},
         }
         self.assertEqual(permanent_loss_total(state), 9)
-
-    def test_corrupt_observation_does_not_block_valid_tombstone_retraction(self):
-        delivered = (self.now - 2000, "valid tombstone delivered late")
-        self.write_transcript([delivered])
-        path = str(self.proj_dir / "s.jsonl")
-        source_id = "uuid:00000000-0000-4000-8000-000000000000:0"
-        block_id = relay_watchdog._assistant_block_id(
-            path, float(int(delivered[0])), delivered[1], source_id
-        )
-        state = {
-            "999": {
-                relay_watchdog.LOSS_OBSERVATIONS_KEY: {"bad": "shape"},
-                relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY: {
-                    block_id: {
-                        "path": path,
-                        "epoch": float(int(delivered[0])),
-                        "confirmed_at": self.now - 1,
-                    }
-                },
-                relay_watchdog.PERMANENT_LOSS_TOTAL_KEY: 1,
-            }
-        }
-        rt = self.make_rt()
-        rt.haystack = norm(delivered[1])
-
-        tick_channel(rt, TICK_CHANNEL, state, self.now)
-
-        chs = state["999"]
-        self.assertEqual(permanent_loss_total(chs), 0)
-        self.assertNotIn(relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY, chs)
-        self.assertEqual(chs[relay_watchdog.PERMANENT_LOSS_QUARANTINE_TOTAL_KEY], 1)
-        self.assertTrue(any("permanent-loss-retracted" in line for line in rt.log_lines))
-        self.assertFalse(any("PERMANENT LOSS ALERT" in line for line in rt.log_lines))
-
-    def test_quarantined_corruption_allows_next_tick_state_progress(self):
-        missing = (self.now - 4000, "progress after corrupt entry")
-        first = (self.now - 3000, "first frontier after corrupt entry")
-        second = (self.now - 2000, "second frontier after corrupt entry")
-        rt = self.make_rt()
-        state = {
-            "999": {
-                relay_watchdog.LOSS_OBSERVATIONS_KEY: {"bad": "shape"},
-            }
-        }
-
-        self.drive_distinct_delivery_advances(rt, state, missing, first, second)
-        self.append_transcript_block(self.now - 1000, "third frontier after quarantine")
-        rt.haystack = norm(
-            f"{first[1]} {second[1]} third frontier after quarantine"
-        )
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
-
-        chs = state["999"]
-        self.assertEqual(permanent_loss_total(chs), 1)
-        self.assertEqual(len(rt.alerts), 1)
-        self.assertEqual(chs[relay_watchdog.PERMANENT_LOSS_QUARANTINE_TOTAL_KEY], 1)
 
     def test_lifecycle_reclaim_preserves_and_escalates_corrupt_loss_state(self):
         target = self.proj_dir / "corrupt-reclaim.jsonl"

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -6483,6 +6483,35 @@ class TickChannelTests(unittest.TestCase):
             any("permanent-loss-state-corrupt" in line for line in rt.log_lines)
         )
 
+    def test_corrupt_state_suppresses_unpersisted_loss_confirmation(self):
+        missing = (self.now - 4000, "corrupt unpersisted skipped response")
+        first = (self.now - 3000, "corrupt first successor")
+        second = (self.now - 2000, "corrupt second successor")
+        rt = self.make_rt()
+        state: dict = {}
+        self.write_transcript([missing, first])
+        rt.haystack = norm(first[1])
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        chs = state["999"]
+        raw_tombstones = {"bad": "shape"}
+        chs[relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY] = raw_tombstones.copy()
+        self.append_transcript_block(*second)
+        rt.haystack = norm(f"{first[1]} {second[1]}")
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+
+        self.assertEqual(
+            chs[relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY], raw_tombstones
+        )
+        self.assertFalse(
+            any("permanent-loss-confirmed" in line for line in rt.log_lines)
+        )
+        self.assertFalse(any("PERMANENT LOSS ALERT" in line for line in rt.log_lines))
+        self.assertEqual(rt.alerts, [])
+        self.assertTrue(
+            any("permanent-loss-state-corrupt" in line for line in rt.log_lines)
+        )
+
     def test_corrupt_tombstone_map_cannot_double_count_total(self):
         state = {
             relay_watchdog.PERMANENT_LOSS_TOTAL_KEY: 9,

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -6541,6 +6541,28 @@ class TickChannelTests(unittest.TestCase):
         ]
         self.assertEqual(len(warnings), 2)
 
+    def test_corruption_warning_refires_between_absent_and_null(self):
+        chs = {
+            relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY: {"bad": "shape"},
+            relay_watchdog.PERMANENT_LOSS_TOTAL_KEY: 9,
+        }
+        state = {"999": chs}
+        self.write_transcript([(self.now - 2000, "absent null warning candidate")])
+        rt = self.make_rt()
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        chs[relay_watchdog.LOSS_OBSERVATIONS_KEY] = None
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        chs.pop(relay_watchdog.LOSS_OBSERVATIONS_KEY)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        warnings = [
+            line
+            for line in rt.log_lines
+            if "permanent-loss-state-corrupt" in line
+        ]
+        self.assertEqual(len(warnings), 3)
+
     def test_corrupt_tick_does_not_increment_overflow_projection(self):
         path = str(self.proj_dir / "s.jsonl")
         observations = {

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -5669,7 +5669,7 @@ class TickChannelTests(unittest.TestCase):
         self.assertNotIn(relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY, chs)
         self.assertFalse(chs.get("alerting", False))
 
-        stale_tick = self.now + rt.cfg.grace_secs + 2
+        stale_tick = self.now + rt.cfg.gap_alert_secs + 2
         rt.haystack = ""
         tick_channel(rt, TICK_CHANNEL, state, stale_tick)
         save_state(state_path, state)
@@ -6099,6 +6099,150 @@ class TickChannelTests(unittest.TestCase):
         rt.haystack = norm("landed fine in discord")
         tick_channel(rt, TICK_CHANNEL, {}, self.now)
         self.assertEqual(rt.alerts, [])
+
+    def test_permanent_loss_tombstone_stops_repeat_gap_alarm(self):
+        missing = (self.now - 2000, "permanently skipped response")
+        delivered_later = (self.now - 1200, "later response reached discord")
+        self.write_transcript([missing, delivered_later])
+        rt = self.make_rt(realert_secs=1)
+        rt.haystack = norm(delivered_later[1])
+        state: dict = {}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(rt.alerts, [])
+        self.assertEqual(
+            state["999"][relay_watchdog.PERMANENT_LOSS_TOTAL_KEY], 0
+        )
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("새 영구 릴레이 유실 확정", rt.alerts[0][0])
+        self.assertIn("현재 미도달 **0건**", rt.alerts[0][0])
+        self.assertIn("영구 유실 **1건 누적**", rt.alerts[0][0])
+        self.assertNotIn("alerting", state["999"])
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 4)
+        self.assertEqual(
+            len(rt.alerts),
+            1,
+            "an existing tombstone must not re-alert while delivery continues",
+        )
+        self.assertEqual(
+            state["999"][relay_watchdog.PERMANENT_LOSS_TOTAL_KEY], 1
+        )
+
+    def test_gap_elapsed_uses_last_actual_delivery_not_missing_block_age(self):
+        prior_delivery = (self.now - 2400, "prior delivered response")
+        missing = (self.now - 1200, "new skipped response")
+        later_missing = (self.now - 800, "still retryable response")
+        self.write_transcript([prior_delivery, missing, later_missing])
+        rt = self.make_rt(gap_alert_secs=900)
+        rt.haystack = norm(prior_delivery[1])
+        state: dict = {}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(rt.alerts, [])
+
+        last_actual_delivery = self.now + 60
+        new_delivery = (self.now + 30, "newly observed real delivery")
+        final_missing = (self.now + 40, "newly retryable response")
+        self.write_transcript(
+            [prior_delivery, missing, later_missing, new_delivery, final_missing]
+        )
+        rt.haystack = norm(f"{prior_delivery[1]} {new_delivery[1]}")
+        tick_channel(rt, TICK_CHANNEL, state, last_actual_delivery)
+
+        rt.haystack = norm(prior_delivery[1])
+        tick_channel(
+            rt,
+            TICK_CHANNEL,
+            state,
+            last_actual_delivery + rt.cfg.gap_alert_secs + 60,
+        )
+
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("마지막 정상 도달 이후 **16분**", rt.alerts[0][0])
+        self.assertNotIn("40분", rt.alerts[0][0])
+
+    def test_new_permanent_loss_after_prior_tombstone_alerts_again(self):
+        first_missing = (self.now - 4000, "first skipped response")
+        first_success = (self.now - 3000, "first delivered successor")
+        self.write_transcript([first_missing, first_success])
+        rt = self.make_rt(realert_secs=1)
+        rt.haystack = norm(first_success[1])
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        self.assertEqual(len(rt.alerts), 1)
+
+        second_missing = (self.now - 2000, "second skipped response")
+        second_success = (self.now - 1000, "second delivered successor")
+        self.write_transcript(
+            [first_missing, first_success, second_missing, second_success]
+        )
+        rt.haystack = norm(f"{first_success[1]} {second_success[1]}")
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 4)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 6)
+
+        permanent_alerts = [
+            body for body, _ in rt.alerts if "새 영구 릴레이 유실 확정" in body
+        ]
+        self.assertEqual(len(permanent_alerts), 2)
+        self.assertIn("영구 유실 **2건 누적**", permanent_alerts[-1])
+        self.assertEqual(
+            state["999"][relay_watchdog.PERMANENT_LOSS_TOTAL_KEY], 2
+        )
+
+    def test_tombstone_survives_state_round_trip_and_restart(self):
+        missing = (self.now - 2000, "restart-persistent skipped response")
+        delivered_later = (self.now - 1200, "restart-persistent successor")
+        self.write_transcript([missing, delivered_later])
+        rt = self.make_rt(realert_secs=1)
+        rt.haystack = norm(delivered_later[1])
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        self.assertEqual(len(rt.alerts), 1)
+        save_state(rt.state_path, state)
+
+        restarted_state = load_state(rt.state_path)
+        restarted = self.make_rt(realert_secs=1)
+        restarted.haystack = norm(delivered_later[1])
+        tick_channel(restarted, TICK_CHANNEL, restarted_state, self.now + 4)
+
+        self.assertEqual(restarted.alerts, [])
+        self.assertEqual(
+            restarted_state["999"][relay_watchdog.PERMANENT_LOSS_TOTAL_KEY], 1
+        )
+        self.assertEqual(
+            len(
+                restarted_state["999"][
+                    relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY
+                ]
+            ),
+            1,
+        )
+
+    def test_nonconsecutive_overtaking_observation_does_not_tombstone(self):
+        missing = (self.now - 2000, "intermittently observed missing response")
+        delivered_later = (self.now - 1200, "intermittent delivered successor")
+        self.write_transcript([missing, delivered_later])
+        rt = self.make_rt()
+        rt.haystack = norm(delivered_later[1])
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        rt.haystack = norm(f"{missing[1]} {delivered_later[1]}")
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        rt.haystack = norm(delivered_later[1])
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        self.assertEqual(
+            state["999"][relay_watchdog.PERMANENT_LOSS_TOTAL_KEY], 0
+        )
+        self.assertNotIn(
+            relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY, state["999"]
+        )
 
     # (d) persistent-gap issue auto-filing is deduplicated
     def test_persistent_gap_files_issue_exactly_once(self):

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -6136,7 +6136,7 @@ class TickChannelTests(unittest.TestCase):
         missing = (self.now - 1200, "new skipped response")
         later_missing = (self.now - 800, "still retryable response")
         self.write_transcript([prior_delivery, missing, later_missing])
-        rt = self.make_rt(gap_alert_secs=900)
+        rt = self.make_rt(gap_alert_secs=3000)
         rt.haystack = norm(prior_delivery[1])
         state: dict = {}
 
@@ -6161,8 +6161,8 @@ class TickChannelTests(unittest.TestCase):
         )
 
         self.assertEqual(len(rt.alerts), 1)
-        self.assertIn("마지막 정상 도달 이후 **16분**", rt.alerts[0][0])
-        self.assertNotIn("40분", rt.alerts[0][0])
+        self.assertIn("마지막 정상 도달 이후 **51분**", rt.alerts[0][0])
+        self.assertNotIn("92분", rt.alerts[0][0])
 
     def test_new_permanent_loss_after_prior_tombstone_alerts_again(self):
         first_missing = (self.now - 4000, "first skipped response")

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -6519,6 +6519,49 @@ class TickChannelTests(unittest.TestCase):
         }
         self.assertEqual(permanent_loss_total(state), 9)
 
+    def test_lifecycle_reclaim_preserves_and_escalates_corrupt_loss_state(self):
+        target = self.proj_dir / "corrupt-reclaim.jsonl"
+        target.write_text("{}\n", encoding="utf-8")
+        path = str(target)
+        raw_observations = {"bad": "shape"}
+        raw_tombstones = {"also-bad": "shape"}
+        state = {
+            "999": {
+                relay_watchdog.RECOVERED_GAP_GUARDS_KEY: {
+                    path: {
+                        "size": target.stat().st_size,
+                        "confirmed_at": self.now,
+                        "last_seen_at": self.now,
+                        "absent_since": self.now + 1,
+                    }
+                },
+                relay_watchdog.LOSS_OBSERVATIONS_KEY: raw_observations.copy(),
+                relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY: raw_tombstones.copy(),
+            }
+        }
+        target.unlink()
+        rt = self.make_rt()
+
+        tick_channel(
+            rt,
+            TICK_CHANNEL,
+            state,
+            self.now + relay_watchdog.RECOVERED_GAP_GUARD_TTL_SECS + 2,
+        )
+
+        chs = state["999"]
+        self.assertEqual(chs[relay_watchdog.LOSS_OBSERVATIONS_KEY], raw_observations)
+        self.assertEqual(
+            chs[relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY], raw_tombstones
+        )
+        self.assertTrue(
+            any(
+                "permanent-loss-state-corrupt during lifecycle reclaim"
+                in line
+                for line in rt.log_lines
+            )
+        )
+
     def test_loss_state_is_bounded_ttl_pruned_and_lifecycle_cleaned(self):
         path = str(self.proj_dir / "s.jsonl")
         old = self.now - relay_watchdog.TRANSCRIPT_HISTORY_TTL_SECS - 1
@@ -6546,7 +6589,9 @@ class TickChannelTests(unittest.TestCase):
             relay_watchdog._validated_loss_observations(state, self.now), {}
         )
         self.assertEqual(permanent_loss_tombstones(state, self.now), {})
-        relay_watchdog._forget_reclaimed_recovered_gap_lifecycles(state, [path])
+        relay_watchdog._forget_reclaimed_recovered_gap_lifecycles(
+            state, [path], loss_state_corrupted=False
+        )
         self.assertNotIn(relay_watchdog.LAST_ACTUAL_DELIVERY_BY_PATH_KEY, state)
 
     # (d) persistent-gap issue auto-filing is deduplicated


### PR DESCRIPTION
## Summary

- closes the relay watchdog review matrix C1-C10, W1-W6, and X1-X3
- retains D2 edge-triggered offset-fallback/corruption warnings
- retains D3 corrupt-tick overflow projection gating
- adds durable delivered-frontier evidence, stable block identity, bounded tombstones/observations, alert retry, late-delivery retraction, and lifecycle-safe raw corruption preservation

## D1 revert

D1 attempted to quarantine malformed loss-state entries in `e9cebdcea`, but independent GPT and Claude Opus review legs reproduced two P0 regressions from unconditional derived-state persistence:

1. a corrupt tick could persist a newly confirmed tombstone while suppressing its alert forever;
2. a malformed tombstone could reduce an existing permanent-loss projection to zero.

The D1 quarantine commit is therefore reverted rather than repaired in place. The revert restores raw corrupt state at its authoritative location and preserves the prior `permanent_loss_total` projection. D2 and D3 remain intact.

D2's corruption-warning edge trigger was explicitly restored after the revert exposed that D1 quarantine had only made it appear edge-triggered by removing the corruption after one tick; unchanged corruption now logs once, while changed corruption logs again.

This is a partial D1 revert: `if overflowed and not corrupted:` was authored in the D1 commit but intentionally remains because it is the D3 corrupt-tick overflow-accounting contract.

## Known limitation

Malformed `permanent_loss_observations` or `permanent_loss_tombstones` can still lock durable loss-state progress until external repair. This is tracked separately in #4954.

Reachability is currently very low:

- both state keys are new to this unshipped branch, so legacy state cannot contain them;
- normal writers emit the same shape enforced by the validators and cannot self-corrupt the keys;
- the only known producer commit, `4628b2afa`, was never released and is not an ancestor of released `origin/main`.

## Verification

- `python3 -m unittest tests.test_relay_watchdog` — 275 tests, OK
- `TEST_LANE_BASELINE_REF=origin/main bash scripts/ci-script-checks.sh` — rc=0
- `python3 -m py_compile scripts/relay_watchdog.py` — OK
- `git diff --check` — OK
- P0-A reproduction after revert: `corrupt_tick_tombstone_stored=False permanent_alerts=0 total=0`
- P0-B reproduction after revert: `before_loss_total=1 after_loss_total=1 raw_tombstone_preserved=True permanent_alerts=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)