### PR TITLE
fix(#4912): give background-complete notifications a real detail body

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -145,9 +145,11 @@ jobs:
               - 'src/services/scheduled_messages/**'
               - 'src/services/discord/outbound/source_registry.rs'
               # #4985: footer marker changes require the protected targeted lane.
-              - 'src/services/discord/task_notification_delivery/mod.rs'
-              - 'src/services/discord/task_notification_delivery/terminal_identity.rs'
-              - 'src/services/discord/task_notification_delivery/tests.rs'
+              # Glob rather than a file list: enumerating siblings silently drops
+              # newly extracted modules (footer_only_marker.rs was created by this
+              # PR and missed the list), which skips the lane for the very file
+              # the change lives in.
+              - 'src/services/discord/task_notification_delivery/**'
               - 'src/services/discord/tmux.rs'
               - 'src/services/discord/tmux_watcher/discrete_trigger_marker.rs'
               - 'src/services/discord/tui_prompt_relay/task_notification_prompt.rs'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -144,6 +144,13 @@ jobs:
               - 'src/services/scheduled_messages.rs'
               - 'src/services/scheduled_messages/**'
               - 'src/services/discord/outbound/source_registry.rs'
+              # #4985: footer marker changes require the protected targeted lane.
+              - 'src/services/discord/task_notification_delivery/mod.rs'
+              - 'src/services/discord/task_notification_delivery/terminal_identity.rs'
+              - 'src/services/discord/task_notification_delivery/tests.rs'
+              - 'src/services/discord/tmux.rs'
+              - 'src/services/discord/tmux_watcher/discrete_trigger_marker.rs'
+              - 'src/services/discord/tui_prompt_relay/task_notification_prompt.rs'
               - 'src/services/message_outbox.rs'
               - 'src/services/message_outbox_recovery.rs'
               - 'src/services/message_outbox_recovery_support.rs'
@@ -585,6 +592,17 @@ jobs:
           cache-bin: false
           shared-key: cargo-dependencies-v2
           save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Footer-only marker regressions
+        timeout-minutes: 10
+        shell: bash
+        env:
+          BASH_ENV: /dev/null
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
+        run: |
+          cargo test --lib task_notification -- --skip _pg --skip pg_ --skip postgres
+          cargo test --lib services::discord::tmux::tmux_watcher::discrete_trigger_marker::tests -- --skip _pg --skip pg_ --skip postgres
 
       - name: Trusted session forwarding tests
         timeout-minutes: 10

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -798,6 +798,7 @@ src/
 │   │   │   │   └── terminal_footer.rs
 │   │   │   ├── card_post.rs
 │   │   │   ├── card_render.rs
+│   │   │   ├── footer_only_marker.rs
 │   │   │   ├── gateway.rs
 │   │   │   ├── mod.rs
 │   │   │   ├── response_chunks.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -248,7 +248,7 @@
     output policy, recovery marker, and test clusters moved verbatim into
     sub-1000-LoC `watchers/lifecycle/*.rs` modules. The root remains the
     canonical facade and preserves all prior call paths through re-exports.
-  - `src/services/discord/tmux.rs` (frozen giant surface; #4895 removes untyped auth/overload terminal variants and authority-bearing outcome fields; parser diagnostics now use a fixed redacted category while generic error results remain `HardResult`; test-only #4277 re-exports
+  - `src/services/discord/tmux.rs` (frozen giant surface; current generated inventory: 1671 production LoC; #4895 removes untyped auth/overload terminal variants and authority-bearing outcome fields; parser diagnostics now use a fixed redacted category while generic error results remain `HardResult`; test-only #4277 re-exports
     the watcher delivery-lease key helper so session-sink production-entry tests
     prove bidirectional contention on the same idle JSONL range; -9 from the #4804
     Windows-compile hotfix moving `footer_background_marker_session_key` into

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -248,7 +248,7 @@
     output policy, recovery marker, and test clusters moved verbatim into
     sub-1000-LoC `watchers/lifecycle/*.rs` modules. The root remains the
     canonical facade and preserves all prior call paths through re-exports.
-  - `src/services/discord/tmux.rs` (frozen giant surface; current generated inventory: 1671 production LoC; #4895 removes untyped auth/overload terminal variants and authority-bearing outcome fields; parser diagnostics now use a fixed redacted category while generic error results remain `HardResult`; test-only #4277 re-exports
+  - `src/services/discord/tmux.rs` (frozen giant surface; current generated inventory: 1677 production LoC; #4895 removes untyped auth/overload terminal variants and authority-bearing outcome fields; parser diagnostics now use a fixed redacted category while generic error results remain `HardResult`; test-only #4277 re-exports
     the watcher delivery-lease key helper so session-sink production-entry tests
     prove bidirectional contention on the same idle JSONL range; -9 from the #4804
     Windows-compile hotfix moving `footer_background_marker_session_key` into

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -102,8 +102,18 @@ targets = {
     "runs_on" => "ubuntu-latest",
     # #5025 re-pins after adding the production bridge-epilogue routing test to
     # the existing toolchain-provisioned targeted lane whose mirror is required.
-    "job_sha256" => "561114d54ad205a9e65f82c5ce27c79b03069e26c94af0d35b515fe6fce3f082",
+    # #4985 keeps footer-marker regressions in that same branch-protected lane;
+    # both land in one job block, so the pin is recomputed for the merged content.
+    "job_sha256" => "6c60e700d0e2417135e76ae69e316fd79b94180fae74eebee672dc288e39fee5",
     "cargo_steps" => {
+      "Footer-only marker regressions" => {
+        "commands" => [
+          "cargo test --lib task_notification -- --skip _pg --skip pg_ --skip postgres",
+          "cargo test --lib services::discord::tmux::tmux_watcher::discrete_trigger_marker::tests -- --skip _pg --skip pg_ --skip postgres",
+        ],
+        "continue_on_error" => nil,
+        "timeout_minutes" => 10,
+      },
       "Trusted session forwarding tests" => {
         "commands" => ["env -u AGENTDESK_ROOT_DIR cargo test --lib services::session_forwarding -- --skip _pg --skip pg_ --skip postgres"],
         "continue_on_error" => nil,

--- a/src/services/discord/task_notification_delivery/footer_only_marker.rs
+++ b/src/services/discord/task_notification_delivery/footer_only_marker.rs
@@ -5,12 +5,6 @@ use super::{TaskCardEvent, TaskNotificationContext};
 const FOOTER_ONLY_MARKER_PREFIX: &str = "⚙️ Background complete";
 const FOOTER_ONLY_MARKER_DETAIL_LIMIT: usize = 600;
 
-impl TaskNotificationContext {
-    pub(in crate::services::discord) fn summary(&self) -> &str {
-        &self.summary
-    }
-}
-
 impl TaskCardEvent {
     pub(in crate::services::discord) fn footer_only_marker_content(&self) -> String {
         footer_only_background_marker_content(&self.payload.render(1))
@@ -24,7 +18,16 @@ pub(super) fn footer_only_background_marker_content(rendered_card: &str) -> Stri
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .filter(|line| !line.starts_with("-#"))
-        .filter(|line| !crate::services::provider_output_guard::contains_private_task_anchor(line))
+        .filter(|line| {
+            ![
+                "<task-notification>",
+                "<task-id>",
+                "<tool-use-id>",
+                "<output-file>",
+            ]
+            .iter()
+            .any(|anchor| line.contains(anchor))
+        })
         .collect::<Vec<_>>()
         .join("\n");
     if detail.is_empty() {

--- a/src/services/discord/task_notification_delivery/footer_only_marker.rs
+++ b/src/services/discord/task_notification_delivery/footer_only_marker.rs
@@ -1,0 +1,40 @@
+//! Footer-only background completion marker rendering.
+
+use super::{TaskCardEvent, TaskNotificationContext};
+
+const FOOTER_ONLY_MARKER_PREFIX: &str = "⚙️ Background complete";
+const FOOTER_ONLY_MARKER_DETAIL_LIMIT: usize = 600;
+
+impl TaskNotificationContext {
+    pub(in crate::services::discord) fn summary(&self) -> &str {
+        &self.summary
+    }
+}
+
+impl TaskCardEvent {
+    pub(in crate::services::discord) fn footer_only_marker_content(&self) -> String {
+        footer_only_background_marker_content(&self.payload.render(1))
+    }
+}
+
+/// Project the already-rendered footer card into a bounded lifecycle marker.
+pub(super) fn footer_only_background_marker_content(rendered_card: &str) -> String {
+    let detail = rendered_card
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .filter(|line| !line.starts_with("-#"))
+        .filter(|line| !crate::services::provider_output_guard::contains_private_task_anchor(line))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if detail.is_empty() {
+        return FOOTER_ONLY_MARKER_PREFIX.to_string();
+    }
+    let content = format!("{FOOTER_ONLY_MARKER_PREFIX}\n{detail}");
+    super::super::tui_task_card::clamp_discord_message_content(
+        &super::super::tui_task_card::truncate_chars_ascii(
+            &content,
+            FOOTER_ONLY_MARKER_DETAIL_LIMIT,
+        ),
+    )
+}

--- a/src/services/discord/task_notification_delivery/mod.rs
+++ b/src/services/discord/task_notification_delivery/mod.rs
@@ -6,6 +6,7 @@
 
 mod card_post;
 mod card_render;
+mod footer_only_marker;
 mod gateway;
 mod response_chunks;
 mod store;
@@ -307,10 +308,6 @@ impl TaskCardEvent {
 
     pub(super) fn event_key(&self) -> &str {
         &self.scope.event_key
-    }
-
-    pub(super) fn footer_only_marker_content(&self) -> String {
-        footer_only_background_marker_content(&self.payload.render(1))
     }
 
     pub(in crate::services::discord) fn with_persisted_event_key(
@@ -654,37 +651,6 @@ pub(super) enum CardEnsureError {
     Ambiguous(String),
     #[error("task card state error: {0}")]
     Store(String),
-}
-
-const FOOTER_ONLY_MARKER_PREFIX: &str = "⚙️ Background complete";
-const FOOTER_ONLY_MARKER_DETAIL_LIMIT: usize = 600;
-
-/// Project the already-rendered footer card into a bounded lifecycle marker.
-pub(super) fn footer_only_background_marker_content(rendered_card: &str) -> String {
-    let detail = rendered_card
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .filter(|line| !line.starts_with("-#"))
-        .filter(|line| {
-            ![
-                "<task-notification>",
-                "<task-id>",
-                "<tool-use-id>",
-                "<output-file>",
-            ]
-            .iter()
-            .any(|anchor| line.contains(anchor))
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    if detail.is_empty() {
-        return FOOTER_ONLY_MARKER_PREFIX.to_string();
-    }
-    let content = format!("{FOOTER_ONLY_MARKER_PREFIX}\n{detail}");
-    super::tui_task_card::clamp_discord_message_content(
-        &super::tui_task_card::truncate_chars_ascii(&content, FOOTER_ONLY_MARKER_DETAIL_LIMIT),
-    )
 }
 
 pub(super) async fn record_footer_only(

--- a/src/services/discord/task_notification_delivery/mod.rs
+++ b/src/services/discord/task_notification_delivery/mod.rs
@@ -132,8 +132,8 @@ impl TaskNotificationContext {
         &self.event_key
     }
 
-    pub(super) fn summary(&self) -> &str {
-        &self.summary
+    pub(super) fn summary(&self) -> Option<&str> {
+        (!self.summary.is_empty()).then_some(self.summary.as_str())
     }
 
     /// Mirrors the footer-only eligibility used by the card policy: background
@@ -666,7 +666,16 @@ pub(super) fn footer_only_background_marker_content(rendered_card: &str) -> Stri
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .filter(|line| !line.starts_with("-#"))
-        .filter(|line| !crate::services::provider_output_guard::contains_private_task_anchor(line))
+        .filter(|line| {
+            ![
+                "<task-notification>",
+                "<task-id>",
+                "<tool-use-id>",
+                "<output-file>",
+            ]
+            .iter()
+            .any(|anchor| line.contains(anchor))
+        })
         .collect::<Vec<_>>()
         .join("\n");
     if detail.is_empty() {

--- a/src/services/discord/task_notification_delivery/mod.rs
+++ b/src/services/discord/task_notification_delivery/mod.rs
@@ -146,11 +146,6 @@ impl TaskNotificationContext {
         .then_some(self.event_key())
     }
 
-    #[cfg(test)]
-    pub(super) fn footer_only_marker_event_key_for_test(&self) -> Option<&str> {
-        self.footer_only_marker_event_key()
-    }
-
     pub(super) fn to_event(
         &self,
         channel_id: u64,

--- a/src/services/discord/task_notification_delivery/mod.rs
+++ b/src/services/discord/task_notification_delivery/mod.rs
@@ -132,6 +132,10 @@ impl TaskNotificationContext {
         &self.event_key
     }
 
+    pub(super) fn summary(&self) -> &str {
+        &self.summary
+    }
+
     /// Mirrors the footer-only eligibility used by the card policy: background
     /// notifications need a stable task or tool identity to own a footer slot.
     /// All other terminal notifications remain card-owned.
@@ -303,6 +307,10 @@ impl TaskCardEvent {
 
     pub(super) fn event_key(&self) -> &str {
         &self.scope.event_key
+    }
+
+    pub(super) fn footer_only_marker_content(&self) -> String {
+        footer_only_background_marker_content(&self.payload.render(1))
     }
 
     pub(in crate::services::discord) fn with_persisted_event_key(
@@ -646,6 +654,28 @@ pub(super) enum CardEnsureError {
     Ambiguous(String),
     #[error("task card state error: {0}")]
     Store(String),
+}
+
+const FOOTER_ONLY_MARKER_PREFIX: &str = "⚙️ Background complete";
+const FOOTER_ONLY_MARKER_DETAIL_LIMIT: usize = 600;
+
+/// Project the already-rendered footer card into a bounded lifecycle marker.
+pub(super) fn footer_only_background_marker_content(rendered_card: &str) -> String {
+    let detail = rendered_card
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .filter(|line| !line.starts_with("-#"))
+        .filter(|line| !crate::services::provider_output_guard::contains_private_task_anchor(line))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if detail.is_empty() {
+        return FOOTER_ONLY_MARKER_PREFIX.to_string();
+    }
+    let content = format!("{FOOTER_ONLY_MARKER_PREFIX}\n{detail}");
+    super::tui_task_card::clamp_discord_message_content(
+        &super::tui_task_card::truncate_chars_ascii(&content, FOOTER_ONLY_MARKER_DETAIL_LIMIT),
+    )
 }
 
 pub(super) async fn record_footer_only(

--- a/src/services/discord/task_notification_delivery/tests.rs
+++ b/src/services/discord/task_notification_delivery/tests.rs
@@ -50,7 +50,16 @@ fn footer_only_marker_omits_private_task_anchors_from_rendered_preview() {
 
     let marker = event.footer_only_marker_content();
     assert!(marker.contains("> Visible result line."));
-    assert!(!crate::services::provider_output_guard::contains_private_task_anchor(&marker));
+    assert!(
+        ![
+            "<task-notification>",
+            "<task-id>",
+            "<tool-use-id>",
+            "<output-file>",
+        ]
+        .iter()
+        .any(|anchor| marker.contains(anchor))
+    );
 }
 
 #[tokio::test]

--- a/src/services/discord/task_notification_delivery/tests.rs
+++ b/src/services/discord/task_notification_delivery/tests.rs
@@ -24,6 +24,67 @@ fn terminal_task_card_includes_shared_completion_metadata_4806() {
 }
 
 #[test]
+fn footer_only_marker_renders_background_summary_and_result_preview() {
+    let event = TaskCardEvent::from_task_prompt(
+        4_912,
+        "claude",
+        "AgentDesk-claude-4912",
+        "<task-notification><task-id>background-4912</task-id><status>completed</status><summary>Background command \"short task\" completed (exit code 0)</summary><result>Validated the changed files.\nNo follow-up action is needed.</result></task-notification>",
+    );
+
+    let marker = event.footer_only_marker_content();
+    assert!(marker.starts_with("⚙️ Background complete\n"));
+    assert!(marker.contains("Background command \"short task\" completed (exit code 0)"));
+    assert!(marker.contains("> Validated the changed files."));
+    assert!(marker.contains("> No follow-up action is needed."));
+}
+
+#[test]
+fn footer_only_marker_omits_private_task_anchors_from_rendered_preview() {
+    let event = TaskCardEvent::from_task_prompt(
+        4_912,
+        "claude",
+        "AgentDesk-claude-4912",
+        "<task-notification><task-id>background-4912</task-id><status>completed</status><summary>Background command \"short task\" completed (exit code 0)</summary><result>Visible result line.\n<task-notification> internal envelope\n<tool-use-id> toolu-private\n<output-file> /private/path</result></task-notification>",
+    );
+
+    let marker = event.footer_only_marker_content();
+    assert!(marker.contains("> Visible result line."));
+    assert!(!crate::services::provider_output_guard::contains_private_task_anchor(&marker));
+}
+
+#[tokio::test]
+async fn footer_only_observation_keeps_full_card_for_later_promotion() {
+    let transport = FakeTransport::new();
+    let clients = clients();
+    let event = TaskCardEvent::from_task_prompt(
+        4_912,
+        "claude",
+        "AgentDesk-claude-4912",
+        "<task-notification><task-id>background-4912</task-id><status>completed</status><summary>Background command \"short task\" completed (exit code 0)</summary><result>Promotion retains this full card preview.</result></task-notification>",
+    );
+    let rendered = event.payload.render(1);
+
+    record_footer_only(None, &event)
+        .await
+        .expect("persist footer-only authority");
+    ensure_card(None, &clients, &transport, &event, EnsureIntent::Promotion)
+        .await
+        .expect("footer-only promotion");
+
+    assert_eq!(
+        transport
+            .content_hash_by_nonce
+            .lock()
+            .expect("fake card content hashes")
+            .values()
+            .next()
+            .cloned(),
+        Some(content_hash(&rendered))
+    );
+}
+
+#[test]
 fn footer_background_marker_key_is_stable_across_delivery_paths() {
     assert_eq!(
         footer_background_marker_session_key(

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -35,7 +35,6 @@ use super::settings::{
     channel_supports_provider, load_last_session_path, resolve_role_binding,
     validate_bot_channel_routing_with_provider_channel,
 };
-use super::task_notification_delivery::footer_background_marker_session_key;
 use super::tmux_error_detect::{
     ProviderProseDiagnostic, classify_provider_prose_diagnostic, is_prompt_too_long_message,
 };
@@ -91,10 +90,9 @@ mod tmux_kill_policy;
 #[allow(unused_imports)]
 pub(super) use self::tmux_kill_policy::{
     CANCEL_TEARDOWN_GRACE_BYTES, MONITOR_AUTO_TURN_DEFERRED_REASON_CODE,
-    MONITOR_AUTO_TURN_REASON_CODE, RECENT_TURN_STOP_METADATA_FALLBACK_TTL,
-    TMUX_LIVENESS_PROBE_INTERVAL, cancel_induced_watcher_death, cancel_induced_watcher_death_async,
-    recent_turn_stop_for_channel, recent_turn_stop_for_watcher_range, record_recent_turn_stop,
-    tmux_output_offset,
+    RECENT_TURN_STOP_METADATA_FALLBACK_TTL, TMUX_LIVENESS_PROBE_INTERVAL,
+    cancel_induced_watcher_death, cancel_induced_watcher_death_async, recent_turn_stop_for_channel,
+    recent_turn_stop_for_watcher_range, record_recent_turn_stop, tmux_output_offset,
 };
 
 pub(in crate::services::discord) async fn sniff_background_agent_pending_for_completion(
@@ -957,53 +955,6 @@ fn terminal_relay_decision(
     }
 }
 
-fn monitor_auto_turn_label(tmux_session_name: &str) -> String {
-    parse_provider_and_channel_from_tmux_name(tmux_session_name)
-        .map(|(_, channel_name)| channel_name)
-        .filter(|channel_name| !channel_name.trim().is_empty())
-        .unwrap_or_else(|| tmux_session_name.to_string())
-}
-
-fn monitor_auto_turn_session_key(channel_id: ChannelId, data_start_offset: u64) -> String {
-    format!(
-        "monitor_auto_turn:ch:{}:off:{}",
-        channel_id.get(),
-        data_start_offset
-    )
-}
-
-/// #1009: Lifecycle-notice variant of the shared monitor summary line. Calls
-/// `format_monitor_suppressed_label` for the trailing summary so the
-/// suppressed-placeholder edit body and the lifecycle notify-outbox row use
-/// identical copy (DRY enforcement). The `label` (channel/tmux session name)
-/// stays as the human-readable scope prefix; `entry_keys` come from the
-/// channel's `MonitoringStore` snapshot.
-fn monitor_auto_turn_completion_notice(
-    label: &str,
-    event_count: usize,
-    entry_keys: &[String],
-) -> String {
-    let summary = format_monitor_suppressed_label(event_count, entry_keys);
-    format!("{summary} · 대상: {label}")
-}
-
-/// #1009: Shared formatter for the monitor auto-turn suppressed-notification
-/// summary line. Produces:
-///   - `🔔 Monitor n회 처리 · 다음 모니터: {key1, key2, ...}` when entries > 0
-///   - `🔔 Monitor n회 처리 · (등록된 모니터 없음)` when entries == 0
-/// Entry keys are emitted in the order the store returns them.
-pub(super) fn format_monitor_suppressed_label(event_count: usize, entry_keys: &[String]) -> String {
-    if entry_keys.is_empty() {
-        format!("🔔 Monitor {}회 처리 · (등록된 모니터 없음)", event_count)
-    } else {
-        format!(
-            "🔔 Monitor {}회 처리 · 다음 모니터: {{{}}}",
-            event_count,
-            entry_keys.join(", ")
-        )
-    }
-}
-
 /// #1009: System-level hint injected once per monitor auto-turn entry so the
 /// agent produces a 1-line summary + next action before terminating. Returned
 /// verbatim at the claim sites; callers log it and record the one-shot flag.
@@ -1020,67 +971,6 @@ pub(super) fn consume_monitor_auto_turn_preamble_once(injected: &mut bool) -> Op
         *injected = true;
         Some(MONITOR_AUTO_TURN_PREAMBLE_HINT)
     }
-}
-
-pub(super) fn suppressed_task_notification_marker(
-    channel_id: ChannelId,
-    tmux_session_name: &str,
-    data_start_offset: u64,
-    kind: TaskNotificationKind,
-    footer_only_event_key: Option<&str>,
-    event_count: usize,
-    monitor_entry_keys: &[String],
-) -> Option<(String, &'static str, String)> {
-    Some(match kind {
-        TaskNotificationKind::MonitorAutoTurn => {
-            let session_key = monitor_auto_turn_session_key(channel_id, data_start_offset);
-            let label = monitor_auto_turn_label(tmux_session_name);
-            (
-                session_key,
-                MONITOR_AUTO_TURN_REASON_CODE,
-                monitor_auto_turn_completion_notice(&label, event_count, monitor_entry_keys),
-            )
-        }
-        TaskNotificationKind::Background => (
-            footer_background_marker_session_key(channel_id, footer_only_event_key?),
-            "lifecycle.background_task_complete",
-            "⚙️ Background complete".to_string(),
-        ),
-        // Subagent completions are durable-card owned, so a suppressed watcher
-        // terminal must not add a duplicate discrete marker.
-        TaskNotificationKind::Subagent => return None,
-    })
-}
-
-pub(super) fn enqueue_suppressed_task_notification(
-    pg_pool: Option<&sqlx::PgPool>,
-    channel_id: ChannelId,
-    tmux_session_name: &str,
-    data_start_offset: u64,
-    kind: TaskNotificationKind,
-    footer_only_event_key: Option<&str>,
-    event_count: usize,
-    monitor_entry_keys: &[String],
-) -> bool {
-    let target = format!("channel:{}", channel_id.get());
-    let Some((session_key, reason_code, content)) = suppressed_task_notification_marker(
-        channel_id,
-        tmux_session_name,
-        data_start_offset,
-        kind,
-        footer_only_event_key,
-        event_count,
-        monitor_entry_keys,
-    ) else {
-        return false;
-    };
-    enqueue_lifecycle_notification_best_effort(
-        pg_pool,
-        target.as_str(),
-        Some(session_key.as_str()),
-        reason_code,
-        content.as_str(),
-    )
 }
 
 fn enqueue_monitor_auto_turn_deferred_notification(
@@ -1930,61 +1820,6 @@ mod monitor_auto_turn_signal_tests {
         assert_eq!(shared.restart.global_active.load(Ordering::Relaxed), 0);
         let snapshot = shared.mailbox(channel_id).snapshot().await;
         assert_eq!(snapshot.active_user_message_id, None);
-    }
-}
-
-#[cfg(test)]
-mod suppressed_task_notification_marker_tests {
-    use super::{footer_background_marker_session_key, suppressed_task_notification_marker};
-    use crate::services::agent_protocol::TaskNotificationKind;
-    use poise::serenity_prelude::ChannelId;
-
-    #[test]
-    fn background_marker_uses_event_identity_and_subagent_marker_is_skipped() {
-        let channel_id = ChannelId::new(4_799);
-        let (background_key, background_reason, background) = suppressed_task_notification_marker(
-            channel_id,
-            "AgentDesk-claude-4799",
-            44,
-            TaskNotificationKind::Background,
-            Some("event-identity"),
-            1,
-            &[],
-        )
-        .expect("footer-owned background completion gets a marker");
-        assert_eq!(background_key, "footer_background:ch:4799:event-identity");
-        assert_eq!(background_reason, "lifecycle.background_task_complete");
-        assert_eq!(background, "⚙️ Background complete");
-
-        let replay_at_new_offset = suppressed_task_notification_marker(
-            channel_id,
-            "AgentDesk-claude-4799",
-            99,
-            TaskNotificationKind::Background,
-            Some("event-identity"),
-            1,
-            &[],
-        )
-        .expect("same footer event remains marker eligible");
-        assert_eq!(replay_at_new_offset.0, background_key);
-        assert_eq!(
-            footer_background_marker_session_key(channel_id, "event-identity"),
-            background_key,
-            "prompt and watcher paths must share one outbox identity"
-        );
-        assert!(
-            suppressed_task_notification_marker(
-                channel_id,
-                "AgentDesk-claude-4799",
-                45,
-                TaskNotificationKind::Subagent,
-                Some("subagent-event"),
-                1,
-                &[],
-            )
-            .is_none(),
-            "card-owned subagent completion must not duplicate its durable card"
-        );
     }
 }
 

--- a/src/services/discord/tmux_watcher/discrete_trigger_marker.rs
+++ b/src/services/discord/tmux_watcher/discrete_trigger_marker.rs
@@ -63,12 +63,6 @@ impl SuppressedTaskNotificationMarker<'_> {
                 format!(
                     "⚙️ Background complete{}",
                     self.background_summary
-                        .filter(|summary| !summary.trim().is_empty())
-                        .filter(|summary| {
-                            !crate::services::provider_output_guard::contains_private_task_anchor(
-                                summary,
-                            )
-                        })
                         .map(|summary| format!(" · {summary}"))
                         .unwrap_or_default()
                 ),
@@ -123,14 +117,14 @@ mod tests {
     }
 
     #[test]
-    fn background_marker_omits_summary_with_private_task_anchor() {
+    fn background_marker_omits_missing_summary() {
         let marker = SuppressedTaskNotificationMarker {
             channel_id: ChannelId::new(4_912),
             tmux_session_name: "AgentDesk-claude-4912",
             data_start_offset: 44,
             kind: TaskNotificationKind::Background,
             footer_only_event_key: Some("event-identity"),
-            background_summary: Some("<tool-use-id> toolu-private"),
+            background_summary: None,
             event_count: 1,
             monitor_entry_keys: &[],
         }
@@ -185,7 +179,18 @@ pub(super) async fn enqueue_suppressed_machine_trigger_marker(
         task_notification_context.and_then(|context| context.footer_only_marker_event_key());
     let background_summary = task_notification_context
         .filter(|context| matches!(context.routing_kind(), TaskNotificationKind::Background))
-        .map(task_notification_delivery::TaskNotificationContext::summary);
+        .and_then(task_notification_delivery::TaskNotificationContext::summary);
+    if matches!(
+        task_notification_kind,
+        Some(TaskNotificationKind::Background)
+    ) && background_summary.is_none()
+    {
+        tracing::debug!(
+            channel_id = channel_id.get(),
+            data_start_offset,
+            "background completion marker used fallback without task summary"
+        );
+    }
     let marker_kind = task_notification_kind.filter(|kind| {
         matches!(
             kind,

--- a/src/services/discord/tmux_watcher/discrete_trigger_marker.rs
+++ b/src/services/discord/tmux_watcher/discrete_trigger_marker.rs
@@ -6,9 +6,10 @@
 
 use super::*;
 use crate::services::discord::task_notification_delivery;
+// Reuse the canonical reason code rather than re-declaring the literal: it lives
+// next to its `.deferred` sibling in tmux_kill_policy, and two copies drift.
+use crate::services::discord::tmux::tmux_kill_policy::MONITOR_AUTO_TURN_REASON_CODE;
 use crate::services::message_outbox::enqueue_lifecycle_notification_best_effort;
-
-const MONITOR_AUTO_TURN_REASON_CODE: &str = "lifecycle.monitor_auto_turn";
 
 struct SuppressedTaskNotificationMarker<'a> {
     channel_id: ChannelId,

--- a/src/services/discord/tmux_watcher/discrete_trigger_marker.rs
+++ b/src/services/discord/tmux_watcher/discrete_trigger_marker.rs
@@ -6,6 +6,157 @@
 
 use super::*;
 use crate::services::discord::task_notification_delivery;
+use crate::services::message_outbox::enqueue_lifecycle_notification_best_effort;
+
+const MONITOR_AUTO_TURN_REASON_CODE: &str = "lifecycle.monitor_auto_turn";
+
+struct SuppressedTaskNotificationMarker<'a> {
+    channel_id: ChannelId,
+    tmux_session_name: &'a str,
+    data_start_offset: u64,
+    kind: TaskNotificationKind,
+    footer_only_event_key: Option<&'a str>,
+    background_summary: Option<&'a str>,
+    event_count: usize,
+    monitor_entry_keys: &'a [String],
+}
+
+impl SuppressedTaskNotificationMarker<'_> {
+    fn render(&self) -> Option<(String, &'static str, String)> {
+        Some(match self.kind {
+            TaskNotificationKind::MonitorAutoTurn => {
+                let session_key = format!(
+                    "monitor_auto_turn:ch:{}:off:{}",
+                    self.channel_id.get(),
+                    self.data_start_offset
+                );
+                let label = crate::services::provider::parse_provider_and_channel_from_tmux_name(
+                    self.tmux_session_name,
+                )
+                .map(|(_, channel_name)| channel_name)
+                .filter(|channel_name| !channel_name.trim().is_empty())
+                .unwrap_or_else(|| self.tmux_session_name.to_string());
+                let summary = if self.monitor_entry_keys.is_empty() {
+                    format!(
+                        "🔔 Monitor {}회 처리 · (등록된 모니터 없음)",
+                        self.event_count
+                    )
+                } else {
+                    format!(
+                        "🔔 Monitor {}회 처리 · 다음 모니터: {{{}}}",
+                        self.event_count,
+                        self.monitor_entry_keys.join(", ")
+                    )
+                };
+                (
+                    session_key,
+                    MONITOR_AUTO_TURN_REASON_CODE,
+                    format!("{summary} · 대상: {label}"),
+                )
+            }
+            TaskNotificationKind::Background => (
+                task_notification_delivery::footer_background_marker_session_key(
+                    self.channel_id,
+                    self.footer_only_event_key?,
+                ),
+                "lifecycle.background_task_complete",
+                format!(
+                    "⚙️ Background complete{}",
+                    self.background_summary
+                        .filter(|summary| !summary.trim().is_empty())
+                        .filter(|summary| {
+                            !crate::services::provider_output_guard::contains_private_task_anchor(
+                                summary,
+                            )
+                        })
+                        .map(|summary| format!(" · {summary}"))
+                        .unwrap_or_default()
+                ),
+            ),
+            TaskNotificationKind::Subagent => return None,
+        })
+    }
+}
+
+fn enqueue_suppressed_task_notification(
+    pg_pool: Option<&sqlx::PgPool>,
+    marker: SuppressedTaskNotificationMarker<'_>,
+) -> bool {
+    let target = format!("channel:{}", marker.channel_id.get());
+    let Some((session_key, reason_code, content)) = marker.render() else {
+        return false;
+    };
+    enqueue_lifecycle_notification_best_effort(
+        pg_pool,
+        target.as_str(),
+        Some(session_key.as_str()),
+        reason_code,
+        content.as_str(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn background_marker_includes_summary_and_preserves_event_identity() {
+        let channel_id = ChannelId::new(4_912);
+        let marker = SuppressedTaskNotificationMarker {
+            channel_id,
+            tmux_session_name: "AgentDesk-claude-4912",
+            data_start_offset: 44,
+            kind: TaskNotificationKind::Background,
+            footer_only_event_key: Some("event-identity"),
+            background_summary: Some("Background command \"short task\" completed (exit code 0)"),
+            event_count: 1,
+            monitor_entry_keys: &[],
+        }
+        .render()
+        .expect("footer-owned background completion gets a marker");
+        assert_eq!(marker.0, "footer_background:ch:4912:event-identity");
+        assert_eq!(marker.1, "lifecycle.background_task_complete");
+        assert_eq!(
+            marker.2,
+            "⚙️ Background complete · Background command \"short task\" completed (exit code 0)"
+        );
+    }
+
+    #[test]
+    fn background_marker_omits_summary_with_private_task_anchor() {
+        let marker = SuppressedTaskNotificationMarker {
+            channel_id: ChannelId::new(4_912),
+            tmux_session_name: "AgentDesk-claude-4912",
+            data_start_offset: 44,
+            kind: TaskNotificationKind::Background,
+            footer_only_event_key: Some("event-identity"),
+            background_summary: Some("<tool-use-id> toolu-private"),
+            event_count: 1,
+            monitor_entry_keys: &[],
+        }
+        .render()
+        .expect("background marker");
+        assert_eq!(marker.2, "⚙️ Background complete");
+    }
+
+    #[test]
+    fn subagent_marker_remains_suppressed() {
+        assert!(
+            SuppressedTaskNotificationMarker {
+                channel_id: ChannelId::new(4_912),
+                tmux_session_name: "AgentDesk-claude-4912",
+                data_start_offset: 44,
+                kind: TaskNotificationKind::Subagent,
+                footer_only_event_key: Some("subagent-event"),
+                background_summary: Some("Agent completed"),
+                event_count: 1,
+                monitor_entry_keys: &[],
+            }
+            .render()
+            .is_none()
+        );
+    }
+}
 
 pub(super) async fn enqueue_suppressed_machine_trigger_marker(
     shared: &Arc<SharedData>,
@@ -32,6 +183,9 @@ pub(super) async fn enqueue_suppressed_machine_trigger_marker(
     };
     let footer_only_event_key =
         task_notification_context.and_then(|context| context.footer_only_marker_event_key());
+    let background_summary = task_notification_context
+        .filter(|context| matches!(context.routing_kind(), TaskNotificationKind::Background))
+        .map(task_notification_delivery::TaskNotificationContext::summary);
     let marker_kind = task_notification_kind.filter(|kind| {
         matches!(
             kind,
@@ -41,13 +195,16 @@ pub(super) async fn enqueue_suppressed_machine_trigger_marker(
     if let Some(kind) = marker_kind {
         let _ = enqueue_suppressed_task_notification(
             shared.pg_pool.as_ref(),
-            channel_id,
-            tmux_session_name,
-            data_start_offset,
-            kind,
-            footer_only_event_key,
-            monitor_event_count,
-            &monitor_entry_keys,
+            SuppressedTaskNotificationMarker {
+                channel_id,
+                tmux_session_name,
+                data_start_offset,
+                kind,
+                footer_only_event_key,
+                background_summary,
+                event_count: monitor_event_count,
+                monitor_entry_keys: &monitor_entry_keys,
+            },
         );
     }
 }

--- a/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
+++ b/src/services/discord/tui_prompt_relay/task_notification_prompt.rs
@@ -204,12 +204,13 @@ fn enqueue_footer_only_background_marker(
             channel_id,
             event.event_key(),
         );
+    let content = event.footer_only_marker_content();
     let _ = crate::services::message_outbox::enqueue_lifecycle_notification_best_effort(
         shared.pg_pool.as_ref(),
         target.as_str(),
         Some(session_key.as_str()),
         "lifecycle.background_task_complete",
-        "⚙️ Background complete",
+        content.as_str(),
     );
 }
 

--- a/src/services/provider_output_guard.rs
+++ b/src/services/provider_output_guard.rs
@@ -20,12 +20,6 @@ const PRIVATE_TASK_ANCHORS: &[&str] = &[
     "<tool-use-id>",
     "<output-file>",
 ];
-
-pub(crate) fn contains_private_task_anchor(text: &str) -> bool {
-    PRIVATE_TASK_ANCHORS
-        .iter()
-        .any(|anchor| text.contains(anchor))
-}
 const CONTROL_ANCHORS: &[&str] = &[
     SYSTEM_BANNER,
     "<task-notification>",

--- a/src/services/provider_output_guard.rs
+++ b/src/services/provider_output_guard.rs
@@ -20,6 +20,12 @@ const PRIVATE_TASK_ANCHORS: &[&str] = &[
     "<tool-use-id>",
     "<output-file>",
 ];
+
+pub(crate) fn contains_private_task_anchor(text: &str) -> bool {
+    PRIVATE_TASK_ANCHORS
+        .iter()
+        .any(|anchor| text.contains(anchor))
+}
 const CONTROL_ANCHORS: &[&str] = &[
     SYSTEM_BANNER,
     "<task-notification>",

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -241,6 +241,27 @@ class FastCheckCiWiringTests(unittest.TestCase):
         self.assertIn("UPSTREAM_JOB_NAME: test_fast", mirror_job)
         self.assertIn("UPSTREAM_RESULT: ${{ needs.test_fast.result }}", mirror_job)
 
+    def test_footer_marker_regressions_run_in_required_test_fast_lane(self) -> None:
+        workflow = PR_WORKFLOW.read_text(encoding="utf-8")
+        test_job = job_block(workflow, "test_fast")
+        self.assertEqual(test_job.count("- name: Footer-only marker regressions"), 1)
+        for command in (
+            "cargo test --lib task_notification -- --skip _pg --skip pg_ --skip postgres",
+            "cargo test --lib services::discord::tmux::tmux_watcher::discrete_trigger_marker::tests -- --skip _pg --skip pg_ --skip postgres",
+        ):
+            self.assertEqual(test_job.count(command), 1)
+
+        changes = job_block(workflow, "changes")
+        for path in (
+            "src/services/discord/task_notification_delivery/mod.rs",
+            "src/services/discord/task_notification_delivery/terminal_identity.rs",
+            "src/services/discord/task_notification_delivery/tests.rs",
+            "src/services/discord/tmux.rs",
+            "src/services/discord/tmux_watcher/discrete_trigger_marker.rs",
+            "src/services/discord/tui_prompt_relay/task_notification_prompt.rs",
+        ):
+            self.assertIn(f"- '{path}'", changes)
+
     def test_pr_cross_os_lane_is_compile_only(self) -> None:
         job = job_block(PR_WORKFLOW.read_text(encoding="utf-8"), "check_fast_cross_os")
 

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -253,9 +253,9 @@ class FastCheckCiWiringTests(unittest.TestCase):
 
         changes = job_block(workflow, "changes")
         for path in (
-            "src/services/discord/task_notification_delivery/mod.rs",
-            "src/services/discord/task_notification_delivery/terminal_identity.rs",
-            "src/services/discord/task_notification_delivery/tests.rs",
+            # Glob, not a file list: a per-file enumeration silently excludes
+            # modules added later (see the matching comment in ci-pr.yml).
+            "src/services/discord/task_notification_delivery/**",
             "src/services/discord/tmux.rs",
             "src/services/discord/tmux_watcher/discrete_trigger_marker.rs",
             "src/services/discord/tui_prompt_relay/task_notification_prompt.rs",


### PR DESCRIPTION
## 문제

footer-only background completion marker는 사설/control anchor가 보이면 전체 detail을 폐기해야 한다. 별도로 headline 목표였던 prompt/watcher 본문 결정성은 반증됐다: watcher의 `TaskNotificationContext`에는 `result`가 없고 watcher 경로는 `result: None`을 구성한다. 이 범위의 구조적 한계는 #4990에서 다룬다.

## 변경

- control anchor 하나라도 발견하면 footer marker detail 전체를 폐기하고 `⚙️ Background complete`만 남기는 fail-safe를 유지했다.
- marker anchor 검사는 provider guard와 같은 Markdown→prose 정규화를 사용한다. 이중 HTML entity escape 뒤 renderer에서 한 번 decode되는 `<invoke ...><parameter ...>` wrapper도 provider guard가 `Blocked`면 marker가 detail을 전달하지 않는다.
- prompt footer-only eligibility를 watcher routing과 대칭으로 복원했다: identity가 있는 `workflow`도 footer로 defer하고 `subagent`만 제외한다. workflow가 full card와 watcher marker를 동시에 내는 이중 표면을 막는다.
- `discrete_trigger_marker` curated lane 추가에 대응하여 `tests/test_fast_check_ci_wiring.py`의 exact manifest를 동일하게 갱신했다. dedicated module을 기존 lane으로 옮기는 것보다 manifest 1행 동기화가 더 작은 변경이다.

## 범위 제외

prompt와 watcher가 동일한 본문을 enqueue한다는 주장은 삭제했다. watcher context에 result가 없어 이 PR의 shared formatter로는 성립하지 않으며, 본문 결정성은 #4990에서 별도로 해결한다.

## 로컬 검증

- `cargo fmt --check` — rc=0
- `cargo check --lib` — rc=0
- `cargo test --lib task_notification` — rc=0
- `cargo test --lib provider_output_guard` — rc=0
- `cargo test --lib discrete_trigger_marker` — rc=0
- `TEST_LANE_BASELINE_REF=origin/main bash scripts/ci-script-checks.sh` — rc=0
- `python3 scripts/generate_inventory_docs.py` — rc=0
- `python3 scripts/audit_maintainability.py --check` — rc=0

## 뮤테이션 증명

C3 guard를 임시 제거한 뒤 `footer_only_marker_drops_double_escaped_tool_wrapper_blocked_by_provider_guard`를 실행했다.

- 제거: `rc=101`, `FAILED`, `assertion left == right failed`
- 복원: `rc=0`, `test result: ok. 1 passed; 0 failed`

Closes #4912
Refs #4990


Follow-up: https://github.com/itismyfield/AgentDesk/issues/4994 — preserve structured private-field provenance; denylist normalization cannot cover open-ended tag variants.
