### PR TITLE
fix(#4953): subscribe before A's release in local-model queue wake E2E

### DIFF
--- a/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
+++ b/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
@@ -467,6 +467,13 @@ async fn local_model_observation_wakes_idle_durable_queue_through_production_wor
     );
     assert_eq!(durable_b[0].message_id, MessageId::new(B_MESSAGE_ID));
 
+    // Subscribe before the release that makes A's placeholder-failure recovery publish its
+    // completion event. `broadcast` only buffers sends that happen after a receiver exists, so
+    // subscribing later left the negative assertion below racing A's normal `QueueEligible`
+    // publish instead of observing the local-only halves.
+    let mut completion_rx =
+        super::super::turn_completion_events::subscribe_turn_completion_events(&shared);
+
     state.release_first_placeholder.notify_waiters();
     assert!(
         wait_until(std::time::Duration::from_secs(1), {
@@ -487,6 +494,14 @@ async fn local_model_observation_wakes_idle_durable_queue_through_production_wor
         .await,
         "production placeholder-failure recovery must leave idle durable B behind an armed normal worker"
     );
+
+    // Drain A's release event explicitly so the local-only assertion below observes only the
+    // `/model` halves rather than whatever A left buffered.
+    let a_release = tokio::time::timeout(std::time::Duration::from_secs(2), completion_rx.recv())
+        .await
+        .expect("A placeholder-failure release must publish one completion event")
+        .expect("completion bus open");
+    assert_eq!(a_release.channel_id, channel_id);
 
     let before_model = mailbox_snapshot(&shared, channel_id).await;
     assert!(before_model.active_user_message_id.is_none());
@@ -513,8 +528,6 @@ async fn local_model_observation_wakes_idle_durable_queue_through_production_wor
         .insert(channel_id, test_watcher_handle(tmux, &transcript_path));
     super::spawn_tui_prompt_relay(shared.clone(), ProviderKind::Claude);
 
-    let mut completion_rx =
-        super::super::turn_completion_events::subscribe_turn_completion_events(&shared);
     let command_half = "<command-message>x</command-message>\n<command-name>/model</command-name>";
     let stdout_half = "<local-command-stdout>Set model to Fable 5</local-command-stdout>";
     assert_eq!(


### PR DESCRIPTION
## 문제

`Full tests (ubuntu-latest)` 레인에서 아래 테스트가 **3커밋 연속 결정론적으로** 실패했다 (`f02e9f7cc` / `6b47cd11a` / `eb519cbfd`).

```
services::discord::tui_prompt_relay::local_model_queue_wake_e2e::local_model_observation_wakes_idle_durable_queue_through_production_workers
panic: local-only halves must not publish completion events
```

## 근인

이 테스트에서 completion 이벤트를 발행하는 런타임 지점은 실행당 **정확히 1개**다:

```
handle_text_message
  -> release_mailbox_after_placeholder_post_failure
    -> mailbox_finish_turn
      -> publish_mailbox_release_completion_event
        -> publish_turn_completion_event
```

즉 A의 placeholder POST가 500을 받고 복구되면서 쏘는 **정상 `QueueEligible` 이벤트**이며, 로컬 `/model` 반쪽과는 아무 상관이 없다.

`tokio::sync::broadcast`는 **subscribe 이후에 발행된 것만** 버퍼링한다. `publish_turn_completion_event`는 수신자가 0명이면 `Err(_no_receivers)` 분기로 빠져 이벤트를 그냥 버린다. 그래서 negative assert는 A의 publish가 테스트의 `subscribe_turn_completion_events()`보다 **우연히 먼저** 일어나 버려지는 데 기대고 있었다. macOS 실측 마진은 **1~5ms**. 부하를 걸면 같은 구간이 0ms → **913ms**로 벌어지는 게 실측됐고, 느린 ubuntu 러너에서 publish가 subscribe 뒤로 밀리면 이벤트가 버퍼에 남아 negative assert가 폭발한다. 방향이 CI red와 정확히 일치한다.

## 이 단언은 지금까지 틀린 이유로 통과해왔다

로컬 전용 가드(`tui_prompt_relay.rs:340` `local_only_control` 분기)는 **정상 동작한다**. 로컬 반쪽 경로에는 publish가 애초에 존재하지 않는다. 즉 이 단언은 "로컬 반쪽이 이벤트를 안 쏜다"를 검증한 적이 없고, **무관한 A의 이벤트가 레이스로 버려지는 것**에 기대어 통과해왔다. 잡아내려던 회귀를 잡을 수 없는 상태였다.

## 수정

1. `subscribe_turn_completion_events()` 호출을 `state.release_first_placeholder.notify_waiters();` **직전으로 이동**. A의 release publish는 반드시 이 notify 이후이므로, subscribe가 publish를 앞서는 것이 **구조적으로 보장**된다.
2. `wait_until` 직후 A의 이벤트를 **명시적으로 1건 소비**한다.

이러면 레이스가 "가정"에서 "동기화 지점"으로 승격되고, 마지막 negative assert는 **로컬 반쪽 구간만** 관측하게 되어 의미가 정확해진다. 또한 A가 2건 이상 쏘면 잔여분이 버퍼에 남아 마지막 assert가 터지므로, "정확히 1건"이 계속 강제된다.

## 영향

- **프로덕션 0줄.** 변경 파일은 `#[cfg(all(test, unix))]`로 게이팅된 테스트 모듈 하나뿐이다.
- 이 수정은 `just test-non-pg` 93행 레인을 풀어준다. 레인은 첫 실패 줄에서 멈추는 마스킹 구조라, **그 뒤 레인들이 이번에 처음으로 노출**된다. 후속 레인에서 새로운 red가 드러날 수 있으며 그건 이 PR이 만든 회귀가 아니라 가려져 있던 것이다.

## 검증

- 해당 레인 **25회 반복 → 0 failure** (모든 로그에서 `1 passed; 0 failed` 확인, 공허 실행 아님)
- `cargo fmt --all --check` RC=0
- `check_agent_maintenance_docs.py --warning-only --line-count-gate` → `agent-maintenance freshness check passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)