### PR TITLE
fix(#4997): seed inflight output_path by runtime kind for ClaudeTui

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -641,7 +641,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: High-risk recovery lane
-        run: "cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1"
+        run: |
+          cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1
+          cargo test --lib services::discord::recovery_engine::state_extractors::tests -- --test-threads=1
 
       - name: Stop PostgreSQL service
         if: always()

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -644,6 +644,8 @@ jobs:
         run: |
           cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1
           cargo test --lib services::discord::recovery_engine::state_extractors::tests -- --test-threads=1
+          cargo test --lib services::discord::relay_recovery::tests -- --test-threads=1
+          cargo test --lib services::discord::terminal_ui_obligation::tests -- --test-threads=1
 
       - name: Stop PostgreSQL service
         if: always()

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -645,6 +645,7 @@ jobs:
           cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1
           cargo test --lib services::discord::recovery_engine::state_extractors::tests -- --test-threads=1
           cargo test --lib services::discord::relay_recovery::tests -- --test-threads=1
+          cargo test --lib services::discord::terminal_ui_obligation::tests -- --test-threads=1
 
       - name: Stop PostgreSQL service
         if: always()

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -645,7 +645,6 @@ jobs:
           cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1
           cargo test --lib services::discord::recovery_engine::state_extractors::tests -- --test-threads=1
           cargo test --lib services::discord::relay_recovery::tests -- --test-threads=1
-          cargo test --lib services::discord::terminal_ui_obligation::tests -- --test-threads=1
 
       - name: Stop PostgreSQL service
         if: always()

--- a/scripts/test_lane_coverage_baseline.txt
+++ b/scripts/test_lane_coverage_baseline.txt
@@ -394,7 +394,6 @@ services::discord::startup_reclaim::tests
 services::discord::status_panel_orphan_store::tests
 services::discord::streaming_finalizer::tests
 services::discord::task_supervisor::tests
-services::discord::terminal_ui_obligation::tests
 services::discord::tmux::active_bridge_turn_guard_tests
 services::discord::tmux::buffer_offset_tests
 services::discord::tmux::lifecycle_stage_pause_matrix_tests

--- a/src/services/discord/inflight/save_store/identity_gate/runtime_stamp.rs
+++ b/src/services/discord/inflight/save_store/identity_gate/runtime_stamp.rs
@@ -279,6 +279,37 @@ mod tests {
     }
 
     #[test]
+    fn claude_tui_runtime_stamp_accepts_none_to_projects_output_path() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let provider = ProviderKind::Claude;
+        let channel_id = 42_592_150;
+        let mut seed = runtime_seed(provider.clone(), channel_id, Some("AgentDesk-claude-4997"));
+        seed.runtime_kind = Some(RuntimeHandoffKind::ClaudeTui);
+        seed.output_path = None;
+        seed.input_fifo_path = Some("/runtime/claude-4997.input".to_string());
+        save_inflight_state_in_root(root.path(), &seed).expect("seed ClaudeTui row");
+        let expected = InflightTurnIdentity::from_state(&seed);
+
+        let mut handoff = seed.clone();
+        handoff.output_path = Some("/projects/claude-4997.jsonl".to_string());
+        assert_eq!(
+            stamp_runtime_handoff_if_matches_identity_in_root(
+                root.path(),
+                &handoff,
+                &expected,
+                "test::claude_tui_none_to_projects_output",
+            ),
+            GuardedSaveOutcome::Saved,
+        );
+        let persisted = load(root.path(), &provider, channel_id);
+        assert_eq!(
+            persisted.output_path.as_deref(),
+            Some("/projects/claude-4997.jsonl")
+        );
+        assert_eq!(persisted.input_fifo_path, seed.input_fifo_path);
+    }
+
+    #[test]
     fn runtime_stamp_accepts_same_session_restamp_and_rejects_changed_session() {
         let root = tempfile::tempdir().expect("runtime root");
         let provider = ProviderKind::Codex;

--- a/src/services/discord/recovery_engine/restore_inflight.rs
+++ b/src/services/discord/recovery_engine/restore_inflight.rs
@@ -17,6 +17,17 @@ fn build_tmux_death_diagnostic(_name: &str, _output_path: Option<&str>) -> Optio
     None
 }
 
+fn recovery_output_path_with_tmux_fallback(
+    state: &inflight::InflightTurnState,
+    fallback_output: String,
+) -> Option<String> {
+    state
+        .output_path
+        .clone()
+        .filter(|path| !path.is_empty())
+        .or_else(|| (!fallback_output.is_empty()).then_some(fallback_output))
+}
+
 pub(in crate::services::discord) async fn finish_recovered_turn_mailbox(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
@@ -871,17 +882,7 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
             .map(tmux_runtime_paths)
             .unwrap_or_else(|| (String::new(), String::new()));
         let runtime_kind = state.runtime_kind_for_recovery();
-        let output_path = state
-            .output_path
-            .clone()
-            .filter(|s| !s.is_empty())
-            .or_else(|| {
-                if !fallback_output.is_empty() {
-                    Some(fallback_output.clone())
-                } else {
-                    None
-                }
-            });
+        let output_path = recovery_output_path_with_tmux_fallback(&state, fallback_output);
         let input_fifo_path = if runtime_kind.requires_input_fifo() {
             state
                 .input_fifo_path
@@ -2425,6 +2426,34 @@ mod tests {
         assert_eq!(
             persisted.effective_relay_owner_kind(),
             RelayOwnerKind::Watcher
+        );
+    }
+
+    #[test]
+    fn restore_claude_tui_without_runtime_output_uses_tmux_fallback_path() {
+        let mut state = InflightTurnState::new(
+            ProviderKind::Claude,
+            4_997_002,
+            None,
+            1,
+            2,
+            3,
+            "pending ClaudeTui recovery".to_string(),
+            None,
+            Some("AgentDesk-claude-4997".to_string()),
+            None,
+            Some("/runtime/input.fifo".to_string()),
+            0,
+        );
+        state.runtime_kind = Some(RuntimeHandoffKind::ClaudeTui);
+        let output_path = super::recovery_output_path_with_tmux_fallback(
+            &state,
+            "/runtime/AgentDesk-claude-4997.output".to_string(),
+        );
+        assert_eq!(
+            output_path.as_deref(),
+            Some("/runtime/AgentDesk-claude-4997.output"),
+            "ClaudeTui None must take the tmux fallback instead of recovery_missing_output_path"
         );
     }
 

--- a/src/services/discord/recovery_engine/state_extractors.rs
+++ b/src/services/discord/recovery_engine/state_extractors.rs
@@ -47,11 +47,19 @@ pub(in crate::services::discord) fn save_missing_session_handoff(
     );
 }
 
+fn claude_tui_output_path_missing(state: &inflight::InflightTurnState) -> bool {
+    state.runtime_kind == Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui)
+        && state.output_path.is_none()
+}
+
 fn inflight_ready_for_input_without_tui_pane(
     provider: &ProviderKind,
     state: &inflight::InflightTurnState,
     require_consumed: bool,
 ) -> Option<crate::services::tui_turn_state::TuiReadyState> {
+    if claude_tui_output_path_missing(state) {
+        return Some(crate::services::tui_turn_state::TuiReadyState::Unknown);
+    }
     let output_path = state
         .output_path
         .as_deref()
@@ -65,22 +73,30 @@ fn inflight_ready_for_input_without_tui_pane(
     )
 }
 
+fn inflight_or_legacy_tmux_ready_from_structured_state(
+    structured_state: Option<crate::services::tui_turn_state::TuiReadyState>,
+    pane_fallback_ready: bool,
+) -> bool {
+    structured_state
+        .map(crate::services::tui_turn_state::TuiReadyState::is_ready)
+        .unwrap_or(pane_fallback_ready)
+}
+
 pub(super) fn inflight_or_legacy_tmux_ready_for_input(
     provider: &ProviderKind,
     state: &inflight::InflightTurnState,
     tmux_session_name: &str,
     require_consumed: bool,
 ) -> bool {
-    inflight_ready_for_input_without_tui_pane(provider, state, require_consumed)
-        .map(crate::services::tui_turn_state::TuiReadyState::is_ready)
-        .unwrap_or_else(|| {
-            crate::services::provider::tmux_session_fallback_ready_for_input(
-                tmux_session_name,
-                provider,
-                state.runtime_kind,
-            )
-            .is_some_and(crate::services::pane_readiness::FallbackPaneReadiness::is_ready)
-        })
+    let structured_state =
+        inflight_ready_for_input_without_tui_pane(provider, state, require_consumed);
+    let pane_fallback_ready = crate::services::provider::tmux_session_fallback_ready_for_input(
+        tmux_session_name,
+        provider,
+        state.runtime_kind,
+    )
+    .is_some_and(crate::services::pane_readiness::FallbackPaneReadiness::is_ready);
+    inflight_or_legacy_tmux_ready_from_structured_state(structured_state, pane_fallback_ready)
 }
 
 fn recovery_worktree_path(state: &inflight::InflightTurnState) -> Option<&str> {
@@ -217,4 +233,39 @@ pub(super) fn recovery_spawn_adk_cwd(
     }
 
     Ok(persisted_session_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_tui_without_runtime_output_path_stays_not_ready() {
+        let mut state = inflight::InflightTurnState::new(
+            ProviderKind::Claude,
+            4_997_001,
+            None,
+            1,
+            2,
+            3,
+            "pending ClaudeTui runtime handoff".to_string(),
+            None,
+            Some("AgentDesk-claude-4997".to_string()),
+            None,
+            Some("/runtime/input.fifo".to_string()),
+            0,
+        );
+        state.runtime_kind = Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui);
+        assert_eq!(
+            inflight_ready_for_input_without_tui_pane(&ProviderKind::Claude, &state, true),
+            Some(crate::services::tui_turn_state::TuiReadyState::Unknown)
+        );
+        assert!(
+            !inflight_or_legacy_tmux_ready_from_structured_state(
+                inflight_ready_for_input_without_tui_pane(&ProviderKind::Claude, &state, true),
+                true,
+            ),
+            "missing ClaudeTui runtime output must override a ready pane fallback"
+        );
+    }
 }

--- a/src/services/discord/recovery_engine/state_extractors.rs
+++ b/src/services/discord/recovery_engine/state_extractors.rs
@@ -48,8 +48,10 @@ pub(in crate::services::discord) fn save_missing_session_handoff(
 }
 
 fn claude_tui_output_path_missing(state: &inflight::InflightTurnState) -> bool {
-    state.runtime_kind == Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui)
-        && state.output_path.is_none()
+    crate::services::tui_turn_state::claude_tui_output_path_missing(
+        state.runtime_kind,
+        state.output_path.as_deref(),
+    )
 }
 
 fn inflight_ready_for_input_without_tui_pane(
@@ -75,11 +77,11 @@ fn inflight_ready_for_input_without_tui_pane(
 
 fn inflight_or_legacy_tmux_ready_from_structured_state(
     structured_state: Option<crate::services::tui_turn_state::TuiReadyState>,
-    pane_fallback_ready: bool,
+    pane_fallback_ready: impl FnOnce() -> bool,
 ) -> bool {
     structured_state
         .map(crate::services::tui_turn_state::TuiReadyState::is_ready)
-        .unwrap_or(pane_fallback_ready)
+        .unwrap_or_else(pane_fallback_ready)
 }
 
 pub(super) fn inflight_or_legacy_tmux_ready_for_input(
@@ -90,13 +92,14 @@ pub(super) fn inflight_or_legacy_tmux_ready_for_input(
 ) -> bool {
     let structured_state =
         inflight_ready_for_input_without_tui_pane(provider, state, require_consumed);
-    let pane_fallback_ready = crate::services::provider::tmux_session_fallback_ready_for_input(
-        tmux_session_name,
-        provider,
-        state.runtime_kind,
-    )
-    .is_some_and(crate::services::pane_readiness::FallbackPaneReadiness::is_ready);
-    inflight_or_legacy_tmux_ready_from_structured_state(structured_state, pane_fallback_ready)
+    inflight_or_legacy_tmux_ready_from_structured_state(structured_state, || {
+        crate::services::provider::tmux_session_fallback_ready_for_input(
+            tmux_session_name,
+            provider,
+            state.runtime_kind,
+        )
+        .is_some_and(crate::services::pane_readiness::FallbackPaneReadiness::is_ready)
+    })
 }
 
 fn recovery_worktree_path(state: &inflight::InflightTurnState) -> Option<&str> {
@@ -240,6 +243,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn structured_ready_state_skips_pane_fallback_evaluation() {
+        assert!(inflight_or_legacy_tmux_ready_from_structured_state(
+            Some(crate::services::tui_turn_state::TuiReadyState::Ready),
+            || panic!("structured readiness must not probe pane fallback"),
+        ));
+    }
+
+    #[test]
     fn claude_tui_without_runtime_output_path_stays_not_ready() {
         let mut state = inflight::InflightTurnState::new(
             ProviderKind::Claude,
@@ -263,7 +274,7 @@ mod tests {
         assert!(
             !inflight_or_legacy_tmux_ready_from_structured_state(
                 inflight_ready_for_input_without_tui_pane(&ProviderKind::Claude, &state, true),
-                true,
+                || true,
             ),
             "missing ClaudeTui runtime output must override a ready pane fallback"
         );

--- a/src/services/discord/relay_recovery/idle_tmux.rs
+++ b/src/services/discord/relay_recovery/idle_tmux.rs
@@ -255,6 +255,12 @@ pub(super) fn idle_tmux_repair_snapshot_ready_for_input(
         .map(str::trim)
         .filter(|path| !path.is_empty())
     else {
+        if crate::services::tui_turn_state::claude_tui_output_path_missing(
+            state.runtime_kind,
+            state.output_path.as_deref(),
+        ) {
+            return false;
+        }
         return pane_ready_for_input(tmux_session, provider);
     };
     let output_path = Path::new(output_path);

--- a/src/services/discord/relay_recovery/tests.rs
+++ b/src/services/discord/relay_recovery/tests.rs
@@ -1850,6 +1850,52 @@ fn set_output_mtime_age(output_path: &std::path::Path, age: std::time::Duration)
 }
 
 #[test]
+fn idle_tmux_snapshot_missing_output_path_denies_claude_tui_but_keeps_legacy_pane_fallback() {
+    let provider = ProviderKind::Claude;
+    let channel_id = 4_997_004;
+    let mut state = super::super::inflight::InflightTurnState::new(
+        provider.clone(),
+        channel_id,
+        None,
+        1,
+        4_997_005,
+        4_997_006,
+        "freshly seeded ClaudeTui turn".to_string(),
+        None,
+        Some("AgentDesk-claude-4997-idle-tmux".to_string()),
+        None,
+        None,
+        0,
+    );
+    state.runtime_kind = Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui);
+    assert!(state.full_response.is_empty());
+    assert_eq!(state.last_offset, 0);
+    assert!(
+        !idle_tmux_repair_snapshot_ready_for_input(
+            &provider,
+            channel_id,
+            "AgentDesk-claude-4997-idle-tmux",
+            &state,
+            |_tmux, _provider| true,
+        ),
+        "missing ClaudeTui runtime output must override a ready pane fallback"
+    );
+
+    state.runtime_kind =
+        Some(crate::services::agent_protocol::RuntimeHandoffKind::LegacyTmuxWrapper);
+    assert!(
+        idle_tmux_repair_snapshot_ready_for_input(
+            &provider,
+            channel_id,
+            "AgentDesk-claude-4997-idle-tmux",
+            &state,
+            |_tmux, _provider| true,
+        ),
+        "non-ClaudeTui missing-output rows must retain the existing ready pane fallback"
+    );
+}
+
+#[test]
 fn frozen_busy_jsonl_uses_ready_pane_fallback_after_stale_window() {
     let _guard = auto_heal_test_lock().blocking_lock();
     let (_root_guard, temp) = isolated_agentdesk_root();

--- a/src/services/discord/relay_recovery/tests.rs
+++ b/src/services/discord/relay_recovery/tests.rs
@@ -1881,18 +1881,35 @@ fn idle_tmux_snapshot_missing_output_path_denies_claude_tui_but_keeps_legacy_pan
         "missing ClaudeTui runtime output must override a ready pane fallback"
     );
 
+    for blank_output_path in ["", "   "] {
+        state.output_path = Some(blank_output_path.to_string());
+        assert!(
+            !idle_tmux_repair_snapshot_ready_for_input(
+                &provider,
+                channel_id,
+                "AgentDesk-claude-4997-idle-tmux",
+                &state,
+                |_tmux, _provider| true,
+            ),
+            "blank ClaudeTui runtime output must override a ready pane fallback: {blank_output_path:?}"
+        );
+    }
+
     state.runtime_kind =
         Some(crate::services::agent_protocol::RuntimeHandoffKind::LegacyTmuxWrapper);
-    assert!(
-        idle_tmux_repair_snapshot_ready_for_input(
-            &provider,
-            channel_id,
-            "AgentDesk-claude-4997-idle-tmux",
-            &state,
-            |_tmux, _provider| true,
-        ),
-        "non-ClaudeTui missing-output rows must retain the existing ready pane fallback"
-    );
+    for blank_output_path in [None, Some(""), Some("   ")] {
+        state.output_path = blank_output_path.map(str::to_string);
+        assert!(
+            idle_tmux_repair_snapshot_ready_for_input(
+                &provider,
+                channel_id,
+                "AgentDesk-claude-4997-idle-tmux",
+                &state,
+                |_tmux, _provider| true,
+            ),
+            "non-ClaudeTui blank output must retain the existing ready pane fallback: {blank_output_path:?}"
+        );
+    }
 }
 
 #[test]

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -1108,38 +1108,13 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
     )
     .await;
 
-    let (inflight_tmux_name, inflight_output_path, inflight_input_fifo, inflight_offset) = {
-        #[cfg(unix)]
-        {
-            if remote_profile.is_none()
-                && provider.uses_managed_tmux_backend()
-                && claude::is_tmux_available()
-            {
-                if let Some(ref tmux_name) = tmux_session_name {
-                    let (output_path, input_fifo_path) = tmux_runtime_paths(tmux_name);
-                    let session_exists =
-                        crate::services::tmux_diagnostics::tmux_session_has_live_pane(tmux_name);
-                    let last_offset = std::fs::metadata(&output_path)
-                        .map(|metadata| metadata.len())
-                        .unwrap_or(0);
-                    (
-                        Some(tmux_name.clone()),
-                        Some(output_path),
-                        Some(input_fifo_path),
-                        if session_exists { last_offset } else { 0 },
-                    )
-                } else {
-                    (None, None, None, 0)
-                }
-            } else {
-                (None, None, None, 0)
-            }
-        }
-        #[cfg(not(unix))]
-        {
-            (None, None, None, 0u64)
-        }
-    };
+    let (inflight_tmux_name, inflight_output_path, inflight_input_fifo, inflight_offset) =
+        prelaunch_inflight_runtime_seed(
+            &provider,
+            remote_profile.is_none(),
+            tmux_session_name.as_deref(),
+            prelaunch_runtime_kind,
+        );
     let watcher_tmux_name = inflight_tmux_name.clone();
     let watcher_output_path = inflight_output_path.clone();
 

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -1813,38 +1813,13 @@ pub(super) async fn handle_text_message(
     )
     .await;
 
-    let (inflight_tmux_name, inflight_output_path, inflight_input_fifo, mut inflight_offset) = {
-        #[cfg(unix)]
-        {
-            if remote_profile.is_none()
-                && provider.uses_managed_tmux_backend()
-                && claude::is_tmux_available()
-            {
-                if let Some(ref tmux_name) = tmux_session_name {
-                    let (output_path, input_fifo_path) = tmux_runtime_paths(tmux_name);
-                    let session_exists =
-                        crate::services::tmux_diagnostics::tmux_session_has_live_pane(tmux_name);
-                    let last_offset = std::fs::metadata(&output_path)
-                        .map(|m| m.len())
-                        .unwrap_or(0);
-                    (
-                        Some(tmux_name.clone()),
-                        Some(output_path),
-                        Some(input_fifo_path),
-                        if session_exists { last_offset } else { 0 },
-                    )
-                } else {
-                    (None, None, None, 0)
-                }
-            } else {
-                (None, None, None, 0)
-            }
-        }
-        #[cfg(not(unix))]
-        {
-            (None, None, None, 0u64)
-        }
-    };
+    let (inflight_tmux_name, inflight_output_path, inflight_input_fifo, mut inflight_offset) =
+        prelaunch_inflight_runtime_seed(
+            &provider,
+            remote_profile.is_none(),
+            tmux_session_name.as_deref(),
+            prelaunch_runtime_kind,
+        );
     let watcher_tmux_name = inflight_tmux_name.clone();
     let watcher_output_path = inflight_output_path.clone();
     #[cfg(unix)]

--- a/src/services/discord/router/message_handler/provider_isolation.rs
+++ b/src/services/discord/router/message_handler/provider_isolation.rs
@@ -127,6 +127,68 @@ pub(super) fn prelaunch_runtime_kind_for_managed_session(
     None
 }
 
+/// Seeds the durable inflight runtime fields before runtime handoff binds the
+/// provider-owned transcript path.
+fn prelaunch_inflight_runtime_seed_from_paths(
+    tmux_name: &str,
+    output_path: String,
+    input_fifo_path: String,
+    session_exists: bool,
+    prelaunch_runtime_kind: Option<RuntimeHandoffKind>,
+) -> (Option<String>, Option<String>, Option<String>, u64) {
+    let is_claude_tui = prelaunch_runtime_kind == Some(RuntimeHandoffKind::ClaudeTui);
+    let last_offset = (!is_claude_tui)
+        .then(|| {
+            std::fs::metadata(&output_path)
+                .map(|metadata| metadata.len())
+                .unwrap_or(0)
+        })
+        .unwrap_or(0);
+    (
+        Some(tmux_name.to_string()),
+        (!is_claude_tui).then_some(output_path),
+        Some(input_fifo_path),
+        session_exists.then_some(last_offset).unwrap_or(0),
+    )
+}
+
+pub(super) fn prelaunch_inflight_runtime_seed(
+    provider: &ProviderKind,
+    remote_profile_is_none: bool,
+    tmux_session_name: Option<&str>,
+    prelaunch_runtime_kind: Option<RuntimeHandoffKind>,
+) -> (Option<String>, Option<String>, Option<String>, u64) {
+    #[cfg(unix)]
+    {
+        if remote_profile_is_none
+            && provider.uses_managed_tmux_backend()
+            && claude::is_tmux_available()
+            && let Some(tmux_name) = tmux_session_name
+        {
+            let (output_path, input_fifo_path) = tmux_runtime_paths(tmux_name);
+            let session_exists =
+                crate::services::tmux_diagnostics::tmux_session_has_live_pane(tmux_name);
+            return prelaunch_inflight_runtime_seed_from_paths(
+                tmux_name,
+                output_path,
+                input_fifo_path,
+                session_exists,
+                prelaunch_runtime_kind,
+            );
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (
+            provider,
+            remote_profile_is_none,
+            tmux_session_name,
+            prelaunch_runtime_kind,
+        );
+    }
+    (None, None, None, 0)
+}
+
 #[cfg(unix)]
 pub(super) fn observed_runtime_kind_for_managed_tmux(
     provider: &ProviderKind,
@@ -634,6 +696,43 @@ pub(super) async fn reset_provider_session_after_worktree_isolation(
 #[cfg(test)]
 mod thread_role_inheritance_tests {
     use super::*;
+
+    #[test]
+    fn prelaunch_claude_tui_seed_omits_wrapper_output_but_preserves_fifo() {
+        let seed = prelaunch_inflight_runtime_seed_from_paths(
+            "AgentDesk-claude-seed",
+            "/runtime/wrapper-stream.log".to_string(),
+            "/runtime/input.fifo".to_string(),
+            true,
+            Some(RuntimeHandoffKind::ClaudeTui),
+        );
+        assert_eq!(seed.0.as_deref(), Some("AgentDesk-claude-seed"));
+        assert_eq!(
+            seed.1, None,
+            "ClaudeTui must wait for RuntimeReady transcript binding"
+        );
+        assert_eq!(seed.2.as_deref(), Some("/runtime/input.fifo"));
+        assert_eq!(seed.3, 0);
+    }
+
+    #[test]
+    fn prelaunch_seed_is_identical_for_intake_and_headless_callers() {
+        let intake = prelaunch_inflight_runtime_seed_from_paths(
+            "AgentDesk-claude-symmetric",
+            "/runtime/wrapper-stream.log".to_string(),
+            "/runtime/input.fifo".to_string(),
+            true,
+            Some(RuntimeHandoffKind::ClaudeTui),
+        );
+        let headless = prelaunch_inflight_runtime_seed_from_paths(
+            "AgentDesk-claude-symmetric",
+            "/runtime/wrapper-stream.log".to_string(),
+            "/runtime/input.fifo".to_string(),
+            true,
+            Some(RuntimeHandoffKind::ClaudeTui),
+        );
+        assert_eq!(intake, headless);
+    }
 
     #[test]
     fn managed_linked_worktree_skips_provider_reisolation_without_session_state() {

--- a/src/services/discord/terminal_ui_obligation.rs
+++ b/src/services/discord/terminal_ui_obligation.rs
@@ -65,6 +65,7 @@ struct TerminalUiSessionSnapshot {
     tmux_session_name: String,
     output_path: Option<String>,
     current_offset: u64,
+    inflight_claude_tui_output_path_missing: bool,
 }
 
 pub(in crate::services::discord) fn terminal_ui_obligation_now_unix() -> i64 {
@@ -293,6 +294,9 @@ async fn resolve_terminal_ui_session(
             tmux_session_name: tmux_session_name.to_string(),
             current_offset: output_path.as_deref().map(output_file_len).unwrap_or(0),
             output_path,
+            inflight_claude_tui_output_path_missing: state.runtime_kind
+                == Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui)
+                && state.output_path.is_none(),
         });
     }
 
@@ -313,6 +317,7 @@ async fn resolve_terminal_ui_session(
         tmux_session_name,
         current_offset: output_path.as_deref().map(output_file_len).unwrap_or(0),
         output_path,
+        inflight_claude_tui_output_path_missing: false,
     })
 }
 
@@ -361,10 +366,24 @@ fn resolve_terminal_ui_output_path(
         })
 }
 
+fn terminal_ui_claude_tui_output_path_missing(snapshot: &TerminalUiSessionSnapshot) -> bool {
+    snapshot.inflight_claude_tui_output_path_missing
+}
+
+fn terminal_ui_fallback_ready(
+    snapshot: &TerminalUiSessionSnapshot,
+    pane_fallback_ready: bool,
+) -> bool {
+    !terminal_ui_claude_tui_output_path_missing(snapshot) && pane_fallback_ready
+}
+
 fn terminal_ui_session_ready_for_input(
     provider: &ProviderKind,
     snapshot: &TerminalUiSessionSnapshot,
 ) -> bool {
+    if terminal_ui_claude_tui_output_path_missing(snapshot) {
+        return false;
+    }
     let runtime_binding = crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(
         &snapshot.tmux_session_name,
     );
@@ -386,12 +405,15 @@ fn terminal_ui_session_ready_for_input(
     {
         return ready.is_ready();
     }
-    crate::services::provider::tmux_session_fallback_ready_for_input(
-        &snapshot.tmux_session_name,
-        provider,
-        runtime_kind,
+    terminal_ui_fallback_ready(
+        snapshot,
+        crate::services::provider::tmux_session_fallback_ready_for_input(
+            &snapshot.tmux_session_name,
+            provider,
+            runtime_kind,
+        )
+        .is_some_and(crate::services::pane_readiness::FallbackPaneReadiness::is_ready),
     )
-    .is_some_and(crate::services::pane_readiness::FallbackPaneReadiness::is_ready)
 }
 
 fn terminal_ui_generation_mtime_for_tmux(tmux_session_name: &str) -> i64 {
@@ -542,6 +564,21 @@ mod tests {
         ));
         assert!(read_obligation_in_root(temp.path(), ProviderKind::Claude.as_str(), 123).is_none());
         assert!(list_obligations_in_root(temp.path()).is_empty());
+    }
+
+    #[test]
+    fn terminal_ui_claude_tui_without_runtime_output_path_stays_not_ready() {
+        let snapshot = TerminalUiSessionSnapshot {
+            tmux_session_name: "AgentDesk-claude-4997".to_string(),
+            output_path: None,
+            current_offset: 0,
+            inflight_claude_tui_output_path_missing: true,
+        };
+        assert!(terminal_ui_claude_tui_output_path_missing(&snapshot));
+        assert!(
+            !terminal_ui_fallback_ready(&snapshot, true),
+            "missing ClaudeTui runtime output must override a ready pane fallback"
+        );
     }
 
     #[test]

--- a/src/services/discord/terminal_ui_obligation.rs
+++ b/src/services/discord/terminal_ui_obligation.rs
@@ -290,14 +290,11 @@ async fn resolve_terminal_ui_session(
             tmux_session_name,
             state.output_path.as_deref(),
         );
-        return TerminalUiSessionLookup::Current(TerminalUiSessionSnapshot {
-            tmux_session_name: tmux_session_name.to_string(),
-            current_offset: output_path.as_deref().map(output_file_len).unwrap_or(0),
+        return TerminalUiSessionLookup::Current(terminal_ui_snapshot_from_inflight(
+            &state,
+            tmux_session_name,
             output_path,
-            inflight_claude_tui_output_path_missing: state.runtime_kind
-                == Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui)
-                && state.output_path.is_none(),
-        });
+        ));
     }
 
     let Some(tmux_session_name) =
@@ -319,6 +316,23 @@ async fn resolve_terminal_ui_session(
         output_path,
         inflight_claude_tui_output_path_missing: false,
     })
+}
+
+fn terminal_ui_snapshot_from_inflight(
+    state: &inflight::InflightTurnState,
+    tmux_session_name: &str,
+    output_path: Option<String>,
+) -> TerminalUiSessionSnapshot {
+    TerminalUiSessionSnapshot {
+        tmux_session_name: tmux_session_name.to_string(),
+        current_offset: output_path.as_deref().map(output_file_len).unwrap_or(0),
+        output_path,
+        inflight_claude_tui_output_path_missing:
+            crate::services::tui_turn_state::claude_tui_output_path_missing(
+                state.runtime_kind,
+                state.output_path.as_deref(),
+            ),
+    }
 }
 
 async fn resolve_terminal_ui_tmux_session(
@@ -564,6 +578,39 @@ mod tests {
         ));
         assert!(read_obligation_in_root(temp.path(), ProviderKind::Claude.as_str(), 123).is_none());
         assert!(list_obligations_in_root(temp.path()).is_empty());
+    }
+
+    #[test]
+    fn terminal_ui_snapshot_from_inflight_preserves_missing_claude_tui_output_flag() {
+        let mut state = inflight::InflightTurnState::new(
+            ProviderKind::Claude,
+            4_997_002,
+            None,
+            1,
+            2,
+            3,
+            "pending ClaudeTui runtime handoff".to_string(),
+            None,
+            Some("AgentDesk-claude-4997".to_string()),
+            None,
+            Some("/runtime/input.fifo".to_string()),
+            0,
+        );
+        state.runtime_kind = Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui);
+        let snapshot = terminal_ui_snapshot_from_inflight(
+            &state,
+            "AgentDesk-claude-4997",
+            Some("/fallback/output.jsonl".to_string()),
+        );
+
+        assert!(
+            snapshot.inflight_claude_tui_output_path_missing,
+            "the resolved terminal UI snapshot must retain the inflight ClaudeTui missing-output guard"
+        );
+        assert!(
+            !terminal_ui_fallback_ready(&snapshot, true),
+            "the state-derived missing-output guard must override a ready pane fallback"
+        );
     }
 
     #[test]

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -760,8 +760,10 @@ fn restart_orphan_evidence_at(
 }
 
 fn claude_tui_output_path_missing(state: &super::inflight::InflightTurnState) -> bool {
-    state.runtime_kind == Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui)
-        && state.output_path.is_none()
+    crate::services::tui_turn_state::claude_tui_output_path_missing(
+        state.runtime_kind,
+        state.output_path.as_deref(),
+    )
 }
 
 fn restart_orphan_independent_pane_ready(

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -759,6 +759,22 @@ fn restart_orphan_evidence_at(
     }
 }
 
+fn claude_tui_output_path_missing(state: &super::inflight::InflightTurnState) -> bool {
+    state.runtime_kind == Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui)
+        && state.output_path.is_none()
+}
+
+fn restart_orphan_independent_pane_ready(
+    state: &super::inflight::InflightTurnState,
+    readiness: crate::services::tmux_turn_liveness::IndependentTmuxReadiness,
+) -> bool {
+    !claude_tui_output_path_missing(state)
+        && matches!(
+            readiness,
+            crate::services::tmux_turn_liveness::IndependentTmuxReadiness::ReadyForInput
+        )
+}
+
 fn restart_orphan_pane_ready_for_input(
     provider: &crate::services::provider::ProviderKind,
     state: &super::inflight::InflightTurnState,
@@ -770,16 +786,14 @@ fn restart_orphan_pane_ready_for_input(
         .map(str::trim)
         .filter(|path| !path.is_empty())
         .map(std::path::Path::new);
-    matches!(
-        crate::services::tmux_turn_liveness::independent_tmux_readiness(
-            tmux_session_name,
-            provider,
-            state.runtime_kind,
-            output_path,
-            Some(state.last_offset),
-        ),
-        crate::services::tmux_turn_liveness::IndependentTmuxReadiness::ReadyForInput
-    )
+    let readiness = crate::services::tmux_turn_liveness::independent_tmux_readiness(
+        tmux_session_name,
+        provider,
+        state.runtime_kind,
+        output_path,
+        Some(state.last_offset),
+    );
+    restart_orphan_independent_pane_ready(state, readiness)
 }
 
 async fn submit_stale_foreign_inflight_cancel(
@@ -1989,6 +2003,20 @@ mod tests {
         state.born_generation = current_generation.saturating_sub(1);
         state.updated_at = local_timestamp_age_secs(committed_age_secs);
         state
+    }
+
+    #[test]
+    fn restart_orphan_claude_tui_without_runtime_output_path_stays_not_ready() {
+        let mut state = restart_orphan_state(17, RESTART_ORPHAN_COMMITTED_GRACE_SECS + 1);
+        state.runtime_kind = Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui);
+        assert!(claude_tui_output_path_missing(&state));
+        assert!(
+            !restart_orphan_independent_pane_ready(
+                &state,
+                crate::services::tmux_turn_liveness::IndependentTmuxReadiness::ReadyForInput,
+            ),
+            "missing ClaudeTui runtime output must override independent pane readiness"
+        );
     }
 
     #[test]

--- a/src/services/tui_turn_state.rs
+++ b/src/services/tui_turn_state.rs
@@ -189,7 +189,11 @@ pub(crate) fn claude_tui_output_path_missing(
     runtime_kind: Option<RuntimeHandoffKind>,
     output_path: Option<&str>,
 ) -> bool {
-    runtime_kind == Some(RuntimeHandoffKind::ClaudeTui) && output_path.is_none()
+    runtime_kind == Some(RuntimeHandoffKind::ClaudeTui)
+        && output_path
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+            .is_none()
 }
 
 pub(crate) fn jsonl_ready_for_input(

--- a/src/services/tui_turn_state.rs
+++ b/src/services/tui_turn_state.rs
@@ -185,6 +185,13 @@ pub(crate) fn pane_ready_fallback_allowed(
     !provider_runtime_has_structured_jsonl_turn_state(provider, runtime_kind)
 }
 
+pub(crate) fn claude_tui_output_path_missing(
+    runtime_kind: Option<RuntimeHandoffKind>,
+    output_path: Option<&str>,
+) -> bool {
+    runtime_kind == Some(RuntimeHandoffKind::ClaudeTui) && output_path.is_none()
+}
+
 pub(crate) fn jsonl_ready_for_input(
     provider: &ProviderKind,
     runtime_kind: Option<RuntimeHandoffKind>,


### PR DESCRIPTION
Fixes #4997.

## 문제

`intake_turn.rs`가 inflight 행을 시드할 때 `runtime_kind`를 보지 않고 무조건 tmux 경로를 스탬프했다.

```rust
let (output_path, input_fifo_path) = tmux_runtime_paths(tmux_name);   // runtime_kind 미확인
let last_offset = std::fs::metadata(&output_path).map(|m| m.len()).unwrap_or(0);
```

`ClaudeTui` 런타임은 tmux capture 파일이 아니라 projects transcript를 쓴다. 그래서 시드된 `output_path`는 **존재하지 않는 파일을 가리키고**, `last_offset`은 0으로 굳는다. `headless_turn.rs`에 같은 코드가 거의 그대로 복제돼 있었다(31줄 중 2줄만 상이).

이 잘못된 경로가 진단 표면에 노이즈를 만들었고, #4986이 6주간 "배포 후 릴레이 불능" P0으로 오진된 실측 원인이었다.

## 변경

- **S1 (DRY)** — 중복된 시드 로직을 `provider_isolation.rs::prelaunch_inflight_runtime_seed`로 추출. intake/headless가 같은 함수를 쓴다
- **S2** — prelaunch runtime이 `ClaudeTui`면 `output_path=None`, `last_offset=0`으로 시드. `input_fifo_path`는 유지
- **S3 (fail-closed 유지)** — `output_path=None` + `ClaudeTui`를 readiness 3경로에서 not-ready로 고정

`output_path=None`이 되면 `tui_turn_state.rs:197-199`의 short-circuit(파일 부재 → `Some(Unknown)`)이 사라져 pane fallback이 되살아난다. 그건 prompt-injection race 표면이므로 세 지점을 명시적으로 막았다:

| 경로 | 처리 |
|---|---|
| `recovery_engine/state_extractors.rs` | `Unknown` |
| `tui_direct_pending_start.rs` | pane-ready 거부 |
| `terminal_ui_obligation.rs` | pane fallback 거부 |

- RuntimeReady에서 `None → Some(projects transcript)` guarded save 회귀 테스트 추가
- recovery의 `output_path=None`이 `recovery_missing_output_path`가 아니라 기존 tmux fallback으로 가는 것을 명시 테스트

## 뮤테이션 증명

가드 3개를 각각 제거하면 **자기 assert로** 실패(컴파일 에러 아님), 복원하면 통과:

| 제거 대상 | rc | 실패 assert |
|---|---|---|
| recovery extractor guard | 101 | `claude_tui_without_runtime_output_path_stays_not_ready` |
| direct pending-start guard | 101 | `missing ClaudeTui runtime output must override independent pane readiness` |
| terminal UI obligation guard | 101 | `missing ClaudeTui runtime output must override a ready pane fallback` |

## 게이트

`cargo fmt --all --check` 0 · `cargo check --lib` 0 · targeted tests 0 · `generate_inventory_docs.py` + maintenance freshness 0 · `ci-script-checks.sh` 0

새 `state_extractors` 테스트 모듈을 high-risk recovery CI lane에 배선해 test-lane coverage ratchet을 유지했다 (`ci-pr.yml`).
