### PR TITLE
fix(#4953): split phase_gate tests so the PG-only test leaves the non-PG lane

### DIFF
--- a/src/services/auto_queue/phase_gate.rs
+++ b/src/services/auto_queue/phase_gate.rs
@@ -601,10 +601,9 @@ async fn create_activate_dispatch_pg_inner(
 }
 
 #[cfg(test)]
-mod tests {
+mod pg_tests {
     use super::*;
     use crate::db::auto_queue::test_support::TestPostgresDb;
-    use crate::dispatch::sandbox_preflight_metadata_disables_external_side_effects;
 
     #[tokio::test]
     async fn cancelled_run_rejects_dispatch_attach() {
@@ -674,6 +673,11 @@ mod tests {
         pool.close().await;
         pg_db.drop().await;
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dispatch::sandbox_preflight_metadata_disables_external_side_effects;
 
     #[test]
     fn sandbox_preflight_metadata_disables_external_side_effects_only_when_safe() {


### PR DESCRIPTION
이슈: [ci-red] job::Full tests (ubuntu-latest) 실패(#4953)

**main이 red다.** run `30416708760` / `CI Main` / `Full tests (ubuntu-latest)`, head `2d60e626b`.

## 문제

```
test services::auto_queue::route::phase_gate::tests::cancelled_run_rejects_dispatch_attach ... FAILED
panicked at src/db/auto_queue/test_support.rs:23:10:
create postgres auto_queue test db: "admin connect postgres: pool timed out while waiting for an open connection"
```

`src/services/auto_queue/phase_gate.rs`의 `mod tests`에 테스트가 2개 섞여 있었다:
- `cancelled_run_rejects_dispatch_attach` — `TestPostgresDb::create()` 사용, **PG 필수**
- `sandbox_preflight_metadata_disables_external_side_effects_only_when_safe` — 순수

non-PG 레인은 `--skip _pg --skip pg_ --skip postgres`로 거르는데 모듈명이 `tests`라 PG 테스트가 안 걸러졌고, PG 서비스가 없는 ubuntu 레인에서 sqlx가 ConnectionRefused를 "서버 기동 중"으로 재시도하다 acquire_timeout에 걸려 PoolTimedOut으로 죽었다.

## 왜 `dd46cc807`이 못 잡았나

그 커밋은 같은 병을 `cancel_run.rs`에서만 고쳤다. `phase_gate.rs`는 남아 있었다. **#4953은 미해결 상태였다.**

## 왜 모듈 통째 rename이 아닌 분리인가

선례 `dd46cc807`이 확립한 대로 `scripts/check_test_lane_coverage.py`는 레인을 **모듈 경로**로 매칭하므로 함수명이 아니라 모듈명을 고쳐야 한다. 다만 `cancel_run.rs`와 달리 이 모듈에는 **순수 테스트도 있어서**, 통째로 `pg_tests`로 바꾸면 순수 테스트가 non-PG 레인에서 소실된다. 그래서 두 모듈로 분리했다.

- `mod pg_tests` — PG 필수 테스트 + `TestPostgresDb` import
- `mod tests` — 순수 테스트 + dispatch helper import만

## 실측 검증

`route.rs:50-51`이 `#[path = "phase_gate.rs"] mod phase_gate;`로 선언하므로 실제 경로는 `services::auto_queue::route::phase_gate`다. 빌드 산출물에서 확인:

```
services::auto_queue::route::phase_gate::pg_tests::cancelled_run_rejects_dispatch_attach: test
```

non-PG 레인 필터를 그대로 재현한 결과:

```
cargo test --lib auto_queue -- --skip _pg --skip pg_ --skip postgres   rc=0
PG 테스트가 non-PG 레인에 잡힌 횟수: 0
순수 테스트가 non-PG 레인에 잡힌 횟수: 1
test result: ok. 85 passed; 0 failed; 1 ignored
```

## 게이트

- `cargo fmt --check` rc=0
- `cargo check --lib --tests` rc=0
- non-PG 레인 재현 rc=0 (위)

CI workflow(`ci-main.yml`/`ci-pr.yml`/`ci-nightly.yml`/`ci-macos-trusted.yml`)와 `tests/test_fast_check_ci_wiring.py`에 `phase_gate`를 직접 지목하는 라인이 없어 wiring 갱신은 불필요하다.

Closes #4953