### PR TITLE
fix(#4953): move PG-only cancel_run tests into the pg_ lane

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,7 +30,6 @@ test-active-usage-4631:
 test-non-pg:
     # #4878: keep the generated queue docs on the canonical thread-group contract.
     cargo test --lib server::routes::docs::inventory::endpoints::part_0 -- --skip _pg --skip pg_ --skip postgres
-    cargo test --lib services::auto_queue::cancel_run::tests -- --test-threads=1
     cargo test --lib services::task_completion_v1::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib source_registry -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib task_notification -- --skip _pg --skip pg_ --skip postgres

--- a/src/services/auto_queue/cancel_run.rs
+++ b/src/services/auto_queue/cancel_run.rs
@@ -1179,8 +1179,13 @@ pub(crate) async fn cancel_with_pg(
     cancel_selected_runs_with_pg(health_registry, pool, &target_run_ids, "auto_queue_cancel").await
 }
 
+// #4953: every test here needs a live PostgreSQL server, so the module name
+// must carry the `pg_` marker that `just test-postgres` and the test-lane
+// coverage gate select on. Naming it `tests` put it outside the PG lane's
+// module-level match while the non-PG lane still ran it, so the PG-less
+// `full_non_pg` CI job executed it and failed with a 15s pool timeout.
 #[cfg(test)]
-mod tests {
+mod pg_tests {
     use super::*;
     use crate::db::auto_queue::test_support::TestPostgresDb;
 

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -23,7 +23,6 @@ BUSY_RETRY_4888_TEST_COMMAND = (
 # attempt to derive the expected coverage from the justfile under test.
 EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --lib server::routes::docs::inventory::endpoints::part_0 -- --skip _pg --skip pg_ --skip postgres",
-    "cargo test --lib services::auto_queue::cancel_run::tests -- --test-threads=1",
     "cargo test --lib services::task_completion_v1::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib source_registry -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib task_notification -- --skip _pg --skip pg_ --skip postgres",


### PR DESCRIPTION
## 문제

main CI `Full tests (ubuntu-latest)` (job id `full_non_pg`) 가 `986f7c743` (#4950) 이후 3연속 red 다.

```
thread 'services::auto_queue::cancel_run::tests::cancel_selected_runs_with_pg_atomically_terminalizes_run_entry_and_dispatch'
panicked at src/db/auto_queue/test_support.rs:23:10:
create postgres auto_queue test db: "db::auto_queue tests admin connect postgres: pool timed out while waiting for an open connection"
```

## 근본 원인

`986f7c743` 이 `justfile` 의 `test-non-pg` 에 한 줄을 추가하면서, 인접한 모든 라인이 달고 있는 `--skip _pg --skip pg_ --skip postgres` 를 빠뜨렸다. 같은 커밋이 도입한 PG 백엔드 테스트가 **postgres service 가 없는** `full_non_pg` job 에서 실행된다.

`full_non_pg` 는 `ci-main.yml:64-128` 에 `services:` 블록이 없고 `POSTGRES_TEST_*` env 도 없다. env 가 없으면 `postgres_base_database_url()` 이 `localhost:5432` fallback 을 만들어 **연결을 시도한다.** sqlx 0.8.6 은 ConnectionRefused 를 "서버가 부팅 중" 으로 간주해 삼키고(`pool/inner.rs:374`) 재시도하다가, `acquire_timeout`(15s) 만료 시 `PoolTimedOut` 으로 바꿔 보고한다(`inner.rs:384`). 즉 이 메시지는 슬롯 고갈이 아니라 **리스닝하는 서버가 없다** 는 뜻이다.

로컬에서 `PGPORT=59999` 로 CI 조건을 모사해 **패닉 문자열이 완전히 일치**하고 소요 `15.09s` 가 `TEST_POSTGRES_OP_TIMEOUT=15s` 와 맞는 것을 확인했다.

## 왜 skip 추가만으로는 안 되는가

`scripts/check_test_lane_coverage.py:101-116` 의 `fully_selects` 는 레인을 **모듈 경로**로 매칭한다:

```python
positive_match = not self.positives or any(positive in module for positive in self.positives)
if not positive_match or any(skip in module for skip in self.skips):
    return False
```

- non-PG 라인에 skip 3종을 달면 → 모듈 내 PG 테스트가 `selects_test`=False → 모듈 미커버
- PG 레인(`test-postgres`: `cargo test -- _pg pg_ postgres`)으로 덮으려 해도 → 모듈 경로 `services::auto_queue::cancel_run::tests` 에 `_pg`/`pg_`/`postgres` 가 없어 `positive_match` 실패

실제로 skip 만 추가하고 게이트를 돌리면 이렇게 막힌다:

```
FAIL: coverage baseline drift: 1 newly uncovered, ... (candidate baseline 680).
  + services::auto_queue::cancel_run::tests
```

## 수정

이 모듈은 테스트가 **정확히 1개**이고 그것이 PG 전용이다. 따라서 `mod tests` → `mod pg_tests` 로 개명하면 모듈 경로가 `pg_` 를 포함해 PG 레인이 모듈 단위로 커버하고, non-PG 라인은 불필요해진다. 그 라인을 제거했다.

## 검증

| 항목 | 결과 |
|---|---|
| `check_test_lane_coverage.py --baseline-ref origin/main` | `RC=0`, 미커버 680 = `8fcb001a5` 베이스라인 일치 |
| `cargo fmt --all -- --check` | 클린 |
| `cargo test --lib --no-run` | `^error` 0건 |
| `cargo test --lib cancel_run::pg_tests -- --list` | 해당 테스트 1건 |

## 남은 것 (이 PR 범위 밖)

main 에는 **별개의 실패가 하나 더** 있다. `04:07` / `06:51` 런에서 `services::discord::tui_prompt_relay::local_model_queue_wake_e2e::local_model_observation_wakes_idle_durable_queue_through_production_workers` 가 실패했고, `07:29` 이후로는 이 PG 실패가 **먼저 터져서 도달조차 못 하고 있다** (11:17 런 로그에 해당 테스트 이름 0건). 이 PR 이 머지되면 그 실패가 다시 드러날 것으로 예상한다. #4953 에 별건으로 분리해 두겠다.
