### PR TITLE
fix(#4974): admit zero-origin relay reattach identity

### DIFF
--- a/src/services/discord/destructive_cancel_gate.rs
+++ b/src/services/discord/destructive_cancel_gate.rs
@@ -396,13 +396,18 @@ mod tests {
         output_path: &std::path::Path,
         last_offset: u64,
     ) -> inflight::InflightTurnState {
+        let current_msg_id = if user_msg_id == 0 {
+            channel_id + 1
+        } else {
+            user_msg_id + 1
+        };
         let mut state = inflight::InflightTurnState::new(
             provider.clone(),
             channel_id,
             None,
             1,
             user_msg_id,
-            user_msg_id + 1,
+            current_msg_id,
             "gate fixture".to_string(),
             None,
             Some(tmux.to_string()),
@@ -456,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn busy_pane_reprobe_freeze_denies_destructive_cancel() {
+    fn growing_capture_for_zero_origin_busy_turn_denies_destructive_cancel() {
         let _lock = crate::config::shared_test_env_lock()
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
@@ -466,8 +471,9 @@ mod tests {
         current_thread_rt().block_on(async {
             let shared = super::super::make_shared_data_for_tests();
             let provider = ProviderKind::Claude;
-            let channel = ChannelId::new(4_035_010);
-            let output_path = root.path().join("busy.jsonl");
+            let channel = ChannelId::new(4_974_010);
+            let tmux = "tmux-4974-zero-origin-busy";
+            let output_path = root.path().join("zero-origin-busy.jsonl");
             let len = write_jsonl(
                 &output_path,
                 &[r#"{"type":"assistant","message":{"content":[{"type":"text","text":"tool still running"}]}}"#],
@@ -475,11 +481,61 @@ mod tests {
             let state = save_gate_state(
                 provider.clone(),
                 channel.get(),
-                4_035_110,
-                "tmux-4035-busy",
+                0,
+                tmux,
                 &output_path,
                 len,
             );
+            assert!(!state.rebind_origin);
+            shared
+                .tmux_watchers
+                .insert(channel, fresh_watcher_handle(tmux, &output_path));
+            let snapshot = DestructiveCancelProbeSnapshot::from_state(
+                &shared,
+                &state,
+                None,
+                channel,
+            );
+            std::fs::write(&output_path, vec![b'x'; usize::try_from(len + 1).unwrap()])
+                .expect("grow live capture");
+
+            let gate = evaluate(&shared, &provider, channel, channel, &snapshot).await;
+
+            assert_eq!(gate.denied_reason(), Some("fresh_watcher_heartbeat"));
+            assert!(
+                inflight::load_inflight_state(&provider, channel.get()).is_some(),
+                "a live zero-origin row with growing capture must be preserved"
+            );
+        });
+    }
+
+    #[test]
+    fn frozen_capture_for_zero_origin_busy_turn_still_denies_destructive_cancel() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let root = tempfile::TempDir::new().expect("runtime root");
+        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", root.path()) };
+        current_thread_rt().block_on(async {
+            let shared = super::super::make_shared_data_for_tests();
+            let provider = ProviderKind::Claude;
+            let channel = ChannelId::new(4_974_011);
+            let output_path = root.path().join("zero-origin-busy-frozen.jsonl");
+            let len = write_jsonl(
+                &output_path,
+                &[r#"{"type":"assistant","message":{"content":[{"type":"text","text":"tool still running"}]}}"#],
+            );
+            stale_mtime(&output_path);
+            let state = save_gate_state(
+                provider.clone(),
+                channel.get(),
+                0,
+                "tmux-4974-zero-origin-busy-frozen",
+                &output_path,
+                len,
+            );
+            assert!(!state.rebind_origin);
             let snapshot = DestructiveCancelProbeSnapshot::from_state(
                 &shared,
                 &state,
@@ -496,7 +552,7 @@ mod tests {
             );
             assert!(
                 inflight::load_inflight_state(&provider, channel.get()).is_some(),
-                "denied destructive gate must preserve the live row"
+                "denied destructive gate must preserve the live zero-origin row"
             );
         });
     }

--- a/src/services/discord/relay_recovery/tests/circuit_breaker_apply.rs
+++ b/src/services/discord/relay_recovery/tests/circuit_breaker_apply.rs
@@ -124,6 +124,121 @@ async fn durable_reattach_circuit_open_preserves_every_live_turn_authority() {
 
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn zero_originating_message_with_a_distinct_mailbox_anchor_reaches_reattach_apply() {
+    let _guard = auto_heal_test_lock().lock().await;
+    clear_auto_heal_attempts_for_tests();
+    let (_root_guard, root_dir) = isolated_agentdesk_root();
+    if !crate::services::platform::tmux::is_available() {
+        eprintln!("skipping #4974 zero-origin reattach: tmux unavailable");
+        return;
+    }
+    let provider = ProviderKind::Claude;
+    let (registry, shared) = registry_with_shared(provider.clone()).await;
+    registry
+        .register_http(
+            provider.as_str().to_string(),
+            Arc::new(poise::serenity_prelude::Http::new("Bot test-token")),
+        )
+        .await;
+    let channel = ChannelId::new(4_974_002);
+    let mailbox_message = MessageId::new(4_974_102);
+    let response_message = MessageId::new(4_974_202);
+    let tmux_session = format!("AgentDesk-claude-e2e4974-{}-cc", std::process::id());
+    let created = crate::services::platform::tmux::create_session(&tmux_session, None, "sleep 60")
+        .expect("create tmux session");
+    assert!(created.status.success());
+    crate::services::tmux_common::write_tmux_runtime_kind_marker(
+        &tmux_session,
+        crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui,
+    )
+    .expect("runtime marker");
+    let output_path = root_dir.path().join("relay-4974-zero-origin.jsonl");
+    std::fs::write(&output_path, vec![b'x'; 128]).expect("seed output");
+
+    let token = start_test_turn(&shared, channel, mailbox_message).await;
+    token.bind_claude_tmux_session(&tmux_session);
+    let mut state = super::super::super::inflight::InflightTurnState::new(
+        provider.clone(),
+        channel.get(),
+        Some("adk-claude".to_string()),
+        0,
+        0,
+        response_message.get(),
+        "zero-origin live turn".to_string(),
+        Some("provider-session-4974-zero-origin".to_string()),
+        Some(tmux_session.clone()),
+        Some(output_path.to_string_lossy().to_string()),
+        None,
+        0,
+    );
+    state.runtime_kind = Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui);
+    state.turn_nonce = Some("nonce-4974-zero-origin".to_string());
+    state.set_relay_owner_kind(super::super::super::inflight::RelayOwnerKind::Watcher);
+    super::super::super::inflight::save_inflight_state_create_new(&state).expect("seed inflight");
+    let (watcher, old_cancel) = test_watcher_handle(&tmux_session, &output_path);
+    watcher.last_heartbeat_ts_ms.store(1, Ordering::Release);
+    shared.tmux_watchers.insert(channel, watcher);
+
+    let snapshot = RelayHealthSnapshot {
+        provider: provider.as_str().to_string(),
+        channel_id: channel.get(),
+        active_turn: RelayActiveTurn::Foreground,
+        tmux_session: Some(tmux_session.clone()),
+        tmux_alive: Some(true),
+        watcher_attached: true,
+        watcher_owner_channel_id: Some(channel.get()),
+        watcher_owns_live_relay: true,
+        bridge_inflight_present: true,
+        bridge_current_msg_id: Some(response_message.get()),
+        mailbox_has_cancel_token: true,
+        mailbox_active_user_msg_id: Some(mailbox_message.get()),
+        mailbox_turn_started_at_ms: None,
+        last_capture_offset: Some(128),
+        last_relay_offset: 0,
+        unread_bytes: Some(128),
+        desynced: true,
+        ..snapshot()
+    };
+    let mut decision = plan_relay_recovery(
+        &snapshot,
+        RelayStallState::TmuxAliveRelayDead,
+        chrono::Utc::now().timestamp_millis(),
+    );
+    decision.affected.finalizer_turn_id = Some(state.effective_finalizer_turn_id());
+    let response = apply_relay_recovery_plan(
+        &registry,
+        &shared,
+        &provider,
+        decision,
+        chrono::Utc::now().timestamp_millis(),
+        RelayRecoveryApplySource::ProbeAutoHeal,
+    )
+    .await;
+
+    let _ = crate::services::platform::tmux::kill_session(
+        &tmux_session,
+        "#4974 zero-origin reattach test cleanup",
+    );
+    assert!(!response.skipped, "{response:?}");
+    assert_ne!(
+        response.decision.auto_heal.skipped_reason,
+        Some("durable_reattach_stale_identity")
+    );
+    assert!(response.applied, "{response:?}");
+    let apply = response.apply_result.expect("apply result");
+    assert_eq!(apply.reattach_watcher_spawned, Some(true));
+    assert_eq!(apply.reattach_watcher_replaced, Some(true));
+    assert!(old_cancel.load(Ordering::Relaxed));
+    assert!(!token.cancelled.load(Ordering::Relaxed));
+    let after =
+        super::super::super::inflight::load_inflight_state_read_only(&provider, channel.get())
+            .expect("zero-origin episode survives");
+    assert_eq!(after.user_msg_id, 0);
+    assert_eq!(after.turn_nonce, state.turn_nonce);
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn first_reserved_dead_frontier_apply_preserves_episode_and_reattaches_watcher() {
     let _guard = auto_heal_test_lock().lock().await;
     clear_auto_heal_attempts_for_tests();

--- a/src/services/discord/relay_recovery_auto_heal_apply.rs
+++ b/src/services/discord/relay_recovery_auto_heal_apply.rs
@@ -230,7 +230,7 @@ pub(super) async fn apply_relay_recovery_plan_with_seams(
     settle_auto_heal_confirmation(&mut apply_result, confirmation, &key, now_ms);
     let skipped = apply_result.status == "reattach_episode_changed";
     if skipped {
-        decision.auto_heal.skipped_reason = Some("durable_reattach_stale_identity");
+        decision.auto_heal.skipped_reason = Some("durable_reattach_confirmation_episode_changed");
     }
     decision.auto_heal.remaining_attempts =
         remaining_auto_heal_attempts(&key, now_ms, decision.auto_heal.max_attempts_per_window);
@@ -596,7 +596,7 @@ mod tests {
         assert!(response.skipped);
         assert_eq!(
             response.decision.auto_heal.skipped_reason,
-            Some("durable_reattach_stale_identity")
+            Some("durable_reattach_confirmation_episode_changed")
         );
         assert_eq!(
             serde_json::to_value(

--- a/src/services/discord/relay_recovery_circuit_breaker.rs
+++ b/src/services/discord/relay_recovery_circuit_breaker.rs
@@ -319,7 +319,8 @@ pub(super) fn reserve_current_episode(
         || decision.affected.provider != provider.as_str()
         || decision.affected.channel_id != decision.channel_id
         || decision.affected.finalizer_turn_id != Some(state.effective_finalizer_turn_id())
-        || decision.affected.mailbox_active_user_msg_id != Some(state.user_msg_id)
+        || (state.user_msg_id != 0
+            && decision.affected.mailbox_active_user_msg_id != Some(state.user_msg_id))
         || decision.affected.tmux_session != state.tmux_session_name
     {
         return CircuitReservation::StaleIdentity;
@@ -1078,6 +1079,83 @@ mod tests {
                 "each hidden provider episode axis must change the exact fingerprint"
             );
         }
+    }
+
+    #[test]
+    fn zero_originating_message_reserves_with_a_distinct_mailbox_anchor() {
+        let temp = tempfile::tempdir().expect("runtime root");
+        let _env = crate::config::set_agentdesk_root_for_test(temp.path());
+        let provider = ProviderKind::Codex;
+        let mut state = state(44_662);
+        state.user_msg_id = 0;
+        super::super::super::inflight::save_inflight_state(&state)
+            .expect("seed zero-origin inflight");
+        let mut decision = decision_for_state(&state);
+        decision.affected.mailbox_active_user_msg_id = Some(44_662_900);
+
+        assert!(matches!(
+            reserve_current_episode(&provider, &decision, 1),
+            CircuitReservation::Reserved { attempt: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn nonzero_originating_message_rejects_a_distinct_mailbox_anchor() {
+        let temp = tempfile::tempdir().expect("runtime root");
+        let _env = crate::config::set_agentdesk_root_for_test(temp.path());
+        let provider = ProviderKind::Codex;
+        let state = state(44_663);
+        super::super::super::inflight::save_inflight_state(&state).expect("seed inflight");
+        let mut decision = decision_for_state(&state);
+        decision.affected.mailbox_active_user_msg_id = Some(state.user_msg_id + 1);
+
+        assert_eq!(
+            reserve_current_episode(&provider, &decision, 1),
+            CircuitReservation::StaleIdentity
+        );
+    }
+
+    #[test]
+    fn nonzero_originating_message_reserves_with_the_same_mailbox_anchor() {
+        let temp = tempfile::tempdir().expect("runtime root");
+        let _env = crate::config::set_agentdesk_root_for_test(temp.path());
+        let provider = ProviderKind::Codex;
+        let state = state(44_664);
+        super::super::super::inflight::save_inflight_state(&state).expect("seed inflight");
+        let decision = decision_for_state(&state);
+
+        assert!(matches!(
+            reserve_current_episode(&provider, &decision, 1),
+            CircuitReservation::Reserved { attempt: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn zero_originating_message_still_rejects_episode_identity_mismatches() {
+        let temp = tempfile::tempdir().expect("runtime root");
+        let _env = crate::config::set_agentdesk_root_for_test(temp.path());
+        let mut old = state(44_665);
+        old.user_msg_id = 0;
+        let old_episode = RelayReattachEpisode::from_state(&old);
+
+        let mut replacement = old.clone();
+        replacement.session_id = Some("provider-session-zero-origin-replacement".to_string());
+        replacement.output_path = Some("/tmp/relay-zero-origin-replacement.jsonl".to_string());
+        replacement.turn_nonce = Some("nonce-zero-origin-replacement".to_string());
+        let replacement_episode = RelayReattachEpisode::from_state(&replacement);
+        super::super::super::inflight::save_inflight_state(&replacement)
+            .expect("install authoritative replacement inflight");
+
+        assert_eq!(
+            reserve_in_root(temp.path(), &old, &old_episode, 0, 1),
+            CircuitReservation::StaleIdentity,
+            "the authoritative re-read must reject the replaced episode"
+        );
+        assert_eq!(
+            reserve_in_root(temp.path(), &old, &replacement_episode, 0, 1),
+            CircuitReservation::StaleIdentity,
+            "the pre-lock snapshot must match the episode it is reserving"
+        );
     }
 
     #[test]


### PR DESCRIPTION
이슈: 릴레이 전면 정지(#4974)

## 근본 원인

`src/services/discord/relay_recovery_circuit_breaker.rs:322`가 **의미가 다른 두 값을 등호 비교**한다:
- 좌변 `decision.affected.mailbox_active_user_msg_id` = **메일박스**의 활성 앵커
- 우변 `state.user_msg_id` = **인플라이트 행**의 originating 메시지 id

`user_msg_id == 0` 턴 클래스(external_input / TUI-direct)에서는 **영구히 불일치**한다. 그래서 시스템이 `tmux_alive_relay_dead → reattach_watcher`를 **올바르게 결정하고 `apply_requested=true`까지 가고도 자동치유가 한 번도 적용되지 못한다.** 릴레이는 데드로 남는다.

증상 3종(프로즈 미도달 / 앵커 `...` 정지 / 새 턴 ABORT)이 **전부 이 하나에서 파생**된다. 2026-07-29 채널 `1479671298497183835`에서 `.stuck-manual-*` 수동 개입 3회가 필요했고, 매번 몇 분 만에 재발한 이유가 이것이다 — 자동치유가 죽어 있었다.

## 앞선 두 시도가 왜 틀렸나 (PR #4976, CLOSED)

1차 시도는 `destructive_cancel_gate`를 완화하려 했고 독립 리뷰 2건이 P0 반려했다. 그 리뷰어들이 수렴한 재설계 방향("캡처 성장의 오귀속만 좁히기")도 **라이브 프로덕션 관측으로 반증**됐다:

고착 행의 capture 성장은 오귀속이 아니라 **그 행 본인 턴의 것**이었다. 트랜스크립트가 행의 `turn_start_offset`을 **1.25MB 넘겨 34초 전에도** 쓰이는 동안 행은 **34분째 동결**이었고 tmux 세션은 살아 있었다.

→ `fresh_watcher_heartbeat` 거부는 **정확한 판단**이다. 완화하면 살아있는 턴을 죽인다. **`destructive_cancel_gate`는 애초에 손댈 곳이 아니었다.**

## 변경

### 프로덕션 (2파일)

`relay_recovery_circuit_breaker.rs:322` — 메일박스 앵커 일치를 `state.user_msg_id != 0`일 때만 요구.
provider / channel / finalizer / tmux 검사와 **pre-lock + flock 아래 authoritative episode identity 재조회는 그대로 유지**한다.

`relay_recovery_auto_heal_apply.rs` — `skipped_reason` 분리. 예약 단계 실패는 `durable_reattach_stale_identity`, 예약 후 confirmation 단계 episode 변경은 `durable_reattach_confirmation_episode_changed`. 같은 문자열이 두 곳에서 생성되던 진단 함정을 제거한다.

### 테스트 (2파일)

`destructive_cancel_gate.rs`는 **`#[cfg(test)]` 모듈만** 변경했다. 프로덕션 로직 무접촉.

## 불변식

> 재부착 에피소드는 행의 reattach identity가 (pre-lock + flock 아래 authoritative 재조회 **양쪽**에서) 불변인 한 예약 가능하며, **메일박스 앵커 일치는 그 행이 실제 Discord 발신 메시지를 보유한 경우에만** 요구된다.

이 수정은 파괴적 동작이 아니라 **릴레이 재부착 허용**이다. 따라서 PR #4976을 반려시킨 반증 1~4(전부 "라이브 턴을 죽이면 안 된다")가 구조적으로 적용되지 않는다.

## 테스트

**예약 술어**
- `zero_originating_message_reserves_with_a_distinct_mailbox_anchor` — 사고 형태가 예약됨
- `nonzero_originating_message_rejects_a_distinct_mailbox_anchor` — 기존 계약 유지
- `nonzero_originating_message_reserves_with_the_same_mailbox_anchor`
- `zero_originating_message_still_rejects_episode_identity_mismatches` — zero-origin이어도 episode 불일치는 거부

**apply 통합**
- `zero_originating_message_with_a_distinct_mailbox_anchor_reaches_reattach_apply` — 실제 사고 형태(인플라이트 `user_msg_id=0` + 메일박스에 별도 실제 메시지 ID + `tmux_alive_relay_dead` + watcher-owned)가 `durable_reattach_stale_identity`로 스킵되지 않고 **실제 watcher reattach까지 도달**하는지 고정

**회귀 잠금 — 미래의 #4976 재시도를 자동 실패시킴**
- `growing_capture_for_zero_origin_busy_turn_denies_destructive_cancel`
- `frozen_capture_for_zero_origin_busy_turn_still_denies_destructive_cancel`

## 뮤테이션 증명 (실행 로그)

```
MUTANT 1: user_msg_id != 0 가드 제거
  zero_originating_message_reserves_with_a_distinct_mailbox_anchor ... FAILED
  zero_originating_message_with_a_distinct_mailbox_anchor_reaches_reattach_apply ... FAILED
  test result: FAILED. 75 passed; 3 failed

MUTANT 2: 메일박스 비교 논리곱 전체 삭제
  nonzero_originating_message_rejects_a_distinct_mailbox_anchor ... FAILED
  test result: FAILED. 76 passed; 2 failed

복원: test result: ok. 78 passed; 0 failed
```

각 뮤턴트가 **예측한 테스트를 정확히** 죽였고 컴파일 에러 사망이 아니라 자기 assert 실패다.
(양 뮤턴트에서 함께 실패한 `enqueue_default_off_leaves_all_circuit_columns_null_pg`는 로컬 PG 공유 상태 영향으로 보이며 복원 시 통과한다.)

## 게이트

- `cargo fmt --check` rc=0
- `cargo check --lib --tests` rc=0
- `cargo test --lib relay_recovery` rc=0 — **78 passed; 0 failed**
- `cargo test --lib destructive_cancel_gate` rc=0 — **8 passed; 0 failed**
- `generate_inventory_docs.py` rc=0 → `check_agent_maintenance_docs.py` rc=0 (`freshness check passed`)
- 신규 테스트가 빌드 산출물에 실재함을 `--list`로 교차확인

**#3016 핫파일 4종 무접촉** (`turn_bridge/mod.rs`, `tmux_watcher.rs`, `session_relay_sink.rs`, `turn_finalizer.rs`)

## 머지 전제조건

설계가 못박은 대로, "재부착이 실제로 릴레이를 되살리는가"는 **추론이지 증명이 아니다.** 머지 후 **라이브 검증 4단계**가 필수이며, 실패 시 워처 지속화 identity 가드로 스코프를 이전한다.

설계 전문: `scratchpad/design-4974-r2.md`

Closes #4974