### PR TITLE
fix(#4981): scope local model completion assertion

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -356,10 +356,16 @@ jobs:
         run: npm run test:policies
 
       # `lint` owns fmt/clippy in its independent required mirror. Keep this
-      # required Ubuntu lane to compilation and policy tests; main and nightly
-      # retain the longer non-PG test coverage outside the PR critical path.
+      # required Ubuntu lane to compilation, policy tests, and the focused
+      # local-model queue-wake regression; main and nightly retain the longer
+      # non-PG test coverage outside the PR critical path.
       - name: cargo check
         run: just cargo-check
+
+      # #5003: this production-path E2E previously ran only in main's broad
+      # non-PG lane, so test-only fixes could merge without executing it on PRs.
+      - name: Local model durable queue wake regression
+        run: env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tui_prompt_relay::local_model_queue_wake_e2e -- --test-threads=1
 
       - name: sccache stats
         if: always()

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -356,16 +356,10 @@ jobs:
         run: npm run test:policies
 
       # `lint` owns fmt/clippy in its independent required mirror. Keep this
-      # required Ubuntu lane to compilation, policy tests, and the focused
-      # local-model queue-wake regression; main and nightly retain the longer
-      # non-PG test coverage outside the PR critical path.
+      # required Ubuntu lane to compilation and policy tests; main and nightly
+      # retain the longer non-PG test coverage outside the PR critical path.
       - name: cargo check
         run: just cargo-check
-
-      # #5003: this production-path E2E previously ran only in main's broad
-      # non-PG lane, so test-only fixes could merge without executing it on PRs.
-      - name: Local model durable queue wake regression
-        run: env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tui_prompt_relay::local_model_queue_wake_e2e -- --test-threads=1
 
       - name: sccache stats
         if: always()
@@ -652,6 +646,11 @@ jobs:
           cargo test --lib services::discord::recovery_engine::state_extractors::tests -- --test-threads=1
           cargo test --lib services::discord::relay_recovery::tests -- --test-threads=1
           cargo test --lib services::discord::terminal_ui_obligation::tests -- --test-threads=1
+
+      # #5003: this production-path E2E previously ran only in main's broad
+      # non-PG lane, so test-only fixes could merge without executing it on PRs.
+      - name: Local model durable queue wake regression
+        run: env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tui_prompt_relay::local_model_queue_wake_e2e -- --test-threads=1
 
       - name: Stop PostgreSQL service
         if: always()

--- a/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
+++ b/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
@@ -194,6 +194,56 @@ async fn gateway_socket(ws: WebSocketUpgrade) -> impl IntoResponse {
     ws.on_upgrade(|mut socket| async move { while socket.recv().await.is_some() {} })
 }
 
+async fn drain_promoted_b_completion_lifecycle(
+    rx: &mut tokio::sync::broadcast::Receiver<
+        super::super::turn_completion_events::TurnCompletionEvent,
+    >,
+    channel_id: ChannelId,
+    timeout: std::time::Duration,
+) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let expected_mailbox_release =
+        super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        );
+    let expected_queue_eligible =
+        super::super::turn_completion_events::TurnCompletionEvent::queue_eligible(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        );
+    let mut mailbox_release_seen = false;
+
+    loop {
+        let event = match tokio::time::timeout_at(deadline, rx.recv()).await {
+            Err(_) => panic!(
+                "promoted B completion lifecycle did not reach QueueEligible before the deadline; mailbox_release_seen={mailbox_release_seen}"
+            ),
+            Ok(Ok(event)) => event,
+            Ok(Err(error)) => panic!(
+                "completion receiver must remain open while draining promoted B; recv error={error:?}"
+            ),
+        };
+        if event == expected_mailbox_release {
+            assert!(
+                !std::mem::replace(&mut mailbox_release_seen, true),
+                "promoted B must publish MailboxReleased exactly once"
+            );
+        } else if event == expected_queue_eligible {
+            assert!(
+                mailbox_release_seen,
+                "promoted B must publish MailboxReleased before QueueEligible"
+            );
+            return;
+        } else {
+            panic!(
+                "only promoted B's ordered completion lifecycle is allowed while draining; received phase={:?}, turn_id={:?}, channel_id={}",
+                event.phase, event.turn_id, event.channel_id
+            );
+        }
+    }
+}
+
 async fn assert_no_local_only_completion_event(
     rx: &mut tokio::sync::broadcast::Receiver<
         super::super::turn_completion_events::TurnCompletionEvent,
@@ -213,6 +263,89 @@ async fn assert_no_local_only_completion_event(
             }
         }
     }
+}
+
+async fn assert_local_only_completion_lifecycle(
+    rx: &mut tokio::sync::broadcast::Receiver<
+        super::super::turn_completion_events::TurnCompletionEvent,
+    >,
+    channel_id: ChannelId,
+    lifecycle_timeout: std::time::Duration,
+    strict_window: std::time::Duration,
+) {
+    drain_promoted_b_completion_lifecycle(rx, channel_id, lifecycle_timeout).await;
+    assert_no_local_only_completion_event(rx, strict_window).await;
+}
+
+async fn completion_guard_must_panic(
+    events: Vec<super::super::turn_completion_events::TurnCompletionEvent>,
+) {
+    let (tx, mut rx) = tokio::sync::broadcast::channel(8);
+    for event in events {
+        tx.send(event).expect("completion receiver registered");
+    }
+    let task = tokio::spawn(async move {
+        assert_local_only_completion_lifecycle(
+            &mut rx,
+            ChannelId::new(CHANNEL_ID),
+            std::time::Duration::from_millis(100),
+            std::time::Duration::from_millis(100),
+        )
+        .await;
+    });
+    let error = task
+        .await
+        .expect_err("the completion lifecycle guard must reject the mutation");
+    assert!(
+        error.is_panic(),
+        "completion lifecycle rejection must terminate through its own assertion"
+    );
+}
+
+#[tokio::test]
+async fn completion_lifecycle_guard_rejects_duplicate_and_out_of_order_edges() {
+    let channel_id = ChannelId::new(CHANNEL_ID);
+    completion_guard_must_panic(vec![
+        super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        ),
+        super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        ),
+        super::super::turn_completion_events::TurnCompletionEvent::queue_eligible(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        ),
+    ])
+    .await;
+    completion_guard_must_panic(vec![
+        super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        ),
+        super::super::turn_completion_events::TurnCompletionEvent::queue_eligible(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        ),
+        super::super::turn_completion_events::TurnCompletionEvent::queue_eligible(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        ),
+    ])
+    .await;
+    completion_guard_must_panic(vec![
+        super::super::turn_completion_events::TurnCompletionEvent::queue_eligible(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        ),
+        super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        ),
+    ])
+    .await;
 }
 
 async fn start_mock_discord(
@@ -549,10 +682,8 @@ async fn local_model_observation_wakes_idle_durable_queue_through_production_wor
         .insert(channel_id, test_watcher_handle(tmux, &transcript_path));
     super::spawn_tui_prompt_relay(shared.clone(), ProviderKind::Claude);
 
-    // Subscribe after draining A's release event. Events published between that drain and this
-    // subscription are outside the local-only observation window. Neither `/model` half may publish
-    // a completion edge: queue-eligible would drive another dequeue, while MailboxReleased would
-    // falsely claim that a promoted turn had already reached bridge or watcher finalization.
+    // Subscribe after draining A's release event so every edge after the local-only observations is
+    // inspected, including promoted B's known two-phase completion lifecycle.
     let mut local_only_completion_rx =
         super::super::turn_completion_events::subscribe_turn_completion_events(&shared);
     let command_half = "<command-message>x</command-message>\n<command-name>/model</command-name>";
@@ -624,8 +755,20 @@ async fn local_model_observation_wakes_idle_durable_queue_through_production_wor
         !super::tui_direct_watcher_synthetic_inflight_matches(inflight.as_ref(), tmux, 1),
         "local-only halves must not create synthetic inflight ownership"
     );
-    assert_no_local_only_completion_event(
+
+    // Source tracing reproduced MailboxReleased(B) 3/3 as promoted B's normal Discord bridge
+    // lifecycle: TerminalEvent::Complete with FinalizeContext::bridge(),
+    // request_owner_name="queue-user", is_external_input_tui_direct=false, and no TUI runtime.
+    // CompletionAdmission::claim_queue_eligible then emits QueueEligible(B) exactly once after its
+    // mailbox-released and terminal barriers settle. Inspect that exact ordered pair before opening
+    // the strict window. The idle-queue consumer continues without dispatch on MailboxReleased; the
+    // other production consumer can only stop B's typing indicator. TODO: a causal-origin issue must
+    // close the remaining value-only gap where a faulty local-only publisher replaces, rather than
+    // duplicates, one of B's own lifecycle edges.
+    assert_local_only_completion_lifecycle(
         &mut local_only_completion_rx,
+        channel_id,
+        std::time::Duration::from_secs(10),
         std::time::Duration::from_millis(100),
     )
     .await;

--- a/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
+++ b/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
@@ -194,14 +194,17 @@ async fn gateway_socket(ws: WebSocketUpgrade) -> impl IntoResponse {
     ws.on_upgrade(|mut socket| async move { while socket.recv().await.is_some() {} })
 }
 
-async fn drain_promoted_b_completion_lifecycle(
-    rx: &mut tokio::sync::broadcast::Receiver<
-        super::super::turn_completion_events::TurnCompletionEvent,
-    >,
+#[derive(Debug, PartialEq, Eq)]
+enum PromotedBCompletionProgress {
+    AwaitingMailboxRelease,
+    AwaitingQueueEligible,
+    Complete,
+}
+
+fn validate_promoted_b_completion_lifecycle(
+    events: &[super::super::turn_completion_events::TurnCompletionEvent],
     channel_id: ChannelId,
-    timeout: std::time::Duration,
-) {
-    let deadline = tokio::time::Instant::now() + timeout;
+) -> Result<PromotedBCompletionProgress, String> {
     let expected_mailbox_release =
         super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
             channel_id,
@@ -212,34 +215,54 @@ async fn drain_promoted_b_completion_lifecycle(
             channel_id,
             Some(B_MESSAGE_ID),
         );
-    let mut mailbox_release_seen = false;
+    match events {
+        [] => Ok(PromotedBCompletionProgress::AwaitingMailboxRelease),
+        [event] if *event == expected_mailbox_release => {
+            Ok(PromotedBCompletionProgress::AwaitingQueueEligible)
+        }
+        [event] => Err(format!(
+            "promoted B must publish MailboxReleased first; received phase={:?}, turn_id={:?}, channel_id={}",
+            event.phase, event.turn_id, event.channel_id
+        )),
+        [mailbox_release, queue_eligible]
+            if *mailbox_release == expected_mailbox_release
+                && *queue_eligible == expected_queue_eligible =>
+        {
+            Ok(PromotedBCompletionProgress::Complete)
+        }
+        [_, event, ..] => Err(format!(
+            "promoted B must publish exactly one MailboxReleased followed by exactly one QueueEligible; received phase={:?}, turn_id={:?}, channel_id={}",
+            event.phase, event.turn_id, event.channel_id
+        )),
+    }
+}
+
+async fn drain_promoted_b_completion_lifecycle(
+    rx: &mut tokio::sync::broadcast::Receiver<
+        super::super::turn_completion_events::TurnCompletionEvent,
+    >,
+    channel_id: ChannelId,
+    timeout: std::time::Duration,
+) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut events = Vec::with_capacity(2);
 
     loop {
         let event = match tokio::time::timeout_at(deadline, rx.recv()).await {
             Err(_) => panic!(
-                "promoted B completion lifecycle did not reach QueueEligible before the deadline; mailbox_release_seen={mailbox_release_seen}"
+                "promoted B completion lifecycle did not reach QueueEligible before the deadline; observed_events={events:?}"
             ),
             Ok(Ok(event)) => event,
             Ok(Err(error)) => panic!(
                 "completion receiver must remain open while draining promoted B; recv error={error:?}"
             ),
         };
-        if event == expected_mailbox_release {
-            assert!(
-                !std::mem::replace(&mut mailbox_release_seen, true),
-                "promoted B must publish MailboxReleased exactly once"
-            );
-        } else if event == expected_queue_eligible {
-            assert!(
-                mailbox_release_seen,
-                "promoted B must publish MailboxReleased before QueueEligible"
-            );
-            return;
-        } else {
-            panic!(
-                "only promoted B's ordered completion lifecycle is allowed while draining; received phase={:?}, turn_id={:?}, channel_id={}",
-                event.phase, event.turn_id, event.channel_id
-            );
+        events.push(event);
+        match validate_promoted_b_completion_lifecycle(&events, channel_id) {
+            Ok(PromotedBCompletionProgress::Complete) => return,
+            Ok(PromotedBCompletionProgress::AwaitingMailboxRelease)
+            | Ok(PromotedBCompletionProgress::AwaitingQueueEligible) => {}
+            Err(error) => panic!("{error}"),
         }
     }
 }
@@ -299,6 +322,48 @@ async fn completion_guard_must_panic(
     assert!(
         error.is_panic(),
         "completion lifecycle rejection must terminate through its own assertion"
+    );
+}
+
+#[test]
+fn promoted_b_completion_lifecycle_validates_order_and_cardinality() {
+    let channel_id = ChannelId::new(CHANNEL_ID);
+    let mailbox_release =
+        super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        );
+    let queue_eligible = super::super::turn_completion_events::TurnCompletionEvent::queue_eligible(
+        channel_id,
+        Some(B_MESSAGE_ID),
+    );
+
+    assert_eq!(
+        validate_promoted_b_completion_lifecycle(
+            &[mailbox_release.clone(), queue_eligible.clone()],
+            channel_id,
+        ),
+        Ok(PromotedBCompletionProgress::Complete)
+    );
+    assert!(
+        validate_promoted_b_completion_lifecycle(
+            &[queue_eligible.clone(), mailbox_release.clone()],
+            channel_id,
+        )
+        .is_err(),
+        "QueueEligible before MailboxReleased must be rejected"
+    );
+    assert!(
+        validate_promoted_b_completion_lifecycle(
+            &[mailbox_release.clone(), mailbox_release],
+            channel_id,
+        )
+        .is_err(),
+        "duplicate MailboxReleased must be rejected"
+    );
+    assert!(
+        validate_promoted_b_completion_lifecycle(&[queue_eligible], channel_id).is_err(),
+        "QueueEligible without MailboxReleased must be rejected"
     );
 }
 

--- a/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
+++ b/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
@@ -343,6 +343,7 @@ async fn completion_lifecycle_rejects_event_after_queue_eligible() {
 }
 
 #[tokio::test]
+#[should_panic(expected = "promoted B must publish MailboxReleased before QueueEligible")]
 async fn completion_lifecycle_rejects_queue_eligible_before_mailbox_release() {
     let channel_id = ChannelId::new(CHANNEL_ID);
     completion_guard_must_panic(vec![

--- a/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
+++ b/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
@@ -303,7 +303,7 @@ async fn completion_guard_must_panic(
 }
 
 #[tokio::test]
-async fn completion_lifecycle_guard_rejects_duplicate_and_out_of_order_edges() {
+async fn completion_lifecycle_rejects_duplicate_mailbox_release() {
     let channel_id = ChannelId::new(CHANNEL_ID);
     completion_guard_must_panic(vec![
         super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
@@ -320,6 +320,11 @@ async fn completion_lifecycle_guard_rejects_duplicate_and_out_of_order_edges() {
         ),
     ])
     .await;
+}
+
+#[tokio::test]
+async fn completion_lifecycle_rejects_event_after_queue_eligible() {
+    let channel_id = ChannelId::new(CHANNEL_ID);
     completion_guard_must_panic(vec![
         super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
             channel_id,
@@ -335,6 +340,11 @@ async fn completion_lifecycle_guard_rejects_duplicate_and_out_of_order_edges() {
         ),
     ])
     .await;
+}
+
+#[tokio::test]
+async fn completion_lifecycle_rejects_queue_eligible_before_mailbox_release() {
+    let channel_id = ChannelId::new(CHANNEL_ID);
     completion_guard_must_panic(vec![
         super::super::turn_completion_events::TurnCompletionEvent::queue_eligible(
             channel_id,

--- a/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
+++ b/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
@@ -194,79 +194,25 @@ async fn gateway_socket(ws: WebSocketUpgrade) -> impl IntoResponse {
     ws.on_upgrade(|mut socket| async move { while socket.recv().await.is_some() {} })
 }
 
-async fn assert_local_only_completion_window(
+async fn assert_no_local_only_completion_event(
     rx: &mut tokio::sync::broadcast::Receiver<
         super::super::turn_completion_events::TurnCompletionEvent,
     >,
-    channel_id: ChannelId,
     window: std::time::Duration,
 ) {
     let deadline = tokio::time::Instant::now() + window;
-    let expected_mailbox_release =
-        super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
-            channel_id,
-            Some(B_MESSAGE_ID),
-        );
-    let mut mailbox_release_seen = false;
-
     loop {
         match tokio::time::timeout_at(deadline, rx.recv()).await {
             Err(_) => return,
-            Ok(Ok(event)) if event.queue_is_eligible() => panic!(
-                "local-only halves must not make a turn queue-eligible; received phase={:?}, turn_id={:?}, channel_id={}",
+            Ok(Ok(event)) => panic!(
+                "local-only halves must not publish a completion event; received phase={:?}, turn_id={:?}, channel_id={}",
                 event.phase, event.turn_id, event.channel_id
-            ),
-            Ok(Ok(event)) if event == expected_mailbox_release => {
-                assert!(
-                    !std::mem::replace(&mut mailbox_release_seen, true),
-                    "the exact B mailbox-release edge may appear at most once"
-                );
-            }
-            Ok(Ok(event)) => assert_eq!(
-                event, expected_mailbox_release,
-                "the only non-eligible edge admitted in this window is the exact B mailbox release"
             ),
             Ok(Err(error)) => {
                 panic!("local-only completion receiver must remain open; recv error={error:?}")
             }
         }
     }
-}
-
-#[tokio::test]
-async fn local_only_completion_window_drains_past_mailbox_release() {
-    let (tx, mut rx) = tokio::sync::broadcast::channel(4);
-    let channel_id = ChannelId::new(CHANNEL_ID);
-    tx.send(
-        super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
-            channel_id,
-            Some(B_MESSAGE_ID),
-        ),
-    )
-    .expect("mailbox-release receiver registered");
-    tx.send(
-        super::super::turn_completion_events::TurnCompletionEvent::queue_eligible(
-            channel_id,
-            Some(B_MESSAGE_ID),
-        ),
-    )
-    .expect("queue-eligible receiver registered");
-
-    let task = tokio::spawn(async move {
-        assert_local_only_completion_window(
-            &mut rx,
-            channel_id,
-            std::time::Duration::from_millis(100),
-        )
-        .await;
-    });
-    let join_error = task
-        .await
-        .expect_err("the guard must inspect and reject an event after MailboxReleased(B)");
-    assert!(
-        join_error.is_panic(),
-        "queue-eligible rejection must terminate through the guard assertion"
-    );
 }
 
 async fn start_mock_discord(
@@ -603,10 +549,10 @@ async fn local_model_observation_wakes_idle_durable_queue_through_production_wor
         .insert(channel_id, test_watcher_handle(tmux, &transcript_path));
     super::spawn_tui_prompt_relay(shared.clone(), ProviderKind::Claude);
 
-    // Subscribe after draining A's release event. The local-only path must not emit the
-    // queue-eligible edge that drives another dequeue. One exact MailboxReleased edge for promoted
-    // B is provisionally admitted without attributing its cause; the idle-queue consumer withholds
-    // dispatch for this phase, while the typing-indicator consumer may stop B's indicator.
+    // Subscribe after draining A's release event. Events published between that drain and this
+    // subscription are outside the local-only observation window. Neither `/model` half may publish
+    // a completion edge: queue-eligible would drive another dequeue, while MailboxReleased would
+    // falsely claim that a promoted turn had already reached bridge or watcher finalization.
     let mut local_only_completion_rx =
         super::super::turn_completion_events::subscribe_turn_completion_events(&shared);
     let command_half = "<command-message>x</command-message>\n<command-name>/model</command-name>";
@@ -678,9 +624,8 @@ async fn local_model_observation_wakes_idle_durable_queue_through_production_wor
         !super::tui_direct_watcher_synthetic_inflight_matches(inflight.as_ref(), tmux, 1),
         "local-only halves must not create synthetic inflight ownership"
     );
-    assert_local_only_completion_window(
+    assert_no_local_only_completion_event(
         &mut local_only_completion_rx,
-        channel_id,
         std::time::Duration::from_millis(100),
     )
     .await;

--- a/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
+++ b/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
@@ -194,6 +194,81 @@ async fn gateway_socket(ws: WebSocketUpgrade) -> impl IntoResponse {
     ws.on_upgrade(|mut socket| async move { while socket.recv().await.is_some() {} })
 }
 
+async fn assert_local_only_completion_window(
+    rx: &mut tokio::sync::broadcast::Receiver<
+        super::super::turn_completion_events::TurnCompletionEvent,
+    >,
+    channel_id: ChannelId,
+    window: std::time::Duration,
+) {
+    let deadline = tokio::time::Instant::now() + window;
+    let expected_mailbox_release =
+        super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        );
+    let mut mailbox_release_seen = false;
+
+    loop {
+        match tokio::time::timeout_at(deadline, rx.recv()).await {
+            Err(_) => return,
+            Ok(Ok(event)) if event.queue_is_eligible() => panic!(
+                "local-only halves must not make a turn queue-eligible; received phase={:?}, turn_id={:?}, channel_id={}",
+                event.phase, event.turn_id, event.channel_id
+            ),
+            Ok(Ok(event)) if event == expected_mailbox_release => {
+                assert!(
+                    !std::mem::replace(&mut mailbox_release_seen, true),
+                    "the exact B mailbox-release edge may appear at most once"
+                );
+            }
+            Ok(Ok(event)) => assert_eq!(
+                event, expected_mailbox_release,
+                "the only non-eligible edge admitted in this window is the exact B mailbox release"
+            ),
+            Ok(Err(error)) => {
+                panic!("local-only completion receiver must remain open; recv error={error:?}")
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn local_only_completion_window_drains_past_mailbox_release() {
+    let (tx, mut rx) = tokio::sync::broadcast::channel(4);
+    let channel_id = ChannelId::new(CHANNEL_ID);
+    tx.send(
+        super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        ),
+    )
+    .expect("mailbox-release receiver registered");
+    tx.send(
+        super::super::turn_completion_events::TurnCompletionEvent::queue_eligible(
+            channel_id,
+            Some(B_MESSAGE_ID),
+        ),
+    )
+    .expect("queue-eligible receiver registered");
+
+    let task = tokio::spawn(async move {
+        assert_local_only_completion_window(
+            &mut rx,
+            channel_id,
+            std::time::Duration::from_millis(100),
+        )
+        .await;
+    });
+    let join_error = task
+        .await
+        .expect_err("the guard must inspect and reject an event after MailboxReleased(B)");
+    assert!(
+        join_error.is_panic(),
+        "queue-eligible rejection must terminate through the guard assertion"
+    );
+}
+
 async fn start_mock_discord(
     state: DiscordMockState,
 ) -> (String, String, tokio::task::JoinHandle<()>) {
@@ -529,9 +604,9 @@ async fn local_model_observation_wakes_idle_durable_queue_through_production_wor
     super::spawn_tui_prompt_relay(shared.clone(), ProviderKind::Claude);
 
     // Subscribe after draining A's release event. The local-only path must not emit the
-    // queue-eligible edge that drives another dequeue. A MailboxReleased edge for promoted B is
-    // allowed: it reports B's independent lifecycle and the queue listener explicitly withholds
-    // dispatch until a later QueueEligible admission edge.
+    // queue-eligible edge that drives another dequeue. One exact MailboxReleased edge for promoted
+    // B is provisionally admitted without attributing its cause; the idle-queue consumer withholds
+    // dispatch for this phase, while the typing-indicator consumer may stop B's indicator.
     let mut local_only_completion_rx =
         super::super::turn_completion_events::subscribe_turn_completion_events(&shared);
     let command_half = "<command-message>x</command-message>\n<command-name>/model</command-name>";
@@ -603,29 +678,12 @@ async fn local_model_observation_wakes_idle_durable_queue_through_production_wor
         !super::tui_direct_watcher_synthetic_inflight_matches(inflight.as_ref(), tmux, 1),
         "local-only halves must not create synthetic inflight ownership"
     );
-    match tokio::time::timeout(
+    assert_local_only_completion_window(
+        &mut local_only_completion_rx,
+        channel_id,
         std::time::Duration::from_millis(100),
-        local_only_completion_rx.recv(),
     )
-    .await
-    {
-        Err(_) => {}
-        Ok(Ok(event)) if event.queue_is_eligible() => panic!(
-            "local-only halves must not make a turn queue-eligible; received phase={:?}, turn_id={:?}, channel_id={}",
-            event.phase, event.turn_id, event.channel_id
-        ),
-        Ok(Ok(event)) => assert_eq!(
-            event,
-            super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
-                channel_id,
-                Some(B_MESSAGE_ID),
-            ),
-            "the only non-eligible edge admitted in this window is B's independent mailbox release"
-        ),
-        Ok(Err(error)) => {
-            panic!("local-only completion receiver must remain open; recv error={error:?}")
-        }
-    }
+    .await;
 
     drop(_dedupe_guard);
     drop(_intake_mode_guard);

--- a/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
+++ b/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
@@ -343,7 +343,6 @@ async fn completion_lifecycle_rejects_event_after_queue_eligible() {
 }
 
 #[tokio::test]
-#[should_panic(expected = "promoted B must publish MailboxReleased before QueueEligible")]
 async fn completion_lifecycle_rejects_queue_eligible_before_mailbox_release() {
     let channel_id = ChannelId::new(CHANNEL_ID);
     completion_guard_must_panic(vec![

--- a/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
+++ b/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
@@ -528,9 +528,10 @@ async fn local_model_observation_wakes_idle_durable_queue_through_production_wor
         .insert(channel_id, test_watcher_handle(tmux, &transcript_path));
     super::spawn_tui_prompt_relay(shared.clone(), ProviderKind::Claude);
 
-    // Subscribe after draining A's release event. This excludes events published between that
-    // drain and this subscription from the local-only assertion. The relay spawn in that interval
-    // is a likely publisher, but its event source has not yet been characterized.
+    // Subscribe after draining A's release event. The local-only path must not emit the
+    // queue-eligible edge that drives another dequeue. A MailboxReleased edge for promoted B is
+    // allowed: it reports B's independent lifecycle and the queue listener explicitly withholds
+    // dispatch until a later QueueEligible admission edge.
     let mut local_only_completion_rx =
         super::super::turn_completion_events::subscribe_turn_completion_events(&shared);
     let command_half = "<command-message>x</command-message>\n<command-name>/model</command-name>";
@@ -609,9 +610,17 @@ async fn local_model_observation_wakes_idle_durable_queue_through_production_wor
     .await
     {
         Err(_) => {}
-        Ok(Ok(event)) => panic!(
-            "local-only halves must not publish completion events; received phase={:?}, turn_id={:?}, channel_id={}",
+        Ok(Ok(event)) if event.queue_is_eligible() => panic!(
+            "local-only halves must not make a turn queue-eligible; received phase={:?}, turn_id={:?}, channel_id={}",
             event.phase, event.turn_id, event.channel_id
+        ),
+        Ok(Ok(event)) => assert_eq!(
+            event,
+            super::super::turn_completion_events::TurnCompletionEvent::mailbox_released(
+                channel_id,
+                Some(B_MESSAGE_ID),
+            ),
+            "the only non-eligible edge admitted in this window is B's independent mailbox release"
         ),
         Ok(Err(error)) => {
             panic!("local-only completion receiver must remain open; recv error={error:?}")

--- a/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
+++ b/src/services/discord/tui_prompt_relay/local_model_queue_wake_e2e.rs
@@ -772,7 +772,7 @@ async fn local_model_observation_wakes_idle_durable_queue_through_production_wor
     // CompletionAdmission::claim_queue_eligible then emits QueueEligible(B) exactly once after its
     // mailbox-released and terminal barriers settle. Inspect that exact ordered pair before opening
     // the strict window. The idle-queue consumer continues without dispatch on MailboxReleased; the
-    // other production consumer can only stop B's typing indicator. TODO: a causal-origin issue must
+    // other production consumer can only stop B's typing indicator. #5018 tracks causal origin to
     // close the remaining value-only gap where a faulty local-only publisher replaces, rather than
     // duplicates, one of B's own lifecycle edges.
     assert_local_only_completion_lifecycle(


### PR DESCRIPTION
이슈 #4981 — main CI red 수리. **프로덕션 Rust 0줄** (모듈 전체가 `#[cfg(all(test, unix))]`).

## 원래 실패

`local_model_queue_wake_e2e::local_model_observation_wakes_idle_durable_queue_through_production_workers` 가 main CI 를 red 로 만들었다. 원인은 **과도하게 엄격한 assertion** — 좁은 창을 열고 "그 창에서 어떤 이벤트도 오면 안 된다" 고 주장했는데, main CI 에서 `received phase=MailboxReleased, turn_id=Some(940487400000012)`(= `B_MESSAGE_ID`) 로 터졌다. **정상 lifecycle 이벤트를 위반으로 판정**했다.

정상 lifecycle 은 **2개 이벤트**다: `MailboxReleased(B)` → `QueueEligible(B)`. 이벤트가 오지 않는다는 전제 자체가 틀렸다.

## 수정 — 이벤트 프록시를 버리고 순서·개수를 검증한다

**통과하는 유일한 트레이스**: `[] → [MR*] → [MR*, QE*]` 후 종료.
(`MR*` = `MailboxReleased(C, Some(B))`, `QE*` = `QueueEligible(C, Some(B))`)

**panic 하는 입력 집합**:
1. 첫 이벤트가 `MR*` 가 아닌 모든 경우 — `QueueEligible(C,Some(B))` 단독 / `QueueEligible(C,None)` / `MailboxReleased(C,None)` / `MailboxReleased(C,Some(A))` / 타 채널 이벤트. `PartialEq` 가 channel_id·turn_id·phase 3필드를 전부 비교한다
2. 두 번째 이벤트가 `QE*` 가 아닌 모든 경우 (`MR*` 중복 포함)
3. `QE*` 이후 100ms 내 도착하는 3번째 이벤트
4. 10s 내 `MR*` 미도착 — **통과가 아니라 panic**
5. 버스 close / Lagged

**이 집합은 프로덕션에서 도달 가능하다**(공허하지 않다):
- `mailbox_finish_turn` / `_owned_turn` / `_cancelled_turn` 이 `publish_mailbox_release_completion_event(…, None, …)` 를 호출하는데, 이 함수는 이름과 달리 **QueueEligible 을 발행**한다 (`turn_completion_events.rs:126-131`) → `QueueEligible(C,None)` 이 실제로 나온다
- `mailbox_finish_turn_if_matches_episode_started_before` 는 **선행 MailboxReleased 없이** `QueueEligible(C,Some(x))` 를 발행한다 (`mailbox_finish.rs:148-155`)

## 구조적 보장 (flake 아님)

- **구독이 B 승격보다 인과적으로 앞선다.** broadcast 는 구독 이후 발행분만 전달하므로 `MR*` 이 구독 전에 발행되어 phase 1 이 굶는 시나리오는 **구조적으로 불가능**하다
- **MR→QE 순서도 구조적이다.** `tmux.rs:2668-2685` 에서 `mailbox_finish_turn_if_matches` 가 먼저 `MR*` 를 발행하고, 그 다음 `note_mailbox_released` 가 액터 배리어를 열어야만 `claim_queue_eligible` 이 통과한다 (`completion_admission.rs:61,74-78`). `removed_token` 없으면 early-return 이라 반쪽 발행도 없다

## 뮤테이션 증명

| 뮤테이션 | rc | witness |
|---|---|---|
| 중복 guard 제거 | 101 | 자체 `expect_err` |
| phase 2 제거 | 101 | 자체 `expect_err` |
| **inverted-order 주입** | **101** | 자체 assert |

⚠️ order assert 를 **제거**하는 뮤테이션은 생존했다. 정상 harness 에서 항상 참인 불변식은 assert 제거로 죽지 않으므로 **방법론 오류**였고, **위반 주입**으로 전환해 rc=101 을 확인했다.

## CI 배선

`ci-pr.yml:650-654` — PR 레인(`high-risk-recovery`)에서 이 E2E 를 **1회 추가 실행**한다. 재시도·반복·`continue-on-error` 가 **아니다** (flake 은폐가 아니라 커버리지 확대).

## 알려진 잔여 갭

오발행 이벤트가 `MR*`/`QE*` 와 값이 완전히 동일하면서 B 자신의 엣지를 **중복이 아니라 대체**하는 경우는 미탐이다. `TurnCompletionEvent` 에 causal origin 이 없어 정상 lifecycle 과 오유발을 구분할 수 없기 때문이며, **#5018** 로 추적한다.

리뷰 P2 2건(오라클이 패닉 메시지를 검사하지 않음, `RecvError::Lagged` 오해 소지 메시지)은 **#5028** 로 이관한다.

Closes #4981