### PR TITLE
feat(#5003): test-target integrity gate for curated cargo test lanes (S1)

### DIFF
--- a/scripts/check_test_target_integrity.py
+++ b/scripts/check_test_target_integrity.py
@@ -6,7 +6,9 @@ pairing the wrong target flag (e.g. `--bin agentdesk`) with a lib-only module
 filter runs 0 tests while its required check stays green. This gate statically
 cross-checks each workflow `cargo test` command's `--lib`/`--bin`/`--test`
 selection against where the filtered module is declared (module tree walked
-from Cargo.toml target roots; no compilation). Default mode is warn-only
+from Cargo.toml target roots, following `#[path = "..."]` redirections; no
+compilation). A filtered command whose selected target declares no modules at
+all is always flagged. Default mode is warn-only
 (rc=0) until the known offenders are repaired; `--enforce` makes violations
 fatal, and opt-in `--run-list-check` additionally runs
 `cargo test ... -- --list` (compiles) to flag lanes selecting 0 tests.
@@ -28,6 +30,8 @@ from pathlib import Path
 MOD_DECL = re.compile(
     r"^\s*(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*([;{])"
 )
+ATTR_PATH = re.compile(r'^\s*#\[path\s*=\s*"([^"]+)"\s*\]')
+ATTR_LINE = re.compile(r"^\s*#\[")
 # Options consuming a value; their value must not be read as a filter.
 CARGO_VALUE_OPTIONS = {
     "-p", "--package", "--exclude", "-j", "--jobs", "--features", "--profile",
@@ -50,8 +54,10 @@ class Violation:
     detail: str
 
     def render(self) -> str:
-        return (f"{self.workflow}:{self.line}: [{self.kind}] {self.detail}\n"
-                f"    command: {self.command}")
+        # Single line: GitHub `::warning::` annotations only surface the
+        # first line, so the command must live on the same line.
+        return (f"{self.workflow}:{self.line}: [{self.kind}] {self.detail} "
+                f"(command: {self.command})")
 
 
 def load_allowlist(path: Path) -> set[str]:
@@ -90,19 +96,35 @@ def collect_modules(root: Path, repo_root: Path) -> dict[str, str]:
         if source in seen or not source.is_file():
             continue
         seen.add(source)
+        pending_path: str | None = None
         for lineno, line in enumerate(source.read_text("utf-8").splitlines(), 1):
+            attr = ATTR_PATH.match(line)
+            if attr:
+                pending_path = attr.group(1)
+                continue
             match = MOD_DECL.match(line)
             if not match:
+                # Other attributes (#[cfg], ...) may sit between #[path] and
+                # the mod item; any other non-blank line detaches the attr.
+                if line.strip() and not ATTR_LINE.match(line):
+                    pending_path = None
                 continue
             name, terminator = match.groups()
+            redirect, pending_path = pending_path, None
             modules.setdefault(name, f"{source.relative_to(repo_root)}:{lineno}")
             if terminator != ";":
                 continue  # inline module: same-file lines are already scanned
-            if source.name in ("lib.rs", "main.rs", "mod.rs"):
+            if redirect is not None:
+                # #[path = "..."] outside inline blocks is relative to the
+                # directory of the declaring source file.
+                candidates: tuple[Path, ...] = (source.parent / redirect,)
+            elif source.name in ("lib.rs", "main.rs", "mod.rs"):
                 base = source.parent
+                candidates = (base / f"{name}.rs", base / name / "mod.rs")
             else:
                 base = source.parent / source.stem
-            for candidate in (base / f"{name}.rs", base / name / "mod.rs"):
+                candidates = (base / f"{name}.rs", base / name / "mod.rs")
+            for candidate in candidates:
                 if candidate.is_file():
                     queue.append(candidate)
                     break
@@ -224,6 +246,12 @@ def validate_command(spec: CommandSpec, inventories: dict[str, dict[str, str]],
             findings.append(("unknown-module", (
                 f"module-path filter `{filt}`: leading segment `{lead}` is "
                 f"not a module in any known target")))
+    if spec.filters and not selected and not findings:
+        # Decisive signal: the selected target declares no modules at all, so
+        # ANY filter (typo'd, ::-less, whatever) selects 0 tests there.
+        findings.append(("empty-target", (
+            f"selected target(s) {'/'.join(spec.targets)} declare no modules; "
+            f"every libtest filter runs 0 tests there and cargo still exits 0")))
     return findings
 
 
@@ -247,15 +275,21 @@ def check_workflows(repo_root: Path, workflows: list[Path], allowlist: set[str],
     }
     violations: list[Violation] = []
     for workflow in workflows:
-        rel = str(workflow.relative_to(repo_root))
+        rel = (str(workflow.relative_to(repo_root))
+               if workflow.is_relative_to(repo_root) else str(workflow))
         for lineno, words, normalized in extract_commands(workflow):
-            if normalized in allowlist:
-                continue
+            allowlisted = normalized in allowlist
             spec = parse_command(words)
             if spec.skipped:
                 continue
             findings = validate_command(spec, inventories, repo_root)
-            if with_list_check and not findings:
+            if allowlisted:
+                # The allowlist only excuses legitimately-empty lanes; a
+                # target-mismatch means the command itself is wrong and must
+                # be fixed, never allowlisted (enforced here, not just docs).
+                findings = [(kind, detail) for kind, detail in findings
+                            if kind == "target-mismatch"]
+            if with_list_check and not findings and not allowlisted:
                 detail = run_list_check(words, repo_root)
                 if detail:
                     findings.append(("zero-match", detail))

--- a/scripts/check_test_target_integrity.py
+++ b/scripts/check_test_target_integrity.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Test-target integrity gate (#5003 S1).
+
+cargo exits 0 when a libtest filter matches zero tests, so a curated CI lane
+pairing the wrong target flag (e.g. `--bin agentdesk`) with a lib-only module
+filter runs 0 tests while its required check stays green. This gate statically
+cross-checks each workflow `cargo test` command's `--lib`/`--bin`/`--test`
+selection against where the filtered module is declared (module tree walked
+from Cargo.toml target roots; no compilation). Default mode is warn-only
+(rc=0) until the known offenders are repaired; `--enforce` makes violations
+fatal, and opt-in `--run-list-check` additionally runs
+`cargo test ... -- --list` (compiles) to flag lanes selecting 0 tests.
+Legitimately-empty lanes (platform `#[cfg]`) are excused via
+scripts/test_target_integrity_allowlist.txt (normalized command per line).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shlex
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+MOD_DECL = re.compile(
+    r"^\s*(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*([;{])"
+)
+# Options consuming a value; their value must not be read as a filter.
+CARGO_VALUE_OPTIONS = {
+    "-p", "--package", "--exclude", "-j", "--jobs", "--features", "--profile",
+    "--target", "--target-dir", "--manifest-path", "--color", "--config",
+    "--bin", "--test", "--bench", "--example",
+}
+TARGET_VALUE_OPTIONS = {"--bin", "--test"}
+# Target selectors we cannot statically map to a module tree (skipped).
+UNSUPPORTED_TARGET_OPTIONS = {"--bins", "--tests", "--bench", "--benches",
+                              "--example", "--examples", "--doc"}
+LIST_SUMMARY = re.compile(r"(\d+) tests?, \d+ benchmarks")
+
+
+@dataclass(frozen=True)
+class Violation:
+    workflow: str
+    line: int
+    command: str
+    kind: str
+    detail: str
+
+    def render(self) -> str:
+        return (f"{self.workflow}:{self.line}: [{self.kind}] {self.detail}\n"
+                f"    command: {self.command}")
+
+
+def load_allowlist(path: Path) -> set[str]:
+    lines = path.read_text("utf-8").splitlines() if path.is_file() else []
+    return {ln.strip() for ln in lines
+            if ln.strip() and not ln.strip().startswith("#")}
+
+
+def discover_targets(repo_root: Path) -> dict[str, Path]:
+    """Map target keys ('lib', 'bin:<name>') to their crate-root source file."""
+    manifest = tomllib.loads((repo_root / "Cargo.toml").read_text("utf-8"))
+    targets: dict[str, Path] = {}
+    lib_path = repo_root / manifest.get("lib", {}).get("path", "src/lib.rs")
+    if lib_path.is_file():
+        targets["lib"] = lib_path
+    package_name = manifest.get("package", {}).get("name", "")
+    for bin_table in manifest.get("bin", []):
+        name, path = bin_table.get("name"), bin_table.get("path")
+        if name and path and (repo_root / path).is_file():
+            targets[f"bin:{name}"] = repo_root / path
+    main_rs = repo_root / "src/main.rs"
+    if package_name and main_rs.is_file() \
+            and not any(key.startswith("bin:") for key in targets):
+        targets[f"bin:{package_name}"] = main_rs
+    for auto_bin in sorted((repo_root / "src/bin").glob("*.rs")):
+        targets.setdefault(f"bin:{auto_bin.stem}", auto_bin)
+    return targets
+
+
+def collect_modules(root: Path, repo_root: Path) -> dict[str, str]:
+    """Walk `mod` declarations from a crate root; name -> first decl site."""
+    modules: dict[str, str] = {}
+    queue, seen = [root], set()
+    while queue:
+        source = queue.pop()
+        if source in seen or not source.is_file():
+            continue
+        seen.add(source)
+        for lineno, line in enumerate(source.read_text("utf-8").splitlines(), 1):
+            match = MOD_DECL.match(line)
+            if not match:
+                continue
+            name, terminator = match.groups()
+            modules.setdefault(name, f"{source.relative_to(repo_root)}:{lineno}")
+            if terminator != ";":
+                continue  # inline module: same-file lines are already scanned
+            if source.name in ("lib.rs", "main.rs", "mod.rs"):
+                base = source.parent
+            else:
+                base = source.parent / source.stem
+            for candidate in (base / f"{name}.rs", base / name / "mod.rs"):
+                if candidate.is_file():
+                    queue.append(candidate)
+                    break
+    return modules
+
+
+def extract_commands(workflow: Path) -> list[tuple[int, list[str], str]]:
+    """Yield (line, argv, normalized) for each `cargo test` line in a workflow."""
+    commands: list[tuple[int, list[str], str]] = []
+    for lineno, line in enumerate(workflow.read_text("utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        start = stripped.find("cargo test")
+        if start < 0:
+            continue
+        snippet = stripped[start:]
+        try:
+            words = shlex.split(snippet, comments=True)
+        except ValueError:
+            # `run: "... cargo test ..."` YAML quoting leaves a dangling
+            # close quote after the command; retry without it.
+            if not (snippet and snippet[-1] in "\"'"):
+                continue
+            try:
+                words = shlex.split(snippet[:-1], comments=True)
+            except ValueError:
+                continue
+        if words[:2] != ["cargo", "test"]:
+            continue
+        commands.append((lineno, words, " ".join(words)))
+    return commands
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    targets: tuple[str, ...]      # 'lib', 'bin:<name>', 'test:<name>'
+    filters: tuple[str, ...]
+    skipped: bool                 # cannot/should not be statically judged
+
+
+def parse_command(words: list[str]) -> CommandSpec:
+    args = words[2:]
+    before, after = args, []
+    if "--" in args:
+        split = args.index("--")
+        before, after = args[:split], args[split + 1:]
+    targets: list[str] = []
+    filters: list[str] = []
+    unsupported = False
+    index = 0
+    while index < len(before):
+        token = before[index]
+        if token in TARGET_VALUE_OPTIONS and index + 1 < len(before):
+            kind = "bin" if token == "--bin" else "test"
+            targets.append(f"{kind}:{before[index + 1]}")
+            index += 2
+            continue
+        if token == "--lib":
+            targets.append("lib")
+        elif token in UNSUPPORTED_TARGET_OPTIONS or token == "--all-targets":
+            unsupported = unsupported or token != "--all-targets"
+            if token == "--all-targets":
+                return CommandSpec((), (), skipped=True)
+        elif token in CARGO_VALUE_OPTIONS:
+            index += 1
+        elif not token.startswith("-"):
+            filters.append(token)
+        index += 1
+    index = 0
+    while index < len(after):
+        token = after[index]
+        if token in ("--skip", "--test-threads", "--format", "--color", "-Z"):
+            index += 1
+        elif not token.startswith("-"):
+            filters.append(token)
+        index += 1
+    # No explicit selection (all default targets run) or a target family we do
+    # not model: nothing to cross-check statically.
+    skipped = unsupported or not targets
+    return CommandSpec(tuple(targets), tuple(filters), skipped=skipped)
+
+
+def validate_command(spec: CommandSpec, inventories: dict[str, dict[str, str]],
+                     repo_root: Path) -> list[tuple[str, str]]:
+    """Return (kind, detail) findings for one parsed cargo test command."""
+    findings: list[tuple[str, str]] = []
+    selected: dict[str, str] = {}
+    for target in spec.targets:
+        if target.startswith("test:"):
+            name = target.partition(":")[2]
+            path = repo_root / "tests" / f"{name}.rs"
+            if not path.is_file():
+                findings.append(("unknown-target",
+                                 f"--test {name}: tests/{name}.rs not found"))
+                continue
+            inventories.setdefault(target, collect_modules(path, repo_root))
+        if target not in inventories:
+            findings.append(("unknown-target",
+                             f"target `{target}` not found in Cargo.toml"))
+            continue
+        selected.update(inventories[target])
+    for filt in spec.filters:
+        lead = filt.split("::", 1)[0]
+        if not lead or lead in selected:
+            continue
+        declared_in = {
+            target: modules[lead]
+            for target, modules in inventories.items() if lead in modules
+        }
+        if declared_in:
+            sites = ", ".join(f"{t} ({site})" for t, site in
+                              sorted(declared_in.items()))
+            findings.append(("target-mismatch", (
+                f"filter `{filt}` names module `{lead}` declared in {sites}, "
+                f"but the command only selects {'/'.join(spec.targets)}; the "
+                f"filter matches 0 tests there and cargo still exits 0")))
+        elif "::" in filt:
+            findings.append(("unknown-module", (
+                f"module-path filter `{filt}`: leading segment `{lead}` is "
+                f"not a module in any known target")))
+    return findings
+
+
+def run_list_check(words: list[str], repo_root: Path) -> str | None:
+    """Run `<command> -- --list`; return a finding detail if 0 tests match."""
+    args = words[:words.index("--")] if "--" in words else list(words)
+    proc = subprocess.run(args + ["--", "--list"], cwd=repo_root,
+                          capture_output=True, text=True)
+    if proc.returncode != 0:
+        return f"--list run failed (rc={proc.returncode}): {proc.stderr[-300:]}"
+    total = sum(int(count) for count in LIST_SUMMARY.findall(proc.stdout))
+    return None if total else \
+        "command selects 0 tests (`-- --list` reported no matches)"
+
+
+def check_workflows(repo_root: Path, workflows: list[Path], allowlist: set[str],
+                    with_list_check: bool) -> list[Violation]:
+    inventories = {
+        target: collect_modules(root, repo_root)
+        for target, root in discover_targets(repo_root).items()
+    }
+    violations: list[Violation] = []
+    for workflow in workflows:
+        rel = str(workflow.relative_to(repo_root))
+        for lineno, words, normalized in extract_commands(workflow):
+            if normalized in allowlist:
+                continue
+            spec = parse_command(words)
+            if spec.skipped:
+                continue
+            findings = validate_command(spec, inventories, repo_root)
+            if with_list_check and not findings:
+                detail = run_list_check(words, repo_root)
+                if detail:
+                    findings.append(("zero-match", detail))
+            violations.extend(Violation(rel, lineno, normalized, kind, detail)
+                              for kind, detail in findings)
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo-root", type=Path,
+                        default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--workflow", action="append", type=Path, default=None,
+                        help="workflow file(s); default .github/workflows/*.yml")
+    parser.add_argument("--allowlist", type=Path, default=None)
+    parser.add_argument("--enforce", action="store_true",
+                        help="exit 1 on violations (default: warn only)")
+    parser.add_argument("--run-list-check", action="store_true",
+                        help="also run `cargo test ... -- --list` (compiles)")
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    workflows = args.workflow or sorted(
+        (repo_root / ".github/workflows").glob("*.yml"))
+    allowlist = load_allowlist(args.allowlist or (
+        repo_root / "scripts/test_target_integrity_allowlist.txt"))
+    violations = check_workflows(repo_root,
+                                 [Path(w).resolve() for w in workflows],
+                                 allowlist, args.run_list_check)
+    for violation in violations:
+        prefix = "ERROR" if args.enforce else "::warning::"
+        print(f"{prefix} {violation.render()}")
+    if violations:
+        mode = "enforced" if args.enforce else "warn-only rollout (#5003)"
+        print(f"test-target integrity: {len(violations)} violation(s) [{mode}]")
+        return 1 if args.enforce else 0
+    print("test-target integrity check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -125,6 +125,15 @@ fi
 "$PYTHON" scripts/check_test_lane_coverage.py --baseline-ref "$TEST_LANE_BASELINE_REF"
 "$PYTHON" -m unittest tests.test_test_lane_coverage
 
+echo "=== Test-target integrity gate (#5003, warn-only rollout) ==="
+# cargo exits 0 on zero filter matches, so a curated lane with the wrong
+# --lib/--bin/--test flag can run 0 tests while its required check stays
+# green. Warn-only until the known offenders are repaired (separate slice);
+# flip to --enforce afterwards. The unittest run below is the gate's own
+# mutation proof (bad fixture must fail, fixed fixture must pass).
+"$PYTHON" scripts/check_test_target_integrity.py
+"$PYTHON" -m unittest tests.test_check_test_target_integrity
+
 echo "=== Scheduled-message PG path-filter wiring contract ==="
 "$PYTHON" -m unittest tests.test_scheduled_messages_ci_wiring
 

--- a/scripts/test_target_integrity_allowlist.txt
+++ b/scripts/test_target_integrity_allowlist.txt
@@ -1,0 +1,10 @@
+# Allowlist for scripts/check_test_target_integrity.py (#5003).
+#
+# One normalized `cargo test` command per line (tokens joined by single
+# spaces, exactly as printed in the violation's `command:` field). Add an
+# entry ONLY for lanes that legitimately select zero tests on some platform
+# (e.g. an entire suite behind #[cfg(target_os = "...")]) and document the
+# reason in a `#` comment directly above the entry.
+#
+# Do NOT allowlist target-mismatch violations (wrong --lib/--bin/--test
+# pairing): fix the command instead.

--- a/scripts/test_target_integrity_allowlist.txt
+++ b/scripts/test_target_integrity_allowlist.txt
@@ -6,5 +6,6 @@
 # (e.g. an entire suite behind #[cfg(target_os = "...")]) and document the
 # reason in a `#` comment directly above the entry.
 #
-# Do NOT allowlist target-mismatch violations (wrong --lib/--bin/--test
-# pairing): fix the command instead.
+# target-mismatch violations (wrong --lib/--bin/--test pairing) can NOT be
+# allowlisted — check_test_target_integrity.py ignores allowlist entries for
+# that kind in code. Fix the command instead.

--- a/tests/test_check_test_target_integrity.py
+++ b/tests/test_check_test_target_integrity.py
@@ -1,0 +1,238 @@
+"""Tests for the test-target integrity gate (#5003 S1).
+
+The gate exists because cargo exits 0 when a libtest filter matches nothing,
+so a curated lane with the wrong target flag runs 0 tests while its required
+check stays green. These tests are the gate's own mutation proof: a known-bad
+command fixture must FAIL validation and its corrected form must PASS.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "check_test_target_integrity.py"
+_spec = importlib.util.spec_from_file_location("check_test_target_integrity", SCRIPT)
+assert _spec and _spec.loader
+integrity = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = integrity
+_spec.loader.exec_module(integrity)
+
+BAD_COMMAND = "cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1"
+GOOD_COMMAND = "cargo test --lib high_risk_recovery:: -- --test-threads=1"
+
+
+def build_fixture_repo(root: Path, command: str) -> Path:
+    """Materialize a minimal crate + workflow mirroring the real layout."""
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "server").mkdir()
+    (root / "Cargo.toml").write_text(
+        '[package]\nname = "agentdesk"\n\n[lib]\npath = "src/lib.rs"\n\n'
+        '[[bin]]\nname = "agentdesk"\npath = "src/main.rs"\n',
+        encoding="utf-8",
+    )
+    (root / "src" / "lib.rs").write_text(
+        "mod server;\nmod high_risk_recovery;\n", encoding="utf-8"
+    )
+    (root / "src" / "high_risk_recovery.rs").write_text(
+        "#[cfg(test)]\nmod tests {}\n", encoding="utf-8"
+    )
+    (root / "src" / "server" / "mod.rs").write_text(
+        "pub(crate) mod multinode_regression;\n", encoding="utf-8"
+    )
+    (root / "src" / "server" / "multinode_regression.rs").write_text(
+        "#[cfg(test)]\nmod tests {}\n", encoding="utf-8"
+    )
+    (root / "src" / "main.rs").write_text("fn main() {}\n", encoding="utf-8")
+    workflows = root / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    workflow = workflows / "ci-fixture.yml"
+    workflow.write_text(
+        f'jobs:\n  lane:\n    steps:\n      - run: "{command}"\n',
+        encoding="utf-8",
+    )
+    return workflow
+
+
+def run_fixture(command: str, allowlist: str = "") -> list:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        workflow = build_fixture_repo(root, command)
+        allow = root / "allowlist.txt"
+        allow.write_text(allowlist, encoding="utf-8")
+        return integrity.check_workflows(
+            root, [workflow], integrity.load_allowlist(allow),
+            with_list_check=False,
+        )
+
+
+class MutationProof(unittest.TestCase):
+    """Known-bad command must fail; the corrected command must pass."""
+
+    def test_bad_bin_command_is_flagged(self) -> None:
+        violations = run_fixture(BAD_COMMAND)
+        self.assertEqual(len(violations), 1, violations)
+        violation = violations[0]
+        self.assertEqual(violation.kind, "target-mismatch")
+        self.assertIn("high_risk_recovery", violation.detail)
+        self.assertIn("src/lib.rs", violation.detail)
+        self.assertIn("bin:agentdesk", violation.detail)
+
+    def test_fixed_lib_command_passes(self) -> None:
+        self.assertEqual(run_fixture(GOOD_COMMAND), [])
+
+    def test_nested_lib_module_under_bin_is_flagged(self) -> None:
+        violations = run_fixture(
+            "cargo test --bin agentdesk multinode_regression:: -- --test-threads=1"
+        )
+        self.assertEqual(len(violations), 1, violations)
+        self.assertIn("src/server/mod.rs", violations[0].detail)
+
+    def test_nested_lib_module_under_lib_passes(self) -> None:
+        violations = run_fixture(
+            "cargo test --lib multinode_regression:: -- --test-threads=1"
+        )
+        self.assertEqual(violations, [])
+
+
+class ExitCodeContract(unittest.TestCase):
+    """Warn-only rollout must exit 0; --enforce must exit 1 on violations."""
+
+    def _main_rc(self, command: str, extra: list[str]) -> int:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workflow = build_fixture_repo(root, command)
+            allow = root / "allowlist.txt"
+            allow.write_text("", encoding="utf-8")
+            argv = ["--repo-root", str(root), "--workflow", str(workflow),
+                    "--allowlist", str(allow)] + extra
+            with contextlib.redirect_stdout(io.StringIO()):
+                return integrity.main(argv)
+
+    def test_warn_only_default_exits_zero_on_violation(self) -> None:
+        self.assertEqual(self._main_rc(BAD_COMMAND, []), 0)
+
+    def test_enforce_exits_nonzero_on_violation(self) -> None:
+        self.assertEqual(self._main_rc(BAD_COMMAND, ["--enforce"]), 1)
+
+    def test_enforce_exits_zero_when_clean(self) -> None:
+        self.assertEqual(self._main_rc(GOOD_COMMAND, ["--enforce"]), 0)
+
+
+class AllowlistContract(unittest.TestCase):
+    def test_allowlisted_command_is_excused(self) -> None:
+        allow = "# platform-cfg suite legitimately empty here\n" + BAD_COMMAND + "\n"
+        self.assertEqual(run_fixture(BAD_COMMAND, allowlist=allow), [])
+
+    def test_comments_and_blanks_do_not_allowlist(self) -> None:
+        allow = "# comment only\n\n"
+        self.assertEqual(len(run_fixture(BAD_COMMAND, allowlist=allow)), 1)
+
+
+class ParserContract(unittest.TestCase):
+    def test_all_targets_and_unfiltered_commands_are_skipped(self) -> None:
+        for command in (
+            "cargo test --all-targets -- --skip _pg_ --skip postgres_",
+            "cargo test postgres_ -- --nocapture --test-threads=1",
+        ):
+            with self.subTest(command=command):
+                self.assertEqual(run_fixture(command), [])
+
+    def test_wrapped_command_is_still_parsed(self) -> None:
+        violations = run_fixture(
+            "env -u AGENTDESK_ROOT_DIR " + BAD_COMMAND
+        )
+        self.assertEqual(len(violations), 1, violations)
+
+    def test_substring_filter_without_module_match_is_skipped(self) -> None:
+        # A bare substring filter (no ::) that is not a module name cannot be
+        # judged statically and must not false-positive.
+        self.assertEqual(
+            run_fixture("cargo test --lib some_test_name_fragment"), []
+        )
+
+
+class RunListCheckContract(unittest.TestCase):
+    """`--run-list-check` parsing, proven without compiling (mocked cargo)."""
+
+    def _proc(self, stdout: str, rc: int = 0):
+        return subprocess.CompletedProcess([], rc, stdout=stdout, stderr="")
+
+    def test_zero_match_is_flagged(self) -> None:
+        with mock.patch.object(
+            integrity.subprocess, "run",
+            return_value=self._proc("0 tests, 0 benchmarks\n"),
+        ):
+            detail = integrity.run_list_check(
+                ["cargo", "test", "--bin", "agentdesk", "high_risk_recovery::"],
+                REPO_ROOT,
+            )
+        self.assertIsNotNone(detail)
+        self.assertIn("0 tests", detail)
+
+    def test_nonzero_match_passes(self) -> None:
+        with mock.patch.object(
+            integrity.subprocess, "run",
+            return_value=self._proc("6 tests, 0 benchmarks\n"),
+        ):
+            self.assertIsNone(integrity.run_list_check(
+                ["cargo", "test", "--lib", "high_risk_recovery::"], REPO_ROOT))
+
+    def test_failed_list_run_is_flagged(self) -> None:
+        with mock.patch.object(
+            integrity.subprocess, "run", return_value=self._proc("", rc=101),
+        ):
+            detail = integrity.run_list_check(["cargo", "test"], REPO_ROOT)
+        self.assertIn("rc=101", detail)
+
+
+class KnownOffenderRegression(unittest.TestCase):
+    """Pin the real-repo offenders the gate was built to catch (#5003).
+
+    The repair slice that fixes these workflow commands must update this
+    expectation (it should drop to an empty set there).
+    """
+
+    KNOWN = {
+        (".github/workflows/ci-main.yml", "high_risk_recovery::"),
+        (".github/workflows/ci-nightly.yml", "multinode_regression::"),
+        (".github/workflows/ci-nightly.yml", "high_risk_recovery::"),
+        (".github/workflows/ci-pr.yml", "high_risk_recovery::"),
+    }
+
+    def test_known_offenders_are_detected_in_real_workflows(self) -> None:
+        workflows = sorted((REPO_ROOT / ".github/workflows").glob("*.yml"))
+        violations = integrity.check_workflows(
+            REPO_ROOT, workflows,
+            integrity.load_allowlist(
+                REPO_ROOT / "scripts/test_target_integrity_allowlist.txt"),
+            with_list_check=False,
+        )
+        mismatches = {
+            (violation.workflow, filter_token)
+            for violation in violations if violation.kind == "target-mismatch"
+            for filter_token in violation.command.split()
+            if filter_token.endswith("::")
+        }
+        self.assertTrue(
+            self.KNOWN <= mismatches,
+            f"expected known offenders {self.KNOWN}, got {mismatches}",
+        )
+        unexpected = [v for v in violations if v.kind != "target-mismatch"]
+        self.assertEqual(unexpected, [], "gate must not false-positive")
+
+    def test_real_repo_warn_only_run_exits_zero(self) -> None:
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(integrity.main([]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_check_test_target_integrity.py
+++ b/tests/test_check_test_target_integrity.py
@@ -40,7 +40,7 @@ def build_fixture_repo(root: Path, command: str) -> Path:
         encoding="utf-8",
     )
     (root / "src" / "lib.rs").write_text(
-        "mod server;\nmod high_risk_recovery;\n", encoding="utf-8"
+        "mod server;\nmod high_risk_recovery;\nmod route;\n", encoding="utf-8"
     )
     (root / "src" / "high_risk_recovery.rs").write_text(
         "#[cfg(test)]\nmod tests {}\n", encoding="utf-8"
@@ -49,6 +49,16 @@ def build_fixture_repo(root: Path, command: str) -> Path:
         "pub(crate) mod multinode_regression;\n", encoding="utf-8"
     )
     (root / "src" / "server" / "multinode_regression.rs").write_text(
+        "#[cfg(test)]\nmod tests {}\n", encoding="utf-8"
+    )
+    # #[path] redirection mirroring src/services/auto_queue/route.rs style:
+    # the redirected file lives next to the declaring file, not under a
+    # directory named after the declaring module.
+    (root / "src" / "route.rs").write_text(
+        '#[cfg(test)]\n#[path = "redirected_impl.rs"]\nmod redirected_impl;\n',
+        encoding="utf-8",
+    )
+    (root / "src" / "redirected_impl.rs").write_text(
         "#[cfg(test)]\nmod tests {}\n", encoding="utf-8"
     )
     (root / "src" / "main.rs").write_text("fn main() {}\n", encoding="utf-8")
@@ -103,6 +113,42 @@ class MutationProof(unittest.TestCase):
         self.assertEqual(violations, [])
 
 
+class PathRedirection(unittest.TestCase):
+    """#[path = "..."] mod declarations must resolve (review blocker #2)."""
+
+    def test_redirected_module_is_not_a_false_positive(self) -> None:
+        self.assertEqual(
+            run_fixture("cargo test --lib redirected_impl::tests"), [])
+
+    def test_real_repo_inventories_path_redirected_modules(self) -> None:
+        # These real modules are only reachable through #[path] redirections
+        # (e.g. src/services/auto_queue/route.rs) and produced false
+        # unknown-module hits before the fix.
+        targets = integrity.discover_targets(REPO_ROOT)
+        modules = integrity.collect_modules(targets["lib"], REPO_ROOT)
+        for name in ("completion_gate", "liveness", "output_policy",
+                     "activate_command"):
+            with self.subTest(module=name):
+                self.assertIn(name, modules)
+
+
+class EmptyTargetRule(unittest.TestCase):
+    """A filtered command on a module-less target always runs 0 tests."""
+
+    def test_typo_filter_on_empty_bin_is_flagged(self) -> None:
+        violations = run_fixture(
+            "cargo test --bin agentdesk high_risk_recovry -- --test-threads=1"
+        )
+        self.assertEqual([v.kind for v in violations], ["empty-target"])
+
+    def test_unfiltered_empty_bin_is_not_flagged(self) -> None:
+        self.assertEqual(run_fixture("cargo test --bin agentdesk"), [])
+
+    def test_mismatch_takes_precedence_over_empty_target(self) -> None:
+        violations = run_fixture(BAD_COMMAND)
+        self.assertEqual([v.kind for v in violations], ["target-mismatch"])
+
+
 class ExitCodeContract(unittest.TestCase):
     """Warn-only rollout must exit 0; --enforce must exit 1 on violations."""
 
@@ -128,9 +174,19 @@ class ExitCodeContract(unittest.TestCase):
 
 
 class AllowlistContract(unittest.TestCase):
-    def test_allowlisted_command_is_excused(self) -> None:
-        allow = "# platform-cfg suite legitimately empty here\n" + BAD_COMMAND + "\n"
-        self.assertEqual(run_fixture(BAD_COMMAND, allowlist=allow), [])
+    def test_allowlist_cannot_excuse_target_mismatch(self) -> None:
+        # A target-mismatch means the command itself is wrong; the allowlist
+        # (meant for legitimately-empty platform-cfg lanes) must not hide it.
+        allow = "# attempted excuse\n" + BAD_COMMAND + "\n"
+        violations = run_fixture(BAD_COMMAND, allowlist=allow)
+        self.assertEqual([v.kind for v in violations], ["target-mismatch"])
+
+    def test_allowlist_excuses_non_mismatch_kinds(self) -> None:
+        command = "cargo test --lib bogus_module::tests"
+        self.assertEqual(
+            [v.kind for v in run_fixture(command)], ["unknown-module"])
+        allow = "# legitimately-empty on this platform\n" + command + "\n"
+        self.assertEqual(run_fixture(command, allowlist=allow), [])
 
     def test_comments_and_blanks_do_not_allowlist(self) -> None:
         allow = "# comment only\n\n"
@@ -195,20 +251,24 @@ class RunListCheckContract(unittest.TestCase):
 
 
 class KnownOffenderRegression(unittest.TestCase):
-    """Pin the real-repo offenders the gate was built to catch (#5003).
+    """Upper-bound ratchet over the real-repo offenders (#5003).
 
-    The repair slice that fixes these workflow commands must update this
-    expectation (it should drop to an empty set there).
+    `mismatches <= KNOWN`: repair slices may shrink the set freely (fixing a
+    lane stays green here), but any NEW target-mismatch lane fails this test.
+    Once all four offenders are repaired this set can be emptied.
     """
 
+    HRR = "cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1"
     KNOWN = {
-        (".github/workflows/ci-main.yml", "high_risk_recovery::"),
-        (".github/workflows/ci-nightly.yml", "multinode_regression::"),
-        (".github/workflows/ci-nightly.yml", "high_risk_recovery::"),
-        (".github/workflows/ci-pr.yml", "high_risk_recovery::"),
+        (".github/workflows/ci-main.yml", HRR),
+        (".github/workflows/ci-nightly.yml", HRR),
+        (".github/workflows/ci-nightly.yml",
+         "cargo test --bin agentdesk multinode_regression:: "
+         "-- --nocapture --test-threads=1"),
+        (".github/workflows/ci-pr.yml", HRR),
     }
 
-    def test_known_offenders_are_detected_in_real_workflows(self) -> None:
+    def test_no_new_offenders_beyond_known_set(self) -> None:
         workflows = sorted((REPO_ROOT / ".github/workflows").glob("*.yml"))
         violations = integrity.check_workflows(
             REPO_ROOT, workflows,
@@ -217,16 +277,18 @@ class KnownOffenderRegression(unittest.TestCase):
             with_list_check=False,
         )
         mismatches = {
-            (violation.workflow, filter_token)
-            for violation in violations if violation.kind == "target-mismatch"
-            for filter_token in violation.command.split()
-            if filter_token.endswith("::")
+            (violation.workflow, violation.command)
+            for violation in violations
+            if violation.kind in ("target-mismatch", "empty-target")
         }
         self.assertTrue(
-            self.KNOWN <= mismatches,
-            f"expected known offenders {self.KNOWN}, got {mismatches}",
+            mismatches <= self.KNOWN,
+            f"NEW mismatch lanes beyond known set: {mismatches - self.KNOWN}",
         )
-        unexpected = [v for v in violations if v.kind != "target-mismatch"]
+        unexpected = [
+            v for v in violations
+            if v.kind not in ("target-mismatch", "empty-target")
+        ]
         self.assertEqual(unexpected, [], "gate must not false-positive")
 
     def test_real_repo_warn_only_run_exits_zero(self) -> None:


### PR DESCRIPTION
## Summary (#5003 S1)

`cargo test` exits 0 when a libtest filter matches zero tests, so curated CI lanes that pair the wrong target flag with a module filter have been running **0 tests while their required checks stayed green**. This slice adds the gate; repairing the offending workflow commands is a separate slice.

New: `scripts/check_test_target_integrity.py` (333 lines) — statically cross-checks every workflow `cargo test` command's `--lib` / `--bin NAME` / `--test NAME` selection against where the filtered module is actually declared (module tree walked from Cargo.toml target roots, following `#[path = "..."]` redirections; no compilation, no `cargo metadata`).

### Offenders it catches today (warn-only, left un-fixed on purpose)

| location | command | why wrong |
|---|---|---|
| `.github/workflows/ci-pr.yml:645` | `cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1` | `high_risk_recovery` is a lib module (`src/lib.rs:252`); the bin target (`src/main.rs`, 7 lines) has no modules, so the lane runs 0 tests |
| `.github/workflows/ci-main.yml:226` | same | same |
| `.github/workflows/ci-nightly.yml:314` | same | same |
| `.github/workflows/ci-nightly.yml:265` | `cargo test --bin agentdesk multinode_regression:: -- --nocapture --test-threads=1` | `multinode_regression` is a lib module (`src/server/mod.rs:8`) |

These lanes were invisible to `check_test_lane_coverage.py` because it drops all `--bin` commands at `scripts/check_test_lane_coverage.py:439` (`_NON_LIB_TARGET_OPTIONS` → `return None`).

### Design decisions

- **Warn-only rollout**: default rc=0 with `::warning::` annotations. `--enforce` flips violations to rc=1 — to be enabled after the offender-repair slice lands.
- **Static check is the required path; `--run-list-check` is opt-in**: running `cargo test ... -- --list` requires compiling all test targets (minutes in the PR lane), while the static declaration cross-check is milliseconds and already catches the entire known class. The list-check parsing logic is still covered by mocked unit tests.
- **Module resolution via `mod` tree walk, not `cargo metadata`**: `cargo metadata` only enumerates targets, not module trees, so it cannot answer "which target declares module X". Walking `mod name;` declarations from the Cargo.toml target roots (`tomllib`, stdlib-only on the Python 3.11 the script suite already requires) is dependency-free and testable against fixtures. Nested modules resolve (e.g. `multinode_regression` under `src/server/`).
- **False-positive guards**: commands with `--all-targets` or no explicit target selector are skipped (they run every target); bare substring filters (no `::`) that don't name a known module are skipped; legitimately-empty lanes (platform `#[cfg]`) go in `scripts/test_target_integrity_allowlist.txt` with a reason comment.

### Wiring

- `scripts/ci-script-checks.sh` runs the gate + its unittest suite; that script is the `Run script checks` step of the required **`scripts` job ("Script checks")** in `ci-pr.yml` (line 798).
- `tests/test_check_test_target_integrity.py` (17 tests) is the gate's own mutation proof: the known-bad fixture command **fails** validation and its `--lib` correction **passes**; enforce/warn exit codes, allowlist semantics, wrapper commands (`env -u ... cargo test`), quoted `run:` scalars, and the four real-repo offenders are pinned (the repair slice must update that pin).

### Adversarial review fixes (r2)

1. **Offender pin flipped to an upper-bound ratchet** — `KnownOffenderRegression` now asserts `mismatches <= KNOWN`: repair slices (e.g. #5002-style `--lib` fixes) shrink the set and stay green, while any NEW mismatch/empty-target lane fails. Both directions proven by mutation (simulated `ci-pr.yml:645` repair → green; appended 5th bad lane → FAILED).
2. **`#[path = "..."] mod` redirections followed** — previously 73/1081 `src/` file stems were unreachable (e.g. the 21 `#[path]` mods in `src/services/auto_queue/route.rs`), producing false `unknown-module` hits on real modules (`completion_gate`, `liveness`, `output_policy`). Now inventoried; the residual 28 stems are files mounted under *different module names* via `#[path]` (e.g. `codex_tui_restore.rs` → `mod codex_restore`), so module-name resolution has no gap.
3. **`empty-target` rule** — the bin target (`src/main.rs`, 7 lines) declares zero modules, so `cargo test --bin agentdesk <anything>` always runs 0 tests. Any filtered command whose selected target has an empty module inventory is now flagged, catching typo'd and `::`-less filters the mismatch rule missed. Zero false positives on current workflows (still exactly the 4 known offenders; `target-mismatch` keeps precedence).
4. **Allowlist hardened in code** — `target-mismatch` findings survive allowlisting (the list is only for legitimately-empty platform-cfg lanes); header text and tests now match the enforced behavior.
5. Nits: single-line `::warning::` rendering (annotations only surface the first line); `relative_to` crash guard for out-of-root `--workflow` paths.

### Follow-ups (deliberately out of scope for this slice)

- Repair the 4 offending workflow lanes, then flip the gate to `--enforce` and empty the `KNOWN` ratchet set (separate slice per #5003 plan).
- Filter validation only resolves the **leading** path segment; deep curated filters (`services::discord::...::tests`) effectively reduce to "is `services` a lib module". Mid/leaf renames would still go silent.
- `extract_commands` is physical-line based; a `\`-continued `cargo test` command would be invisible (none exist in current workflows).
- `--all-targets` / `--bins` lanes (7 macOS lanes) and commands with no target flag (`ci-nightly.yml:209/213`) are skipped by the static check; `--run-list-check` covers them but is opt-in.
- ~23% effective coverage today (bare substring filters receive no static judgment).
- Allowlist has no reason-comment enforcement or stale-entry detection (currently 0 entries, so no immediate exposure).

### Verification

- `bash scripts/ci-script-checks.sh` → rc=0 (warn-only gate prints the 4 offenders; suite green)
- `python3 -m unittest tests.test_check_test_target_integrity` → 23 tests OK
- `python3 scripts/check_test_target_integrity.py --enforce` → rc=1 with exactly the 4 known offenders (no false positives across all `.github/workflows/*.yml`)
- `python3 scripts/generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → `agent-maintenance freshness check passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
