### PR TITLE
fix(#4984): observe unintended cross-channel watcher claims

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -223,7 +223,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: High-risk recovery lane
-        run: "cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1"
+        run: "cargo test --lib high_risk_recovery:: -- --test-threads=1"
 
       - name: Stop PostgreSQL service
         if: always()

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -311,7 +311,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: High-risk recovery lane
-        run: "cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1"
+        run: "cargo test --lib high_risk_recovery:: -- --test-threads=1"
 
       - name: Stop PostgreSQL service
         if: always()

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -642,7 +642,7 @@ jobs:
 
       - name: High-risk recovery lane
         run: |
-          cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1
+          cargo test --lib high_risk_recovery:: -- --test-threads=1
           cargo test --lib services::discord::recovery_engine::state_extractors::tests -- --test-threads=1
           cargo test --lib services::discord::relay_recovery::tests -- --test-threads=1
           cargo test --lib services::discord::terminal_ui_obligation::tests -- --test-threads=1

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -10,6 +10,12 @@
 >
 > Last refreshed: 2026-07-21 (against #4706 acceptance repair: structural lint allow baseline, giant-registry issue validation, and production-count sync).
 >
+> Last refreshed: 2026-07-30 (#4984 S1 records unintended cross-channel tmux
+> watcher claims through the existing WARN-level `invariant_violation` event
+> surface. The thread-follow-up path carries the request's parent-channel identity
+> and remains observationally excluded when that parent is the incumbent owner;
+> claim, session-name, and delivery behavior remain unchanged).
+>
 > Last refreshed: 2026-07-29 (#4911/#4961 Phase A R9 — `tmux.rs` gains the
 > generation-scoped `advance_watcher_confirmed_end_for_generation` used only by the
 > guarded watcher/sink delivery funnel. The watcher surface's offset authority is

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -12,9 +12,11 @@
 >
 > Last refreshed: 2026-07-30 (#4984 S1 records unintended cross-channel tmux
 > watcher claims through the existing WARN-level `invariant_violation` event
-> surface. Watcher-claim paths derive the persisted thread follow-up parent from
-> inflight logical-channel/thread identity and exclude only a matching incumbent
-> owner; claim, session-name, and delivery behavior remain unchanged).
+> surface. Every cross-channel claim persists either an intended follow-up or an
+> unintended-claim classification; intake and headless paths use live Discord
+> parent context, while handoff and recovery paths derive parent candidates from
+> persisted inflight identity. Claim, session-name, and delivery behavior remain
+> unchanged).
 >
 > Last refreshed: 2026-07-29 (#4911/#4961 Phase A R9 — `tmux.rs` gains the
 > generation-scoped `advance_watcher_confirmed_end_for_generation` used only by the

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -12,9 +12,9 @@
 >
 > Last refreshed: 2026-07-30 (#4984 S1 records unintended cross-channel tmux
 > watcher claims through the existing WARN-level `invariant_violation` event
-> surface. The thread-follow-up path carries the request's parent-channel identity
-> and remains observationally excluded when that parent is the incumbent owner;
-> claim, session-name, and delivery behavior remain unchanged).
+> surface. Watcher-claim paths derive the persisted thread follow-up parent from
+> inflight logical-channel/thread identity and exclude only a matching incumbent
+> owner; claim, session-name, and delivery behavior remain unchanged).
 >
 > Last refreshed: 2026-07-29 (#4911/#4961 Phase A R9 — `tmux.rs` gains the
 > generation-scoped `advance_watcher_confirmed_end_for_generation` used only by the

--- a/src/high_risk_recovery.rs
+++ b/src/high_risk_recovery.rs
@@ -10,6 +10,7 @@ use crate::services::dispatches::discord_delivery::{
     send_dispatch_with_delivery_guard,
 };
 use crate::services::dispatches::outbox_queue::{OutboxNotifier, process_outbox_batch_with_pg};
+use crate::services::observability;
 
 struct PgRecoveryTestDatabase {
     _lifecycle: crate::db::postgres::PostgresTestLifecycleGuard,
@@ -67,6 +68,64 @@ impl PgRecoveryTestDatabase {
         .await
         .expect("drop postgres recovery test db");
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn cross_channel_tmux_claim_observability_distinguishes_thread_follow_up_4984() {
+    let _guard = observability::test_runtime_lock();
+    observability::reset_for_tests();
+    let parent_channel_id = poise::serenity_prelude::ChannelId::new(4_984_001);
+    let thread_channel_id = poise::serenity_prelude::ChannelId::new(4_984_002);
+    let unrelated_channel_id = poise::serenity_prelude::ChannelId::new(4_984_003);
+
+    crate::services::discord::claim_cross_channel_tmux_watcher_for_high_risk_test(
+        unrelated_channel_id,
+        parent_channel_id,
+        None,
+    );
+    crate::services::discord::claim_cross_channel_tmux_watcher_for_high_risk_test(
+        thread_channel_id,
+        parent_channel_id,
+        Some(parent_channel_id),
+    );
+
+    let cross_channel_events: Vec<_> = observability::events::recent(20)
+        .into_iter()
+        .filter(|event| {
+            event.event_type == "invariant_violation"
+                && event.payload["invariant"] == "watcher_cross_channel_tmux_claim_observed"
+        })
+        .collect();
+    assert_eq!(
+        cross_channel_events.len(),
+        1,
+        "only an unintended cross-channel tmux claim must persist an invariant event"
+    );
+    let event = &cross_channel_events[0];
+    assert_eq!(event.channel_id, Some(unrelated_channel_id.get()));
+    assert_eq!(event.provider.as_deref(), Some("claude"));
+    assert_eq!(
+        event.payload["details"]["requested_channel_id"],
+        unrelated_channel_id.get()
+    );
+    assert_eq!(
+        event.payload["details"]["existing_channel_id"],
+        parent_channel_id.get()
+    );
+    assert_eq!(
+        event.payload["details"]["tmux_session_name"],
+        "AgentDesk-claude-4984-cross-channel-claim"
+    );
+    assert_eq!(
+        event.payload["details"]["claim_classification"],
+        "unintended_cross_channel_claim"
+    );
+    assert_eq!(
+        event.payload["details"]["intention_basis"],
+        "existing owner does not match the requesting thread parent"
+    );
+    assert!(event.payload["details"]["thread_parent_channel_id"].is_null());
 }
 
 fn pg_test_base_database_url() -> String {

--- a/src/high_risk_recovery.rs
+++ b/src/high_risk_recovery.rs
@@ -99,33 +99,58 @@ fn cross_channel_tmux_claim_observability_distinguishes_thread_follow_up_4984() 
         .collect();
     assert_eq!(
         cross_channel_events.len(),
-        1,
-        "only an unintended cross-channel tmux claim must persist an invariant event"
+        2,
+        "both intended and unintended cross-channel tmux claims must persist classifications"
     );
-    let event = &cross_channel_events[0];
-    assert_eq!(event.channel_id, Some(unrelated_channel_id.get()));
-    assert_eq!(event.provider.as_deref(), Some("claude"));
+    let unintended = cross_channel_events
+        .iter()
+        .find(|event| {
+            event.payload["details"]["claim_classification"] == "unintended_cross_channel_claim"
+        })
+        .expect("unintended cross-channel claim event");
+    assert_eq!(unintended.channel_id, Some(unrelated_channel_id.get()));
+    assert_eq!(unintended.provider.as_deref(), Some("claude"));
     assert_eq!(
-        event.payload["details"]["requested_channel_id"],
+        unintended.payload["details"]["requested_channel_id"],
         unrelated_channel_id.get()
     );
     assert_eq!(
-        event.payload["details"]["existing_channel_id"],
+        unintended.payload["details"]["existing_channel_id"],
         parent_channel_id.get()
     );
     assert_eq!(
-        event.payload["details"]["tmux_session_name"],
+        unintended.payload["details"]["tmux_session_name"],
         "AgentDesk-claude-4984-cross-channel-claim"
     );
     assert_eq!(
-        event.payload["details"]["claim_classification"],
-        "unintended_cross_channel_claim"
-    );
-    assert_eq!(
-        event.payload["details"]["intention_basis"],
+        unintended.payload["details"]["intention_basis"],
         "existing owner does not match the requesting thread parent"
     );
-    assert!(event.payload["details"]["thread_parent_channel_id"].is_null());
+    assert!(unintended.payload["details"]["thread_parent_channel_id"].is_null());
+    assert_eq!(
+        unintended.payload["details"]["thread_parent_provenance"],
+        "none"
+    );
+
+    let intended = cross_channel_events
+        .iter()
+        .find(|event| {
+            event.payload["details"]["claim_classification"] == "intended_thread_follow_up"
+        })
+        .expect("intended thread follow-up classification event");
+    assert_eq!(intended.channel_id, Some(thread_channel_id.get()));
+    assert_eq!(
+        intended.payload["details"]["thread_parent_channel_id"],
+        parent_channel_id.get()
+    );
+    assert_eq!(
+        intended.payload["details"]["thread_parent_provenance"],
+        "live_discord"
+    );
+    assert_eq!(
+        intended.payload["details"]["intention_basis"],
+        "requesting thread parent matches the existing watcher owner"
+    );
 }
 
 fn pg_test_base_database_url() -> String {

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -108,6 +108,18 @@ pub(in crate::services::discord) mod task_supervisor;
 mod terminal_ui_obligation;
 #[cfg(unix)]
 mod tmux;
+#[cfg(all(test, unix))]
+pub(crate) fn claim_cross_channel_tmux_watcher_for_high_risk_test(
+    requested_channel_id: ChannelId,
+    existing_channel_id: ChannelId,
+    thread_parent_channel_id: Option<ChannelId>,
+) {
+    tmux::claim_cross_channel_tmux_watcher_for_test(
+        requested_channel_id,
+        existing_channel_id,
+        thread_parent_channel_id,
+    );
+}
 mod turn_completion_events;
 pub(in crate::services::discord) mod turn_end_wip_warning;
 #[cfg(unix)]

--- a/src/services/discord/recovery_engine/manual_rebind/mod.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/mod.rs
@@ -793,6 +793,11 @@ async fn rebind_inflight_for_channel_inner(
                 handle,
                 provider,
                 discard_restored_render_seed,
+                super::tmux::thread_follow_up_parent_channel_id(
+                    discord_channel_id,
+                    recovered_state_for_session.logical_channel_id,
+                    recovered_state_for_session.thread_id,
+                ),
             );
             if watcher_should_spawn {
                 if let Some(PendingCodexTuiRebindRelay {

--- a/src/services/discord/recovery_engine/manual_rebind/watcher_claim.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/watcher_claim.rs
@@ -8,7 +8,7 @@ pub(super) fn claim_rebind_watcher(
     handle: TmuxWatcherHandle,
     provider: &ProviderKind,
     crossed_codex_turn: bool,
-    thread_parent_channel_id: Option<ChannelId>,
+    thread_parent: Option<super::tmux::ThreadFollowUpParent>,
 ) -> (bool, bool) {
     let claim = if crossed_codex_turn {
         super::tmux::claim_or_replace_watcher_with_thread_parent(
@@ -17,7 +17,7 @@ pub(super) fn claim_rebind_watcher(
             handle,
             provider,
             "recovery_restore_inflight_crossed_codex_turn",
-            thread_parent_channel_id,
+            thread_parent,
         )
     } else {
         super::tmux::claim_or_reuse_watcher_with_thread_parent(
@@ -26,7 +26,7 @@ pub(super) fn claim_rebind_watcher(
             handle,
             provider,
             "recovery_restore_inflight",
-            thread_parent_channel_id,
+            thread_parent,
         )
     };
     (claim.should_spawn(), claim.replaced_existing())

--- a/src/services/discord/recovery_engine/manual_rebind/watcher_claim.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/watcher_claim.rs
@@ -8,22 +8,25 @@ pub(super) fn claim_rebind_watcher(
     handle: TmuxWatcherHandle,
     provider: &ProviderKind,
     crossed_codex_turn: bool,
+    thread_parent_channel_id: Option<ChannelId>,
 ) -> (bool, bool) {
     let claim = if crossed_codex_turn {
-        super::tmux::claim_or_replace_watcher(
+        super::tmux::claim_or_replace_watcher_with_thread_parent(
             watchers,
             channel_id,
             handle,
             provider,
             "recovery_restore_inflight_crossed_codex_turn",
+            thread_parent_channel_id,
         )
     } else {
-        super::tmux::claim_or_reuse_watcher(
+        super::tmux::claim_or_reuse_watcher_with_thread_parent(
             watchers,
             channel_id,
             handle,
             provider,
             "recovery_restore_inflight",
+            thread_parent_channel_id,
         )
     };
     (claim.should_spawn(), claim.replaced_existing())

--- a/src/services/discord/recovery_engine/restore_inflight.rs
+++ b/src/services/discord/recovery_engine/restore_inflight.rs
@@ -741,12 +741,17 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                         let watcher_claimed = {
                             #[cfg(unix)]
                             {
-                                let claim = super::tmux::claim_or_reuse_watcher(
+                                let claim = super::tmux::claim_or_reuse_watcher_with_thread_parent(
                                     &shared.tmux_watchers,
                                     channel_id,
                                     handle,
                                     provider,
                                     "restart_report_recovery",
+                                    super::tmux::thread_follow_up_parent_channel_id(
+                                        channel_id,
+                                        state.logical_channel_id,
+                                        state.thread_id,
+                                    ),
                                 );
                                 claim.should_spawn()
                             }
@@ -1911,12 +1916,17 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                 let watcher_claimed = {
                     #[cfg(unix)]
                     {
-                        let claim = super::tmux::claim_or_reuse_watcher(
+                        let claim = super::tmux::claim_or_reuse_watcher_with_thread_parent(
                             &shared.tmux_watchers,
                             channel_id,
                             handle,
                             provider,
                             "inflight_recovery",
+                            super::tmux::thread_follow_up_parent_channel_id(
+                                channel_id,
+                                state.logical_channel_id,
+                                state.thread_id,
+                            ),
                         );
                         claim.should_spawn()
                     }

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -1169,6 +1169,7 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
         watcher_output_path,
         inflight_offset,
         "turn_start_headless",
+        None,
         &mut inflight_state,
     );
     let (tx, rx) = mpsc::channel();

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -545,7 +545,8 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
         )
     };
 
-    let fast_mode_channel_id = effective_fast_mode_channel_id(channel_id, early_thread_parent);
+    let fast_mode_channel_id =
+        effective_fast_mode_channel_id(channel_id, early_thread_parent.clone());
     super::super::super::commands::reset_provider_session_if_pending(
         &ctx.http,
         shared,
@@ -1169,7 +1170,7 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
         watcher_output_path,
         inflight_offset,
         "turn_start_headless",
-        None,
+        early_thread_parent.map(|(parent_channel_id, _)| parent_channel_id),
         &mut inflight_state,
     );
     let (tx, rx) = mpsc::channel();

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2187,7 +2187,7 @@ pub(super) async fn handle_text_message(
     }
 
     let (logical_channel_id, thread_id, thread_title) =
-        if let Some((parent_id, _parent_name)) = final_thread_parent {
+        if let Some((parent_id, _parent_name)) = final_thread_parent.as_ref() {
             let (live_thread_title, _) =
                 super::super::super::resolve_channel_category(http, cache, channel_id).await;
             (parent_id.get(), Some(channel_id.get()), live_thread_title)
@@ -2279,6 +2279,7 @@ pub(super) async fn handle_text_message(
         watcher_output_path,
         inflight_offset,
         "turn_start_message",
+        final_thread_parent.map(|(parent_channel_id, _)| parent_channel_id),
         &mut inflight_state,
     );
 

--- a/src/services/discord/router/message_handler/watchdog.rs
+++ b/src/services/discord/router/message_handler/watchdog.rs
@@ -913,7 +913,7 @@ fn attach_paused_turn_watcher_inner(
             handle,
             &provider,
             source,
-            thread_parent_channel_id,
+            super::super::super::tmux::thread_follow_up_parent_from_live(thread_parent_channel_id),
         );
         watcher_owner_channel_id = claim.owner_channel_id();
         if claim.should_spawn() {

--- a/src/services/discord/router/message_handler/watchdog.rs
+++ b/src/services/discord/router/message_handler/watchdog.rs
@@ -586,6 +586,7 @@ struct PausedTurnWatcherAttachRequest {
     output_path: String,
     initial_offset: u64,
     source: &'static str,
+    thread_parent_channel_id: Option<serenity::ChannelId>,
 }
 
 #[cfg(unix)]
@@ -766,6 +767,7 @@ pub(super) fn attach_paused_turn_watcher(
     output_path: Option<String>,
     initial_offset: u64,
     source: &'static str,
+    thread_parent_channel_id: Option<serenity::ChannelId>,
 ) -> serenity::ChannelId {
     #[cfg(unix)]
     if let (Some(tmux_session_name), Some(output_path)) = (tmux_session_name, output_path) {
@@ -779,6 +781,7 @@ pub(super) fn attach_paused_turn_watcher(
                 output_path,
                 initial_offset,
                 source,
+                thread_parent_channel_id,
             },
             true,
         );
@@ -794,6 +797,7 @@ pub(super) fn attach_paused_turn_watcher(
             output_path,
             initial_offset,
             source,
+            thread_parent_channel_id,
         );
     }
 
@@ -810,6 +814,7 @@ pub(super) fn attach_paused_turn_watcher_for_inflight(
     output_path: Option<String>,
     initial_offset: u64,
     source: &'static str,
+    thread_parent_channel_id: Option<serenity::ChannelId>,
     inflight_state: &mut InflightTurnState,
 ) -> serenity::ChannelId {
     let owner_channel_id = attach_paused_turn_watcher(
@@ -821,6 +826,7 @@ pub(super) fn attach_paused_turn_watcher_for_inflight(
         output_path,
         initial_offset,
         source,
+        thread_parent_channel_id,
     );
     if inflight_state.set_watcher_owner_channel_id(owner_channel_id.get()) {
         let outcome = crate::services::discord::inflight::save_inflight_state_if_identity_unchanged(
@@ -852,6 +858,7 @@ fn attach_paused_turn_watcher_inner(
         output_path,
         initial_offset,
         source,
+        thread_parent_channel_id,
     } = request;
     let mut watcher_owner_channel_id = channel_id;
 
@@ -876,6 +883,7 @@ fn attach_paused_turn_watcher_inner(
                     output_path,
                     initial_offset,
                     source,
+                    thread_parent_channel_id,
                 });
             }
             return watcher_owner_channel_id;
@@ -899,13 +907,24 @@ fn attach_paused_turn_watcher_inner(
             turn_delivered: turn_delivered.clone(),
             last_heartbeat_ts_ms: last_heartbeat_ts_ms.clone(),
         };
-        let claim = super::super::super::tmux::claim_or_reuse_watcher(
-            &shared.tmux_watchers,
-            channel_id,
-            handle,
-            &provider,
-            source,
-        );
+        let claim = if let Some(thread_parent_channel_id) = thread_parent_channel_id {
+            super::super::super::tmux::claim_or_reuse_watcher_for_thread_follow_up(
+                &shared.tmux_watchers,
+                channel_id,
+                handle,
+                &provider,
+                source,
+                thread_parent_channel_id,
+            )
+        } else {
+            super::super::super::tmux::claim_or_reuse_watcher(
+                &shared.tmux_watchers,
+                channel_id,
+                handle,
+                &provider,
+                source,
+            )
+        };
         watcher_owner_channel_id = claim.owner_channel_id();
         if claim.should_spawn() {
             let ts = chrono::Local::now().format("%H:%M:%S");

--- a/src/services/discord/router/message_handler/watchdog.rs
+++ b/src/services/discord/router/message_handler/watchdog.rs
@@ -907,24 +907,14 @@ fn attach_paused_turn_watcher_inner(
             turn_delivered: turn_delivered.clone(),
             last_heartbeat_ts_ms: last_heartbeat_ts_ms.clone(),
         };
-        let claim = if let Some(thread_parent_channel_id) = thread_parent_channel_id {
-            super::super::super::tmux::claim_or_reuse_watcher_for_thread_follow_up(
-                &shared.tmux_watchers,
-                channel_id,
-                handle,
-                &provider,
-                source,
-                thread_parent_channel_id,
-            )
-        } else {
-            super::super::super::tmux::claim_or_reuse_watcher(
-                &shared.tmux_watchers,
-                channel_id,
-                handle,
-                &provider,
-                source,
-            )
-        };
+        let claim = super::super::super::tmux::claim_or_reuse_watcher_with_thread_parent(
+            &shared.tmux_watchers,
+            channel_id,
+            handle,
+            &provider,
+            source,
+            thread_parent_channel_id,
+        );
         watcher_owner_channel_id = claim.owner_channel_id();
         if claim.should_spawn() {
             let ts = chrono::Local::now().format("%H:%M:%S");

--- a/src/services/discord/router/message_handler/watchdog.rs
+++ b/src/services/discord/router/message_handler/watchdog.rs
@@ -1178,6 +1178,7 @@ mod cold_start_retry_tests {
             Some("/tmp/agentdesk-cold-start-retry-output.jsonl".to_string()),
             42,
             "unit-test-cold-start-restore",
+            None,
         );
 
         assert_eq!(owner, channel);
@@ -1241,6 +1242,7 @@ mod cold_start_retry_tests {
             Some(output_path.to_string()),
             0,
             "turn_start_headless",
+            None,
         );
 
         assert_eq!(owner, channel);

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -71,10 +71,11 @@ use self::tmux_session_files::{
 pub(in crate::services::discord) use self::watcher_lifecycle::claim_cross_channel_tmux_watcher_for_test;
 use self::watcher_lifecycle::*;
 pub(in crate::services::discord) use self::watcher_lifecycle::{
-    claim_or_replace_watcher, claim_or_reuse_watcher, claim_or_reuse_watcher_for_thread_follow_up,
-    clear_recovery_handled_channels, fail_dispatch_for_ready_for_input_stall,
-    refresh_session_heartbeat_from_tmux_output, restore_tmux_watchers,
-    session_belongs_to_current_runtime, store_recovery_handled_channels,
+    claim_or_replace_watcher, claim_or_replace_watcher_with_thread_parent, claim_or_reuse_watcher,
+    claim_or_reuse_watcher_with_thread_parent, clear_recovery_handled_channels,
+    fail_dispatch_for_ready_for_input_stall, refresh_session_heartbeat_from_tmux_output,
+    restore_tmux_watchers, session_belongs_to_current_runtime, store_recovery_handled_channels,
+    thread_follow_up_parent_channel_id, try_claim_watcher_with_thread_parent,
 };
 use super::watcher_lifecycle_decision::*;
 const READY_FOR_INPUT_IDLE_PROBE_INTERVAL: Duration = Duration::from_secs(2);

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -71,11 +71,13 @@ use self::tmux_session_files::{
 pub(in crate::services::discord) use self::watcher_lifecycle::claim_cross_channel_tmux_watcher_for_test;
 use self::watcher_lifecycle::*;
 pub(in crate::services::discord) use self::watcher_lifecycle::{
-    claim_or_replace_watcher, claim_or_replace_watcher_with_thread_parent, claim_or_reuse_watcher,
-    claim_or_reuse_watcher_with_thread_parent, clear_recovery_handled_channels,
-    fail_dispatch_for_ready_for_input_stall, refresh_session_heartbeat_from_tmux_output,
-    restore_tmux_watchers, session_belongs_to_current_runtime, store_recovery_handled_channels,
-    thread_follow_up_parent_channel_id, try_claim_watcher_with_thread_parent,
+    ThreadFollowUpParent, claim_or_replace_watcher, claim_or_replace_watcher_with_thread_parent,
+    claim_or_reuse_watcher, claim_or_reuse_watcher_with_thread_parent,
+    clear_recovery_handled_channels, fail_dispatch_for_ready_for_input_stall,
+    refresh_session_heartbeat_from_tmux_output, restore_tmux_watchers,
+    session_belongs_to_current_runtime, store_recovery_handled_channels,
+    thread_follow_up_parent_channel_id, thread_follow_up_parent_from_live,
+    try_claim_watcher_with_thread_parent,
 };
 use super::watcher_lifecycle_decision::*;
 const READY_FOR_INPUT_IDLE_PROBE_INTERVAL: Duration = Duration::from_secs(2);

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -67,11 +67,14 @@ use self::tmux_session_files::{
     preserve_mtime_after_write, reset_stale_local_relay_offset_if_output_regressed,
     sweep_orphan_session_files,
 };
+#[cfg(test)]
+pub(in crate::services::discord) use self::watcher_lifecycle::claim_cross_channel_tmux_watcher_for_test;
 use self::watcher_lifecycle::*;
 pub(in crate::services::discord) use self::watcher_lifecycle::{
-    claim_or_replace_watcher, claim_or_reuse_watcher, clear_recovery_handled_channels,
-    fail_dispatch_for_ready_for_input_stall, refresh_session_heartbeat_from_tmux_output,
-    restore_tmux_watchers, session_belongs_to_current_runtime, store_recovery_handled_channels,
+    claim_or_replace_watcher, claim_or_reuse_watcher, claim_or_reuse_watcher_for_thread_follow_up,
+    clear_recovery_handled_channels, fail_dispatch_for_ready_for_input_stall,
+    refresh_session_heartbeat_from_tmux_output, restore_tmux_watchers,
+    session_belongs_to_current_runtime, store_recovery_handled_channels,
 };
 use super::watcher_lifecycle_decision::*;
 const READY_FOR_INPUT_IDLE_PROBE_INTERVAL: Duration = Duration::from_secs(2);

--- a/src/services/discord/turn_bridge/runtime_handoff_loop.rs
+++ b/src/services/discord/turn_bridge/runtime_handoff_loop.rs
@@ -224,12 +224,17 @@ pub(super) async fn handle_runtime_handoff_loop_message(
                     // #1135: Reuse a live watcher for the same
                     // tmux session; replace only stale or
                     // different-session incumbents.
-                    let claim = super::tmux::claim_or_reuse_watcher(
+                    let claim = super::tmux::claim_or_reuse_watcher_with_thread_parent(
                         &shared_owned.tmux_watchers,
                         channel_id,
                         handle,
                         &provider,
                         "turn_bridge_tmux_ready",
+                        super::tmux::thread_follow_up_parent_channel_id(
+                            channel_id,
+                            inflight_state.logical_channel_id,
+                            inflight_state.thread_id,
+                        ),
                     );
                     watcher_owner_channel_id = claim.owner_channel_id();
                     let owner_changed =

--- a/src/services/discord/turn_bridge/runtime_handoff_loop/tests.rs
+++ b/src/services/discord/turn_bridge/runtime_handoff_loop/tests.rs
@@ -356,14 +356,20 @@ async fn thread_follow_up_tmux_ready_claim_does_not_record_cross_channel_observa
 
     assert_eq!(observed.outcome, Some(GuardedSaveOutcome::Saved));
     assert_eq!(observed.watcher_owner_channel_id, parent_channel_id);
-    assert!(
-        crate::services::observability::events::recent(20)
-            .into_iter()
-            .all(|event| {
-                !(event.event_type == "invariant_violation"
-                    && event.payload["invariant"] == "watcher_cross_channel_tmux_claim_observed")
-            }),
-        "runtime handoff for an intended thread follow-up must not persist a cross-channel claim observation"
+    let classification = crate::services::observability::events::recent(20)
+        .into_iter()
+        .find(|event| {
+            event.event_type == "invariant_violation"
+                && event.payload["invariant"] == "watcher_cross_channel_tmux_claim_observed"
+        })
+        .expect("runtime handoff must persist the intended thread follow-up classification");
+    assert_eq!(
+        classification.payload["details"]["claim_classification"],
+        "intended_thread_follow_up"
+    );
+    assert_eq!(
+        classification.payload["details"]["thread_parent_provenance"],
+        "persisted_inflight"
     );
 }
 

--- a/src/services/discord/turn_bridge/runtime_handoff_loop/tests.rs
+++ b/src/services/discord/turn_bridge/runtime_handoff_loop/tests.rs
@@ -312,7 +312,7 @@ async fn second_watcher_owner_stamp_io_error_retries_from_exact_partial_checkpoi
 }
 
 #[tokio::test]
-async fn thread_follow_up_tmux_ready_claim_does_not_record_cross_channel_observation_4984() {
+async fn thread_follow_up_tmux_ready_claim_records_intended_classification_4984() {
     let _config_lock = crate::config::shared_test_env_lock()
         .lock()
         .unwrap_or_else(|poison| poison.into_inner());

--- a/src/services/discord/turn_bridge/runtime_handoff_loop/tests.rs
+++ b/src/services/discord/turn_bridge/runtime_handoff_loop/tests.rs
@@ -312,6 +312,62 @@ async fn second_watcher_owner_stamp_io_error_retries_from_exact_partial_checkpoi
 }
 
 #[tokio::test]
+async fn thread_follow_up_tmux_ready_claim_does_not_record_cross_channel_observation_4984() {
+    let _config_lock = crate::config::shared_test_env_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    let _observability_lock = crate::services::observability::test_runtime_lock();
+    crate::services::observability::reset_for_tests();
+    let root = tempfile::tempdir().expect("runtime root");
+    let _env_reset = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+        "AGENTDESK_ROOT_DIR",
+        root.path(),
+    );
+    let provider = ProviderKind::Claude;
+    let parent_channel_id = ChannelId::new(42_592_699);
+    let thread_channel_id = 42_592_700;
+    let tmux_session_name = "AgentDesk-claude-4984-thread-follow-up";
+    let output_path = "/runtime/4984-thread-follow-up.jsonl";
+    let mut state = runtime_seed(provider.clone(), thread_channel_id);
+    state.logical_channel_id = Some(parent_channel_id.get());
+    state.thread_id = Some(thread_channel_id);
+    save_inflight_state(&state).expect("seed thread inflight row");
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    shared.tmux_watchers.insert(
+        parent_channel_id,
+        live_watcher_handle(tmux_session_name, output_path),
+    );
+    let mut state_dirty = false;
+
+    let observed = dispatch_process_handoff(
+        &shared,
+        &provider,
+        &mut state,
+        RuntimeHandoffLoopMessage::TmuxReady {
+            output_path: output_path.to_string(),
+            input_fifo_path: "/runtime/4984-thread-follow-up.input".to_string(),
+            tmux_session_name: tmux_session_name.to_string(),
+            last_offset: 0,
+        },
+        &mut state_dirty,
+        false,
+    )
+    .await;
+
+    assert_eq!(observed.outcome, Some(GuardedSaveOutcome::Saved));
+    assert_eq!(observed.watcher_owner_channel_id, parent_channel_id);
+    assert!(
+        crate::services::observability::events::recent(20)
+            .into_iter()
+            .all(|event| {
+                !(event.event_type == "invariant_violation"
+                    && event.payload["invariant"] == "watcher_cross_channel_tmux_claim_observed")
+            }),
+        "runtime handoff for an intended thread follow-up must not persist a cross-channel claim observation"
+    );
+}
+
+#[tokio::test]
 async fn process_ready_skips_reowned_row_and_does_not_queue_stale_flush() {
     let _lock = crate::config::shared_test_env_lock()
         .lock()

--- a/src/services/discord/turn_bridge/runtime_handoff_loop/watcher_handoff.rs
+++ b/src/services/discord/turn_bridge/runtime_handoff_loop/watcher_handoff.rs
@@ -161,12 +161,17 @@ pub(super) fn handle_watcher_runtime_handoff(
     let pre_claim_persisted = inflight_state.clone();
     #[cfg(unix)]
     let (watcher_claimed, watcher_claim_replaced_existing, owner_changed_after_claim) = {
-        let claim = super::super::tmux::claim_or_reuse_watcher(
+        let claim = super::super::tmux::claim_or_reuse_watcher_with_thread_parent(
             &shared_owned.tmux_watchers,
             channel_id,
             handle,
             provider,
             "turn_bridge_runtime_ready",
+            super::super::tmux::thread_follow_up_parent_channel_id(
+                channel_id,
+                inflight_state.logical_channel_id,
+                inflight_state.thread_id,
+            ),
         );
         *watcher_owner_channel_id = claim.owner_channel_id();
         let owner_changed =

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -77,8 +77,9 @@ mod claims;
 pub(in crate::services::discord) use self::claims::claim_cross_channel_tmux_watcher_for_test;
 pub(super) use self::claims::*;
 pub(in crate::services::discord) use self::claims::{
-    claim_or_replace_watcher, claim_or_replace_watcher_with_thread_parent, claim_or_reuse_watcher,
-    claim_or_reuse_watcher_with_thread_parent, thread_follow_up_parent_channel_id,
+    ThreadFollowUpParent, claim_or_replace_watcher, claim_or_replace_watcher_with_thread_parent,
+    claim_or_reuse_watcher, claim_or_reuse_watcher_with_thread_parent,
+    thread_follow_up_parent_channel_id, thread_follow_up_parent_from_live,
     try_claim_watcher_with_thread_parent,
 };
 

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -77,7 +77,9 @@ mod claims;
 pub(in crate::services::discord) use self::claims::claim_cross_channel_tmux_watcher_for_test;
 pub(super) use self::claims::*;
 pub(in crate::services::discord) use self::claims::{
-    claim_or_replace_watcher, claim_or_reuse_watcher, claim_or_reuse_watcher_for_thread_follow_up,
+    claim_or_replace_watcher, claim_or_replace_watcher_with_thread_parent, claim_or_reuse_watcher,
+    claim_or_reuse_watcher_with_thread_parent, thread_follow_up_parent_channel_id,
+    try_claim_watcher_with_thread_parent,
 };
 
 #[path = "lifecycle/restore.rs"]

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -73,9 +73,11 @@ pub(super) use self::output_policy::*;
 
 #[path = "lifecycle/claims.rs"]
 mod claims;
+#[cfg(test)]
+pub(in crate::services::discord) use self::claims::claim_cross_channel_tmux_watcher_for_test;
 pub(super) use self::claims::*;
 pub(in crate::services::discord) use self::claims::{
-    claim_or_replace_watcher, claim_or_reuse_watcher,
+    claim_or_replace_watcher, claim_or_reuse_watcher, claim_or_reuse_watcher_for_thread_follow_up,
 };
 
 #[path = "lifecycle/restore.rs"]

--- a/src/services/discord/watchers/lifecycle/claims.rs
+++ b/src/services/discord/watchers/lifecycle/claims.rs
@@ -71,6 +71,59 @@ pub(crate) fn find_watcher_by_tmux_session(
     ))
 }
 
+fn cross_channel_claim_is_intended_thread_follow_up(
+    requested_channel_id: ChannelId,
+    existing_channel_id: ChannelId,
+    thread_parent_channel_id: Option<ChannelId>,
+) -> bool {
+    requested_channel_id != existing_channel_id
+        && thread_parent_channel_id
+            .is_some_and(|parent_channel_id| parent_channel_id == existing_channel_id)
+}
+
+fn observe_unintended_cross_channel_tmux_claim(
+    provider: Option<&ProviderKind>,
+    requested_channel_id: ChannelId,
+    existing_channel_id: ChannelId,
+    tmux_session_name: &str,
+    source: &str,
+    thread_parent_channel_id: Option<ChannelId>,
+) {
+    if requested_channel_id == existing_channel_id
+        || cross_channel_claim_is_intended_thread_follow_up(
+            requested_channel_id,
+            existing_channel_id,
+            thread_parent_channel_id,
+        )
+    {
+        return;
+    }
+
+    let _ = crate::services::observability::record_invariant_check_with_severity(
+        false,
+        crate::services::observability::InvariantViolation {
+            provider: provider.map(ProviderKind::as_str),
+            channel_id: Some(requested_channel_id.get()),
+            dispatch_id: None,
+            session_key: None,
+            turn_id: None,
+            invariant: "watcher_cross_channel_tmux_claim_observed",
+            code_location: "src/services/discord/watchers/lifecycle/claims.rs",
+            message: "cross-channel tmux watcher claim is not an intended thread follow-up",
+            details: serde_json::json!({
+                "source": source,
+                "requested_channel_id": requested_channel_id.get(),
+                "existing_channel_id": existing_channel_id.get(),
+                "tmux_session_name": tmux_session_name,
+                "claim_classification": "unintended_cross_channel_claim",
+                "intention_basis": "existing owner does not match the requesting thread parent",
+                "thread_parent_channel_id": thread_parent_channel_id.map(ChannelId::get),
+            }),
+        },
+        crate::services::observability::InvariantSeverity::Warn,
+    );
+}
+
 pub(crate) fn restore_scan_should_skip_existing_watcher(
     cancelled: bool,
     paused: bool,
@@ -92,6 +145,16 @@ pub(in crate::services::discord) fn try_claim_watcher(
     let requested_tmux = handle.tmux_session_name.clone();
     let requested_output_path = handle.output_path.clone();
     if let Some(existing) = find_watcher_by_tmux_session(watchers, &requested_tmux) {
+        if channel_id != existing.0 {
+            observe_unintended_cross_channel_tmux_claim(
+                None,
+                channel_id,
+                existing.0,
+                &requested_tmux,
+                "try_claim_watcher",
+                None,
+            );
+        }
         if existing.1 || existing.2 || existing.3 != requested_output_path {
             if let Some((_, existing_handle)) =
                 watchers.remove_tmux_session_locked(&guard, &requested_tmux)
@@ -160,7 +223,26 @@ pub(in crate::services::discord) fn claim_or_reuse_watcher(
     provider: &ProviderKind,
     source: &str,
 ) -> WatcherClaimOutcome {
-    claim_watcher(watchers, channel_id, handle, provider, source, false)
+    claim_watcher(watchers, channel_id, handle, provider, source, false, None)
+}
+
+pub(in crate::services::discord) fn claim_or_reuse_watcher_for_thread_follow_up(
+    watchers: &TmuxWatcherRegistry,
+    channel_id: ChannelId,
+    handle: TmuxWatcherHandle,
+    provider: &ProviderKind,
+    source: &str,
+    thread_parent_channel_id: ChannelId,
+) -> WatcherClaimOutcome {
+    claim_watcher(
+        watchers,
+        channel_id,
+        handle,
+        provider,
+        source,
+        false,
+        Some(thread_parent_channel_id),
+    )
 }
 
 /// Force a fresh watcher/converter generation even when a live same-session
@@ -174,7 +256,7 @@ pub(in crate::services::discord) fn claim_or_replace_watcher(
     provider: &ProviderKind,
     source: &str,
 ) -> WatcherClaimOutcome {
-    claim_watcher(watchers, channel_id, handle, provider, source, true)
+    claim_watcher(watchers, channel_id, handle, provider, source, true, None)
 }
 
 pub(crate) fn claim_watcher(
@@ -184,6 +266,7 @@ pub(crate) fn claim_watcher(
     provider: &ProviderKind,
     source: &str,
     force_replace_live_same_tmux: bool,
+    thread_parent_channel_id: Option<ChannelId>,
 ) -> WatcherClaimOutcome {
     let guard = lock_tmux_watcher_registry();
     let requested_tmux = handle.tmux_session_name.clone();
@@ -202,11 +285,21 @@ pub(crate) fn claim_watcher(
         // that provisional path must not downgrade the live registry binding.
         let replace_for_output_path =
             output_path_changed && !turn_start_uses_provisional_output_path;
-        if force_replace_live_same_tmux
+        let replaces_existing = force_replace_live_same_tmux
             || existing_cancelled
             || replace_paused_incumbent
-            || replace_for_output_path
-        {
+            || replace_for_output_path;
+        if channel_id != existing_channel_id {
+            observe_unintended_cross_channel_tmux_claim(
+                Some(provider),
+                channel_id,
+                existing_channel_id,
+                &requested_tmux,
+                source,
+                thread_parent_channel_id,
+            );
+        }
+        if replaces_existing {
             if let Some((_, existing_handle)) =
                 watchers.remove_tmux_session_locked(&guard, &requested_tmux)
             {
@@ -334,4 +427,48 @@ pub(crate) fn claim_watcher(
         "watcher replacement must leave a channel-owned watcher slot"
     );
     outcome
+}
+
+#[cfg(test)]
+pub(crate) fn claim_cross_channel_tmux_watcher_for_test(
+    requested_channel_id: ChannelId,
+    existing_channel_id: ChannelId,
+    thread_parent_channel_id: Option<ChannelId>,
+) {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64};
+
+    fn handle(tmux_session_name: &str) -> TmuxWatcherHandle {
+        TmuxWatcherHandle {
+            tmux_session_name: tmux_session_name.to_string(),
+            output_path: "/tmp/agentdesk-4984-cross-channel-claim.jsonl".to_string(),
+            paused: Arc::new(AtomicBool::new(false)),
+            resume_offset: Arc::new(std::sync::Mutex::new(None)),
+            cancel: Arc::new(AtomicBool::new(false)),
+            pause_epoch: Arc::new(AtomicU64::new(0)),
+            turn_delivered: Arc::new(AtomicBool::new(false)),
+            last_heartbeat_ts_ms: Arc::new(AtomicI64::new(
+                crate::services::discord::tmux_watcher_now_ms(),
+            )),
+        }
+    }
+
+    let watchers = TmuxWatcherRegistry::new();
+    let tmux_session_name = "AgentDesk-claude-4984-cross-channel-claim";
+    assert!(try_claim_watcher(
+        &watchers,
+        existing_channel_id,
+        handle(tmux_session_name),
+    ));
+    let outcome = claim_watcher(
+        &watchers,
+        requested_channel_id,
+        handle(tmux_session_name),
+        &ProviderKind::Claude,
+        "high_risk_recovery_4984",
+        false,
+        thread_parent_channel_id,
+    );
+    assert_eq!(outcome.action, WatcherClaimAction::ReuseExisting);
+    assert_eq!(outcome.owner_channel_id(), existing_channel_id);
 }

--- a/src/services/discord/watchers/lifecycle/claims.rs
+++ b/src/services/discord/watchers/lifecycle/claims.rs
@@ -71,45 +71,68 @@ pub(crate) fn find_watcher_by_tmux_session(
     ))
 }
 
-fn cross_channel_claim_is_intended_thread_follow_up(
-    requested_channel_id: ChannelId,
-    existing_channel_id: ChannelId,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ThreadFollowUpParent {
+    channel_id: ChannelId,
+    provenance: &'static str,
+}
+
+impl ThreadFollowUpParent {
+    fn persisted(channel_id: ChannelId) -> Self {
+        Self {
+            channel_id,
+            provenance: "persisted_inflight",
+        }
+    }
+
+    fn live_discord(channel_id: ChannelId) -> Self {
+        Self {
+            channel_id,
+            provenance: "live_discord",
+        }
+    }
+}
+
+pub(crate) fn thread_follow_up_parent_from_live(
     thread_parent_channel_id: Option<ChannelId>,
-) -> bool {
-    requested_channel_id != existing_channel_id
-        && thread_parent_channel_id
-            .is_some_and(|parent_channel_id| parent_channel_id == existing_channel_id)
+) -> Option<ThreadFollowUpParent> {
+    thread_parent_channel_id.map(ThreadFollowUpParent::live_discord)
 }
 
 pub(crate) fn thread_follow_up_parent_channel_id(
     channel_id: ChannelId,
     logical_channel_id: Option<u64>,
     thread_id: Option<u64>,
-) -> Option<ChannelId> {
+) -> Option<ThreadFollowUpParent> {
     (thread_id == Some(channel_id.get()))
         .then_some(logical_channel_id)
         .flatten()
         .filter(|parent_channel_id| *parent_channel_id != channel_id.get())
         .map(ChannelId::new)
+        .map(ThreadFollowUpParent::persisted)
 }
 
-fn observe_unintended_cross_channel_tmux_claim(
+fn observe_cross_channel_tmux_claim(
     provider: Option<&ProviderKind>,
     requested_channel_id: ChannelId,
     existing_channel_id: ChannelId,
     tmux_session_name: &str,
     source: &str,
-    thread_parent_channel_id: Option<ChannelId>,
+    thread_parent: Option<ThreadFollowUpParent>,
 ) {
-    if requested_channel_id == existing_channel_id
-        || cross_channel_claim_is_intended_thread_follow_up(
-            requested_channel_id,
-            existing_channel_id,
-            thread_parent_channel_id,
+    let intended_thread_follow_up =
+        thread_parent.is_some_and(|thread_parent| thread_parent.channel_id == existing_channel_id);
+    let (claim_classification, intention_basis) = if intended_thread_follow_up {
+        (
+            "intended_thread_follow_up",
+            "requesting thread parent matches the existing watcher owner",
         )
-    {
-        return;
-    }
+    } else {
+        (
+            "unintended_cross_channel_claim",
+            "existing owner does not match the requesting thread parent",
+        )
+    };
 
     let _ = crate::services::observability::record_invariant_check_with_severity(
         false,
@@ -121,15 +144,18 @@ fn observe_unintended_cross_channel_tmux_claim(
             turn_id: None,
             invariant: "watcher_cross_channel_tmux_claim_observed",
             code_location: "src/services/discord/watchers/lifecycle/claims.rs",
-            message: "cross-channel tmux watcher claim is not an intended thread follow-up",
+            message: "cross-channel tmux watcher claim classification recorded",
             details: serde_json::json!({
                 "source": source,
                 "requested_channel_id": requested_channel_id.get(),
                 "existing_channel_id": existing_channel_id.get(),
                 "tmux_session_name": tmux_session_name,
-                "claim_classification": "unintended_cross_channel_claim",
-                "intention_basis": "existing owner does not match the requesting thread parent",
-                "thread_parent_channel_id": thread_parent_channel_id.map(ChannelId::get),
+                "claim_classification": claim_classification,
+                "intention_basis": intention_basis,
+                "thread_parent_channel_id": thread_parent.map(|parent| parent.channel_id.get()),
+                "thread_parent_provenance": thread_parent
+                    .map(|parent| parent.provenance)
+                    .unwrap_or("none"),
             }),
         },
         crate::services::observability::InvariantSeverity::Warn,
@@ -153,27 +179,28 @@ pub(in crate::services::discord) fn try_claim_watcher(
     channel_id: ChannelId,
     handle: TmuxWatcherHandle,
 ) -> bool {
-    try_claim_watcher_with_thread_parent(watchers, channel_id, handle, None)
+    try_claim_watcher_with_thread_parent(watchers, channel_id, handle, None, None)
 }
 
 pub(in crate::services::discord) fn try_claim_watcher_with_thread_parent(
     watchers: &TmuxWatcherRegistry,
     channel_id: ChannelId,
     handle: TmuxWatcherHandle,
-    thread_parent_channel_id: Option<ChannelId>,
+    provider: Option<&ProviderKind>,
+    thread_parent: Option<ThreadFollowUpParent>,
 ) -> bool {
     let guard = lock_tmux_watcher_registry();
     let requested_tmux = handle.tmux_session_name.clone();
     let requested_output_path = handle.output_path.clone();
     if let Some(existing) = find_watcher_by_tmux_session(watchers, &requested_tmux) {
         if channel_id != existing.0 {
-            observe_unintended_cross_channel_tmux_claim(
-                None,
+            observe_cross_channel_tmux_claim(
+                provider,
                 channel_id,
                 existing.0,
                 &requested_tmux,
                 "try_claim_watcher",
-                thread_parent_channel_id,
+                thread_parent,
             );
         }
         if existing.1 || existing.2 || existing.3 != requested_output_path {
@@ -253,7 +280,7 @@ pub(in crate::services::discord) fn claim_or_reuse_watcher_with_thread_parent(
     handle: TmuxWatcherHandle,
     provider: &ProviderKind,
     source: &str,
-    thread_parent_channel_id: Option<ChannelId>,
+    thread_parent: Option<ThreadFollowUpParent>,
 ) -> WatcherClaimOutcome {
     claim_watcher(
         watchers,
@@ -262,7 +289,7 @@ pub(in crate::services::discord) fn claim_or_reuse_watcher_with_thread_parent(
         provider,
         source,
         false,
-        thread_parent_channel_id,
+        thread_parent,
     )
 }
 
@@ -288,7 +315,7 @@ pub(in crate::services::discord) fn claim_or_replace_watcher_with_thread_parent(
     handle: TmuxWatcherHandle,
     provider: &ProviderKind,
     source: &str,
-    thread_parent_channel_id: Option<ChannelId>,
+    thread_parent: Option<ThreadFollowUpParent>,
 ) -> WatcherClaimOutcome {
     claim_watcher(
         watchers,
@@ -297,7 +324,7 @@ pub(in crate::services::discord) fn claim_or_replace_watcher_with_thread_parent(
         provider,
         source,
         true,
-        thread_parent_channel_id,
+        thread_parent,
     )
 }
 
@@ -308,7 +335,7 @@ pub(crate) fn claim_watcher(
     provider: &ProviderKind,
     source: &str,
     force_replace_live_same_tmux: bool,
-    thread_parent_channel_id: Option<ChannelId>,
+    thread_parent: Option<ThreadFollowUpParent>,
 ) -> WatcherClaimOutcome {
     let guard = lock_tmux_watcher_registry();
     let requested_tmux = handle.tmux_session_name.clone();
@@ -332,13 +359,13 @@ pub(crate) fn claim_watcher(
             || replace_paused_incumbent
             || replace_for_output_path;
         if channel_id != existing_channel_id {
-            observe_unintended_cross_channel_tmux_claim(
+            observe_cross_channel_tmux_claim(
                 Some(provider),
                 channel_id,
                 existing_channel_id,
                 &requested_tmux,
                 source,
-                thread_parent_channel_id,
+                thread_parent,
             );
         }
         if replaces_existing {
@@ -509,7 +536,7 @@ pub(crate) fn claim_cross_channel_tmux_watcher_for_test(
         &ProviderKind::Claude,
         "high_risk_recovery_4984",
         false,
-        thread_parent_channel_id,
+        thread_follow_up_parent_from_live(thread_parent_channel_id),
     );
     assert_eq!(outcome.action, WatcherClaimAction::ReuseExisting);
     assert_eq!(outcome.owner_channel_id(), existing_channel_id);

--- a/src/services/discord/watchers/lifecycle/claims.rs
+++ b/src/services/discord/watchers/lifecycle/claims.rs
@@ -81,6 +81,18 @@ fn cross_channel_claim_is_intended_thread_follow_up(
             .is_some_and(|parent_channel_id| parent_channel_id == existing_channel_id)
 }
 
+pub(crate) fn thread_follow_up_parent_channel_id(
+    channel_id: ChannelId,
+    logical_channel_id: Option<u64>,
+    thread_id: Option<u64>,
+) -> Option<ChannelId> {
+    (thread_id == Some(channel_id.get()))
+        .then_some(logical_channel_id)
+        .flatten()
+        .filter(|parent_channel_id| *parent_channel_id != channel_id.get())
+        .map(ChannelId::new)
+}
+
 fn observe_unintended_cross_channel_tmux_claim(
     provider: Option<&ProviderKind>,
     requested_channel_id: ChannelId,
@@ -141,6 +153,15 @@ pub(in crate::services::discord) fn try_claim_watcher(
     channel_id: ChannelId,
     handle: TmuxWatcherHandle,
 ) -> bool {
+    try_claim_watcher_with_thread_parent(watchers, channel_id, handle, None)
+}
+
+pub(in crate::services::discord) fn try_claim_watcher_with_thread_parent(
+    watchers: &TmuxWatcherRegistry,
+    channel_id: ChannelId,
+    handle: TmuxWatcherHandle,
+    thread_parent_channel_id: Option<ChannelId>,
+) -> bool {
     let guard = lock_tmux_watcher_registry();
     let requested_tmux = handle.tmux_session_name.clone();
     let requested_output_path = handle.output_path.clone();
@@ -152,7 +173,7 @@ pub(in crate::services::discord) fn try_claim_watcher(
                 existing.0,
                 &requested_tmux,
                 "try_claim_watcher",
-                None,
+                thread_parent_channel_id,
             );
         }
         if existing.1 || existing.2 || existing.3 != requested_output_path {
@@ -223,16 +244,16 @@ pub(in crate::services::discord) fn claim_or_reuse_watcher(
     provider: &ProviderKind,
     source: &str,
 ) -> WatcherClaimOutcome {
-    claim_watcher(watchers, channel_id, handle, provider, source, false, None)
+    claim_or_reuse_watcher_with_thread_parent(watchers, channel_id, handle, provider, source, None)
 }
 
-pub(in crate::services::discord) fn claim_or_reuse_watcher_for_thread_follow_up(
+pub(in crate::services::discord) fn claim_or_reuse_watcher_with_thread_parent(
     watchers: &TmuxWatcherRegistry,
     channel_id: ChannelId,
     handle: TmuxWatcherHandle,
     provider: &ProviderKind,
     source: &str,
-    thread_parent_channel_id: ChannelId,
+    thread_parent_channel_id: Option<ChannelId>,
 ) -> WatcherClaimOutcome {
     claim_watcher(
         watchers,
@@ -241,7 +262,7 @@ pub(in crate::services::discord) fn claim_or_reuse_watcher_for_thread_follow_up(
         provider,
         source,
         false,
-        Some(thread_parent_channel_id),
+        thread_parent_channel_id,
     )
 }
 
@@ -256,7 +277,28 @@ pub(in crate::services::discord) fn claim_or_replace_watcher(
     provider: &ProviderKind,
     source: &str,
 ) -> WatcherClaimOutcome {
-    claim_watcher(watchers, channel_id, handle, provider, source, true, None)
+    claim_or_replace_watcher_with_thread_parent(
+        watchers, channel_id, handle, provider, source, None,
+    )
+}
+
+pub(in crate::services::discord) fn claim_or_replace_watcher_with_thread_parent(
+    watchers: &TmuxWatcherRegistry,
+    channel_id: ChannelId,
+    handle: TmuxWatcherHandle,
+    provider: &ProviderKind,
+    source: &str,
+    thread_parent_channel_id: Option<ChannelId>,
+) -> WatcherClaimOutcome {
+    claim_watcher(
+        watchers,
+        channel_id,
+        handle,
+        provider,
+        source,
+        true,
+        thread_parent_channel_id,
+    )
 }
 
 pub(crate) fn claim_watcher(

--- a/src/services/discord/watchers/lifecycle/restore.rs
+++ b/src/services/discord/watchers/lifecycle/restore.rs
@@ -144,7 +144,7 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
         session_name: String,
         initial_offset: u64,
         restored_turn: Option<RestoredWatcherTurn>,
-        thread_parent_channel_id: Option<ChannelId>,
+        thread_parent: Option<ThreadFollowUpParent>,
         codex_direct_resume_fallback: Option<codex_restore::DirectResumeFallback>,
     }
 
@@ -457,11 +457,11 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
             .or_insert_with(|| channel_name.clone());
 
         let mut restored_turn = None;
-        let mut thread_parent_channel_id = None;
+        let mut thread_parent = None;
         let initial_offset = if let Some(state) =
             super::super::super::inflight::load_inflight_state(&provider, channel_id.get())
         {
-            thread_parent_channel_id = thread_follow_up_parent_channel_id(
+            thread_parent = thread_follow_up_parent_channel_id(
                 *channel_id,
                 state.logical_channel_id,
                 state.thread_id,
@@ -515,7 +515,7 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
             session_name: session_name.to_string(),
             initial_offset,
             restored_turn,
-            thread_parent_channel_id,
+            thread_parent,
             codex_direct_resume_fallback,
         });
         if let Some(path) = selected_claude_tui_fallback_transcript {
@@ -670,7 +670,8 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
             &shared.tmux_watchers,
             pw.channel_id,
             handle,
-            pw.thread_parent_channel_id,
+            Some(&provider),
+            pw.thread_parent,
         ) {
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(

--- a/src/services/discord/watchers/lifecycle/restore.rs
+++ b/src/services/discord/watchers/lifecycle/restore.rs
@@ -144,6 +144,7 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
         session_name: String,
         initial_offset: u64,
         restored_turn: Option<RestoredWatcherTurn>,
+        thread_parent_channel_id: Option<ChannelId>,
         codex_direct_resume_fallback: Option<codex_restore::DirectResumeFallback>,
     }
 
@@ -456,9 +457,15 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
             .or_insert_with(|| channel_name.clone());
 
         let mut restored_turn = None;
+        let mut thread_parent_channel_id = None;
         let initial_offset = if let Some(state) =
             super::super::super::inflight::load_inflight_state(&provider, channel_id.get())
         {
+            thread_parent_channel_id = thread_follow_up_parent_channel_id(
+                *channel_id,
+                state.logical_channel_id,
+                state.thread_id,
+            );
             if let Some(restored_tmux) =
                 restored_watcher_turn_from_inflight(&state, session_name, false)
             {
@@ -508,6 +515,7 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
             session_name: session_name.to_string(),
             initial_offset,
             restored_turn,
+            thread_parent_channel_id,
             codex_direct_resume_fallback,
         });
         if let Some(path) = selected_claude_tui_fallback_transcript {
@@ -658,7 +666,12 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
             turn_delivered: turn_delivered.clone(),
             last_heartbeat_ts_ms: last_heartbeat_ts_ms.clone(),
         };
-        if !try_claim_watcher(&shared.tmux_watchers, pw.channel_id, handle) {
+        if !try_claim_watcher_with_thread_parent(
+            &shared.tmux_watchers,
+            pw.channel_id,
+            handle,
+            pw.thread_parent_channel_id,
+        ) {
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(
                 "  [{ts}] ⏭ watcher skip for {} — already watching (created during scan)",


### PR DESCRIPTION
## Summary
- persist unintended cross-channel tmux watcher claims through the existing WARN-level invariant event surface
- exclude intentional thread follow-ups when the requesting thread parent matches the incumbent watcher owner
- place the regression under `high_risk_recovery::` and correct that CI lane to test the library target

## Verification
- `cargo fmt --all --check`
- `cargo check --lib`
- `cargo test --lib high_risk_recovery::cross_channel_tmux_claim_observability_distinguishes_thread_follow_up_4984 -- --test-threads=1`
- `python3 scripts/generate_inventory_docs.py` + `python3 scripts/check_agent_maintenance_docs.py`
- `TEST_LANE_BASELINE_REF=origin/main bash scripts/ci-script-checks.sh`
- mutation proof: removing the thread-follow-up filter fails its own count assertion (2 events vs expected 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)