### PR TITLE
fix(relay): bound stalled redrive recovery

### DIFF
--- a/docs/relay-state-contract.md
+++ b/docs/relay-state-contract.md
@@ -466,6 +466,21 @@ plan.
   controller mutation-sensitive post-count tests, delivery-record generation/EOF
   tests, and controller/legacy owner wiring tests).
 
+## I12. Bounded no-progress redrive (#4906)
+
+- Definition: a redrive cannot move below the committed frontier or enqueue the
+  same still-pending frontier twice.
+- Producer: the relay auto-healer computes the requested frontier as the maximum
+  of the watcher snapshot and committed frontier, then rejects already-covered
+  or identical pending requests before mutating watcher state.
+- Consumer: six no-progress actions enter a one-hour degraded backoff and then
+  re-arm the same stalled episode; reaching the cap never abandons recovery
+  permanently.
+- Violation surface: a frozen frontier is enqueued on every health pass, or a
+  capped stalled episode is never reconsidered after its bounded backoff.
+- Invariant keys/events: `watcher_redrive_frontier_regression_rejected`,
+  `redrive_frontier_no_progress`, and `redrive_no_progress_capped`.
+
 ## How to add a new invariant
 
 1. Document it here with the same structure (definition, producer,

--- a/docs/relay-state-contract.md
+++ b/docs/relay-state-contract.md
@@ -478,8 +478,9 @@ plan.
   permanently.
 - Violation surface: a frozen frontier is enqueued on every health pass, or a
   capped stalled episode is never reconsidered after its bounded backoff.
-- Invariant keys/events: `watcher_redrive_frontier_regression_rejected`,
-  `redrive_frontier_no_progress`, and `redrive_no_progress_capped`.
+- Tracing events: `redrive_frontier_no_progress` and
+  `redrive_no_progress_capped`. This recovery path currently emits tracing logs
+  rather than `record_invariant_check` observability rows.
 
 ## How to add a new invariant
 

--- a/justfile
+++ b/justfile
@@ -67,6 +67,7 @@ test-non-pg:
     env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::turn_finalizer::completion_admission_actor::tests -- --skip _pg --skip pg_ --skip postgres --test-threads=1
     env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::turn_finalizer::cleanup::tests::late_already_finalized_cleanup_releases_mailbox_and_rearms_once_4906 -- --exact --test-threads=1
     env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::turn_finalizer::cleanup::tests::mailbox_release_backstop_coalesces_duplicate_arms_and_eventually_fires_4906 -- --exact --test-threads=1
+    env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tmux::tmux_watcher::placeholder_reclaim::redrive_reclaim_e2e_tests::live_tmux_redrive_reclaim_cycle_terminates_4299 -- --exact --test-threads=1
     env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::recovery_engine::runtime::reregister_ledger_reseed_tests -- --test-threads=1
     env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::placeholder_sweeper::abandon_guard::tests -- --test-threads=1
     # #4892: keep the live panel and spinner-merged latest-tool contracts in the retained lane.

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -1535,7 +1535,7 @@ mod tests {
             *resume_offset.lock().expect("resume offset") = None;
         }
         let (_, capped_logs) = capture_errors(|| {
-            for elapsed in [960, 1_890] {
+            for elapsed in [960, 1_890, 930 + REDRIVE_CAPPED_REARM_SECS - 1] {
                 assert_eq!(
                     gated_nudge(&shared, &provider, &snapshot, channel_id, base + elapsed),
                     (false, None),
@@ -1543,9 +1543,15 @@ mod tests {
                 );
             }
             assert_eq!(
-                gated_nudge(&shared, &provider, &snapshot, channel_id, base + 86_400),
+                gated_nudge(
+                    &shared,
+                    &provider,
+                    &snapshot,
+                    channel_id,
+                    base + 930 + REDRIVE_CAPPED_REARM_SECS,
+                ),
                 (true, Some(1)),
-                "a still-stalled capped episode must re-arm after the long backoff"
+                "a still-stalled capped episode must re-arm at the long-backoff boundary"
             );
         });
         let alarm_count = logs.matches("redrive_no_progress_capped").count()

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -13,13 +13,15 @@ use crate::services::discord::relay_recovery::{
 use crate::services::discord::{RelayFrontierToken, SharedData};
 use crate::services::provider::ProviderKind;
 
-// Delay after each admitted attempt. The sixth (960s) is the terminal capped
-// horizon from the issue contract; no seventh action is admitted. Consequently
-// the six actual action times are cumulative +0/+30/+90/+210/+450/+930. The
-// hard placeholder shield expires at +900, so the final action intentionally
-// runs under the reclaim semantics restored by that bound.
+// Delay after each admitted attempt. The six initial action times are
+// cumulative +0/+30/+90/+210/+450/+930. The hard placeholder shield expires at
+// +900, so the sixth action intentionally runs under the reclaim semantics
+// restored by that bound. A still-stalled episode then enters a one-hour
+// degraded backoff before a new bounded attempt cycle is admitted; it is never
+// permanently abandoned solely because the first cycle reached its cap.
 const REDRIVE_BACKOFF_SECS: [i64; 6] = [30, 60, 120, 240, 480, 960];
 const REDRIVE_MAX_NO_PROGRESS_ATTEMPTS: u8 = 6;
+const REDRIVE_CAPPED_REARM_SECS: i64 = 3600;
 const _: () = assert!(REDRIVE_BACKOFF_SECS.len() == REDRIVE_MAX_NO_PROGRESS_ATTEMPTS as usize);
 
 type RedriveKey = (String, String, u64);
@@ -154,10 +156,15 @@ impl SharedData {
             debug_assert_eq!(REDRIVE_BACKOFF_SECS[REDRIVE_BACKOFF_SECS.len() - 1], 960);
             let emit_capped_alarm = !state.capped_alarm_emitted;
             state.capped_alarm_emitted = true;
-            return RedriveAttemptDecision {
-                attempt: None,
-                emit_capped_alarm,
-            };
+            if now_unix.saturating_sub(state.last_attempt_unix).max(0) < REDRIVE_CAPPED_REARM_SECS {
+                return RedriveAttemptDecision {
+                    attempt: None,
+                    emit_capped_alarm,
+                };
+            }
+            state.attempts = 0;
+            state.capped_alarm_emitted = false;
+            state.retry_not_before_unix = None;
         }
         if state
             .retry_not_before_unix
@@ -527,7 +534,8 @@ fn trace_redrive_cap_if_needed(
             channel_id = channel_id.get(),
             last_relay_offset = snapshot.last_relay_offset,
             attempts = REDRIVE_MAX_NO_PROGRESS_ATTEMPTS,
-            "redrive stopped after the no-progress attempt cap"
+            rearm_after_secs = REDRIVE_CAPPED_REARM_SECS,
+            "redrive entered degraded long backoff after the no-progress attempt cap"
         );
     }
 }
@@ -643,7 +651,24 @@ fn nudge_watcher_handle_for_backlog(
     {
         return false;
     }
-    *resume_offset = Some(snapshot.last_relay_offset);
+    let requested_frontier = snapshot.last_relay_offset.max(token.committed_offset);
+    if resume_offset
+        .as_ref()
+        .is_some_and(|pending| *pending <= token.committed_offset || *pending == requested_frontier)
+    {
+        tracing::error!(
+            target: "agentdesk::discord::relay_recovery",
+            event = "redrive_frontier_no_progress",
+            channel_id = channel_id.get(),
+            requested_frontier,
+            pending_frontier = ?*resume_offset,
+            committed_frontier = token.committed_offset,
+            unread_bytes = ?snapshot.unread_bytes,
+            "redrive refused to enqueue the same non-progressing frontier twice"
+        );
+        return false;
+    }
+    *resume_offset = Some(requested_frontier);
     watcher.turn_delivered.store(false, Ordering::Release);
     true
 }
@@ -1147,6 +1172,20 @@ mod tests {
             *resume_offset.lock().unwrap(),
             Some(snapshot.last_relay_offset)
         );
+        assert!(
+            !nudge_watcher_handle_for_backlog(
+                &shared,
+                &snapshot,
+                shared.tmux_watchers.get(&channel_id).unwrap().value(),
+                channel_id,
+                shared.relay_frontier_token(channel_id),
+            ),
+            "a still-pending identical frontier must not be enqueued again"
+        );
+        assert_eq!(
+            *resume_offset.lock().unwrap(),
+            Some(snapshot.last_relay_offset)
+        );
 
         stall_liveness::clear_stall_watchdog_liveness_state(
             &provider,
@@ -1443,7 +1482,12 @@ mod tests {
         let turn_delivered = Arc::new(AtomicBool::new(true));
         shared.tmux_watchers.insert(
             channel_id,
-            watcher_handle(tmux_session, output_path, resume_offset, turn_delivered),
+            watcher_handle(
+                tmux_session,
+                output_path,
+                resume_offset.clone(),
+                turn_delivered,
+            ),
         );
         clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
 
@@ -1473,6 +1517,7 @@ mod tests {
                 if nudged {
                     nudge_times.push(elapsed);
                     attempts.push(attempt.expect("a successful nudge is an admitted attempt"));
+                    *resume_offset.lock().expect("resume offset") = None;
                 }
             }
             (nudge_times, attempts)
@@ -1482,15 +1527,21 @@ mod tests {
         if sixth_nudge {
             nudge_times.push(930);
             attempts.push(sixth_attempt.expect("sixth nudge must carry attempt ordinal"));
+            *resume_offset.lock().expect("resume offset") = None;
         }
         let (_, capped_logs) = capture_errors(|| {
-            for elapsed in [960, 1_890, 86_400] {
+            for elapsed in [960, 1_890] {
                 assert_eq!(
                     gated_nudge(&shared, &provider, &snapshot, channel_id, base + elapsed),
                     (false, None),
-                    "time alone must never re-arm a capped episode"
+                    "the capped episode must remain dormant during its long backoff"
                 );
             }
+            assert_eq!(
+                gated_nudge(&shared, &provider, &snapshot, channel_id, base + 86_400),
+                (true, Some(1)),
+                "a still-stalled capped episode must re-arm after the long backoff"
+            );
         });
         let alarm_count = logs.matches("redrive_no_progress_capped").count()
             + sixth_logs.matches("redrive_no_progress_capped").count()
@@ -1736,13 +1787,33 @@ mod tests {
             base + stall_liveness::STALL_LIVENESS_STATE_TTL_SECS as i64 + 1,
         );
         assert_eq!(
-            shared.redrive_attempt_decision(&provider, channel_id, &snapshot, base + 10 * 86_400,),
+            shared.redrive_attempt_decision(
+                &provider,
+                channel_id,
+                &snapshot,
+                base + 930 + REDRIVE_CAPPED_REARM_SECS - 1,
+            ),
             RedriveAttemptDecision {
                 attempt: None,
                 emit_capped_alarm: false,
             },
-            "elapsed time and liveness-state GC must not re-arm capped redrive"
+            "the capped episode must respect its degraded long backoff"
         );
+        assert_eq!(
+            shared.redrive_attempt_decision(
+                &provider,
+                channel_id,
+                &snapshot,
+                base + 930 + REDRIVE_CAPPED_REARM_SECS,
+            ),
+            RedriveAttemptDecision {
+                attempt: Some(1),
+                emit_capped_alarm: false,
+            },
+            "a still-stalled capped episode must re-arm after the long backoff"
+        );
+        clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
+        drive_attempt_state_to_cap(&shared, &provider, channel_id, &snapshot, base + 100_000);
         let mut missing_identity = snapshot.clone();
         missing_identity.inflight_identity = None;
         assert_eq!(
@@ -1751,11 +1822,11 @@ mod tests {
                     &provider,
                     channel_id,
                     &missing_identity,
-                    base + 11 * 86_400,
+                    base + 100_930 + REDRIVE_CAPPED_REARM_SECS - 1,
                 )
                 .attempt,
             None,
-            "identity disappearance is not a replacement and must not re-arm"
+            "identity disappearance alone does not bypass the capped backoff"
         );
 
         let mut progressed = snapshot.clone();

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -1445,6 +1445,7 @@ mod tests {
                     .expect("production redrive entrypoint"),
                 "producer liveness must not suppress admitted relay recovery attempt at +{elapsed}s"
             );
+            *resume_offset.lock().expect("resume offset") = None;
         }
         assert!(
             !registry
@@ -1459,7 +1460,11 @@ mod tests {
             capped_alarm_count, 1,
             "a vouched producer must neither suppress nor duplicate the capped relay alarm"
         );
-        assert_eq!(*resume_offset.lock().unwrap(), Some(128));
+        assert_eq!(
+            *resume_offset.lock().unwrap(),
+            None,
+            "the fixture consumes each admitted request before the next health pass"
+        );
 
         crate::services::discord::inflight::clear_inflight_state(&provider, channel_id.get());
         clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
@@ -2063,12 +2068,13 @@ mod tests {
         let tmux_session = "AgentDesk-codex-4299-owner-shield";
         let output_path = "/tmp/agentdesk-4299-owner-shield.jsonl";
         let shared = crate::services::discord::make_shared_data_for_tests();
+        let resume_offset = Arc::new(Mutex::new(None));
         shared.tmux_watchers.insert(
             owner_channel_id,
             watcher_handle(
                 tmux_session,
                 output_path,
-                Arc::new(Mutex::new(None)),
+                resume_offset.clone(),
                 Arc::new(AtomicBool::new(true)),
             ),
         );
@@ -2149,6 +2155,7 @@ mod tests {
             gated_nudge(&shared, &provider, &snapshot, channel_id, base),
             (true, Some(1))
         );
+        *resume_offset.lock().expect("resume offset") = None;
         let episode_started = shared
             .redrive_placeholder_shield_context(&provider, owner_channel_id)
             .expect("first attempt re-arms the owner shield")

--- a/src/services/discord/health/stall_liveness.rs
+++ b/src/services/discord/health/stall_liveness.rs
@@ -1452,7 +1452,11 @@ mod tests {
             STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
             Some(0),
         );
-        assert!(first.should_defer());
+        assert_eq!(
+            first.action,
+            StallWatchdogLivenessAction::ProceedNoEvidence,
+            "the initial backlog observation has no independent progress evidence"
+        );
         assert!(first.evidence.has_undelivered_backlog);
 
         for (tick, delivered_offset) in [(1, 64), (2, 128), (3, 192)] {

--- a/src/services/discord/health/stall_liveness.rs
+++ b/src/services/discord/health/stall_liveness.rs
@@ -19,11 +19,9 @@ pub(super) const STALL_WATCHDOG_POSITIVE_LIVENESS_SECS: u64 = 120;
 /// liveness keeps being observed. A deferral only ever fires when
 /// `has_positive_liveness` is true: fresh bytes are demonstrably flowing (pane or
 /// relay offset advanced cross-tick, transcript/runtime jsonl mtime inside
-/// `POSITIVE_LIVENESS_SECS`, or a fresh background-synthetic anchor), or an
-/// undelivered backlog is still inside the short no-progress observation grace
-/// used to prove whether it is draining. Once that backlog grace expires without
-/// relay-offset progress, `reason_codes == none` and the first eligible cleanup
-/// tick proceeds instead of waiting for the absolute backstop.
+/// `POSITIVE_LIVENESS_SECS`, or a fresh background-synthetic anchor). An
+/// undelivered backlog remains diagnostic telemetry but never self-justifies a
+/// deferral without independent producer or delivery progress.
 ///
 /// #3582: raised 3 -> 20. At the old value a *live* turn that kept emitting output
 /// for longer than `THRESHOLD_SECS + 3 * INTERVAL_SECS` (~600s + ~90s) was killed
@@ -250,8 +248,8 @@ impl StallWatchdogLivenessEvidence {
     }
 
     pub(super) fn has_positive_liveness(&self, freshness_secs: u64) -> bool {
-        self.composite_progress(freshness_secs).class
-            != super::relay_progress::RelayProgressClass::NoObservedProgress
+        let progress = self.composite_progress(freshness_secs);
+        progress.source_recent || progress.delivery_recent
     }
 }
 
@@ -1349,7 +1347,7 @@ mod tests {
     }
 
     #[test]
-    fn frozen_undelivered_backlog_cleans_after_no_progress_grace() {
+    fn frozen_undelivered_backlog_never_self_justifies_liveness() {
         let provider = ProviderKind::Codex;
         let channel = ChannelId::new(4178_002);
         let tmux_session = "AgentDesk-codex-frozen-backlog-liveness";
@@ -1376,8 +1374,8 @@ mod tests {
         );
         assert_eq!(
             first.action,
-            StallWatchdogLivenessAction::Defer { deferral_count: 0 },
-            "first backlog observation gets only the short no-progress grace"
+            StallWatchdogLivenessAction::ProceedNoEvidence,
+            "backlog existence without producer or delivery progress cannot defer cleanup"
         );
         assert!(first.evidence.has_undelivered_backlog);
         assert_eq!(
@@ -1399,8 +1397,8 @@ mod tests {
         );
         assert_eq!(
             still_inside_grace.action,
-            StallWatchdogLivenessAction::Defer { deferral_count: 0 },
-            "a frozen backlog may defer only inside the bounded grace"
+            StallWatchdogLivenessAction::ProceedNoEvidence,
+            "bounded backlog observation remains telemetry, not positive liveness"
         );
 
         let expired = evaluate_stall_watchdog_liveness(

--- a/src/services/discord/tmux_watcher/placeholder_reclaim.rs
+++ b/src/services/discord/tmux_watcher/placeholder_reclaim.rs
@@ -236,22 +236,22 @@ mod redrive_reclaim_e2e_tests {
             let mut creates = 0;
             let mut deletes = 0;
             let mut nudges = 0;
-            for pass in 0..20 {
+            for elapsed in [0, 30, 90, 210, 450] {
                 let nudged = registry
                     .redrive_undelivered_backlog_at(
                         &provider,
                         shared.clone(),
                         channel_id,
-                        base + i64::from(pass) * 30,
+                        base + elapsed,
                     )
                     .await
                     .expect("redrive pass");
-                if nudged {
-                    nudges += 1;
-                    if placeholder_msg_id.is_none() {
-                        placeholder_msg_id = Some(message_id_at(base + 300, 2));
-                        creates += 1;
-                    }
+                assert!(nudged, "scheduled redrive must fire at +{elapsed}s");
+                nudges += 1;
+                *resume_offset.lock().expect("resume offset") = None;
+                if placeholder_msg_id.is_none() {
+                    placeholder_msg_id = Some(message_id_at(base + 300, 2));
+                    creates += 1;
                 }
                 if placeholder_msg_id.is_some() {
                     let reclaimed = reclaim_orphan_external_input_placeholder(
@@ -292,6 +292,7 @@ mod redrive_reclaim_e2e_tests {
                     .expect("sixth redrive pass")
             );
             nudges += 1;
+            *resume_offset.lock().expect("resume offset") = None;
             assert!(
                 !registry
                     .redrive_undelivered_backlog_at(

--- a/src/services/discord/tmux_watcher/placeholder_reclaim.rs
+++ b/src/services/discord/tmux_watcher/placeholder_reclaim.rs
@@ -303,6 +303,29 @@ mod redrive_reclaim_e2e_tests {
                     .await
                     .expect("capped redrive pass")
             );
+            assert!(
+                !registry
+                    .redrive_undelivered_backlog_at(
+                        &provider,
+                        shared.clone(),
+                        channel_id,
+                        base + 4_529,
+                    )
+                    .await
+                    .expect("pre-rearm boundary pass")
+            );
+            assert!(
+                registry
+                    .redrive_undelivered_backlog_at(
+                        &provider,
+                        shared.clone(),
+                        channel_id,
+                        base + 4_530,
+                    )
+                    .await
+                    .expect("post-rearm boundary pass")
+            );
+            nudges += 1;
             (creates, deletes, nudges)
         });
 
@@ -311,7 +334,10 @@ mod redrive_reclaim_e2e_tests {
             delete_count, 0,
             "no post-nudge placeholder may churn inside 900s"
         );
-        assert_eq!(nudge_count, 6, "redrive must stop permanently at the cap");
+        assert_eq!(
+            nudge_count, 7,
+            "redrive must remain capped for one hour, then re-arm"
+        );
         assert_eq!(*resume_offset.lock().unwrap(), Some(0));
         if let Some((_, handle)) = shared.tmux_watchers.remove(&channel_id) {
             handle.cancel.store(true, Ordering::Release);

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -58,6 +58,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::turn_finalizer::completion_admission_actor::tests -- --skip _pg --skip pg_ --skip postgres --test-threads=1",
     "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::turn_finalizer::cleanup::tests::late_already_finalized_cleanup_releases_mailbox_and_rearms_once_4906 -- --exact --test-threads=1",
     "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::turn_finalizer::cleanup::tests::mailbox_release_backstop_coalesces_duplicate_arms_and_eventually_fires_4906 -- --exact --test-threads=1",
+    "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tmux::tmux_watcher::placeholder_reclaim::redrive_reclaim_e2e_tests::live_tmux_redrive_reclaim_cycle_terminates_4299 -- --exact --test-threads=1",
     "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::recovery_engine::runtime::reregister_ledger_reseed_tests -- --test-threads=1",
     "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::placeholder_sweeper::abandon_guard::tests -- --test-threads=1",
     "env -u AGENTDESK_ROOT_DIR cargo test --lib placeholder_live_events -- --skip _pg --skip pg_ --skip postgres",


### PR DESCRIPTION
## Summary

Partial fix for #4906. The soft-terminal authority relaxation approach was abandoned after two consecutive review rounds left P0 findings open; none of that authority/fingerprint work is included here.

This independent slice closes the production-observed recovery loop where:

- the committed relay frontier remains stuck at 0,
- recovery re-enqueues the same frontier about every 31 seconds,
- `has_undelivered_backlog` permanently self-justifies STALL-WATCHDOG liveness,
- and the six-attempt cap otherwise leaves recovery permanently dormant.

The remaining exactly-once defect stays open in #4906.

## Changes

- Require independent source or delivery progress for positive stall-watchdog liveness; backlog presence remains diagnostic only.
- Refuse redrive below the committed frontier or when the identical frontier is already pending.
- Re-arm a still-stalled episode after the six-attempt cap and one-hour degraded backoff.
- Document only the bounded redrive/backoff contract in I12.

Explicitly excluded from the abandoned soft-authority contract:

- three immediate rewinds for fresh unauthorized non-empty ranges,
- 30-second degraded retention after that cap,
- zero-width/already-covered soft-authority replay drop,
- all soft-terminal identity/fingerprint authority changes.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --lib`
- `cargo test --lib --no-run`
- `cargo test --lib relay_auto_heal -- --test-threads=1` — 12 passed
- `cargo test --lib stall_liveness -- --test-threads=1` — 35 passed
- `python3 scripts/generate_inventory_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate` — freshness check passed

Mutation proof:

- Restoring backlog-as-liveness makes `frozen_undelivered_backlog_never_self_justifies_liveness` fail.
- Removing capped re-arm makes `redrive_frozen_backlog_backs_off_and_caps_once_4299` fail.
