### PR TITLE
fix(#4974): let identity-less inflight rows be demoted

### DIFF
--- a/src/services/discord/destructive_cancel_gate.rs
+++ b/src/services/discord/destructive_cancel_gate.rs
@@ -56,6 +56,10 @@ pub(in crate::services::discord) struct DestructiveCancelProbeSnapshot {
     pub output_path: Option<String>,
     pub output_len: Option<u64>,
     pub relay_frontier: Option<u64>,
+    /// `0` is the codebase-wide "no turn identity" sentinel (see
+    /// `delivery_lease_key`, `abandon_request_store`). A row carrying it owns no
+    /// user turn, so it cannot own an undelivered user-visible response.
+    pub user_msg_id: u64,
 }
 
 impl DestructiveCancelProbeSnapshot {
@@ -97,6 +101,7 @@ impl DestructiveCancelProbeSnapshot {
             output_path,
             output_len,
             relay_frontier,
+            user_msg_id: state.user_msg_id,
         }
     }
 }
@@ -135,6 +140,14 @@ pub(in crate::services::discord) fn terminal_envelope_present(
     snapshot.output_path.as_deref().is_some_and(|path| {
         crate::services::tui_turn_state::jsonl_turn_end_terminator_idle(provider, Path::new(path))
     })
+}
+
+/// A row with no turn identity that has never relayed a frame owns nothing a
+/// destructive demotion could lose. Both halves are required: `user_msg_id == 0`
+/// alone can be a creation-time race, and a non-`None` relay frontier means the
+/// row did put bytes on the wire.
+fn identityless_row_owns_no_response(snapshot: &DestructiveCancelProbeSnapshot) -> bool {
+    snapshot.user_msg_id == 0 && snapshot.relay_frontier.is_none()
 }
 
 fn fresh_watcher_heartbeat_should_block(
@@ -213,6 +226,16 @@ pub(in crate::services::discord) async fn evaluate(
 ) -> DestructiveCancelGate {
     if snapshot.pin.finalizer_turn_id == 0 {
         return DestructiveCancelGate::Denied("missing_finalizer_turn_id");
+    }
+
+    // An ownership-only row carries no turn identity and has never relayed a
+    // frame, so demoting it cannot drop user-visible output. The capture
+    // evidence consulted below is drawn from the *shared* tmux session, which
+    // keeps advancing because the next turn is running; attributing that
+    // liveness to this row makes it immortal and livelocks every subsequent
+    // synthetic start.
+    if identityless_row_owns_no_response(snapshot) {
+        return DestructiveCancelGate::Allowed("identityless_row_never_relayed");
     }
 
     // Fresh watcher heartbeat wins before terminal-envelope evidence. A live
@@ -376,6 +399,48 @@ mod tests {
         body.push('\n');
         std::fs::write(path, body).expect("write jsonl");
         std::fs::metadata(path).expect("jsonl metadata").len()
+    }
+
+    fn probe_snapshot(
+        user_msg_id: u64,
+        relay_frontier: Option<u64>,
+    ) -> DestructiveCancelProbeSnapshot {
+        DestructiveCancelProbeSnapshot {
+            pin: DestructiveCancelIdentityPin {
+                finalizer_turn_id: 4242,
+                mailbox_active_user_msg_id: None,
+                tmux_session_name: Some("AgentDesk-claude-test".to_string()),
+            },
+            updated_at: "2026-07-29 16:57:51".to_string(),
+            save_generation: 7,
+            output_path: None,
+            output_len: None,
+            relay_frontier,
+            user_msg_id,
+        }
+    }
+
+    #[test]
+    fn identityless_row_that_never_relayed_is_demotable() {
+        // The livelock shape: an ownership-only row froze with no turn identity
+        // and no relayed frame, while the shared tmux session kept advancing for
+        // the next turn. Capture-progress evidence must not protect it.
+        assert!(identityless_row_owns_no_response(&probe_snapshot(0, None)));
+    }
+
+    #[test]
+    fn row_with_turn_identity_or_relayed_bytes_is_protected() {
+        // A real turn is never demotable on this path...
+        assert!(!identityless_row_owns_no_response(&probe_snapshot(
+            1531926242671071404,
+            None
+        )));
+        // ...nor is an identity-less row that already put bytes on the wire,
+        // which guards the creation-time race where the identity is not yet set.
+        assert!(!identityless_row_owns_no_response(&probe_snapshot(
+            0,
+            Some(934_552)
+        )));
     }
 
     #[test]


### PR DESCRIPTION
이슈: 릴레이 전면 정지(#4974)

## 문제

`user_msg_id == 0`(codebase-wide "no turn identity" 센티널)인 인플라이트 행이 **영구히 demote 불가**였다. `destructive_cancel_gate`가 매번 `fresh_watcher_heartbeat`로 거부했기 때문.

그 거부 근거인 capture evidence(`output_len` 증가)는 **공유 tmux 세션의 트랜스크립트**에서 나온다. 다음 턴이 돌고 있으면 계속 증가한다. 그 liveness를 얼어붙은 특정 행에 귀속하면 행이 불사화되고, 이후 모든 `tui_direct_pending_start`가 synthetic turn-start를 ABORT해 Discord에 프로즈가 한 줄도 도달하지 않는다.

실측(채널 `1479671298497183835`, 2026-07-29): 하루에 `.stuck-manual-*` 수동 개입 **3회**.

## 변경

- `DestructiveCancelProbeSnapshot`에 `user_msg_id` 추가 (`state.user_msg_id`에서 채움)
- `identityless_row_owns_no_response()`: `user_msg_id == 0 && relay_frontier.is_none()`
- `evaluate()`에서 `finalizer_turn_id == 0` 거부 직후 조기 `Allowed("identityless_row_never_relayed")`

**두 조건 모두 필요한 이유**: `user_msg_id == 0` 단독은 생성 시점 race일 수 있고, relay frontier가 있으면 실제로 바이트를 내보낸 행이라 잃을 출력이 있다.

## 불변식

demote가 허용되는 행은 (1) 사용자 턴 identity가 없고 (2) 프레임을 릴레이한 적이 없다 → 파괴적 demotion으로 잃을 사용자 가시 출력이 존재하지 않는다.

## 테스트 / 뮤테이션 증명

가드 본문을 `false`로 치환:
```
identityless_row_that_never_relayed_is_demotable ... FAILED
test result: FAILED. 8 passed; 1 failed
```
복원 시 `9 passed; 0 failed`. 컴파일 에러 사망이 아니라 **자기 assert로 실패**.

## 게이트

- `cargo fmt --check` rc=0
- `cargo check --lib` rc=0
- `cargo test --lib destructive_cancel_gate` 9 passed 0 failed
- `generate_inventory_docs.py` rc=0 → `check_agent_maintenance_docs.py` rc=0 (`freshness check passed`)

Closes #4974