### PR TITLE
fix(#4961): require sustained transcript loss before corroborating coverage desync

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -3076,6 +3076,23 @@ def tick_coverage(
     transcript_probe: CoverageTranscriptProbe | None = None,
 ) -> None:
     """Observe I2 only; never repair, return early from, or suppress gap checks."""
+    # #4961: a momentary lost>0 is ordinary relay batching, so it must not
+    # corroborate a desync on its own. Persist the first loss observation the
+    # same way the sibling delivery-gap alarm persists `gap_since` (set once,
+    # popped on the first clean observation) so the corroboration check below
+    # can demand the same gap_alert_secs dwell that alarm already demands.
+    # Maintained before any verdict branch returns, so a covered tick with
+    # lost==0 still clears the timer.
+    if transcript_probe is not None:
+        if transcript_probe.lost > 0:
+            raw_loss_since = chs.get("loss_since")
+            if not (
+                _is_finite_nonnegative_number(raw_loss_since)
+                and float(raw_loss_since) <= now
+            ):
+                chs["loss_since"] = now
+        else:
+            chs.pop("loss_since", None)
     expected_name = expected_tmux_session_name(ch)
     live_sessions = rt.live_tmux_sessions()
     expected_alive = None if live_sessions is None else expected_name in live_sessions
@@ -3180,8 +3197,18 @@ def tick_coverage(
         growing_without_loss = bool(
             zero_loss_observed and transcript_probe is not None and transcript_probe.growing
         )
-        transcript_loss_active = bool(
+        transcript_loss_observed = bool(
             transcript_probe is not None and transcript_probe.lost > 0
+        )
+        # `loss_since` is set/validated for exactly this condition earlier in
+        # the tick, so the read is safe whenever loss is observed.
+        loss_for = (
+            max(0.0, now - float(chs["loss_since"]))
+            if transcript_loss_observed
+            else 0.0
+        )
+        transcript_loss_active = bool(
+            transcript_loss_observed and loss_for >= rt.cfg.gap_alert_secs
         )
         inflight_progress_alive = bool(
             inflight_update_advanced or inflight_update_recent
@@ -3212,6 +3239,14 @@ def tick_coverage(
                 f"[{cid}] coverage desync has zero loss and recent relay "
                 f"blocks={transcript_probe.blocks} growing={transcript_probe.growing} "
                 "— not alarming"
+            )
+            return
+        if not delivery_gap_active and transcript_loss_observed:
+            rt.log(
+                f"[{cid}] coverage desync transcript loss not yet sustained "
+                f"duration={int(loss_for)}s lost={transcript_probe.lost} "
+                f"(< {rt.cfg.gap_alert_secs}s alert threshold — relay batching, "
+                "not down) — not alarming"
             )
             return
         if not delivery_gap_active:

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -100,6 +100,17 @@ COVERAGE_CONFIRM_TICKS = 2
 # genuinely stalled foreground turn resume normal two-tick escalation.
 COVERAGE_ACTIVITY_FRESH_SECS = 10 * 60
 COVERAGE_INFLIGHT_UPDATED_AT_KEY = "coverage_inflight_updated_at"
+# #4961: `lost` returning to 0 is NOT proof of health. `evaluate()` only counts
+# blocks newer than the delivered_ts watermark, so every delivery that advances
+# that watermark drops permanently-lost older blocks out of the tally — chronic
+# partial loss therefore oscillates lost>0 -> 0 -> lost>0 at tick scale. A
+# single clean tick must not reset the sustained-loss dwell or that pattern
+# starves the threshold forever (it also stays STATE_LAGGING, so gap_since
+# never backstops it). Require this many consecutive ticks that each carry real
+# evidence (blocks > 0 AND lost == 0). Deliberately small: large enough to
+# outlast tick-scale oscillation, small enough that a genuinely recovered
+# channel clears instead of being pinned in alarm forever.
+COVERAGE_LOSS_RECOVERY_TICKS = 3
 
 # Independent selector-sync states (#4408 phase 2, I1).  Compares the dcserver's
 # asserted relay bind (B = watcher-state `bound_output_path`) against the
@@ -3077,22 +3088,36 @@ def tick_coverage(
 ) -> None:
     """Observe I2 only; never repair, return early from, or suppress gap checks."""
     # #4961: a momentary lost>0 is ordinary relay batching, so it must not
-    # corroborate a desync on its own. Persist the first loss observation the
-    # same way the sibling delivery-gap alarm persists `gap_since` (set once,
-    # popped on the first clean observation) so the corroboration check below
-    # can demand the same gap_alert_secs dwell that alarm already demands.
-    # Maintained before any verdict branch returns, so a covered tick with
-    # lost==0 still clears the timer.
+    # corroborate a desync on its own — the corroboration check below demands a
+    # gap_alert_secs dwell first. The dwell is only released on sustained health
+    # (see COVERAGE_LOSS_RECOVERY_TICKS): like the sibling delivery-gap alarm,
+    # which preserves `gap_since` through every STATE_LAGGING tick and clears it
+    # only on a STATE_OK verdict, sub-threshold loss must never reset the timer.
+    # `blocks == 0` carries no evidence either way — it is the same unobserved
+    # state as a missing probe, so it preserves the timer rather than clearing
+    # it. Maintained before any verdict branch returns, so covered ticks still
+    # advance recovery.
     if transcript_probe is not None:
         if transcript_probe.lost > 0:
+            chs.pop("loss_clear_ticks", None)
             raw_loss_since = chs.get("loss_since")
             if not (
                 _is_finite_nonnegative_number(raw_loss_since)
                 and float(raw_loss_since) <= now
             ):
                 chs["loss_since"] = now
-        else:
-            chs.pop("loss_since", None)
+        elif transcript_probe.blocks > 0:
+            raw_clear_ticks = chs.get("loss_clear_ticks", 0)
+            if not isinstance(raw_clear_ticks, int) or isinstance(
+                raw_clear_ticks, bool
+            ):
+                raw_clear_ticks = 0
+            clear_ticks = max(0, raw_clear_ticks) + 1
+            if clear_ticks >= COVERAGE_LOSS_RECOVERY_TICKS:
+                chs.pop("loss_since", None)
+                chs.pop("loss_clear_ticks", None)
+            else:
+                chs["loss_clear_ticks"] = clear_ticks
     expected_name = expected_tmux_session_name(ch)
     live_sessions = rt.live_tmux_sessions()
     expected_alive = None if live_sessions is None else expected_name in live_sessions

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -100,17 +100,6 @@ COVERAGE_CONFIRM_TICKS = 2
 # genuinely stalled foreground turn resume normal two-tick escalation.
 COVERAGE_ACTIVITY_FRESH_SECS = 10 * 60
 COVERAGE_INFLIGHT_UPDATED_AT_KEY = "coverage_inflight_updated_at"
-# #4961: `lost` returning to 0 is NOT proof of health. `evaluate()` only counts
-# blocks newer than the delivered_ts watermark, so every delivery that advances
-# that watermark drops permanently-lost older blocks out of the tally — chronic
-# partial loss therefore oscillates lost>0 -> 0 -> lost>0 at tick scale. A
-# single clean tick must not reset the sustained-loss dwell or that pattern
-# starves the threshold forever (it also stays STATE_LAGGING, so gap_since
-# never backstops it). Require this many consecutive ticks that each carry real
-# evidence (blocks > 0 AND lost == 0). Deliberately small: large enough to
-# outlast tick-scale oscillation, small enough that a genuinely recovered
-# channel clears instead of being pinned in alarm forever.
-COVERAGE_LOSS_RECOVERY_TICKS = 3
 
 # Independent selector-sync states (#4408 phase 2, I1).  Compares the dcserver's
 # asserted relay bind (B = watcher-state `bound_output_path`) against the
@@ -3087,37 +3076,6 @@ def tick_coverage(
     transcript_probe: CoverageTranscriptProbe | None = None,
 ) -> None:
     """Observe I2 only; never repair, return early from, or suppress gap checks."""
-    # #4961: a momentary lost>0 is ordinary relay batching, so it must not
-    # corroborate a desync on its own — the corroboration check below demands a
-    # gap_alert_secs dwell first. The dwell is only released on sustained health
-    # (see COVERAGE_LOSS_RECOVERY_TICKS): like the sibling delivery-gap alarm,
-    # which preserves `gap_since` through every STATE_LAGGING tick and clears it
-    # only on a STATE_OK verdict, sub-threshold loss must never reset the timer.
-    # `blocks == 0` carries no evidence either way — it is the same unobserved
-    # state as a missing probe, so it preserves the timer rather than clearing
-    # it. Maintained before any verdict branch returns, so covered ticks still
-    # advance recovery.
-    if transcript_probe is not None:
-        if transcript_probe.lost > 0:
-            chs.pop("loss_clear_ticks", None)
-            raw_loss_since = chs.get("loss_since")
-            if not (
-                _is_finite_nonnegative_number(raw_loss_since)
-                and float(raw_loss_since) <= now
-            ):
-                chs["loss_since"] = now
-        elif transcript_probe.blocks > 0:
-            raw_clear_ticks = chs.get("loss_clear_ticks", 0)
-            if not isinstance(raw_clear_ticks, int) or isinstance(
-                raw_clear_ticks, bool
-            ):
-                raw_clear_ticks = 0
-            clear_ticks = max(0, raw_clear_ticks) + 1
-            if clear_ticks >= COVERAGE_LOSS_RECOVERY_TICKS:
-                chs.pop("loss_since", None)
-                chs.pop("loss_clear_ticks", None)
-            else:
-                chs["loss_clear_ticks"] = clear_ticks
     expected_name = expected_tmux_session_name(ch)
     live_sessions = rt.live_tmux_sessions()
     expected_alive = None if live_sessions is None else expected_name in live_sessions
@@ -3222,19 +3180,6 @@ def tick_coverage(
         growing_without_loss = bool(
             zero_loss_observed and transcript_probe is not None and transcript_probe.growing
         )
-        transcript_loss_observed = bool(
-            transcript_probe is not None and transcript_probe.lost > 0
-        )
-        # `loss_since` is set/validated for exactly this condition earlier in
-        # the tick, so the read is safe whenever loss is observed.
-        loss_for = (
-            max(0.0, now - float(chs["loss_since"]))
-            if transcript_loss_observed
-            else 0.0
-        )
-        transcript_loss_active = bool(
-            transcript_loss_observed and loss_for >= rt.cfg.gap_alert_secs
-        )
         inflight_progress_alive = bool(
             inflight_update_advanced or inflight_update_recent
         )
@@ -3244,7 +3189,6 @@ def tick_coverage(
         delivery_gap_active = bool(
             chs.get("gap_since")
             or chs.get("alerting")
-            or transcript_loss_active
             or growing_relay_stall
         )
         if (
@@ -3264,14 +3208,6 @@ def tick_coverage(
                 f"[{cid}] coverage desync has zero loss and recent relay "
                 f"blocks={transcript_probe.blocks} growing={transcript_probe.growing} "
                 "— not alarming"
-            )
-            return
-        if not delivery_gap_active and transcript_loss_observed:
-            rt.log(
-                f"[{cid}] coverage desync transcript loss not yet sustained "
-                f"duration={int(loss_for)}s lost={transcript_probe.lost} "
-                f"(< {rt.cfg.gap_alert_secs}s alert threshold — relay batching, "
-                "not down) — not alarming"
             )
             return
         if not delivery_gap_active:

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -2931,9 +2931,11 @@ class TickChannelTests(unittest.TestCase):
         state = {
             "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
             "coverage_desync_since": self.now,
-            # #4961: loss corroborates only once it has persisted for
-            # gap_alert_secs, so this fixture carries a sustained timer.
-            "loss_since": tick_at - rt.cfg.gap_alert_secs,
+            # #4961: transcript loss no longer corroborates a desync on its own.
+            # Corroboration is delegated to `gap_since`, the delivery-gap
+            # watermark that `evaluate()` already maintains monotonically, so
+            # this fixture carries the sustained-loss evidence in that key.
+            "gap_since": tick_at - rt.cfg.gap_alert_secs,
         }
 
         tick_coverage(
@@ -2954,10 +2956,13 @@ class TickChannelTests(unittest.TestCase):
             last_relay_ts_ms=int(tick_at * 1000) - 1,
         )
 
-    def test_first_transcript_loss_tick_records_timer_without_alarm(self):
+    def test_isolated_transcript_loss_without_gap_since_does_not_corroborate(self):
         # #4961 regression: two real false positives (ticks=83 gap=678s and
         # ticks=4 gap=799s, same channel) fired off a single lost>0 tick whose
         # neighbours both reported lost=0 — relay batching, not a dead relay.
+        # A momentary `lost > 0` carries no duration evidence, so on its own it
+        # must not corroborate the desync. Sustained loss is expressed by
+        # `gap_since`, which is absent here.
         rt = self.make_rt()
         tick_at = self.now + 600
         self.arm_coverage(rt, self._loss_corroboration_probe(tick_at))
@@ -2976,24 +2981,27 @@ class TickChannelTests(unittest.TestCase):
 
         self.assertEqual(rt.alerts, [])
         self.assertNotIn("last_coverage_alert", state)
-        self.assertEqual(state["loss_since"], tick_at)
+        # tick_coverage observes only; it must not invent a corroboration key.
+        self.assertNotIn("gap_since", state)
         self.assertTrue(
             any(
-                "transcript loss not yet sustained" in line
-                and "duration=0s" in line
-                and "lost=1" in line
-                for line in rt.log_lines
+                "coverage desync uncorroborated" in line for line in rt.log_lines
             )
         )
 
-    def test_sustained_transcript_loss_corroborates_desync_coverage_alarm(self):
+    def test_transcript_loss_with_gap_since_corroborates_desync_coverage_alarm(self):
+        # The real signal is preserved: once `evaluate()` has opened a delivery
+        # gap (STATE_GAP -> `gap_since`), transcript loss corroborates the
+        # desync and the alarm fires. `gap_since` is owned by the gap path, so
+        # tick_coverage must read it without rewriting it.
         rt = self.make_rt()
         tick_at = self.now + 600
         self.arm_coverage(rt, self._loss_corroboration_probe(tick_at))
+        gap_since = tick_at - rt.cfg.gap_alert_secs
         state = {
             "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
             "coverage_desync_since": self.now,
-            "loss_since": tick_at - rt.cfg.gap_alert_secs,
+            "gap_since": gap_since,
         }
 
         tick_coverage(
@@ -3006,164 +3014,7 @@ class TickChannelTests(unittest.TestCase):
 
         self.assertEqual(len(rt.alerts), 1)
         self.assertIn("attached_but_desynced", rt.alerts[0][0])
-        self.assertEqual(state["loss_since"], tick_at - rt.cfg.gap_alert_secs)
-
-    def test_clean_tick_clears_loss_timer_and_restarts_dwell(self):
-        rt = self.make_rt()
-        first_tick = self.now + 600
-        self.arm_coverage(rt, self._loss_corroboration_probe(first_tick))
-        state = {
-            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
-            "coverage_desync_since": self.now,
-        }
-
-        tick_coverage(
-            rt,
-            TICK_CHANNEL,
-            state,
-            first_tick,
-            CoverageTranscriptProbe(growing=True, blocks=723, lost=1),
-        )
-        self.assertEqual(state["loss_since"], first_tick)
-
-        # #4961 B1: a single clean tick must NOT release the dwell — `lost`
-        # legitimately returns to 0 while earlier blocks stay dropped. Only a
-        # sustained healthy run clears it.
-        for i in range(relay_watchdog.COVERAGE_LOSS_RECOVERY_TICKS):
-            clean_tick = first_tick + 60 * (i + 1)
-            rt.watcher_probe = self._loss_corroboration_probe(clean_tick)
-            tick_coverage(
-                rt,
-                TICK_CHANNEL,
-                state,
-                clean_tick,
-                CoverageTranscriptProbe(growing=True, blocks=723, lost=0),
-            )
-        self.assertNotIn("loss_since", state)
-
-        # A later loss restarts the dwell from zero: without the clear this
-        # tick would already be gap_alert_secs old and would alarm.
-        relapse_tick = first_tick + rt.cfg.gap_alert_secs + 60
-        rt.watcher_probe = self._loss_corroboration_probe(relapse_tick)
-        tick_coverage(
-            rt,
-            TICK_CHANNEL,
-            state,
-            relapse_tick,
-            CoverageTranscriptProbe(growing=True, blocks=723, lost=1),
-        )
-
-        self.assertEqual(rt.alerts, [])
-        self.assertEqual(state["loss_since"], relapse_tick)
-
-    def _run_loss_tick(self, rt, state, tick_at, lost, blocks=723):
-        self.arm_coverage(rt, self._loss_corroboration_probe(tick_at))
-        tick_coverage(
-            rt,
-            TICK_CHANNEL,
-            state,
-            tick_at,
-            CoverageTranscriptProbe(growing=True, blocks=blocks, lost=lost),
-        )
-
-    def test_oscillating_loss_still_reaches_sustained_threshold(self):
-        # #4961 B1: chronic partial loss oscillates lost>0 -> 0 -> lost>0 because
-        # `evaluate()` drops permanently-lost blocks below the advancing
-        # delivered_ts watermark. If a single clean tick reset the dwell this
-        # channel would starve the threshold forever and never alarm.
-        rt = self.make_rt()
-        start = self.now + 600
-        state = {
-            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
-            "coverage_desync_since": self.now,
-        }
-        poll = rt.cfg.poll_secs
-        # Alternate lost=1 / lost=0 (starting and ending on loss) well past
-        # gap_alert_secs of wall clock.
-        ticks = (rt.cfg.gap_alert_secs // poll) * 2 + 5
-        for i in range(ticks):
-            self._run_loss_tick(rt, state, start + poll * i, lost=1 - i % 2)
-
-        # The dwell survived every clean tick, so it still dates to the first
-        # loss and the elapsed wall clock clears the threshold.
-        self.assertEqual(state["loss_since"], start)
-        self.assertGreater(
-            start + poll * (ticks - 1) - state["loss_since"],
-            rt.cfg.gap_alert_secs,
-        )
-        self.assertTrue(rt.alerts)
-        self.assertIn("attached_but_desynced", rt.alerts[0][0])
-
-    def test_unobserved_zero_block_tick_preserves_loss_dwell(self):
-        # #4961 B2: blocks==0 carries no evidence — it is the same unobserved
-        # state as a missing probe, not proof of recovery.
-        rt = self.make_rt()
-        first_tick = self.now + 600
-        state = {
-            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
-            "coverage_desync_since": self.now,
-        }
-        self._run_loss_tick(rt, state, first_tick, lost=1)
-        self.assertEqual(state["loss_since"], first_tick)
-
-        for i in range(relay_watchdog.COVERAGE_LOSS_RECOVERY_TICKS + 2):
-            self._run_loss_tick(
-                rt, state, first_tick + 60 * (i + 1), lost=0, blocks=0
-            )
-
-        self.assertEqual(state["loss_since"], first_tick)
-        self.assertNotIn("loss_clear_ticks", state)
-
-    def test_sustained_recovery_clears_dwell_only_at_full_streak(self):
-        # Pairs with B1: hysteresis must not pin a recovered channel in alarm.
-        rt = self.make_rt()
-        first_tick = self.now + 600
-        state = {
-            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
-            "coverage_desync_since": self.now,
-        }
-        self._run_loss_tick(rt, state, first_tick, lost=1)
-
-        streak = relay_watchdog.COVERAGE_LOSS_RECOVERY_TICKS
-        for i in range(streak - 1):
-            self._run_loss_tick(rt, state, first_tick + 60 * (i + 1), lost=0)
-            self.assertEqual(state["loss_since"], first_tick)
-            self.assertEqual(state["loss_clear_ticks"], i + 1)
-
-        self._run_loss_tick(rt, state, first_tick + 60 * streak, lost=0)
-        self.assertNotIn("loss_since", state)
-        self.assertNotIn("loss_clear_ticks", state)
-
-    def test_realistic_recovery_releases_dwell_within_five_clean_ticks(self):
-        # #4961 upper bound. The other clear-path tests derive their loop count
-        # from COVERAGE_LOSS_RECOVERY_TICKS, so they can never fail no matter how
-        # large it grows — and a large value resurrects the very false positive
-        # this PR removes (an isolated lost=1 tick alarming because the dwell was
-        # never released). The 5 below is therefore a deliberate literal, NOT
-        # derived from the constant: raising the constant past 5 must fail here.
-        # Together with test_oscillating_loss_still_reaches_sustained_threshold
-        # (which pins the lower bound at >= 2) this fixes 2 <= CONST <= 5.
-        rt = self.make_rt()
-        first_tick = self.now + 600
-        state = {
-            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
-            "coverage_desync_since": self.now,
-        }
-        self._run_loss_tick(rt, state, first_tick, lost=1)
-        self.assertEqual(state["loss_since"], first_tick)
-
-        for i in range(5):
-            self._run_loss_tick(rt, state, first_tick + 60 * (i + 1), lost=0)
-        self.assertNotIn("loss_since", state)
-
-        # #4961 issue body, ticks=4 gap=799s: an isolated lost=1 whose
-        # neighbours both read lost=0 must not alarm even long after the
-        # original loss, because a real recovery restarted the dwell.
-        relapse_tick = first_tick + rt.cfg.gap_alert_secs + 600
-        self._run_loss_tick(rt, state, relapse_tick, lost=1)
-
-        self.assertEqual(state["loss_since"], relapse_tick)
-        self.assertEqual(rt.alerts, [])
+        self.assertEqual(state["gap_since"], gap_since)
 
     def test_growth_with_stale_relay_and_advanced_inflight_update_is_suppressed(self):
         rt = self.make_rt()

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -3026,15 +3026,19 @@ class TickChannelTests(unittest.TestCase):
         )
         self.assertEqual(state["loss_since"], first_tick)
 
-        clean_tick = first_tick + 60
-        rt.watcher_probe = self._loss_corroboration_probe(clean_tick)
-        tick_coverage(
-            rt,
-            TICK_CHANNEL,
-            state,
-            clean_tick,
-            CoverageTranscriptProbe(growing=True, blocks=723, lost=0),
-        )
+        # #4961 B1: a single clean tick must NOT release the dwell — `lost`
+        # legitimately returns to 0 while earlier blocks stay dropped. Only a
+        # sustained healthy run clears it.
+        for i in range(relay_watchdog.COVERAGE_LOSS_RECOVERY_TICKS):
+            clean_tick = first_tick + 60 * (i + 1)
+            rt.watcher_probe = self._loss_corroboration_probe(clean_tick)
+            tick_coverage(
+                rt,
+                TICK_CHANNEL,
+                state,
+                clean_tick,
+                CoverageTranscriptProbe(growing=True, blocks=723, lost=0),
+            )
         self.assertNotIn("loss_since", state)
 
         # A later loss restarts the dwell from zero: without the clear this
@@ -3051,6 +3055,84 @@ class TickChannelTests(unittest.TestCase):
 
         self.assertEqual(rt.alerts, [])
         self.assertEqual(state["loss_since"], relapse_tick)
+
+    def _run_loss_tick(self, rt, state, tick_at, lost, blocks=723):
+        self.arm_coverage(rt, self._loss_corroboration_probe(tick_at))
+        tick_coverage(
+            rt,
+            TICK_CHANNEL,
+            state,
+            tick_at,
+            CoverageTranscriptProbe(growing=True, blocks=blocks, lost=lost),
+        )
+
+    def test_oscillating_loss_still_reaches_sustained_threshold(self):
+        # #4961 B1: chronic partial loss oscillates lost>0 -> 0 -> lost>0 because
+        # `evaluate()` drops permanently-lost blocks below the advancing
+        # delivered_ts watermark. If a single clean tick reset the dwell this
+        # channel would starve the threshold forever and never alarm.
+        rt = self.make_rt()
+        start = self.now + 600
+        state = {
+            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+            "coverage_desync_since": self.now,
+        }
+        poll = rt.cfg.poll_secs
+        # Alternate lost=1 / lost=0 (starting and ending on loss) well past
+        # gap_alert_secs of wall clock.
+        ticks = (rt.cfg.gap_alert_secs // poll) * 2 + 5
+        for i in range(ticks):
+            self._run_loss_tick(rt, state, start + poll * i, lost=1 - i % 2)
+
+        # The dwell survived every clean tick, so it still dates to the first
+        # loss and the elapsed wall clock clears the threshold.
+        self.assertEqual(state["loss_since"], start)
+        self.assertGreater(
+            start + poll * (ticks - 1) - state["loss_since"],
+            rt.cfg.gap_alert_secs,
+        )
+        self.assertTrue(rt.alerts)
+        self.assertIn("attached_but_desynced", rt.alerts[0][0])
+
+    def test_unobserved_zero_block_tick_preserves_loss_dwell(self):
+        # #4961 B2: blocks==0 carries no evidence — it is the same unobserved
+        # state as a missing probe, not proof of recovery.
+        rt = self.make_rt()
+        first_tick = self.now + 600
+        state = {
+            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+            "coverage_desync_since": self.now,
+        }
+        self._run_loss_tick(rt, state, first_tick, lost=1)
+        self.assertEqual(state["loss_since"], first_tick)
+
+        for i in range(relay_watchdog.COVERAGE_LOSS_RECOVERY_TICKS + 2):
+            self._run_loss_tick(
+                rt, state, first_tick + 60 * (i + 1), lost=0, blocks=0
+            )
+
+        self.assertEqual(state["loss_since"], first_tick)
+        self.assertNotIn("loss_clear_ticks", state)
+
+    def test_sustained_recovery_clears_dwell_only_at_full_streak(self):
+        # Pairs with B1: hysteresis must not pin a recovered channel in alarm.
+        rt = self.make_rt()
+        first_tick = self.now + 600
+        state = {
+            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+            "coverage_desync_since": self.now,
+        }
+        self._run_loss_tick(rt, state, first_tick, lost=1)
+
+        streak = relay_watchdog.COVERAGE_LOSS_RECOVERY_TICKS
+        for i in range(streak - 1):
+            self._run_loss_tick(rt, state, first_tick + 60 * (i + 1), lost=0)
+            self.assertEqual(state["loss_since"], first_tick)
+            self.assertEqual(state["loss_clear_ticks"], i + 1)
+
+        self._run_loss_tick(rt, state, first_tick + 60 * streak, lost=0)
+        self.assertNotIn("loss_since", state)
+        self.assertNotIn("loss_clear_ticks", state)
 
     def test_growth_with_stale_relay_and_advanced_inflight_update_is_suppressed(self):
         rt = self.make_rt()

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -3134,6 +3134,37 @@ class TickChannelTests(unittest.TestCase):
         self.assertNotIn("loss_since", state)
         self.assertNotIn("loss_clear_ticks", state)
 
+    def test_realistic_recovery_releases_dwell_within_five_clean_ticks(self):
+        # #4961 upper bound. The other clear-path tests derive their loop count
+        # from COVERAGE_LOSS_RECOVERY_TICKS, so they can never fail no matter how
+        # large it grows — and a large value resurrects the very false positive
+        # this PR removes (an isolated lost=1 tick alarming because the dwell was
+        # never released). The 5 below is therefore a deliberate literal, NOT
+        # derived from the constant: raising the constant past 5 must fail here.
+        # Together with test_oscillating_loss_still_reaches_sustained_threshold
+        # (which pins the lower bound at >= 2) this fixes 2 <= CONST <= 5.
+        rt = self.make_rt()
+        first_tick = self.now + 600
+        state = {
+            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+            "coverage_desync_since": self.now,
+        }
+        self._run_loss_tick(rt, state, first_tick, lost=1)
+        self.assertEqual(state["loss_since"], first_tick)
+
+        for i in range(5):
+            self._run_loss_tick(rt, state, first_tick + 60 * (i + 1), lost=0)
+        self.assertNotIn("loss_since", state)
+
+        # #4961 issue body, ticks=4 gap=799s: an isolated lost=1 whose
+        # neighbours both read lost=0 must not alarm even long after the
+        # original loss, because a real recovery restarted the dwell.
+        relapse_tick = first_tick + rt.cfg.gap_alert_secs + 600
+        self._run_loss_tick(rt, state, relapse_tick, lost=1)
+
+        self.assertEqual(state["loss_since"], relapse_tick)
+        self.assertEqual(rt.alerts, [])
+
     def test_growth_with_stale_relay_and_advanced_inflight_update_is_suppressed(self):
         rt = self.make_rt()
         tick_at = self.now + 600

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -2931,6 +2931,9 @@ class TickChannelTests(unittest.TestCase):
         state = {
             "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
             "coverage_desync_since": self.now,
+            # #4961: loss corroborates only once it has persisted for
+            # gap_alert_secs, so this fixture carries a sustained timer.
+            "loss_since": tick_at - rt.cfg.gap_alert_secs,
         }
 
         tick_coverage(
@@ -2943,6 +2946,111 @@ class TickChannelTests(unittest.TestCase):
 
         self.assertEqual(len(rt.alerts), 1)
         self.assertIn("attached_but_desynced", rt.alerts[0][0])
+
+    def _loss_corroboration_probe(self, tick_at):
+        return self.active_foreground_probe(
+            queue_depth=1,
+            last_outbound_activity_ms=None,
+            last_relay_ts_ms=int(tick_at * 1000) - 1,
+        )
+
+    def test_first_transcript_loss_tick_records_timer_without_alarm(self):
+        # #4961 regression: two real false positives (ticks=83 gap=678s and
+        # ticks=4 gap=799s, same channel) fired off a single lost>0 tick whose
+        # neighbours both reported lost=0 — relay batching, not a dead relay.
+        rt = self.make_rt()
+        tick_at = self.now + 600
+        self.arm_coverage(rt, self._loss_corroboration_probe(tick_at))
+        state = {
+            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+            "coverage_desync_since": self.now,
+        }
+
+        tick_coverage(
+            rt,
+            TICK_CHANNEL,
+            state,
+            tick_at,
+            CoverageTranscriptProbe(growing=True, blocks=723, lost=1),
+        )
+
+        self.assertEqual(rt.alerts, [])
+        self.assertNotIn("last_coverage_alert", state)
+        self.assertEqual(state["loss_since"], tick_at)
+        self.assertTrue(
+            any(
+                "transcript loss not yet sustained" in line
+                and "duration=0s" in line
+                and "lost=1" in line
+                for line in rt.log_lines
+            )
+        )
+
+    def test_sustained_transcript_loss_corroborates_desync_coverage_alarm(self):
+        rt = self.make_rt()
+        tick_at = self.now + 600
+        self.arm_coverage(rt, self._loss_corroboration_probe(tick_at))
+        state = {
+            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+            "coverage_desync_since": self.now,
+            "loss_since": tick_at - rt.cfg.gap_alert_secs,
+        }
+
+        tick_coverage(
+            rt,
+            TICK_CHANNEL,
+            state,
+            tick_at,
+            CoverageTranscriptProbe(growing=True, blocks=723, lost=1),
+        )
+
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("attached_but_desynced", rt.alerts[0][0])
+        self.assertEqual(state["loss_since"], tick_at - rt.cfg.gap_alert_secs)
+
+    def test_clean_tick_clears_loss_timer_and_restarts_dwell(self):
+        rt = self.make_rt()
+        first_tick = self.now + 600
+        self.arm_coverage(rt, self._loss_corroboration_probe(first_tick))
+        state = {
+            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+            "coverage_desync_since": self.now,
+        }
+
+        tick_coverage(
+            rt,
+            TICK_CHANNEL,
+            state,
+            first_tick,
+            CoverageTranscriptProbe(growing=True, blocks=723, lost=1),
+        )
+        self.assertEqual(state["loss_since"], first_tick)
+
+        clean_tick = first_tick + 60
+        rt.watcher_probe = self._loss_corroboration_probe(clean_tick)
+        tick_coverage(
+            rt,
+            TICK_CHANNEL,
+            state,
+            clean_tick,
+            CoverageTranscriptProbe(growing=True, blocks=723, lost=0),
+        )
+        self.assertNotIn("loss_since", state)
+
+        # A later loss restarts the dwell from zero: without the clear this
+        # tick would already be gap_alert_secs old and would alarm.
+        relapse_tick = first_tick + rt.cfg.gap_alert_secs + 60
+        rt.watcher_probe = self._loss_corroboration_probe(relapse_tick)
+        tick_coverage(
+            rt,
+            TICK_CHANNEL,
+            state,
+            relapse_tick,
+            CoverageTranscriptProbe(growing=True, blocks=723, lost=1),
+        )
+
+        self.assertEqual(rt.alerts, [])
+        self.assertEqual(state["loss_since"], relapse_tick)
 
     def test_growth_with_stale_relay_and_advanced_inflight_update_is_suppressed(self):
         rt = self.make_rt()


### PR DESCRIPTION
## 문제

`tick_coverage`의 `attached_but_desynced` 알람은 코로보레이션(corroboration)이 있어야 발화한다. 그런데 코로보레이터 중 하나인 `transcript_loss_active`가 **배칭 허용치 없이** 단일 tick의 `lost > 0`만으로 참이 됐다.

```python
transcript_loss_active = bool(
    transcript_probe is not None and transcript_probe.lost > 0
)
```

형제 알람인 delivery gap은 같은 증거에 대해 `gap_alert_secs = 900`s의 지속(dwell)을 요구한다(`evaluate()`: `lost and gap_secs > gap_alert_secs`). 릴레이는 정상 동작 중에도 배칭되므로 순간적인 `lost>0`은 흔하고, 이쪽만 임계가 없어 오탐이 났다.

## 실측 오탐 2건 (같은 날, 같은 채널)

| tick | gap | 인접 tick |
|---|---|---|
| `ticks=83` | 678s | `lost=0` |
| `ticks=4` | 799s | `lost=0` |

두 건 모두 gap이 900s 미만이라 `STATE_LAGGING`이었고, 알람 본문 자체가 "relay batching, not down"이라고 적고 있었다. 인접 tick에서 `lost=0`이 관측됐다 — 배칭이었다.

## 반드시 살아있어야 하는 진성 반례

같은 날, 프론티어가 `17651229`에 고정된 채 `unread_bytes`가 1.46MB → 1.68MB로 증가하고 `redrive_no_progress_capped`가 **동일 offset에서 두 번** 찍힌 사건. 이건 계속 알람이 떠야 한다.

이 케이스는 손실이 지속되므로 900s dwell을 통과해 계속 발화한다. 더불어 `gap_secs > gap_alert_secs`이므로 `STATE_GAP` → `gap_since`가 세팅되어 **독립 코로보레이터로도 이중 보호**된다. 이 PR로 죽지 않는다.

## 수정

손실이 `gap_alert_secs` 이상 **지속**될 때만 코로보레이션으로 인정한다.

- `chs`에 `loss_since` 키를 추가했다. 기존 `gap_since`와 대칭 — 같은 채널 상태 dict의 평범한 키, `now` 저장, 최초 1회 세팅, `pop`으로 클리어. 새 상수·새 저장 방식은 도입하지 않았고 임계는 기존 `cfg.gap_alert_secs`를 재사용했다.
- `lost == 0`이 관측되면 즉시 클리어한다(배칭 해소). 타이머 유지 로직은 **모든 verdict 분기의 early-return보다 앞**에 둬서, coverage가 covered인 tick에서 `lost=0`이 나와도 타이머가 정상적으로 비워지도록 했다.
- 임계 미달은 조용히 넘기지 않고 기존 "not alarming" 로그와 같은 형식으로 `duration=` / `lost=`를 남긴다.

읽기는 `coverage_desync_since`가 같은 함수에서 쓰는 `_is_finite_nonnegative_number` 검증을 따라, 영속화된 state에 깨진 값이 있어도 self-heal 되게 했다.

## 테스트

`tests/test_relay_watchdog.py`에 3케이스 추가:

1. `lost=1` 최초 관측 → 알람 없음, `loss_since` 기록, `duration=0s lost=1` 로그
2. `lost=1`이 900s 지속 → 알람 발화
3. `lost=1` → `lost=0` → 타이머 클리어 → 재발 시 dwell이 처음부터 재시작(원래대로면 이미 900s 경과했을 시점에도 발화 안 함)

기존 `test_growth_with_loss_still_alerts_desync_coverage`는 단일 tick `lost=1` 발화(= 제거 대상 동작)를 인코딩하고 있었다. 단언은 그대로 두고(여전히 알람 1건 발화를 요구) 픽스처에만 지속된 `loss_since`를 넣어 새 전제를 반영했다.

**비공허성 증명:** `loss_for >= rt.cfg.gap_alert_secs` 조건을 임시 무력화하니 케이스 1·3이 실패했고(`AssertionError: Lists differ: [...커버리지 불변식 위반...] != []`), 복원 후 279 tests OK.

## 검증

- `python3 -m unittest tests.test_relay_watchdog` → **Ran 279 tests, OK**
- `python3 -m py_compile scripts/relay_watchdog.py` → ok
- `TEST_LANE_BASELINE_REF=origin/main bash scripts/ci-script-checks.sh` → **RC=0**

프로덕션 변경은 `scripts/relay_watchdog.py` +36/-1.
