### PR TITLE
fix(#5014): E0+E1 — flock 임계구역 안에서 파괴 커밋 pin 검증 + watcher cancel 설정

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -565,6 +565,7 @@ src/
 │   │   │   │   └── flake_isolation_4422.rs
 │   │   │   ├── anchor_repost.rs
 │   │   │   ├── budget.rs
+│   │   │   ├── destructive_commit.rs
 │   │   │   ├── episode_guard.rs
 │   │   │   ├── finalizer_identity.rs
 │   │   │   ├── invariant_test_capture.rs
@@ -868,6 +869,8 @@ src/
 │   │   │   ├── store.rs
 │   │   │   ├── sweep.rs
 │   │   │   └── tombstone.rs
+│   │   ├── tui_direct_pending_start/
+│   │   │   └── watcher_cancel.rs
 │   │   ├── tui_prompt_relay/
 │   │   │   ├── synthetic_start/
 │   │   │   │   └── stale_reclaim.rs

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -446,6 +446,13 @@
   before merging.
 
 ### Audited touches
+- 2026-07-30 — #5014 / PR #5020 destructive cancel commit: the inflight
+  sidecar flock, watcher cancel `AtomicBool`, and registry identity CAS remain
+  **worker-local** authority. The primitive adds no PostgreSQL lease, distributed
+  epoch, leader check, remote-owner RPC, durable cancel intent, worker placement,
+  or cross-node fencing; another node can independently verify the same channel
+  row. Gateway lease containment narrows that deployment condition but does not
+  turn the host-local commit into cluster authority.
 - 2026-07-26 — #4898 untrusted deploy-gate containment: PostgreSQL migration
   0100 adds a validated cluster-wide `CHECK` constraint that rejects normalized
   `deploy-gate` provenance. The `ALTER TABLE` lock serializes concurrent legacy

--- a/justfile
+++ b/justfile
@@ -61,7 +61,8 @@ test-non-pg:
     cargo test --lib services::tmux_common::sentinel_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib services::discord::turn_bridge::followup_requeue::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib services::discord::turn_bridge::terminal_outcome_delivery::busy_followup_retry::tests -- --skip _pg --skip pg_ --skip postgres
-    # #4259: keep exact bridge-entry and guarded stream authority modules in a curated lane.
+    # #4259/#5014: keep exact bridge-entry and destructive-commit modules in a curated lane.
+    env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::inflight::destructive_commit::tests -- --test-threads=1
     env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::inflight::save_store::bridge_entry_guard_tests -- --test-threads=1
     env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::inflight::save_store::identity_gate::bridge_entry::tests -- --test-threads=1
     env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::inflight::save_store::identity_gate::claude_e_stamp::tests -- --test-threads=1

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -1829,6 +1829,23 @@ fn backfill_legacy_rebind_origin_turn_source(path: &std::path::Path) -> bool {
         "turn_source".to_string(),
         serde_json::Value::String("external_adopted".to_string()),
     );
+    let next_save_generation = object
+        .get("save_generation")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0)
+        .saturating_add(1);
+    object.insert(
+        "save_generation".to_string(),
+        serde_json::Value::from(next_save_generation),
+    );
+    object.insert(
+        "updated_at".to_string(),
+        serde_json::Value::String(
+            chrono::Local::now()
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string(),
+        ),
+    );
     let Ok(updated) = serde_json::to_string_pretty(&value) else {
         return false;
     };
@@ -1883,9 +1900,16 @@ mod stale_inflight_sweep_tests {
     }
 
     #[test]
-    fn stale_sweep_preserves_legacy_rebind_origin_without_turn_source() {
+    fn stale_sweep_legacy_backfill_invalidates_prior_destructive_cancel_pin() {
         let root = tempfile::tempdir().expect("temp root");
-        let legacy = write_stale_inflight(root.path(), "legacy", r#"{"rebind_origin":true}"#);
+        let original_updated_at = "2026-07-30 12:00:00";
+        let legacy = write_stale_inflight(
+            root.path(),
+            "legacy",
+            &format!(
+                r#"{{"rebind_origin":true,"save_generation":14,"updated_at":"{original_updated_at}"}}"#
+            ),
+        );
 
         let removed = sweep_stale_inflight_files_at(root.path(), Duration::from_secs(60));
 
@@ -1898,6 +1922,8 @@ mod stale_inflight_sweep_tests {
             serde_json::from_str(&fs::read_to_string(&legacy).expect("legacy body"))
                 .expect("updated legacy json");
         assert_eq!(updated["turn_source"], "external_adopted");
+        assert_eq!(updated["save_generation"], 15);
+        assert_ne!(updated["updated_at"], original_updated_at);
     }
 
     #[test]

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -1840,11 +1840,7 @@ fn backfill_legacy_rebind_origin_turn_source(path: &std::path::Path) -> bool {
     );
     object.insert(
         "updated_at".to_string(),
-        serde_json::Value::String(
-            chrono::Local::now()
-                .format("%Y-%m-%d %H:%M:%S")
-                .to_string(),
-        ),
+        serde_json::Value::String(chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string()),
     );
     let Ok(updated) = serde_json::to_string_pretty(&value) else {
         return false;

--- a/src/services/discord/destructive_cancel_gate.rs
+++ b/src/services/discord/destructive_cancel_gate.rs
@@ -51,6 +51,7 @@ impl DestructiveCancelIdentityPin {
 #[derive(Clone, Debug)]
 pub(in crate::services::discord) struct DestructiveCancelProbeSnapshot {
     pub pin: DestructiveCancelIdentityPin,
+    pub inflight_identity: inflight::InflightTurnIdentity,
     pub updated_at: String,
     pub save_generation: u64,
     pub output_path: Option<String>,
@@ -92,6 +93,7 @@ impl DestructiveCancelProbeSnapshot {
         );
         Self {
             pin,
+            inflight_identity: inflight::InflightTurnIdentity::from_state(state),
             updated_at: state.updated_at.clone(),
             save_generation: state.save_generation,
             output_path,

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -7,6 +7,7 @@
 
 pub(in crate::services::discord) mod anchor_repost;
 pub(in crate::services::discord) mod budget;
+mod destructive_commit;
 mod finalizer_identity;
 #[cfg(test)]
 mod invariant_test_capture;
@@ -40,6 +41,10 @@ mod store;
 // (root callers only) and is brought in via a plain import. `InflightStateFileLock`
 // is named nowhere outside `store` (it only flows as a return type), so it keeps
 // its module-tree visibility there without a parent re-export.
+pub(in crate::services::discord) use destructive_commit::{
+    CommitError, CommitEvidence, DestructiveCancelCommitOutcome, DestructiveCancelPinField,
+    commit_destructive_cancel_locked,
+};
 pub(in crate::services::discord) use episode_guard::{
     InflightEpisodeLockError, InflightEpisodePin, LockedInflightEpisode,
     adopt_and_lock_inflight_episode, lock_inflight_episode,

--- a/src/services/discord/inflight/destructive_commit.rs
+++ b/src/services/discord/inflight/destructive_commit.rs
@@ -1,0 +1,272 @@
+use std::path::Path;
+
+use super::{
+    InflightTurnIdentity, InflightTurnState, inflight_runtime_root, inflight_state_path,
+    lock_inflight_state_path,
+};
+use crate::services::provider::ProviderKind;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) enum DestructiveCancelPinField {
+    Identity,
+    UpdatedAt,
+    SaveGeneration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) enum DestructiveCancelCommitOutcome {
+    Committed,
+    PinMismatch { field: DestructiveCancelPinField },
+    RowMissing,
+    RowMalformed,
+    LockUnavailable,
+    IoError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) struct CommitEvidence;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::services::discord) struct CommitError {
+    pub message: String,
+}
+
+/// Commits a destructive cancel while holding the inflight row's sidecar flock.
+///
+/// Excluded writers: every resurrection that already completed a flock-held
+/// persist (the three watcher persists and both creation APIs). If such a writer
+/// advanced the row identity, `updated_at`, or `save_generation`, the commit
+/// aborts with `PinMismatch`.
+///
+/// Not closed: delivery/persist from the last watcher iteration before it observes
+/// cancel; row recreation after destruction (#5012/E3); durable observation of a
+/// partially degraded finalizer commit (E2/E6).
+///
+/// The callback must not acquire the watcher-registry mutex. E2 may prepare and
+/// fsync a temporary intent before this call, but while the flock is held its
+/// callback may only rename that prepared file; directory fsync belongs after
+/// this function returns and before destruction proceeds.
+pub(in crate::services::discord) fn commit_destructive_cancel_locked(
+    provider: &ProviderKind,
+    channel_id: u64,
+    expected_identity: &InflightTurnIdentity,
+    expected_updated_at: &str,
+    expected_save_generation: u64,
+    on_verified: impl FnOnce(&InflightTurnState) -> Result<CommitEvidence, CommitError>,
+) -> DestructiveCancelCommitOutcome {
+    let Some(root) = inflight_runtime_root() else {
+        return DestructiveCancelCommitOutcome::IoError;
+    };
+    let path = inflight_state_path(&root, provider, channel_id);
+    commit_destructive_cancel_locked_at_path(
+        &path,
+        expected_identity,
+        expected_updated_at,
+        expected_save_generation,
+        on_verified,
+    )
+}
+
+fn commit_destructive_cancel_locked_at_path(
+    path: &Path,
+    expected_identity: &InflightTurnIdentity,
+    expected_updated_at: &str,
+    expected_save_generation: u64,
+    on_verified: impl FnOnce(&InflightTurnState) -> Result<CommitEvidence, CommitError>,
+) -> DestructiveCancelCommitOutcome {
+    let Ok(_flock) = lock_inflight_state_path(path) else {
+        return DestructiveCancelCommitOutcome::LockUnavailable;
+    };
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return DestructiveCancelCommitOutcome::RowMissing;
+        }
+        Err(_) => return DestructiveCancelCommitOutcome::IoError,
+    };
+    let current = match serde_json::from_str::<InflightTurnState>(&content) {
+        Ok(current) => current,
+        Err(_) => return DestructiveCancelCommitOutcome::RowMalformed,
+    };
+    if !expected_identity.matches_state(&current) {
+        return DestructiveCancelCommitOutcome::PinMismatch {
+            field: DestructiveCancelPinField::Identity,
+        };
+    }
+    if current.updated_at != expected_updated_at {
+        return DestructiveCancelCommitOutcome::PinMismatch {
+            field: DestructiveCancelPinField::UpdatedAt,
+        };
+    }
+    if current.save_generation != expected_save_generation {
+        return DestructiveCancelCommitOutcome::PinMismatch {
+            field: DestructiveCancelPinField::SaveGeneration,
+        };
+    }
+    match on_verified(&current) {
+        Ok(_) => DestructiveCancelCommitOutcome::Committed,
+        Err(_) => DestructiveCancelCommitOutcome::IoError,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::*;
+
+    fn state() -> InflightTurnState {
+        let mut state = InflightTurnState::new(
+            ProviderKind::Codex,
+            5014,
+            None,
+            1,
+            501_401,
+            501_402,
+            "destructive commit fixture".to_string(),
+            None,
+            Some("AgentDesk-codex-5014".to_string()),
+            Some("/fixture/output.jsonl".to_string()),
+            None,
+            0,
+        );
+        state.started_at = "2026-07-30 12:00:00".to_string();
+        state.updated_at = "2026-07-30 12:02:00".to_string();
+        state.turn_start_offset = Some(17);
+        state.save_generation = 9;
+        state
+    }
+
+    fn write(path: &Path, state: &InflightTurnState) {
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+        std::fs::write(
+            path,
+            serde_json::to_string_pretty(state).expect("serialize"),
+        )
+        .expect("write row");
+    }
+
+    fn commit(
+        path: &Path,
+        expected: &InflightTurnState,
+        callback: impl FnOnce(&InflightTurnState) -> Result<CommitEvidence, CommitError>,
+    ) -> DestructiveCancelCommitOutcome {
+        commit_destructive_cancel_locked_at_path(
+            path,
+            &InflightTurnIdentity::from_state(expected),
+            &expected.updated_at,
+            expected.save_generation,
+            callback,
+        )
+    }
+
+    #[test]
+    fn typed_outcomes_cover_commit_and_every_pin_field() {
+        let root = tempfile::tempdir().expect("root");
+        let path = root.path().join("row.json");
+        let baseline = state();
+        write(&path, &baseline);
+        assert_eq!(
+            commit(&path, &baseline, |_| Ok(CommitEvidence)),
+            DestructiveCancelCommitOutcome::Committed
+        );
+
+        let mut changed = baseline.clone();
+        changed.user_msg_id += 1;
+        write(&path, &changed);
+        assert_eq!(
+            commit(&path, &baseline, |_| Ok(CommitEvidence)),
+            DestructiveCancelCommitOutcome::PinMismatch {
+                field: DestructiveCancelPinField::Identity
+            }
+        );
+
+        let mut changed = baseline.clone();
+        changed.updated_at.push('1');
+        write(&path, &changed);
+        assert_eq!(
+            commit(&path, &baseline, |_| Ok(CommitEvidence)),
+            DestructiveCancelCommitOutcome::PinMismatch {
+                field: DestructiveCancelPinField::UpdatedAt
+            }
+        );
+
+        let mut changed = baseline.clone();
+        changed.save_generation += 1;
+        write(&path, &changed);
+        assert_eq!(
+            commit(&path, &baseline, |_| Ok(CommitEvidence)),
+            DestructiveCancelCommitOutcome::PinMismatch {
+                field: DestructiveCancelPinField::SaveGeneration
+            }
+        );
+    }
+
+    #[test]
+    fn typed_outcomes_cover_missing_malformed_lock_and_io_failures() {
+        let root = tempfile::tempdir().expect("root");
+        let baseline = state();
+        let missing = root.path().join("missing.json");
+        assert_eq!(
+            commit(&missing, &baseline, |_| Ok(CommitEvidence)),
+            DestructiveCancelCommitOutcome::RowMissing
+        );
+
+        let malformed = root.path().join("malformed.json");
+        std::fs::write(&malformed, "{").expect("write malformed");
+        assert_eq!(
+            commit(&malformed, &baseline, |_| Ok(CommitEvidence)),
+            DestructiveCancelCommitOutcome::RowMalformed
+        );
+
+        let blocked_parent = root.path().join("not-a-directory");
+        std::fs::write(&blocked_parent, "file").expect("write blocking file");
+        assert_eq!(
+            commit(&blocked_parent.join("row.json"), &baseline, |_| Ok(
+                CommitEvidence
+            )),
+            DestructiveCancelCommitOutcome::LockUnavailable
+        );
+
+        let directory_row = root.path().join("directory-row.json");
+        std::fs::create_dir(&directory_row).expect("create directory row");
+        assert_eq!(
+            commit(&directory_row, &baseline, |_| Ok(CommitEvidence)),
+            DestructiveCancelCommitOutcome::IoError
+        );
+
+        write(&malformed, &baseline);
+        assert_eq!(
+            commit(&malformed, &baseline, |_| {
+                Err(CommitError {
+                    message: "intent rename failed".to_string(),
+                })
+            }),
+            DestructiveCancelCommitOutcome::IoError
+        );
+    }
+
+    #[test]
+    fn generation_advance_aborts_before_cancel_store() {
+        let root = tempfile::tempdir().expect("root");
+        let path = root.path().join("row.json");
+        let baseline = state();
+        let mut revived = baseline.clone();
+        revived.save_generation += 1;
+        write(&path, &revived);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cancel_for_commit = cancel.clone();
+
+        assert_eq!(
+            commit(&path, &baseline, move |_| {
+                cancel_for_commit.store(true, Ordering::Release);
+                Ok(CommitEvidence)
+            }),
+            DestructiveCancelCommitOutcome::PinMismatch {
+                field: DestructiveCancelPinField::SaveGeneration
+            }
+        );
+        assert!(!cancel.load(Ordering::Acquire));
+    }
+}

--- a/src/services/discord/inflight/destructive_commit.rs
+++ b/src/services/discord/inflight/destructive_commit.rs
@@ -16,7 +16,9 @@ pub(in crate::services::discord) enum DestructiveCancelPinField {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::services::discord) enum DestructiveCancelCommitOutcome {
     Committed,
-    PinMismatch { field: DestructiveCancelPinField },
+    PinMismatch {
+        field: DestructiveCancelPinField,
+    },
     RowMissing,
     RowMalformed,
     /// Lock setup or syscall failure. Lock contention blocks because the flock

--- a/src/services/discord/inflight/destructive_commit.rs
+++ b/src/services/discord/inflight/destructive_commit.rs
@@ -19,6 +19,8 @@ pub(in crate::services::discord) enum DestructiveCancelCommitOutcome {
     PinMismatch { field: DestructiveCancelPinField },
     RowMissing,
     RowMalformed,
+    /// Lock setup or syscall failure. Lock contention blocks because the flock
+    /// uses `LOCK_EX` without `LOCK_NB` or a timeout; it does not return this.
     LockUnavailable,
     IoError,
 }
@@ -31,18 +33,44 @@ pub(in crate::services::discord) struct CommitError {
     pub message: String,
 }
 
-/// Commits a destructive cancel while holding the inflight row's sidecar flock.
+/// Verifies the inflight row under its sidecar flock and then runs a callback.
+///
+/// `Committed` means only that the row matched the identity plus
+/// `save_generation` pin at that instant and the callback returned success. It
+/// does not mean that destructive authority was acquired exclusively or durably.
+/// `updated_at` is checked as supplemental diagnostics, but its one-second local
+/// timestamp resolution means it is not an independent fencing dimension.
 ///
 /// Excluded writers: every resurrection that already completed a flock-held
-/// persist (the three watcher persists and both creation APIs). If such a writer
-/// advanced the row identity, `updated_at`, or `save_generation`, the commit
-/// aborts with `PinMismatch`.
+/// persist (the three watcher persists, both creation APIs, and the legacy
+/// rebind-origin backfill). Those writers advance `save_generation`; a different
+/// turn changes the identity, so either change aborts with `PinMismatch`.
 ///
-/// Not closed: delivery/persist from the last watcher iteration before it observes
-/// cancel; row recreation after destruction (#5012/E3); durable observation of a
-/// partially degraded finalizer commit (E2/E6).
+/// Not closed:
+/// - delivery/persist from the last watcher iteration before it observes cancel;
+/// - row recreation after destruction (#5012/E3);
+/// - durable observation of a partially degraded finalizer commit (E2/E6);
+/// - a committed in-memory cancel followed by registry CAS failure skips both the
+///   finalizer and row clear, leaving a partially destructive state;
+/// - the callback writes no durable intent/epoch, so a crash after `Committed`
+///   can erase the cancel decision before finalization starts;
+/// - the callback does not advance row version, so multiple serialized callers
+///   may receive `Committed`; downstream registry CAS and the finalizer's
+///   exact-key ledger prevent duplicate finalization, not duplicate commit claims;
+/// - the cancel `Arc` is captured outside the flock and may name a replaced
+///   watcher incarnation; registry CAS then fails closed, but `Committed` was
+///   already returned;
+/// - sidecar flock authority is host-local and does not fence another node's
+///   watcher, inflight row, or mailbox authority;
+/// - the age/lifecycle-qualified stale-row sweep in `reconcile.rs` removes rows
+///   without taking this sidecar flock.
 ///
-/// The callback must not acquire the watcher-registry mutex. E2 may prepare and
+/// # Safety
+///
+/// The callback must not acquire the watcher-registry mutex. This is a caller
+/// contract rather than a type-level guarantee: violating it can create an ABBA
+/// deadlock with a registry holder waiting for the sidecar flock, causing a
+/// permanent hang rather than a recoverable commit failure. E2 may prepare and
 /// fsync a temporary intent before this call, but while the flock is held its
 /// callback may only rename that prepared file; directory fsync belongs after
 /// this function returns and before destruction proceeds.

--- a/src/services/discord/inflight/destructive_commit.rs
+++ b/src/services/discord/inflight/destructive_commit.rs
@@ -15,7 +15,10 @@ pub(in crate::services::discord) enum DestructiveCancelPinField {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::services::discord) enum DestructiveCancelCommitOutcome {
-    Committed,
+    /// The pin matched and the callback actually signalled a watcher cancel.
+    CommittedCancelled,
+    /// The pin matched, but no watcher existed for the callback to cancel.
+    CommittedNoWatcher,
     PinMismatch {
         field: DestructiveCancelPinField,
     },
@@ -28,7 +31,10 @@ pub(in crate::services::discord) enum DestructiveCancelCommitOutcome {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::services::discord) struct CommitEvidence;
+pub(in crate::services::discord) enum CommitEvidence {
+    CancelledWatcher,
+    NoWatcher,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::services::discord) struct CommitError {
@@ -37,9 +43,11 @@ pub(in crate::services::discord) struct CommitError {
 
 /// Verifies the inflight row under its sidecar flock and then runs a callback.
 ///
-/// `Committed` means only that the row matched the identity plus
-/// `save_generation` pin at that instant and the callback returned success. It
-/// does not mean that destructive authority was acquired exclusively or durably.
+/// A `Committed*` outcome means only that the row matched the identity plus
+/// `save_generation` pin at that instant and the callback returned typed evidence.
+/// `CommittedCancelled` distinguishes an actual watcher cancel from
+/// `CommittedNoWatcher`. Neither means that destructive authority was acquired
+/// exclusively or durably.
 /// `updated_at` is checked as supplemental diagnostics, but its one-second local
 /// timestamp resolution means it is not an independent fencing dimension.
 ///
@@ -54,13 +62,13 @@ pub(in crate::services::discord) struct CommitError {
 /// - durable observation of a partially degraded finalizer commit (E2/E6);
 /// - a committed in-memory cancel followed by registry CAS failure skips both the
 ///   finalizer and row clear, leaving a partially destructive state;
-/// - the callback writes no durable intent/epoch, so a crash after `Committed`
+/// - the callback writes no durable intent/epoch, so a crash after a `Committed*` outcome
 ///   can erase the cancel decision before finalization starts;
 /// - the callback does not advance row version, so multiple serialized callers
-///   may receive `Committed`; downstream registry CAS and the finalizer's
+///   may receive a `Committed*` outcome; downstream registry CAS and the finalizer's
 ///   exact-key ledger prevent duplicate finalization, not duplicate commit claims;
 /// - the cancel `Arc` is captured outside the flock and may name a replaced
-///   watcher incarnation; registry CAS then fails closed, but `Committed` was
+///   watcher incarnation; registry CAS then fails closed, but a `Committed*` outcome was
 ///   already returned;
 /// - sidecar flock authority is host-local and does not fence another node's
 ///   watcher, inflight row, or mailbox authority;
@@ -134,7 +142,8 @@ fn commit_destructive_cancel_locked_at_path(
         };
     }
     match on_verified(&current) {
-        Ok(_) => DestructiveCancelCommitOutcome::Committed,
+        Ok(CommitEvidence::CancelledWatcher) => DestructiveCancelCommitOutcome::CommittedCancelled,
+        Ok(CommitEvidence::NoWatcher) => DestructiveCancelCommitOutcome::CommittedNoWatcher,
         Err(_) => DestructiveCancelCommitOutcome::IoError,
     }
 }
@@ -198,15 +207,19 @@ mod tests {
         let baseline = state();
         write(&path, &baseline);
         assert_eq!(
-            commit(&path, &baseline, |_| Ok(CommitEvidence)),
-            DestructiveCancelCommitOutcome::Committed
+            commit(&path, &baseline, |_| Ok(CommitEvidence::CancelledWatcher)),
+            DestructiveCancelCommitOutcome::CommittedCancelled
+        );
+        assert_eq!(
+            commit(&path, &baseline, |_| Ok(CommitEvidence::NoWatcher)),
+            DestructiveCancelCommitOutcome::CommittedNoWatcher
         );
 
         let mut changed = baseline.clone();
         changed.user_msg_id += 1;
         write(&path, &changed);
         assert_eq!(
-            commit(&path, &baseline, |_| Ok(CommitEvidence)),
+            commit(&path, &baseline, |_| Ok(CommitEvidence::CancelledWatcher)),
             DestructiveCancelCommitOutcome::PinMismatch {
                 field: DestructiveCancelPinField::Identity
             }
@@ -216,7 +229,7 @@ mod tests {
         changed.updated_at.push('1');
         write(&path, &changed);
         assert_eq!(
-            commit(&path, &baseline, |_| Ok(CommitEvidence)),
+            commit(&path, &baseline, |_| Ok(CommitEvidence::CancelledWatcher)),
             DestructiveCancelCommitOutcome::PinMismatch {
                 field: DestructiveCancelPinField::UpdatedAt
             }
@@ -226,7 +239,7 @@ mod tests {
         changed.save_generation += 1;
         write(&path, &changed);
         assert_eq!(
-            commit(&path, &baseline, |_| Ok(CommitEvidence)),
+            commit(&path, &baseline, |_| Ok(CommitEvidence::CancelledWatcher)),
             DestructiveCancelCommitOutcome::PinMismatch {
                 field: DestructiveCancelPinField::SaveGeneration
             }
@@ -239,14 +252,18 @@ mod tests {
         let baseline = state();
         let missing = root.path().join("missing.json");
         assert_eq!(
-            commit(&missing, &baseline, |_| Ok(CommitEvidence)),
+            commit(&missing, &baseline, |_| Ok(
+                CommitEvidence::CancelledWatcher
+            )),
             DestructiveCancelCommitOutcome::RowMissing
         );
 
         let malformed = root.path().join("malformed.json");
         std::fs::write(&malformed, "{").expect("write malformed");
         assert_eq!(
-            commit(&malformed, &baseline, |_| Ok(CommitEvidence)),
+            commit(&malformed, &baseline, |_| Ok(
+                CommitEvidence::CancelledWatcher
+            )),
             DestructiveCancelCommitOutcome::RowMalformed
         );
 
@@ -254,7 +271,7 @@ mod tests {
         std::fs::write(&blocked_parent, "file").expect("write blocking file");
         assert_eq!(
             commit(&blocked_parent.join("row.json"), &baseline, |_| Ok(
-                CommitEvidence
+                CommitEvidence::CancelledWatcher
             )),
             DestructiveCancelCommitOutcome::LockUnavailable
         );
@@ -262,7 +279,9 @@ mod tests {
         let directory_row = root.path().join("directory-row.json");
         std::fs::create_dir(&directory_row).expect("create directory row");
         assert_eq!(
-            commit(&directory_row, &baseline, |_| Ok(CommitEvidence)),
+            commit(&directory_row, &baseline, |_| Ok(
+                CommitEvidence::CancelledWatcher
+            )),
             DestructiveCancelCommitOutcome::IoError
         );
 
@@ -291,7 +310,7 @@ mod tests {
         assert_eq!(
             commit(&path, &baseline, move |_| {
                 cancel_for_commit.store(true, Ordering::Release);
-                Ok(CommitEvidence)
+                Ok(CommitEvidence::CancelledWatcher)
             }),
             DestructiveCancelCommitOutcome::PinMismatch {
                 field: DestructiveCancelPinField::SaveGeneration

--- a/src/services/discord/inflight/save_store/post_loop_identity_guard_tests.rs
+++ b/src/services/discord/inflight/save_store/post_loop_identity_guard_tests.rs
@@ -21,6 +21,7 @@ fn post_loop_state() -> InflightTurnState {
     );
     state.full_response = "partial response".to_string();
     state.long_running_placeholder_active = true;
+    state.updated_at = "2026-07-30 12:00:00".to_string();
     state
 }
 
@@ -36,6 +37,8 @@ fn post_loop_finalize_saves_require_matching_identity() {
     );
     let original = post_loop_state();
     save_inflight_state(&original).expect("seed current turn row");
+    let original = load_inflight_state(&ProviderKind::Codex, original.channel_id)
+        .expect("persisted current turn row");
 
     let mut same_turn_finalize = original.clone();
     same_turn_finalize.long_running_placeholder_active = false;

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1083,6 +1083,15 @@ impl TmuxWatcherRegistry {
         self.by_tmux_session.get(&tmux_session_name)
     }
 
+    pub(super) fn cancel_for_tmux_session(
+        &self,
+        tmux_session_name: &str,
+    ) -> Option<Arc<std::sync::atomic::AtomicBool>> {
+        self.by_tmux_session
+            .get(tmux_session_name)
+            .map(|entry| entry.cancel.clone())
+    }
+
     // #3034: test-only convenience wrapper (prod code calls `insert_locked`
     // with an explicit registry guard). Used only by `#[cfg(test)]` setup.
     #[allow(dead_code)]

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1083,15 +1083,6 @@ impl TmuxWatcherRegistry {
         self.by_tmux_session.get(&tmux_session_name)
     }
 
-    pub(super) fn cancel_for_tmux_session(
-        &self,
-        tmux_session_name: &str,
-    ) -> Option<Arc<std::sync::atomic::AtomicBool>> {
-        self.by_tmux_session
-            .get(tmux_session_name)
-            .map(|entry| entry.cancel.clone())
-    }
-
     // #3034: test-only convenience wrapper (prod code calls `insert_locked`
     // with an explicit registry guard). Used only by `#[cfg(test)]` setup.
     #[allow(dead_code)]

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -98,9 +98,8 @@ type IdleTmuxReattachInflightCandidateHook =
 type DestructiveCancelPostGateHook = Arc<dyn Fn() + Send + Sync + 'static>;
 
 #[cfg(test)]
-static DESTRUCTIVE_CANCEL_POST_GATE_HOOK: OnceLock<
-    Mutex<Option<DestructiveCancelPostGateHook>>,
-> = OnceLock::new();
+static DESTRUCTIVE_CANCEL_POST_GATE_HOOK: OnceLock<Mutex<Option<DestructiveCancelPostGateHook>>> =
+    OnceLock::new();
 #[cfg(test)]
 static IDLE_TMUX_REATTACH_INFLIGHT_CANDIDATE_HOOK: OnceLock<
     Mutex<Option<IdleTmuxReattachInflightCandidateHook>>,

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -94,11 +94,55 @@ const ORPHAN_PENDING_TOKEN_ADMISSION_GRACE: Duration = Duration::from_secs(30);
 #[cfg(test)]
 type IdleTmuxReattachInflightCandidateHook =
     Arc<dyn Fn(&super::inflight::InflightTurnState) + Send + Sync + 'static>;
+#[cfg(test)]
+type DestructiveCancelPostGateHook = Arc<dyn Fn() + Send + Sync + 'static>;
 
+#[cfg(test)]
+static DESTRUCTIVE_CANCEL_POST_GATE_HOOK: OnceLock<
+    Mutex<Option<DestructiveCancelPostGateHook>>,
+> = OnceLock::new();
 #[cfg(test)]
 static IDLE_TMUX_REATTACH_INFLIGHT_CANDIDATE_HOOK: OnceLock<
     Mutex<Option<IdleTmuxReattachInflightCandidateHook>>,
 > = OnceLock::new();
+
+#[cfg(test)]
+fn destructive_cancel_post_gate_hook() -> &'static Mutex<Option<DestructiveCancelPostGateHook>> {
+    DESTRUCTIVE_CANCEL_POST_GATE_HOOK.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(test)]
+fn run_destructive_cancel_post_gate_hook_for_tests() {
+    let hook = destructive_cancel_post_gate_hook()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .clone();
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
+#[cfg(test)]
+struct DestructiveCancelPostGateHookGuard;
+
+#[cfg(test)]
+impl Drop for DestructiveCancelPostGateHookGuard {
+    fn drop(&mut self) {
+        *destructive_cancel_post_gate_hook()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = None;
+    }
+}
+
+#[cfg(test)]
+fn set_destructive_cancel_post_gate_hook_for_tests(
+    hook: DestructiveCancelPostGateHook,
+) -> DestructiveCancelPostGateHookGuard {
+    *destructive_cancel_post_gate_hook()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner()) = Some(hook);
+    DestructiveCancelPostGateHookGuard
+}
 
 #[cfg(test)]
 fn idle_tmux_reattach_inflight_candidate_hook()

--- a/src/services/discord/relay_recovery/apply.rs
+++ b/src/services/discord/relay_recovery/apply.rs
@@ -206,6 +206,8 @@ pub(super) async fn apply_relay_recovery_decision(
                         )
                         .await;
                         if gate.is_allowed() {
+                            #[cfg(test)]
+                            super::run_destructive_cancel_post_gate_hook_for_tests();
                             let mailbox_active_user_msg_id =
                                 mailbox_snapshot(shared, owner_channel_id)
                                     .await

--- a/src/services/discord/relay_recovery/apply.rs
+++ b/src/services/discord/relay_recovery/apply.rs
@@ -206,97 +206,106 @@ pub(super) async fn apply_relay_recovery_decision(
                         )
                         .await;
                         if gate.is_allowed() {
-                            let current = super::inflight::load_inflight_state(
-                                provider,
-                                owner_channel_id.get(),
-                            );
                             let mailbox_active_user_msg_id =
                                 mailbox_snapshot(shared, owner_channel_id)
                                     .await
                                     .active_user_message_id
                                     .map(|id| id.get());
-                            let current_matches_probe = current.as_ref().is_some_and(|state| {
-                                probe.pin.matches_state(state)
-                                    && mailbox_active_user_msg_id
-                                        == probe.pin.mailbox_active_user_msg_id
-                                    && state.updated_at == probe.updated_at
-                                    && state.save_generation == probe.save_generation
-                            });
-                            if !current_matches_probe {
+                            if mailbox_active_user_msg_id != probe.pin.mailbox_active_user_msg_id {
                                 tracing::warn!(
                                     target: "agentdesk::discord::relay_recovery",
                                     provider = provider.as_str(),
                                     channel_id = decision.channel_id,
                                     watcher_owner_channel_id = owner_channel_id.get(),
                                     death_evidence = gate.allowed_reason().unwrap_or("unknown"),
-                                    expected_updated_at = %probe.updated_at,
-                                    current_updated_at = %current.as_ref().map(|state| state.updated_at.as_str()).unwrap_or("<missing>"),
-                                    expected_save_generation = probe.save_generation,
-                                    current_save_generation = current.as_ref().map(|state| state.save_generation).unwrap_or(0),
                                     expected_mailbox_active_user_msg_id = probe.pin.mailbox_active_user_msg_id.unwrap_or(0),
                                     mailbox_active_user_msg_id = mailbox_active_user_msg_id.unwrap_or(0),
-                                    "relay recovery skipped destructive watcher cancel after gate; owner row changed during death-evidence reprobe"
+                                    "relay recovery skipped destructive watcher cancel after gate; mailbox episode changed"
                                 );
                             } else if let Some((tmux_session_name, output_path, cancel)) =
                                 expected_watcher.as_ref()
                             {
-                                let watcher_removed =
-                                    shared.tmux_watchers.cancel_and_remove_channel_if_current(
-                                        &owner_channel_id,
-                                        tmux_session_name,
-                                        output_path,
-                                        cancel,
+                                let expected_identity = probe.inflight_identity.clone();
+                                let cancel_for_commit = cancel.clone();
+                                let commit_outcome =
+                                    super::inflight::commit_destructive_cancel_locked(
+                                        provider,
+                                        owner_channel_id.get(),
+                                        &expected_identity,
+                                        &probe.updated_at,
+                                        probe.save_generation,
+                                        move |_| {
+                                            cancel_for_commit.store(true, Ordering::Release);
+                                            Ok(super::inflight::CommitEvidence)
+                                        },
                                     );
-                                if !watcher_removed {
+                                if commit_outcome
+                                    != super::inflight::DestructiveCancelCommitOutcome::Committed
+                                {
                                     tracing::warn!(
                                         target: "agentdesk::discord::relay_recovery",
                                         provider = provider.as_str(),
                                         channel_id = decision.channel_id,
                                         watcher_owner_channel_id = owner_channel_id.get(),
                                         death_evidence = gate.allowed_reason().unwrap_or("unknown"),
-                                        "relay recovery skipped destructive watcher cancel after gate; expected watcher was not current"
+                                        ?commit_outcome,
+                                        "relay recovery skipped destructive watcher cancel after gate; flock-held pin commit failed"
                                     );
                                 } else {
-                                    let current =
-                                        current.expect("checked by current_matches_probe");
-                                    let lifecycle_identity =
-                                        super::inflight::InflightTurnIdentity::from_state(&current);
-                                    let lifecycle_updated_at = current.updated_at.clone();
-                                    let lifecycle_save_generation = current.save_generation;
-                                    let finalize_outcome = finalize_cancelled_watcher_owner_turn(
-                                        shared,
-                                        provider,
-                                        decision,
-                                        owner_channel_id,
-                                    )
-                                    .await;
-                                    let lifecycle_clear_outcome =
-                                        super::inflight::clear_lifecycle_inflight_state_if_matches_identity_after_death_evidence(
-                                            provider,
-                                            owner_channel_id.get(),
-                                            &lifecycle_identity,
-                                            &lifecycle_updated_at,
-                                            lifecycle_save_generation,
+                                    // The flock is released before registry CAS; the two lock domains never overlap.
+                                    let watcher_removed =
+                                        shared.tmux_watchers.cancel_and_remove_channel_if_current(
+                                            &owner_channel_id,
+                                            tmux_session_name,
+                                            output_path,
+                                            cancel,
                                         );
-                                    tracing::warn!(
-                                        target: "agentdesk::discord::relay_recovery",
-                                        provider = provider.as_str(),
-                                        channel_id = decision.channel_id,
-                                        watcher_owner_channel_id = owner_channel_id.get(),
-                                        last_relay_offset = decision.evidence.last_relay_offset,
-                                        last_capture_offset = ?decision.evidence.last_capture_offset,
-                                        unread_bytes = ?decision.evidence.unread_bytes,
-                                        death_evidence = gate.allowed_reason().unwrap_or("unknown"),
-                                        watcher_removed,
-                                        lifecycle_clear_outcome = ?lifecycle_clear_outcome,
-                                        finalizer_outcome = match finalize_outcome {
-                                            Some(super::turn_finalizer::FinalizeOutcome::Finalized { .. }) => "finalized",
-                                            Some(super::turn_finalizer::FinalizeOutcome::AlreadyFinalized) => "already_finalized",
-                                            Some(super::turn_finalizer::FinalizeOutcome::Deferred) => "deferred",
-                                            None => "missing_identity",
-                                        },
-                                        "relay recovery cancelled watcher with death evidence before reattach"
-                                    );
+                                    if !watcher_removed {
+                                        tracing::warn!(
+                                            target: "agentdesk::discord::relay_recovery",
+                                            provider = provider.as_str(),
+                                            channel_id = decision.channel_id,
+                                            watcher_owner_channel_id = owner_channel_id.get(),
+                                            death_evidence = gate.allowed_reason().unwrap_or("unknown"),
+                                            "relay recovery skipped finalizer after committed cancel; expected watcher was not current"
+                                        );
+                                    } else {
+                                        let finalize_outcome =
+                                            finalize_cancelled_watcher_owner_turn(
+                                                shared,
+                                                provider,
+                                                decision,
+                                                owner_channel_id,
+                                            )
+                                            .await;
+                                        let lifecycle_clear_outcome =
+                                            super::inflight::clear_lifecycle_inflight_state_if_matches_identity_after_death_evidence(
+                                                provider,
+                                                owner_channel_id.get(),
+                                                &expected_identity,
+                                                &probe.updated_at,
+                                                probe.save_generation,
+                                            );
+                                        tracing::warn!(
+                                            target: "agentdesk::discord::relay_recovery",
+                                            provider = provider.as_str(),
+                                            channel_id = decision.channel_id,
+                                            watcher_owner_channel_id = owner_channel_id.get(),
+                                            last_relay_offset = decision.evidence.last_relay_offset,
+                                            last_capture_offset = ?decision.evidence.last_capture_offset,
+                                            unread_bytes = ?decision.evidence.unread_bytes,
+                                            death_evidence = gate.allowed_reason().unwrap_or("unknown"),
+                                            watcher_removed,
+                                            lifecycle_clear_outcome = ?lifecycle_clear_outcome,
+                                            finalizer_outcome = match finalize_outcome {
+                                                Some(super::turn_finalizer::FinalizeOutcome::Finalized { .. }) => "finalized",
+                                                Some(super::turn_finalizer::FinalizeOutcome::AlreadyFinalized) => "already_finalized",
+                                                Some(super::turn_finalizer::FinalizeOutcome::Deferred) => "deferred",
+                                                None => "missing_identity",
+                                            },
+                                            "relay recovery cancelled watcher with death evidence before reattach"
+                                        );
+                                    }
                                 }
                             } else {
                                 tracing::warn!(

--- a/src/services/discord/relay_recovery/apply.rs
+++ b/src/services/discord/relay_recovery/apply.rs
@@ -238,11 +238,11 @@ pub(super) async fn apply_relay_recovery_decision(
                                         probe.save_generation,
                                         move |_| {
                                             cancel_for_commit.store(true, Ordering::Release);
-                                            Ok(super::inflight::CommitEvidence)
+                                            Ok(super::inflight::CommitEvidence::CancelledWatcher)
                                         },
                                     );
                                 if commit_outcome
-                                    != super::inflight::DestructiveCancelCommitOutcome::Committed
+                                    != super::inflight::DestructiveCancelCommitOutcome::CommittedCancelled
                                 {
                                     tracing::warn!(
                                         target: "agentdesk::discord::relay_recovery",

--- a/src/services/discord/relay_recovery/tests.rs
+++ b/src/services/discord/relay_recovery/tests.rs
@@ -605,6 +605,103 @@ async fn dead_frontier_watcher_cancel_finalizes_owner_and_releases_inflight() {
 }
 
 #[tokio::test]
+async fn dead_frontier_gate_pass_then_generation_mismatch_preserves_turn() {
+    let _guard = auto_heal_test_lock().lock().await;
+    clear_auto_heal_attempts_for_tests();
+    let (_root_guard, root_dir) = isolated_agentdesk_root();
+    let provider = ProviderKind::Codex;
+    let (registry, shared) = registry_with_shared(provider.clone()).await;
+    let channel = ChannelId::new(4_030_004);
+    let user_msg = MessageId::new(4_030_104);
+    let tmux = "AgentDesk-codex-4030-generation-race";
+    let output_path = root_dir.path().join("generation-race.jsonl");
+    std::fs::write(
+        &output_path,
+        r#"{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}"#,
+    )
+    .expect("write terminal output fixture");
+    let token = start_test_turn(&shared, channel, user_msg).await;
+    shared.restart.global_active.store(1, Ordering::Relaxed);
+
+    let mut state = super::super::inflight::InflightTurnState::new(
+        provider.clone(),
+        channel.get(),
+        None,
+        1,
+        user_msg.get(),
+        4_030_204,
+        "watcher-owned generation race".to_string(),
+        None,
+        Some(tmux.to_string()),
+        Some(output_path.to_string_lossy().to_string()),
+        None,
+        0,
+    );
+    state.runtime_kind = Some(crate::services::agent_protocol::RuntimeHandoffKind::CodexTui);
+    state.set_relay_owner_kind(super::super::inflight::RelayOwnerKind::Watcher);
+    super::super::inflight::save_inflight_state(&state).expect("save watcher inflight");
+    let persisted = super::super::inflight::load_inflight_state(&provider, channel.get())
+        .expect("load watcher inflight");
+    shared.turn_finalizer.register_start(
+        super::super::turn_finalizer::TurnKey::new(
+            channel,
+            persisted.effective_finalizer_turn_id(),
+            shared.restart.current_generation,
+        ),
+        provider.clone(),
+        super::super::inflight::RelayOwnerKind::Watcher,
+        &shared,
+    );
+    let (watcher, watcher_cancel) = test_watcher_handle(tmux, &output_path);
+    watcher.last_heartbeat_ts_ms.store(1, Ordering::Release);
+    shared.tmux_watchers.insert(channel, watcher);
+
+    let hook_provider = provider.clone();
+    let _hook = set_destructive_cancel_post_gate_hook_for_tests(Arc::new(move || {
+        let current = super::super::inflight::load_inflight_state(&hook_provider, channel.get())
+            .expect("load post-gate inflight");
+        super::super::inflight::save_inflight_state(&current)
+            .expect("advance save generation after gate");
+    }));
+    let snapshot = RelayHealthSnapshot {
+        provider: provider.as_str().to_string(),
+        channel_id: channel.get(),
+        active_turn: RelayActiveTurn::Foreground,
+        tmux_session: Some(tmux.to_string()),
+        tmux_alive: Some(true),
+        watcher_attached: true,
+        watcher_attached_stale: true,
+        watcher_owner_channel_id: Some(channel.get()),
+        watcher_owns_live_relay: true,
+        bridge_inflight_present: true,
+        mailbox_has_cancel_token: true,
+        mailbox_active_user_msg_id: Some(user_msg.get()),
+        last_capture_offset: Some(0),
+        last_relay_offset: 0,
+        unread_bytes: Some(0),
+        desynced: true,
+        ..snapshot()
+    };
+    let mut decision = plan_relay_recovery(&snapshot, RelayStallState::TmuxAliveRelayDead, 1_000);
+    decision.affected.finalizer_turn_id = Some(persisted.effective_finalizer_turn_id());
+
+    let _ = apply_relay_recovery_decision(
+        &registry,
+        &shared,
+        &provider,
+        &decision,
+        None,
+        RelayRecoveryApplySource::ProbeAutoHeal,
+    )
+    .await;
+
+    assert!(!watcher_cancel.load(Ordering::Acquire));
+    assert!(shared.tmux_watchers.contains_key(&channel));
+    assert!(!token.cancelled.load(Ordering::Relaxed));
+    assert!(super::super::inflight::load_inflight_state(&provider, channel.get()).is_some());
+}
+
+#[tokio::test]
 async fn reattach_idle_tmux_clear_release_publishes_completion_event() {
     let _guard = auto_heal_test_lock().lock().await;
     clear_auto_heal_attempts_for_tests();

--- a/src/services/discord/relay_recovery/tests.rs
+++ b/src/services/discord/relay_recovery/tests.rs
@@ -689,14 +689,20 @@ async fn dead_frontier_gate_pass_then_generation_mismatch_preserves_turn() {
         bridge_inflight_present: true,
         mailbox_has_cancel_token: true,
         mailbox_active_user_msg_id: Some(user_msg.get()),
-        last_capture_offset: Some(0),
+        last_capture_offset: Some(1),
         last_relay_offset: 0,
-        unread_bytes: Some(0),
+        unread_bytes: Some(1),
         desynced: true,
         ..snapshot()
     };
     let mut decision = plan_relay_recovery(&snapshot, RelayStallState::TmuxAliveRelayDead, 1_000);
     decision.affected.finalizer_turn_id = Some(persisted.effective_finalizer_turn_id());
+    assert_eq!(
+        relay_frontier_dead_reattach_owner(&decision),
+        Some(channel),
+        "fixture must reach the destructive dead-frontier branch"
+    );
+    assert!(decision.affected.finalizer_turn_id.is_some());
 
     let _ = apply_relay_recovery_decision(
         &registry,

--- a/src/services/discord/relay_recovery/tests.rs
+++ b/src/services/discord/relay_recovery/tests.rs
@@ -658,10 +658,23 @@ async fn dead_frontier_gate_pass_then_generation_mismatch_preserves_turn() {
 
     let hook_provider = provider.clone();
     let _hook = set_destructive_cancel_post_gate_hook_for_tests(Arc::new(move || {
-        let current = super::super::inflight::load_inflight_state(&hook_provider, channel.get())
-            .expect("load post-gate inflight");
-        super::super::inflight::save_inflight_state(&current)
-            .expect("advance save generation after gate");
+        let root = super::super::inflight::inflight_runtime_root().expect("inflight root");
+        let path =
+            super::super::inflight::inflight_state_path(&root, &hook_provider, channel.get());
+        let _lock = super::super::lock_inflight_state_path(&path).expect("lock post-gate row");
+        let body = std::fs::read_to_string(&path).expect("read post-gate inflight");
+        let mut value: serde_json::Value =
+            serde_json::from_str(&body).expect("parse post-gate inflight");
+        let next = value["save_generation"]
+            .as_u64()
+            .expect("save generation")
+            .saturating_add(1);
+        value["save_generation"] = serde_json::Value::from(next);
+        super::super::runtime_store::atomic_write(
+            &path,
+            &serde_json::to_string_pretty(&value).expect("serialize post-gate inflight"),
+        )
+        .expect("advance save generation after gate");
     }));
     let snapshot = RelayHealthSnapshot {
         provider: provider.as_str().to_string(),

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -808,42 +808,69 @@ async fn submit_stale_foreign_inflight_cancel(
     if finalizer_turn_id == 0 {
         return false;
     }
-    let Some(current) = super::inflight::load_inflight_state(provider, channel_id.get()) else {
-        tracing::info!(
-            provider = %provider.as_str(),
-            channel_id = channel_id.get(),
-            finalizer_turn_id,
-            "tui_direct_pending_start: stale FOREIGN cancel no-op; inflight disappeared before finalizer submit"
-        );
-        return false;
-    };
     let mailbox_active_user_msg_id = super::mailbox_snapshot(shared, channel_id)
         .await
         .active_user_message_id
         .map(|id| id.get());
-    if !probe.pin.matches_state(&current)
-        || mailbox_active_user_msg_id != probe.pin.mailbox_active_user_msg_id
-        || current.updated_at != probe.updated_at
-        || current.save_generation != probe.save_generation
+    if mailbox_active_user_msg_id != probe.pin.mailbox_active_user_msg_id {
+        tracing::info!(
+            provider = %provider.as_str(),
+            channel_id = channel_id.get(),
+            expected_mailbox_active_user_msg_id = probe.pin.mailbox_active_user_msg_id.unwrap_or(0),
+            mailbox_active_user_msg_id = mailbox_active_user_msg_id.unwrap_or(0),
+            "tui_direct_pending_start: stale FOREIGN cancel no-op; mailbox episode changed"
+        );
+        return false;
+    }
+    let expected_cancel = probe
+        .pin
+        .tmux_session_name
+        .as_deref()
+        .and_then(|tmux_session| shared.tmux_watchers.cancel_for_tmux_session(tmux_session));
+    let cancel_for_commit = expected_cancel.clone();
+    let commit_outcome = super::inflight::commit_destructive_cancel_locked(
+        provider,
+        channel_id.get(),
+        &probe.inflight_identity,
+        &probe.updated_at,
+        probe.save_generation,
+        move |_| {
+            if let Some(cancel) = cancel_for_commit {
+                cancel.store(true, std::sync::atomic::Ordering::Release);
+            }
+            Ok(super::inflight::CommitEvidence)
+        },
+    );
+    if commit_outcome != super::inflight::DestructiveCancelCommitOutcome::Committed {
+        tracing::info!(
+            provider = %provider.as_str(),
+            channel_id = channel_id.get(),
+            ?commit_outcome,
+            "tui_direct_pending_start: stale FOREIGN cancel no-op; flock-held pin commit failed"
+        );
+        return false;
+    }
+    // The flock is released before registry CAS; the two lock domains never overlap.
+    if let (Some(tmux_session), Some(cancel)) = (
+        probe.pin.tmux_session_name.as_deref(),
+        expected_cancel.as_ref(),
+    ) && shared
+        .tmux_watchers
+        .remove_tmux_session_if_current(tmux_session, cancel)
+        .is_none()
     {
         tracing::info!(
             provider = %provider.as_str(),
             channel_id = channel_id.get(),
-            expected_finalizer_turn_id = finalizer_turn_id,
-            current_finalizer_turn_id = current.effective_finalizer_turn_id(),
-            expected_mailbox_active_user_msg_id = probe.pin.mailbox_active_user_msg_id.unwrap_or(0),
-            mailbox_active_user_msg_id = mailbox_active_user_msg_id.unwrap_or(0),
-            expected_tmux_session = ?probe.pin.tmux_session_name,
-            current_tmux_session = ?current.tmux_session_name,
-            expected_updated_at = %probe.updated_at,
-            current_updated_at = %current.updated_at,
-            expected_save_generation = probe.save_generation,
-            current_save_generation = current.save_generation,
-            "tui_direct_pending_start: stale FOREIGN cancel no-op; identity/death-evidence pin no longer matches"
+            tmux_session,
+            "tui_direct_pending_start: stale FOREIGN cancel committed but watcher incarnation changed; finalizer skipped"
         );
         return false;
     }
-    let stale_identity = super::inflight::InflightTurnIdentity::from_state(&current);
+    // E1 closes the watcher left behind at destruction time. It does not close a
+    // last pre-cancel self-heal iteration or later restoration/reclaim recreation
+    // (#5012/E3), nor durable observation of finalizer degradation (E2/E6).
+    let stale_identity = probe.inflight_identity.clone();
     let _ = shared
         .turn_finalizer
         .submit_terminal(

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -1662,6 +1662,31 @@ mod tests {
         LOCK.lock().unwrap_or_else(|poison| poison.into_inner())
     }
 
+    fn test_watcher_handle(
+        tmux_session_name: &str,
+        output_path: &std::path::Path,
+    ) -> (
+        super::super::TmuxWatcherHandle,
+        Arc<std::sync::atomic::AtomicBool>,
+    ) {
+        let cancel = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        (
+            super::super::TmuxWatcherHandle {
+                tmux_session_name: tmux_session_name.to_string(),
+                output_path: output_path.to_string_lossy().to_string(),
+                paused: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                resume_offset: Arc::new(std::sync::Mutex::new(None)),
+                cancel: cancel.clone(),
+                pause_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                turn_delivered: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                last_heartbeat_ts_ms: Arc::new(std::sync::atomic::AtomicI64::new(
+                    super::super::tmux_watcher_now_ms(),
+                )),
+            },
+            cancel,
+        )
+    }
+
     struct EnvReset(Option<std::ffi::OsString>);
 
     impl Drop for EnvReset {
@@ -2743,6 +2768,113 @@ mod tests {
                 "frozen nonzero relay frontier with unchanged ready capture is death evidence"
             );
             assert!(token.cancelled.load(std::sync::atomic::Ordering::Relaxed));
+        });
+    }
+
+    #[test]
+    fn stale_foreign_demote_cancels_and_removes_current_watcher() {
+        let _guard = worker_test_lock();
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let root = tempfile::TempDir::new().expect("runtime root");
+        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", root.path()) };
+        current_thread_rt().block_on(async {
+            let shared = super::super::make_shared_data_for_tests();
+            let provider = crate::services::provider::ProviderKind::Claude;
+            let channel_id = 4_030_116;
+            let channel = poise::serenity_prelude::ChannelId::new(channel_id);
+            let stale_msg = 4_030_216;
+            let tmux = "tmux-4030-e1-watcher";
+            let output_path = root.path().join("ready-e1-watcher.jsonl");
+            std::fs::write(
+                &output_path,
+                r#"{"type":"system","subtype":"init","session_id":"s"}"#,
+            )
+            .expect("write ready output");
+            let token = Arc::new(crate::services::provider::CancelToken::new());
+            assert!(
+                super::super::mailbox_try_start_turn(
+                    &shared,
+                    channel,
+                    token.clone(),
+                    poise::serenity_prelude::UserId::new(1),
+                    poise::serenity_prelude::MessageId::new(stale_msg),
+                )
+                .await
+            );
+            shared
+                .restart
+                .global_active
+                .store(1, std::sync::atomic::Ordering::Relaxed);
+            let mut state =
+                stale_foreign_state(provider.clone(), channel_id, stale_msg, tmux, &output_path);
+            stamp_claude_ready_for_input_evidence(&mut state, &output_path);
+            write_inflight_fixture(root.path(), &provider, &state);
+            let (watcher, watcher_cancel) = test_watcher_handle(tmux, &output_path);
+            watcher
+                .last_heartbeat_ts_ms
+                .store(1, std::sync::atomic::Ordering::Release);
+            shared.tmux_watchers.insert(channel, watcher);
+            let mut rec = record("claude", channel_id, 4_030_316);
+            rec.tmux_session_name = tmux.to_string();
+
+            assert!(demote_stale_foreign_inflight_if_current(&shared, &rec).await);
+            assert!(watcher_cancel.load(std::sync::atomic::Ordering::Acquire));
+            assert!(!shared.tmux_watchers.has_live_watcher_handle(tmux));
+            assert!(token.cancelled.load(std::sync::atomic::Ordering::Relaxed));
+        });
+    }
+
+    #[test]
+    fn stale_foreign_demote_without_watcher_still_commits_cancel() {
+        let _guard = worker_test_lock();
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let root = tempfile::TempDir::new().expect("runtime root");
+        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", root.path()) };
+        current_thread_rt().block_on(async {
+            let shared = super::super::make_shared_data_for_tests();
+            let provider = crate::services::provider::ProviderKind::Claude;
+            let channel_id = 4_030_117;
+            let channel = poise::serenity_prelude::ChannelId::new(channel_id);
+            let stale_msg = 4_030_217;
+            let tmux = "tmux-4030-e1-no-watcher";
+            let output_path = root.path().join("ready-e1-no-watcher.jsonl");
+            std::fs::write(
+                &output_path,
+                r#"{"type":"system","subtype":"init","session_id":"s"}"#,
+            )
+            .expect("write ready output");
+            let token = Arc::new(crate::services::provider::CancelToken::new());
+            assert!(
+                super::super::mailbox_try_start_turn(
+                    &shared,
+                    channel,
+                    token.clone(),
+                    poise::serenity_prelude::UserId::new(1),
+                    poise::serenity_prelude::MessageId::new(stale_msg),
+                )
+                .await
+            );
+            shared
+                .restart
+                .global_active
+                .store(1, std::sync::atomic::Ordering::Relaxed);
+            let mut state =
+                stale_foreign_state(provider.clone(), channel_id, stale_msg, tmux, &output_path);
+            stamp_claude_ready_for_input_evidence(&mut state, &output_path);
+            write_inflight_fixture(root.path(), &provider, &state);
+            let mut rec = record("claude", channel_id, 4_030_317);
+            rec.tmux_session_name = tmux.to_string();
+
+            assert!(!shared.tmux_watchers.has_live_watcher_handle(tmux));
+            assert!(demote_stale_foreign_inflight_if_current(&shared, &rec).await);
+            assert!(token.cancelled.load(std::sync::atomic::Ordering::Relaxed));
+            assert!(super::super::inflight::load_inflight_state(&provider, channel_id).is_none());
         });
     }
 

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -40,6 +40,9 @@ use serde::{Deserialize, Serialize};
 
 use super::SharedData;
 
+#[path = "tui_direct_pending_start/watcher_cancel.rs"]
+mod watcher_cancel;
+
 /// Conservative poll interval for the wait predicate.
 pub(super) const PENDING_START_POLL: Duration = Duration::from_millis(100);
 
@@ -826,7 +829,9 @@ async fn submit_stale_foreign_inflight_cancel(
         .pin
         .tmux_session_name
         .as_deref()
-        .and_then(|tmux_session| shared.tmux_watchers.cancel_for_tmux_session(tmux_session));
+        .and_then(|tmux_session| {
+            watcher_cancel::cancel_for_tmux_session(&shared.tmux_watchers, tmux_session)
+        });
     let cancel_for_commit = expected_cancel.clone();
     let commit_outcome = super::inflight::commit_destructive_cancel_locked(
         provider,

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -878,14 +878,19 @@ async fn submit_stale_foreign_inflight_cancel(
         &probe.inflight_identity,
         &probe.updated_at,
         probe.save_generation,
-        move |_| {
-            if let Some(cancel) = cancel_for_commit {
+        move |_| match cancel_for_commit {
+            Some(cancel) => {
                 cancel.store(true, std::sync::atomic::Ordering::Release);
+                Ok(super::inflight::CommitEvidence::CancelledWatcher)
             }
-            Ok(super::inflight::CommitEvidence)
+            None => Ok(super::inflight::CommitEvidence::NoWatcher),
         },
     );
-    if commit_outcome != super::inflight::DestructiveCancelCommitOutcome::Committed {
+    if !matches!(
+        commit_outcome,
+        super::inflight::DestructiveCancelCommitOutcome::CommittedCancelled
+            | super::inflight::DestructiveCancelCommitOutcome::CommittedNoWatcher
+    ) {
         tracing::info!(
             provider = %provider.as_str(),
             channel_id = channel_id.get(),

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -2868,11 +2868,9 @@ mod tests {
             let hook_root = root.path().to_path_buf();
             let hook_provider = provider.clone();
             let _hook = set_destructive_cancel_post_gate_hook_for_tests(Arc::new(move || {
-                let current = super::super::inflight::load_inflight_state(
-                    &hook_provider,
-                    channel_id,
-                )
-                .expect("load post-gate inflight");
+                let current =
+                    super::super::inflight::load_inflight_state(&hook_provider, channel_id)
+                        .expect("load post-gate inflight");
                 write_inflight_fixture(&hook_root, &hook_provider, &current);
             }));
 

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -43,6 +43,45 @@ use super::SharedData;
 #[path = "tui_direct_pending_start/watcher_cancel.rs"]
 mod watcher_cancel;
 
+#[cfg(test)]
+type DestructiveCancelPostGateHook = Arc<dyn Fn() + Send + Sync + 'static>;
+#[cfg(test)]
+static DESTRUCTIVE_CANCEL_POST_GATE_HOOK: LazyLock<Mutex<Option<DestructiveCancelPostGateHook>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+#[cfg(test)]
+fn run_destructive_cancel_post_gate_hook_for_tests() {
+    let hook = DESTRUCTIVE_CANCEL_POST_GATE_HOOK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .clone();
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
+#[cfg(test)]
+struct DestructiveCancelPostGateHookGuard;
+
+#[cfg(test)]
+impl Drop for DestructiveCancelPostGateHookGuard {
+    fn drop(&mut self) {
+        *DESTRUCTIVE_CANCEL_POST_GATE_HOOK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = None;
+    }
+}
+
+#[cfg(test)]
+fn set_destructive_cancel_post_gate_hook_for_tests(
+    hook: DestructiveCancelPostGateHook,
+) -> DestructiveCancelPostGateHookGuard {
+    *DESTRUCTIVE_CANCEL_POST_GATE_HOOK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner()) = Some(hook);
+    DestructiveCancelPostGateHookGuard
+}
+
 /// Conservative poll interval for the wait predicate.
 pub(super) const PENDING_START_POLL: Duration = Duration::from_millis(100);
 
@@ -1132,6 +1171,8 @@ pub(in crate::services::discord) async fn demote_stale_foreign_inflight_if_curre
         return false;
     }
 
+    #[cfg(test)]
+    run_destructive_cancel_post_gate_hook_for_tests();
     let demoted = submit_stale_foreign_inflight_cancel(shared, &provider, channel, &probe).await;
     if demoted {
         tracing::warn!(
@@ -2773,6 +2814,73 @@ mod tests {
                 "frozen nonzero relay frontier with unchanged ready capture is death evidence"
             );
             assert!(token.cancelled.load(std::sync::atomic::Ordering::Relaxed));
+        });
+    }
+
+    #[test]
+    fn stale_foreign_gate_pass_then_generation_mismatch_preserves_turn() {
+        let _guard = worker_test_lock();
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let root = tempfile::TempDir::new().expect("runtime root");
+        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", root.path()) };
+        current_thread_rt().block_on(async {
+            let shared = super::super::make_shared_data_for_tests();
+            let provider = crate::services::provider::ProviderKind::Claude;
+            let channel_id = 4_030_118;
+            let channel = poise::serenity_prelude::ChannelId::new(channel_id);
+            let stale_msg = 4_030_218;
+            let tmux = "tmux-4030-generation-race";
+            let output_path = root.path().join("ready-generation-race.jsonl");
+            std::fs::write(
+                &output_path,
+                r#"{"type":"result","result":"done","session_id":"s"}"#,
+            )
+            .expect("write terminal output");
+            let token = Arc::new(crate::services::provider::CancelToken::new());
+            assert!(
+                super::super::mailbox_try_start_turn(
+                    &shared,
+                    channel,
+                    token.clone(),
+                    poise::serenity_prelude::UserId::new(1),
+                    poise::serenity_prelude::MessageId::new(stale_msg),
+                )
+                .await
+            );
+            shared
+                .restart
+                .global_active
+                .store(1, std::sync::atomic::Ordering::Relaxed);
+            let state =
+                stale_foreign_state(provider.clone(), channel_id, stale_msg, tmux, &output_path);
+            write_inflight_fixture(root.path(), &provider, &state);
+            let (watcher, watcher_cancel) = test_watcher_handle(tmux, &output_path);
+            watcher
+                .last_heartbeat_ts_ms
+                .store(1, std::sync::atomic::Ordering::Release);
+            shared.tmux_watchers.insert(channel, watcher);
+            let mut rec = record("claude", channel_id, 4_030_318);
+            rec.tmux_session_name = tmux.to_string();
+
+            let hook_root = root.path().to_path_buf();
+            let hook_provider = provider.clone();
+            let _hook = set_destructive_cancel_post_gate_hook_for_tests(Arc::new(move || {
+                let current = super::super::inflight::load_inflight_state(
+                    &hook_provider,
+                    channel_id,
+                )
+                .expect("load post-gate inflight");
+                write_inflight_fixture(&hook_root, &hook_provider, &current);
+            }));
+
+            assert!(!demote_stale_foreign_inflight_if_current(&shared, &rec).await);
+            assert!(!watcher_cancel.load(std::sync::atomic::Ordering::Acquire));
+            assert!(shared.tmux_watchers.has_live_watcher_handle(tmux));
+            assert!(!token.cancelled.load(std::sync::atomic::Ordering::Relaxed));
+            assert!(super::super::inflight::load_inflight_state(&provider, channel_id).is_some());
         });
     }
 

--- a/src/services/discord/tui_direct_pending_start/watcher_cancel.rs
+++ b/src/services/discord/tui_direct_pending_start/watcher_cancel.rs
@@ -1,0 +1,14 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use super::super::TmuxWatcherRegistry;
+
+pub(super) fn cancel_for_tmux_session(
+    registry: &TmuxWatcherRegistry,
+    tmux_session_name: &str,
+) -> Option<Arc<AtomicBool>> {
+    registry
+        .iter()
+        .find(|entry| entry.key() == tmux_session_name)
+        .map(|entry| entry.cancel.clone())
+}

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -54,6 +54,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --lib services::tmux_common::sentinel_tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib services::discord::turn_bridge::followup_requeue::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib services::discord::turn_bridge::terminal_outcome_delivery::busy_followup_retry::tests -- --skip _pg --skip pg_ --skip postgres",
+    "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::inflight::destructive_commit::tests -- --test-threads=1",
     "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::inflight::save_store::bridge_entry_guard_tests -- --test-threads=1",
     "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::inflight::save_store::identity_gate::bridge_entry::tests -- --test-threads=1",
     "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::inflight::save_store::identity_gate::claude_e_stamp::tests -- --test-threads=1",


### PR DESCRIPTION
이슈 #5014 (E0+E1). #5007의 원자성 확보 최소 조건이며 #4992/#5005 파괴 활성화의 선행 조건이다.

## 배경

#5007 설계가 카운터리뷰에서 두 번 같은 이유로 기각됐다: "펜스라고 가정한 것이 실제로는 모든 writer를 배제하지 못함". 이 PR은 전역 펜스를 주장하지 않고, 배제하는 host-local writer 집합과 닫지 않는 범위를 명시한다.

## E0 — host-local 커밋 프리미티브

`src/services/discord/inflight/destructive_commit.rs`

sidecar flock 임계구역 안에서 identity + `save_generation` pin을 검증하고, `updated_at`은 1초 해상도 보조 진단값으로 확인한다. 검증 통과 후 비동기 작업 없이 callback을 실행한다.

성공 outcome은 실제 callback 증거를 구분한다.

- `CommittedCancelled`: pin 일치 후 watcher cancel `AtomicBool`을 실제 설정함
- `CommittedNoWatcher`: pin은 일치했지만 취소할 watcher가 없었음

두 outcome 모두 배타적·내구적 파괴 권위 획득을 뜻하지 않는다.

배제하는 writer 집합: flock-held persist를 완료한 watcher persist 3종, 생성 API 2종, legacy rebind-origin backfill. 같은 턴 writer는 `save_generation`, 다른 턴은 identity 변경으로 차단된다.

## E1 — 파괴 시점 watcher 종료

두 경로 모두 inflight row의 tmux session에 연결된 watcher cancel Arc를 flock 안에서 설정한다.

- `relay_recovery/apply.rs`: watcher가 반드시 있어야 진입하므로 `CommittedCancelled`만 성공으로 인정
- `tui_direct_pending_start.rs`: watcher 유무에 따라 `CommittedCancelled` / `CommittedNoWatcher`를 구분하고, 실제 watcher가 있었던 경우 registry identity CAS를 추가 확인

registry mutex와 sidecar flock은 중첩하지 않는다. callback은 atomic store만 수행하며 `.await`가 없다.

## 명시적으로 닫지 않는 범위

- cancel 관측 직전 watcher iteration의 delivery/persist
- 파괴 뒤 row 재생성 (#5012/E3)
- partially degraded finalizer commit의 durable 관측 (E2/E6)
- cancel 뒤 registry CAS 실패 시 부분 파괴 상태
- durable cancel intent/epoch 부재에 따른 crash 소실
- row version을 전진시키지 않아 복수 serialized caller가 commit outcome을 받을 수 있음
- flock 밖에서 캡처한 stale cancel Arc
- host-local flock이 다른 node의 watcher/row/mailbox를 fence하지 못함
- flock 없이 동작하는 age/lifecycle-qualified stale-row sweep

분산 fence와 durable intent 후속 작업: #5037.

## Legacy backfill fence 수정

`backfill_legacy_rebind_origin_turn_source`도 raw JSON backfill 시 `save_generation`을 단조 증가시키고 `updated_at`을 갱신한다. 이전 pin이 더 이상 통과하지 않는 mutation test를 포함한다.

## 배선 및 mutation 증명

- `dead_frontier_gate_pass_then_generation_mismatch_preserves_turn`
- `stale_foreign_gate_pass_then_generation_mismatch_preserves_turn`

두 테스트 모두 gate를 통과한 뒤 disk generation을 전진시키며 cancel/registry removal/row clear가 일어나지 않음을 검증한다.

- backfill generation bump 제거: `rc=101`, 복원: `rc=0`
- relay recovery commit-outcome 조기 반환 제거: `rc=101`, 복원: `rc=0`
- pending-start commit-outcome 조기 반환 제거: `rc=101`, 복원: `rc=0`

모두 컴파일 실패가 아니라 테스트 assertion으로 실패한다.

## Multinode 분류

`docs/agent-maintenance/multinode-transition.md`의 Audited touches에 worker-local 분류를 기록했다. 이 PR은 PG lease, distributed epoch, leader check, remote-owner RPC, durable intent, worker placement 또는 cross-node authority를 추가하지 않는다.

## 규모

레포의 `scripts/generate_inventory_docs.py::split_prod_test_lines`로 직접 측정한 현재 PR 전체 production LoC 순증은 **+316**이다. `#[cfg(test)]` 자유 함수/정적 hook은 레포 계산기가 test LoC로 제외하지 않으므로 production으로 계수된다.

| 파일 | prod 증감 |
|---|---:|
| `inflight/destructive_commit.rs` | +150 |
| `tui_direct_pending_start.rs` | +78 |
| `relay_recovery.rs` | +43 |
| `tui_direct_pending_start/watcher_cancel.rs` | +14 |
| `reconcile.rs` | +13 |
| `relay_recovery/apply.rs` | +11 |
| `inflight.rs` | +5 |
| `destructive_cancel_gate.rs` | +2 |

frozen baseline, giant-file registry, cap 인상은 없다.

## 검증

- `cargo fmt --all --check`
- `cargo check --lib`
- focused `inflight`, `relay_recovery`, `tui_direct_pending_start`, `reconcile` tests
- `generate_inventory_docs.py`
- `check_agent_maintenance_docs.py`
- `TEST_LANE_BASELINE_REF=origin/main bash scripts/ci-script-checks.sh`
- PG test-lane membership day-one gate
- Trusted macOS self-hosted check

Closes #5014
