### PR TITLE
fix(#5021): stop settling no-op relay reattach as a healed round

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1256,10 +1256,11 @@
   - `src/services/discord/recovery_engine/completion_delivery.rs` (sub-1000;
     behavior-preserving #3834 r2 extraction of recovery terminal relay,
     visible completion/status-panel completion helpers, and their tests.)
-  - `src/services/discord/recovery_engine/manual_rebind/mod.rs` (911 prod lines
-    after the #4712 pure-move extraction of the test-only race-seam barrier
-    cluster into `manual_rebind/test_barriers.rs` (114 prod lines); no longer a
-    prod giant. Keeps the manual rebind entrypoints,
+  - `src/services/discord/recovery_engine/manual_rebind/mod.rs` (950 prod lines
+    after #5021 added explicit relay-repair accounting and the #4712 pure-move
+    extraction of the test-only race-seam barrier cluster into
+    `manual_rebind/test_barriers.rs` (114 prod lines); no longer a prod giant.
+    Keeps the manual rebind entrypoints,
     rollback carrier, session refresh, active-turn re-registration hook, and
     watcher claim/spawn path. #4465's durable automatic lane performs the
     blocking exact-episode adoption on `spawn_blocking`, retains that same

--- a/src/services/discord/readopted_mailbox_ledger.rs
+++ b/src/services/discord/readopted_mailbox_ledger.rs
@@ -224,6 +224,23 @@ impl SharedData {
             .remove(&(provider.clone(), channel_id));
     }
 
+    pub(in crate::services::discord) fn has_readopted_mailbox_owner_for_episode(
+        &self,
+        provider: &ProviderKind,
+        channel_id: u64,
+        state: &InflightTurnState,
+    ) -> bool {
+        let turn_pin = ReadoptedMailboxTurnPin::from_state(state);
+        self.readopted_mailbox_ledger
+            .entries
+            .get(&(provider.clone(), channel_id))
+            .is_some_and(|entry| {
+                entry.owner_user_id == state.request_owner_user_id
+                    && entry.active_user_message_id == state.effective_finalizer_turn_id()
+                    && entry.turn_pin.as_ref() == Some(&turn_pin)
+            })
+    }
+
     #[cfg(test)]
     pub(in crate::services::discord) fn readopted_mailbox_turn_pin_for_test(
         &self,

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -167,7 +167,9 @@ pub(crate) use self::manual_rebind::{
     rebind_inflight_for_channel, rebind_inflight_for_channel_with_minimum_start_offset,
 };
 pub(crate) use self::manual_rebind_override::ManualRebindOverrides;
-pub(in crate::services::discord) use self::runtime::reregister_active_turn_from_inflight_under_episode_guard;
+pub(in crate::services::discord) use self::runtime::{
+    ActiveTurnReregisterOutcome, reregister_active_turn_from_inflight_under_episode_guard,
+};
 // #3834: `reregister_active_turn_from_inflight` is re-exported (not just
 // re-imported) so the `recovery_engine::reregister_active_turn_from_inflight`
 // path stays valid for its `watchers::lifecycle` caller (via the `recovery`
@@ -433,6 +435,9 @@ pub struct RebindOutcome {
     /// from a zombie-slot recovery, which is the common case where an old
     /// watcher kept its DashMap entry after its tmux exited.
     pub watcher_replaced: bool,
+    /// `true` when this call changed durable inflight adoption, restored a
+    /// session/mailbox/runtime binding, or spawned/replaced a watcher.
+    pub repaired_state: bool,
 }
 
 /// #896: Errors from [`rebind_inflight_for_channel`]. Map 1:1 to HTTP status

--- a/src/services/discord/recovery_engine/manual_rebind/episode_handoff.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/episode_handoff.rs
@@ -2,6 +2,12 @@
 
 use super::*;
 
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct EpisodeSideEffectOutcome {
+    pub finish_mailbox_on_completion: bool,
+    pub repaired_state: bool,
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn commit_episode_side_effects(
     shared: &Arc<SharedData>,
@@ -18,7 +24,13 @@ pub(super) async fn commit_episode_side_effects(
     output_path: &str,
     tmux_session_name: &str,
     initial_offset: u64,
-) -> Result<(Option<super::inflight::LockedInflightEpisode>, bool), RebindError> {
+) -> Result<
+    (
+        Option<super::inflight::LockedInflightEpisode>,
+        EpisodeSideEffectOutcome,
+    ),
+    RebindError,
+> {
     // A terminal commit is a lifecycle-authority transition, not a reattachable
     // episode. The reservation pin normally rejects a commit that wins before
     // adoption; keep this lock-held check as defense in depth so the guarded
@@ -45,6 +57,7 @@ pub(super) async fn commit_episode_side_effects(
         );
     }
 
+    let previous_session = core.sessions.get(&discord_channel_id).cloned();
     let session = core
         .sessions
         .entry(discord_channel_id)
@@ -86,6 +99,25 @@ pub(super) async fn commit_episode_side_effects(
         session.session_id = authoritative_session_id.clone();
     }
     restore_recovered_session_worktree(session, authoritative_state);
+    let session_binding_changed = previous_session.as_ref().is_none_or(|previous| {
+        previous.session_id != session.session_id
+            || previous.channel_id != session.channel_id
+            || previous.channel_name != session.channel_name
+            || previous.current_path != session.current_path
+            || previous.worktree.as_ref().map(|worktree| {
+                (
+                    worktree.original_path.as_str(),
+                    worktree.worktree_path.as_str(),
+                    worktree.branch_name.as_str(),
+                )
+            }) != session.worktree.as_ref().map(|worktree| {
+                (
+                    worktree.original_path.as_str(),
+                    worktree.worktree_path.as_str(),
+                    worktree.branch_name.as_str(),
+                )
+            })
+    });
     drop(core);
 
     #[cfg(test)]
@@ -93,7 +125,7 @@ pub(super) async fn commit_episode_side_effects(
         super::test_barriers::await_episode_authority_held_barrier().await;
     }
 
-    let finish_mailbox_on_completion = if existing_inflight_present {
+    let reregister_outcome = if existing_inflight_present {
         if locked_episode.is_some() {
             super::reregister_active_turn_from_inflight_under_episode_guard(
                 shared,
@@ -101,13 +133,21 @@ pub(super) async fn commit_episode_side_effects(
             )
             .await
         } else {
-            reregister_active_turn_from_inflight(shared, authoritative_state).await
+            let finish_mailbox_on_completion =
+                reregister_active_turn_from_inflight(shared, authoritative_state).await;
+            super::ActiveTurnReregisterOutcome {
+                finish_mailbox_on_completion,
+                mailbox_binding_changed: finish_mailbox_on_completion,
+            }
         }
     } else {
-        false
+        super::ActiveTurnReregisterOutcome::default()
     };
+    let finish_mailbox_on_completion = reregister_outcome.finish_mailbox_on_completion;
+    let mut readoption_marker_changed = false;
 
     if finish_mailbox_on_completion && let Some(guard) = locked_episode.as_mut() {
+        readoption_marker_changed = !guard.state().readopted_from_inflight;
         let outcome = guard.mark_readopted_under_guard();
         if !matches!(outcome, super::inflight::GuardedSaveOutcome::Saved) {
             shared.evict_readopted_mailbox_owner(provider, channel_id);
@@ -129,25 +169,46 @@ pub(super) async fn commit_episode_side_effects(
         .as_ref()
         .and_then(|_| authoritative_state.tmux_session_name.as_deref())
         .unwrap_or(tmux_session_name);
-    if claude_tui_rebind_should_reregister_runtime_binding(
+    let runtime_binding_changed = if claude_tui_rebind_should_reregister_runtime_binding(
         authoritative_runtime_kind,
         authoritative_output_path,
     ) {
+        let binding = crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
+            runtime_kind: RuntimeHandoffKind::ClaudeTui,
+            output_path: authoritative_output_path.to_string(),
+            relay_output_path: None,
+            input_fifo_path: authoritative_state.input_fifo_path.clone(),
+            session_id: authoritative_session_id,
+            last_offset: initial_offset.max(authoritative_state.last_offset),
+            relay_last_offset: None,
+        };
+        let changed = crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(
+            authoritative_tmux_session,
+        )
+        .as_ref()
+            != Some(&binding)
+            || crate::services::tui_prompt_dedupe::owner_channel_for_tmux_session(
+                authoritative_tmux_session,
+            ) != Some(channel_id);
         crate::services::tui_prompt_dedupe::register_rehydrated_tmux_runtime_binding(
             provider.as_str(),
             authoritative_tmux_session,
             channel_id,
-            crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
-                runtime_kind: RuntimeHandoffKind::ClaudeTui,
-                output_path: authoritative_output_path.to_string(),
-                relay_output_path: None,
-                input_fifo_path: authoritative_state.input_fifo_path.clone(),
-                session_id: authoritative_session_id,
-                last_offset: initial_offset.max(authoritative_state.last_offset),
-                relay_last_offset: None,
-            },
+            binding,
         );
-    }
+        changed
+    } else {
+        false
+    };
 
-    Ok((locked_episode, finish_mailbox_on_completion))
+    Ok((
+        locked_episode,
+        EpisodeSideEffectOutcome {
+            finish_mailbox_on_completion,
+            repaired_state: session_binding_changed
+                || reregister_outcome.mailbox_binding_changed
+                || readoption_marker_changed
+                || runtime_binding_changed,
+        },
+    ))
 }

--- a/src/services/discord/recovery_engine/manual_rebind/episode_handoff.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/episode_handoff.rs
@@ -173,20 +173,30 @@ pub(super) async fn commit_episode_side_effects(
         authoritative_runtime_kind,
         authoritative_output_path,
     ) {
+        let previous_binding = crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(
+            authoritative_tmux_session,
+        );
         let binding = crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
             runtime_kind: RuntimeHandoffKind::ClaudeTui,
             output_path: authoritative_output_path.to_string(),
             relay_output_path: None,
             input_fifo_path: authoritative_state.input_fifo_path.clone(),
             session_id: authoritative_session_id,
-            last_offset: initial_offset.max(authoritative_state.last_offset),
+            last_offset: previous_binding
+                .as_ref()
+                .filter(|previous| previous.output_path == authoritative_output_path)
+                .map_or(
+                    initial_offset.max(authoritative_state.last_offset),
+                    |previous| {
+                        previous
+                            .last_offset
+                            .max(initial_offset)
+                            .max(authoritative_state.last_offset)
+                    },
+                ),
             relay_last_offset: None,
         };
-        let changed = crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(
-            authoritative_tmux_session,
-        )
-        .as_ref()
-            != Some(&binding)
+        let changed = previous_binding.as_ref() != Some(&binding)
             || crate::services::tui_prompt_dedupe::owner_channel_for_tmux_session(
                 authoritative_tmux_session,
             ) != Some(channel_id);

--- a/src/services/discord/recovery_engine/manual_rebind/episode_handoff.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/episode_handoff.rs
@@ -133,12 +133,7 @@ pub(super) async fn commit_episode_side_effects(
             )
             .await
         } else {
-            let finish_mailbox_on_completion =
-                reregister_active_turn_from_inflight(shared, authoritative_state).await;
-            super::ActiveTurnReregisterOutcome {
-                finish_mailbox_on_completion,
-                mailbox_binding_changed: finish_mailbox_on_completion,
-            }
+            reregister_active_turn_from_inflight(shared, authoritative_state).await
         }
     } else {
         super::ActiveTurnReregisterOutcome::default()
@@ -173,40 +168,28 @@ pub(super) async fn commit_episode_side_effects(
         authoritative_runtime_kind,
         authoritative_output_path,
     ) {
-        let previous_binding = crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(
-            authoritative_tmux_session,
-        );
-        let binding = crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
+        let desired_binding = crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
             runtime_kind: RuntimeHandoffKind::ClaudeTui,
             output_path: authoritative_output_path.to_string(),
             relay_output_path: None,
             input_fifo_path: authoritative_state.input_fifo_path.clone(),
             session_id: authoritative_session_id,
-            last_offset: previous_binding
-                .as_ref()
-                .filter(|previous| previous.output_path == authoritative_output_path)
-                .map_or(
-                    initial_offset.max(authoritative_state.last_offset),
-                    |previous| {
-                        previous
-                            .last_offset
-                            .max(initial_offset)
-                            .max(authoritative_state.last_offset)
-                    },
-                ),
+            // Recovery can intentionally restart at zero when this output file
+            // was recreated/truncated below the durable cursor. Monotonic merge
+            // is therefore scoped to an existing binding for this exact path.
+            last_offset: initial_offset.max(authoritative_state.last_offset),
             relay_last_offset: None,
         };
-        let changed = previous_binding.as_ref() != Some(&binding)
-            || crate::services::tui_prompt_dedupe::owner_channel_for_tmux_session(
-                authoritative_tmux_session,
-            ) != Some(channel_id);
-        crate::services::tui_prompt_dedupe::register_rehydrated_tmux_runtime_binding(
+        crate::services::tui_prompt_dedupe::merge_rehydrated_tmux_runtime_binding(
             provider.as_str(),
             authoritative_tmux_session,
             channel_id,
-            binding,
-        );
-        changed
+            desired_binding,
+        )
+        .is_some_and(|(previous_binding, installed_binding, previous_channel)| {
+            previous_binding.as_ref() != Some(&installed_binding)
+                || previous_channel != Some(channel_id)
+        })
     } else {
         false
     };

--- a/src/services/discord/recovery_engine/manual_rebind/episode_handoff.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/episode_handoff.rs
@@ -168,16 +168,27 @@ pub(super) async fn commit_episode_side_effects(
         authoritative_runtime_kind,
         authoritative_output_path,
     ) {
+        let previous_binding = crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(
+            authoritative_tmux_session,
+        );
         let desired_binding = crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
             runtime_kind: RuntimeHandoffKind::ClaudeTui,
             output_path: authoritative_output_path.to_string(),
             relay_output_path: None,
             input_fifo_path: authoritative_state.input_fifo_path.clone(),
             session_id: authoritative_session_id,
-            // Recovery can intentionally restart at zero when this output file
-            // was recreated/truncated below the durable cursor. Monotonic merge
-            // is therefore scoped to an existing binding for this exact path.
-            last_offset: initial_offset.max(authoritative_state.last_offset),
+            last_offset: previous_binding
+                .as_ref()
+                .filter(|previous| previous.output_path == authoritative_output_path)
+                .map_or(
+                    initial_offset.max(authoritative_state.last_offset),
+                    |previous| {
+                        previous
+                            .last_offset
+                            .max(initial_offset)
+                            .max(authoritative_state.last_offset)
+                    },
+                ),
             relay_last_offset: None,
         };
         crate::services::tui_prompt_dedupe::merge_rehydrated_tmux_runtime_binding(

--- a/src/services/discord/recovery_engine/manual_rebind/mod.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/mod.rs
@@ -574,7 +574,9 @@ async fn rebind_inflight_for_channel_inner(
     if expected_episode.is_some() {
         await_post_adoption_claim_barrier().await;
     }
-    let mut adoption_changed = existing_inflight.is_none();
+    // The no-inflight branch below durably creates a watcher-owned rebind row;
+    // that is an authoritative repair even if an incumbent watcher is reused.
+    let mut durable_inflight_changed = existing_inflight.is_none();
     let recovered_state_for_session = if let Some(mut existing) = existing_inflight.clone() {
         let rollback_state = existing.clone();
         let expected = super::inflight::InflightTurnIdentity::from_state(&existing);
@@ -639,7 +641,7 @@ async fn rebind_inflight_for_channel_inner(
                 expected_turn_start_offset,
             )
         };
-        adoption_changed = rebind_adoption_repaired_state(&rollback_state, &existing);
+        durable_inflight_changed = rebind_adoption_repaired_state(&rollback_state, &existing);
         if !matches!(save_outcome, super::inflight::GuardedSaveOutcome::Saved) {
             tracing::warn!(
                 channel_id,
@@ -908,7 +910,7 @@ async fn rebind_inflight_for_channel_inner(
         watcher_spawned,
         watcher_replaced,
         repaired_state: rebind_repaired_state(
-            adoption_changed,
+            durable_inflight_changed,
             episode_side_effects.repaired_state,
             watcher_spawned,
             watcher_replaced,
@@ -935,12 +937,12 @@ fn rebind_adoption_repaired_state(
 }
 
 fn rebind_repaired_state(
-    adoption_changed: bool,
+    durable_inflight_changed: bool,
     episode_side_effects_changed: bool,
     watcher_spawned: bool,
     watcher_replaced: bool,
 ) -> bool {
-    adoption_changed || episode_side_effects_changed || watcher_spawned || watcher_replaced
+    durable_inflight_changed || episode_side_effects_changed || watcher_spawned || watcher_replaced
 }
 
 #[cfg(test)]

--- a/src/services/discord/recovery_engine/manual_rebind/mod.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/mod.rs
@@ -927,18 +927,6 @@ fn rebind_repaired_state(
 }
 
 #[cfg(test)]
-mod repaired_state_tests {
-    use super::rebind_repaired_state;
-
-    #[test]
-    fn reused_watcher_still_reports_prior_authoritative_repair() {
-        assert!(rebind_repaired_state(true, false, false, false));
-        assert!(rebind_repaired_state(false, true, false, false));
-        assert!(!rebind_repaired_state(false, false, false, false));
-    }
-}
-
-#[cfg(test)]
 #[path = "post_adoption_guard_tests.rs"]
 mod post_adoption_guard_tests;
 
@@ -948,6 +936,13 @@ mod post_work_evidence_tests {
     use crate::services::agent_protocol::{RuntimeHandoff, RuntimeHandoffKind};
     use crate::services::discord::inflight;
     use crate::services::provider::ProviderKind;
+
+    #[test]
+    fn reused_watcher_still_reports_prior_authoritative_repair() {
+        assert!(rebind_repaired_state(true, false, false, false));
+        assert!(rebind_repaired_state(false, true, false, false));
+        assert!(!rebind_repaired_state(false, false, false, false));
+    }
 
     #[test]
     fn recovery_input_fifo_requirement_is_runtime_specific() {

--- a/src/services/discord/recovery_engine/manual_rebind/mod.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/mod.rs
@@ -574,6 +574,7 @@ async fn rebind_inflight_for_channel_inner(
     if expected_episode.is_some() {
         await_post_adoption_claim_barrier().await;
     }
+    let mut adoption_changed = existing_inflight.is_none();
     let recovered_state_for_session = if let Some(mut existing) = existing_inflight.clone() {
         let rollback_state = existing.clone();
         let expected = super::inflight::InflightTurnIdentity::from_state(&existing);
@@ -595,6 +596,8 @@ async fn rebind_inflight_for_channel_inner(
             existing.session_id = session_id_for_state.clone();
         }
         existing.set_relay_owner_kind(super::inflight::RelayOwnerKind::Watcher);
+        adoption_changed =
+            serde_json::to_value(&rollback_state).ok() != serde_json::to_value(&existing).ok();
         let rollback_expected = super::inflight::InflightTurnIdentity::from_state(&existing);
         let rollback_expected_turn_start_offset = existing.turn_start_offset;
         let rollback_expected_last_offset_for_rebase =
@@ -747,24 +750,23 @@ async fn rebind_inflight_for_channel_inner(
         state
     };
 
-    let (locked_episode, finish_mailbox_on_completion) =
-        episode_handoff::commit_episode_side_effects(
-            shared,
-            provider,
-            channel_id,
-            discord_channel_id,
-            &recovered_state_for_session,
-            locked_episode_from_adoption.take(),
-            existing_inflight.is_some(),
-            &existing_session_id,
-            &channel_name,
-            &session_id_for_state,
-            runtime_kind_for_state,
-            &output_path,
-            &tmux_session_name,
-            initial_offset,
-        )
-        .await?;
+    let (locked_episode, episode_side_effects) = episode_handoff::commit_episode_side_effects(
+        shared,
+        provider,
+        channel_id,
+        discord_channel_id,
+        &recovered_state_for_session,
+        locked_episode_from_adoption.take(),
+        existing_inflight.is_some(),
+        &existing_session_id,
+        &channel_name,
+        &session_id_for_state,
+        runtime_kind_for_state,
+        &output_path,
+        &tmux_session_name,
+        initial_offset,
+    )
+    .await?;
 
     let (watcher_spawned, watcher_replaced) = {
         #[cfg(unix)]
@@ -866,7 +868,7 @@ async fn rebind_inflight_for_channel_inner(
                     super::tmux::restored_watcher_turn_from_inflight(
                         &recovered_state_for_session,
                         &tmux_session_name,
-                        finish_mailbox_on_completion,
+                        episode_side_effects.finish_mailbox_on_completion,
                     )
                 };
                 super::task_supervisor::spawn_observed_tmux_watcher(
@@ -906,7 +908,34 @@ async fn rebind_inflight_for_channel_inner(
         initial_offset,
         watcher_spawned,
         watcher_replaced,
+        repaired_state: rebind_repaired_state(
+            adoption_changed,
+            episode_side_effects.repaired_state,
+            watcher_spawned,
+            watcher_replaced,
+        ),
     })
+}
+
+fn rebind_repaired_state(
+    adoption_changed: bool,
+    episode_side_effects_changed: bool,
+    watcher_spawned: bool,
+    watcher_replaced: bool,
+) -> bool {
+    adoption_changed || episode_side_effects_changed || watcher_spawned || watcher_replaced
+}
+
+#[cfg(test)]
+mod repaired_state_tests {
+    use super::rebind_repaired_state;
+
+    #[test]
+    fn reused_watcher_still_reports_prior_authoritative_repair() {
+        assert!(rebind_repaired_state(true, false, false, false));
+        assert!(rebind_repaired_state(false, true, false, false));
+        assert!(!rebind_repaired_state(false, false, false, false));
+    }
 }
 
 #[cfg(test)]

--- a/src/services/discord/recovery_engine/manual_rebind/mod.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/mod.rs
@@ -596,8 +596,6 @@ async fn rebind_inflight_for_channel_inner(
             existing.session_id = session_id_for_state.clone();
         }
         existing.set_relay_owner_kind(super::inflight::RelayOwnerKind::Watcher);
-        adoption_changed =
-            serde_json::to_value(&rollback_state).ok() != serde_json::to_value(&existing).ok();
         let rollback_expected = super::inflight::InflightTurnIdentity::from_state(&existing);
         let rollback_expected_turn_start_offset = existing.turn_start_offset;
         let rollback_expected_last_offset_for_rebase =
@@ -641,6 +639,7 @@ async fn rebind_inflight_for_channel_inner(
                 expected_turn_start_offset,
             )
         };
+        adoption_changed = rebind_adoption_repaired_state(&rollback_state, &existing);
         if !matches!(save_outcome, super::inflight::GuardedSaveOutcome::Saved) {
             tracing::warn!(
                 channel_id,
@@ -915,6 +914,24 @@ async fn rebind_inflight_for_channel_inner(
             watcher_replaced,
         ),
     })
+}
+
+fn rebind_adoption_repaired_state(
+    before: &super::inflight::InflightTurnState,
+    after: &super::inflight::InflightTurnState,
+) -> bool {
+    before.tmux_session_name != after.tmux_session_name
+        || before.output_path != after.output_path
+        || before.input_fifo_path != after.input_fifo_path
+        || before.runtime_kind != after.runtime_kind
+        || before.session_id != after.session_id
+        || before.effective_relay_owner_kind() != after.effective_relay_owner_kind()
+        || before.last_offset != after.last_offset
+        || before.turn_start_offset != after.turn_start_offset
+        || before.last_watcher_relayed_offset != after.last_watcher_relayed_offset
+        || before.last_watcher_relayed_generation_mtime_ns
+            != after.last_watcher_relayed_generation_mtime_ns
+        || before.finalizer_turn_id != after.finalizer_turn_id
 }
 
 fn rebind_repaired_state(

--- a/src/services/discord/recovery_engine/manual_rebind/post_adoption_guard_tests.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/post_adoption_guard_tests.rs
@@ -222,10 +222,10 @@ fn replacement_after_adoption_before_claim_is_untouched() {
         "AGENTDESK_ROOT_DIR",
         tmp.path(),
     );
-    if !crate::services::platform::tmux::is_available() {
-        eprintln!("skipping post-adoption exact-episode test: tmux unavailable");
-        return;
-    }
+    assert!(
+        crate::services::platform::tmux::is_available(),
+        "post-adoption exact-episode integration test requires tmux"
+    );
 
     let provider = ProviderKind::Claude;
     let channel_id = 4_465_880_000_001_u64;
@@ -497,10 +497,10 @@ fn full_rebind_noop_reuse_reports_no_repair_and_mutation_reports_repair() {
         "AGENTDESK_ROOT_DIR",
         tmp.path(),
     );
-    if !crate::services::platform::tmux::is_available() {
-        eprintln!("skipping full-path repair detector test: tmux unavailable");
-        return;
-    }
+    assert!(
+        crate::services::platform::tmux::is_available(),
+        "full-path repair detector integration test requires tmux"
+    );
 
     let provider = ProviderKind::Claude;
     let channel_id = 4_465_880_000_003_u64;
@@ -594,7 +594,6 @@ fn full_rebind_noop_reuse_reports_no_repair_and_mutation_reports_repair() {
         },
     );
 
-    let pin = super::inflight::InflightEpisodePin::from_state(&state);
     let first = runtime
         .block_on(rebind_inflight_for_channel(
             &http,
@@ -603,7 +602,7 @@ fn full_rebind_noop_reuse_reports_no_repair_and_mutation_reports_repair() {
             channel_id,
             Some(tmux_session.clone()),
             ManualRebindOverrides::default(),
-            Some(&pin),
+            None,
         ))
         .expect("initial session repair");
     assert!(
@@ -611,9 +610,6 @@ fn full_rebind_noop_reuse_reports_no_repair_and_mutation_reports_repair() {
         "missing session must be detected as repair"
     );
 
-    let pin = super::inflight::InflightEpisodePin::from_state(
-        &super::inflight::load_inflight_state(&provider, channel_id).expect("reload inflight"),
-    );
     let noop = runtime
         .block_on(rebind_inflight_for_channel(
             &http,
@@ -622,7 +618,7 @@ fn full_rebind_noop_reuse_reports_no_repair_and_mutation_reports_repair() {
             channel_id,
             Some(tmux_session.clone()),
             ManualRebindOverrides::default(),
-            Some(&pin),
+            None,
         ))
         .expect("no-op rebind");
     assert!(!noop.watcher_spawned);
@@ -646,9 +642,6 @@ fn full_rebind_noop_reuse_reports_no_repair_and_mutation_reports_repair() {
         channel_id,
         regressed,
     );
-    let pin = super::inflight::InflightEpisodePin::from_state(
-        &super::inflight::load_inflight_state(&provider, channel_id).expect("reload inflight"),
-    );
     let repaired = runtime
         .block_on(rebind_inflight_for_channel(
             &http,
@@ -657,7 +650,7 @@ fn full_rebind_noop_reuse_reports_no_repair_and_mutation_reports_repair() {
             channel_id,
             Some(tmux_session.clone()),
             ManualRebindOverrides::default(),
-            Some(&pin),
+            None,
         ))
         .expect("repair rebind");
     assert!(!repaired.watcher_spawned);
@@ -687,9 +680,6 @@ fn full_rebind_noop_reuse_reports_no_repair_and_mutation_reports_repair() {
             relay_last_offset: None,
         },
     );
-    let pin = super::inflight::InflightEpisodePin::from_state(
-        &super::inflight::load_inflight_state(&provider, channel_id).expect("reload inflight"),
-    );
     let newer_cursor = runtime
         .block_on(rebind_inflight_for_channel(
             &http,
@@ -698,7 +688,7 @@ fn full_rebind_noop_reuse_reports_no_repair_and_mutation_reports_repair() {
             channel_id,
             Some(tmux_session.clone()),
             ManualRebindOverrides::default(),
-            Some(&pin),
+            None,
         ))
         .expect("monotonic cursor rebind");
     assert!(!newer_cursor.repaired_state);
@@ -730,10 +720,10 @@ fn replacement_writer_linearizes_after_episode_authority_handoff() {
         "AGENTDESK_ROOT_DIR",
         tmp.path(),
     );
-    if !crate::services::platform::tmux::is_available() {
-        eprintln!("skipping episode-authority serialization test: tmux unavailable");
-        return;
-    }
+    assert!(
+        crate::services::platform::tmux::is_available(),
+        "episode-authority serialization integration test requires tmux"
+    );
 
     let provider = ProviderKind::Claude;
     let channel_id = 4_465_880_000_002_u64;

--- a/src/services/discord/recovery_engine/manual_rebind/post_adoption_guard_tests.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/post_adoption_guard_tests.rs
@@ -146,7 +146,7 @@ fn durable_episode_authority_lexically_covers_every_handoff_side_effect() {
         "note_footer_suppressed_for_message_takeover",
         "let session = core",
         "reregister_active_turn_from_inflight_under_episode_guard",
-        "register_rehydrated_tmux_runtime_binding",
+        "merge_rehydrated_tmux_runtime_binding",
     ] {
         handoff
             .find(mutation)

--- a/src/services/discord/recovery_engine/manual_rebind/post_adoption_guard_tests.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/post_adoption_guard_tests.rs
@@ -488,6 +488,195 @@ fn replacement_after_adoption_before_claim_is_untouched() {
 
 #[cfg(unix)]
 #[test]
+fn full_rebind_noop_reuse_reports_no_repair_and_mutation_reports_repair() {
+    let _lock = crate::config::shared_test_env_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _env = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+        "AGENTDESK_ROOT_DIR",
+        tmp.path(),
+    );
+    if !crate::services::platform::tmux::is_available() {
+        eprintln!("skipping full-path repair detector test: tmux unavailable");
+        return;
+    }
+
+    let provider = ProviderKind::Claude;
+    let channel_id = 4_465_880_000_003_u64;
+    let channel = ChannelId::new(channel_id);
+    let tmux_session = format!("AgentDesk-claude-e2e5021-{}-cc", std::process::id());
+    let created = crate::services::platform::tmux::create_session(&tmux_session, None, "sleep 60")
+        .expect("create tmux session");
+    assert!(created.status.success());
+    crate::services::tmux_common::write_tmux_runtime_kind_marker(
+        &tmux_session,
+        RuntimeHandoffKind::ClaudeTui,
+    )
+    .expect("runtime marker");
+    let output_path = tmp
+        .path()
+        .join("78fdb7f3-0000-4000-8000-000000005021.jsonl");
+    std::fs::write(&output_path, vec![b'x'; 128]).expect("seed transcript");
+    let mut state = super::inflight::InflightTurnState::new(
+        provider.clone(),
+        channel_id,
+        None,
+        343_742_347,
+        5_021_001,
+        5_021_002,
+        "repair detector".to_string(),
+        Some("78fdb7f3-0000-4000-8000-000000005021".to_string()),
+        Some(tmux_session.clone()),
+        Some(output_path.display().to_string()),
+        None,
+        128,
+    );
+    state.finalizer_turn_id = state.user_msg_id;
+    state.runtime_kind = Some(RuntimeHandoffKind::ClaudeTui);
+    state.set_relay_owner_kind(super::inflight::RelayOwnerKind::Watcher);
+    state.readopted_from_inflight = true;
+    super::inflight::save_inflight_state(&state).expect("seed inflight");
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let shared = runtime.block_on(async { crate::services::discord::make_shared_data_for_tests() });
+    let http = std::sync::Arc::new(serenity::Http::new("Bot test-token"));
+    runtime.block_on(async {
+        let token = std::sync::Arc::new(crate::services::provider::CancelToken::new());
+        super::turn_bridge::bind_cancel_token_tmux_runtime(
+            &provider,
+            &token,
+            &tmux_session,
+            "seed repair detector",
+        );
+        assert!(
+            super::mailbox_try_start_turn(
+                &shared,
+                channel,
+                token,
+                UserId::new(state.request_owner_user_id),
+                MessageId::new(state.user_msg_id),
+            )
+            .await
+        );
+    });
+    let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    shared.tmux_watchers.insert(
+        channel,
+        TmuxWatcherHandle {
+            tmux_session_name: tmux_session.clone(),
+            output_path: output_path.display().to_string(),
+            paused: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            resume_offset: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            cancel: cancel.clone(),
+            pause_epoch: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            turn_delivered: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            last_heartbeat_ts_ms: std::sync::Arc::new(std::sync::atomic::AtomicI64::new(
+                super::tmux_watcher_now_ms(),
+            )),
+        },
+    );
+    crate::services::tui_prompt_dedupe::register_rehydrated_tmux_runtime_binding(
+        provider.as_str(),
+        &tmux_session,
+        channel_id,
+        crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
+            runtime_kind: RuntimeHandoffKind::ClaudeTui,
+            output_path: output_path.display().to_string(),
+            relay_output_path: None,
+            input_fifo_path: None,
+            session_id: state.session_id.clone(),
+            last_offset: 128,
+            relay_last_offset: None,
+        },
+    );
+
+    let pin = super::inflight::InflightEpisodePin::from_state(&state);
+    let first = runtime
+        .block_on(rebind_inflight_for_channel(
+            &http,
+            &shared,
+            &provider,
+            channel_id,
+            Some(tmux_session.clone()),
+            ManualRebindOverrides::default(),
+            Some(&pin),
+        ))
+        .expect("initial session repair");
+    assert!(
+        first.repaired_state,
+        "missing session must be detected as repair"
+    );
+
+    let pin = super::inflight::InflightEpisodePin::from_state(
+        &super::inflight::load_inflight_state(&provider, channel_id).expect("reload inflight"),
+    );
+    let noop = runtime
+        .block_on(rebind_inflight_for_channel(
+            &http,
+            &shared,
+            &provider,
+            channel_id,
+            Some(tmux_session.clone()),
+            ManualRebindOverrides::default(),
+            Some(&pin),
+        ))
+        .expect("no-op rebind");
+    assert!(!noop.watcher_spawned);
+    assert!(
+        !noop.repaired_state,
+        "true no-op reuse must not report repair"
+    );
+
+    let regressed = crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
+        runtime_kind: RuntimeHandoffKind::ClaudeTui,
+        output_path: output_path.display().to_string(),
+        relay_output_path: None,
+        input_fifo_path: None,
+        session_id: state.session_id.clone(),
+        last_offset: 64,
+        relay_last_offset: None,
+    };
+    crate::services::tui_prompt_dedupe::register_rehydrated_tmux_runtime_binding(
+        provider.as_str(),
+        &tmux_session,
+        channel_id,
+        regressed,
+    );
+    let pin = super::inflight::InflightEpisodePin::from_state(
+        &super::inflight::load_inflight_state(&provider, channel_id).expect("reload inflight"),
+    );
+    let repaired = runtime
+        .block_on(rebind_inflight_for_channel(
+            &http,
+            &shared,
+            &provider,
+            channel_id,
+            Some(tmux_session.clone()),
+            ManualRebindOverrides::default(),
+            Some(&pin),
+        ))
+        .expect("repair rebind");
+    assert!(!repaired.watcher_spawned);
+    assert!(
+        repaired.repaired_state,
+        "runtime-binding mutation must be detected through the full rebind path"
+    );
+
+    if let Some((_, handle)) = shared.tmux_watchers.remove(&channel) {
+        handle
+            .cancel
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+    let _ = crate::services::tui_prompt_dedupe::clear_tmux_runtime_binding(&tmux_session);
+    let _ = crate::services::platform::tmux::kill_session(&tmux_session, "#5021 test cleanup");
+}
+
+#[cfg(unix)]
+#[test]
 fn replacement_writer_linearizes_after_episode_authority_handoff() {
     let _lock = crate::config::shared_test_env_lock()
         .lock()

--- a/src/services/discord/recovery_engine/manual_rebind/post_adoption_guard_tests.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/post_adoption_guard_tests.rs
@@ -665,6 +665,50 @@ fn full_rebind_noop_reuse_reports_no_repair_and_mutation_reports_repair() {
         repaired.repaired_state,
         "runtime-binding mutation must be detected through the full rebind path"
     );
+    assert_eq!(
+        crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(&tmux_session)
+            .expect("repaired runtime binding")
+            .last_offset,
+        128,
+        "rebind must repair a stale cursor forward without rewinding a newer cursor"
+    );
+
+    crate::services::tui_prompt_dedupe::register_rehydrated_tmux_runtime_binding(
+        provider.as_str(),
+        &tmux_session,
+        channel_id,
+        crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
+            runtime_kind: RuntimeHandoffKind::ClaudeTui,
+            output_path: output_path.display().to_string(),
+            relay_output_path: None,
+            input_fifo_path: None,
+            session_id: state.session_id.clone(),
+            last_offset: 192,
+            relay_last_offset: None,
+        },
+    );
+    let pin = super::inflight::InflightEpisodePin::from_state(
+        &super::inflight::load_inflight_state(&provider, channel_id).expect("reload inflight"),
+    );
+    let newer_cursor = runtime
+        .block_on(rebind_inflight_for_channel(
+            &http,
+            &shared,
+            &provider,
+            channel_id,
+            Some(tmux_session.clone()),
+            ManualRebindOverrides::default(),
+            Some(&pin),
+        ))
+        .expect("monotonic cursor rebind");
+    assert!(!newer_cursor.repaired_state);
+    assert_eq!(
+        crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(&tmux_session)
+            .expect("preserved runtime binding")
+            .last_offset,
+        192,
+        "rebind must not rewind a newer same-output runtime cursor"
+    );
 
     if let Some((_, handle)) = shared.tmux_watchers.remove(&channel) {
         handle

--- a/src/services/discord/recovery_engine/restore_inflight.rs
+++ b/src/services/discord/recovery_engine/restore_inflight.rs
@@ -710,7 +710,9 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                 )
                 .await;
                 let finish_mailbox_on_completion =
-                    reregister_active_turn_from_inflight(shared, &state).await;
+                    reregister_active_turn_from_inflight(shared, &state)
+                        .await
+                        .finish_mailbox_on_completion;
 
                 // Spawn the tmux watcher immediately rather than deferring to
                 // restore_tmux_watchers(): the "watcher will adopt" approach raced
@@ -1872,8 +1874,9 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                 http, shared, provider, &mut state,
             )
             .await;
-            let finish_mailbox_on_completion =
-                reregister_active_turn_from_inflight(shared, &state).await;
+            let finish_mailbox_on_completion = reregister_active_turn_from_inflight(shared, &state)
+                .await
+                .finish_mailbox_on_completion;
 
             // #4380 backstop: `reregister_active_turn_from_inflight` stamps
             // `readopted_from_inflight`, which the watcher-yield escape hatch honours

--- a/src/services/discord/recovery_engine/runtime.rs
+++ b/src/services/discord/recovery_engine/runtime.rs
@@ -403,6 +403,49 @@ mod delivered_inflight_reregister_tests {
         assert!(recovery_terminal_delivery_already_committed(&state));
     }
 
+    #[tokio::test]
+    async fn committed_terminal_cleanup_reports_authoritative_mutation() {
+        use serenity::model::id::{ChannelId, MessageId, UserId};
+        use std::sync::Arc;
+
+        let shared = super::super::make_shared_data_for_tests_with_storage(None);
+        let channel = ChannelId::new(4_245);
+        let mut state = inflight::InflightTurnState::new(
+            ProviderKind::Claude,
+            channel.get(),
+            Some("adk-cc".to_string()),
+            7,
+            9_301,
+            9_302,
+            "already delivered".to_string(),
+            Some("session-4".to_string()),
+            Some("AgentDesk-claude-adk-cc".to_string()),
+            Some("/tmp/claude-transcript.jsonl".to_string()),
+            None,
+            256,
+        );
+        state.terminal_delivery_committed = true;
+        let token = Arc::new(crate::services::provider::CancelToken::new());
+        shared
+            .mailbox(channel)
+            .restore_active_turn(token, UserId::new(7), MessageId::new(state.user_msg_id))
+            .await;
+
+        let outcome =
+            super::reregister_active_turn_from_inflight_inner(&shared, &state, false).await;
+        assert!(!outcome.finish_mailbox_on_completion);
+        assert!(
+            outcome.mailbox_binding_changed,
+            "terminal commit cleanup must count as an authoritative repair"
+        );
+        assert!(
+            super::super::mailbox_snapshot(&shared, channel)
+                .await
+                .cancel_token
+                .is_none()
+        );
+    }
+
     #[test]
     fn ordinary_inflight_still_recoverable_even_with_relayed_prefix() {
         let mut state = inflight::InflightTurnState::new(

--- a/src/services/discord/recovery_engine/runtime.rs
+++ b/src/services/discord/recovery_engine/runtime.rs
@@ -271,7 +271,13 @@ async fn reregister_active_turn_from_inflight_inner(
             );
             // #4370: a real-user turn re-bound to the mailbox across a restart.
             if readopted_ledger_record_allowed(state) {
-                let marker_changed = !state.readopted_from_inflight;
+                let ledger_changed = !persist_durable_marker
+                    && !shared.has_readopted_mailbox_owner_for_episode(
+                        &provider,
+                        channel_id.get(),
+                        state,
+                    );
+                let marker_changed = persist_durable_marker && !state.readopted_from_inflight;
                 let marker_outcome = mark_readopted_from_inflight(
                     shared,
                     &provider,
@@ -279,8 +285,8 @@ async fn reregister_active_turn_from_inflight_inner(
                     state,
                     persist_durable_marker,
                 );
-                mailbox_binding_changed |=
-                    marker_changed && matches!(marker_outcome, inflight::GuardedSaveOutcome::Saved);
+                mailbox_binding_changed |= (ledger_changed || marker_changed)
+                    && matches!(marker_outcome, inflight::GuardedSaveOutcome::Saved);
             }
         }
         return ActiveTurnReregisterOutcome {

--- a/src/services/discord/recovery_engine/runtime.rs
+++ b/src/services/discord/recovery_engine/runtime.rs
@@ -182,11 +182,17 @@ pub(super) fn mark_readopted_from_inflight(
     outcome
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub(in crate::services::discord) struct ActiveTurnReregisterOutcome {
+    pub finish_mailbox_on_completion: bool,
+    pub mailbox_binding_changed: bool,
+}
+
 async fn reregister_active_turn_from_inflight_inner(
     shared: &Arc<SharedData>,
     state: &inflight::InflightTurnState,
     persist_durable_marker: bool,
-) -> bool {
+) -> ActiveTurnReregisterOutcome {
     let Some(finalizer_msg_id) =
         super::inflight::opt_message_id(state.effective_finalizer_turn_id())
     else {
@@ -194,11 +200,11 @@ async fn reregister_active_turn_from_inflight_inner(
             channel_id = state.channel_id,
             "inflight reregister skipped because finalizer turn id is zero"
         );
-        return false;
+        return ActiveTurnReregisterOutcome::default();
     };
     let Some(channel_id) = super::inflight::opt_channel_id(state.channel_id) else {
         tracing::warn!("inflight reregister skipped because persisted channel id is zero");
-        return false;
+        return ActiveTurnReregisterOutcome::default();
     };
     let finalizer_turn_id = finalizer_msg_id.get();
     let snapshot = super::mailbox_snapshot(shared, channel_id).await;
@@ -208,7 +214,7 @@ async fn reregister_active_turn_from_inflight_inner(
             state.provider,
             state.channel_id
         );
-        return false;
+        return ActiveTurnReregisterOutcome::default();
     };
     if recovery_terminal_delivery_already_committed(state) {
         tracing::info!(
@@ -233,21 +239,26 @@ async fn reregister_active_turn_from_inflight_inner(
                 "inflight reregister skipped recursive clear while exact-episode guard owns the sidecar flock"
             );
         }
-        return false;
+        return ActiveTurnReregisterOutcome::default();
     }
     if snapshot.cancel_token.is_some() {
-        if let Some(token) = snapshot.cancel_token.as_ref()
-            && snapshot.active_user_message_id == Some(finalizer_msg_id)
-        {
-            super::ensure_cancel_token_bound_from_inflight_state(
-                &provider,
-                state,
-                token,
-                "inflight reregister existing active turn",
-            );
-        }
         let restored = snapshot.active_user_message_id == Some(finalizer_msg_id);
+        let mailbox_binding_changed = if restored {
+            snapshot.cancel_token.as_ref().is_some_and(|token| {
+                token.tmux_session_name().as_deref() != state.tmux_session_name.as_deref()
+            })
+        } else {
+            false
+        };
         if restored {
+            if let Some(token) = snapshot.cancel_token.as_ref() {
+                super::ensure_cancel_token_bound_from_inflight_state(
+                    &provider,
+                    state,
+                    token,
+                    "inflight reregister existing active turn",
+                );
+            }
             reseed_recovered_finalizer_ledger(
                 shared,
                 channel_id,
@@ -266,7 +277,10 @@ async fn reregister_active_turn_from_inflight_inner(
                 );
             }
         }
-        return restored;
+        return ActiveTurnReregisterOutcome {
+            finish_mailbox_on_completion: restored,
+            mailbox_binding_changed,
+        };
     }
 
     if state.request_owner_user_id == 0 {
@@ -277,7 +291,7 @@ async fn reregister_active_turn_from_inflight_inner(
             &provider,
             state.effective_relay_owner_kind(),
         );
-        return false;
+        return ActiveTurnReregisterOutcome::default();
     }
 
     let cancel_token = Arc::new(CancelToken::new());
@@ -320,14 +334,19 @@ async fn reregister_active_turn_from_inflight_inner(
             );
         }
     }
-    started
+    ActiveTurnReregisterOutcome {
+        finish_mailbox_on_completion: started,
+        mailbox_binding_changed: started,
+    }
 }
 
 pub(in crate::services::discord) async fn reregister_active_turn_from_inflight(
     shared: &Arc<SharedData>,
     state: &inflight::InflightTurnState,
 ) -> bool {
-    reregister_active_turn_from_inflight_inner(shared, state, true).await
+    reregister_active_turn_from_inflight_inner(shared, state, true)
+        .await
+        .finish_mailbox_on_completion
 }
 
 /// Automatic reattach holds the canonical episode flock across mailbox and
@@ -338,7 +357,7 @@ pub(in crate::services::discord) async fn reregister_active_turn_from_inflight(
 pub(in crate::services::discord) async fn reregister_active_turn_from_inflight_under_episode_guard(
     shared: &Arc<SharedData>,
     state: &inflight::InflightTurnState,
-) -> bool {
+) -> ActiveTurnReregisterOutcome {
     reregister_active_turn_from_inflight_inner(shared, state, false).await
 }
 

--- a/src/services/discord/recovery_engine/runtime.rs
+++ b/src/services/discord/recovery_engine/runtime.rs
@@ -23,23 +23,28 @@ use super::*;
 /// watcher owner. Ownerless/non-watcher terminal paths do not emit a watcher
 /// projection edge, so they use immediate admission; watcher-owned rows retain
 /// the deferred projection barrier and far-backstop.
-fn reseed_recovered_finalizer_ledger(
+async fn reseed_recovered_finalizer_ledger(
     shared: &Arc<SharedData>,
     channel_id: ChannelId,
     finalizer_turn_id: u64,
     provider: &ProviderKind,
     relay_owner: super::inflight::RelayOwnerKind,
-) {
+) -> bool {
     // id-0 would key the channel-only orphan slot. Only seed a full-identity
     // Watcher entry; synthetic live turns use their persisted finalizer_turn_id.
     if finalizer_turn_id == 0 {
-        return;
+        return false;
     }
     let completion_admission_plan = if relay_owner == super::inflight::RelayOwnerKind::Watcher {
         super::turn_finalizer::CompletionAdmissionPlan::AfterTerminalProjectionSettled
     } else {
         super::turn_finalizer::CompletionAdmissionPlan::Immediate
     };
+    let changed = relay_owner == super::inflight::RelayOwnerKind::Watcher
+        && !shared
+            .turn_finalizer
+            .has_live_watcher_pending(channel_id, shared.restart.current_generation)
+            .await;
     shared
         .turn_finalizer
         .register_start_with_completion_admission(
@@ -53,6 +58,7 @@ fn reseed_recovered_finalizer_ledger(
             completion_admission_plan,
             shared, // #3016 phase-5a: prime the reconcile cache at register time.
         );
+    changed
 }
 
 /// #4370 (review r3): may THIS re-adopted row own a ledger entry / on-disk marker?
@@ -262,13 +268,14 @@ async fn reregister_active_turn_from_inflight_inner(
                 mailbox_binding_changed =
                     before != (token.tmux_session_name(), token.child_pid_value());
             }
-            reseed_recovered_finalizer_ledger(
+            mailbox_binding_changed |= reseed_recovered_finalizer_ledger(
                 shared,
                 channel_id,
                 finalizer_turn_id,
                 &provider,
                 state.effective_relay_owner_kind(),
-            );
+            )
+            .await;
             // #4370: a real-user turn re-bound to the mailbox across a restart.
             if readopted_ledger_record_allowed(state) {
                 let ledger_changed = !persist_durable_marker
@@ -296,14 +303,18 @@ async fn reregister_active_turn_from_inflight_inner(
     }
 
     if state.request_owner_user_id == 0 {
-        reseed_recovered_finalizer_ledger(
+        let mailbox_binding_changed = reseed_recovered_finalizer_ledger(
             shared,
             channel_id,
             finalizer_turn_id,
             &provider,
             state.effective_relay_owner_kind(),
-        );
-        return ActiveTurnReregisterOutcome::default();
+        )
+        .await;
+        return ActiveTurnReregisterOutcome {
+            finish_mailbox_on_completion: false,
+            mailbox_binding_changed,
+        };
     }
 
     let cancel_token = Arc::new(CancelToken::new());
@@ -323,13 +334,14 @@ async fn reregister_active_turn_from_inflight_inner(
     )
     .await;
     if started {
-        reseed_recovered_finalizer_ledger(
+        let _ = reseed_recovered_finalizer_ledger(
             shared,
             channel_id,
             finalizer_turn_id,
             &provider,
             state.effective_relay_owner_kind(),
-        );
+        )
+        .await;
         // #4370: the mailbox now carries a re-adopted-from-inflight REAL user turn
         // (owner == request_owner_user_id). Record it in the ledger + on-disk
         // marker so a later starved injection / task-notification synthetic turn

--- a/src/services/discord/recovery_engine/runtime.rs
+++ b/src/services/discord/recovery_engine/runtime.rs
@@ -206,6 +206,7 @@ async fn reregister_active_turn_from_inflight_inner(
     shared: &Arc<SharedData>,
     state: &inflight::InflightTurnState,
     persist_durable_marker: bool,
+    clear_durable_state: fn(&ProviderKind, u64) -> bool,
 ) -> ActiveTurnReregisterOutcome {
     let Some(finalizer_msg_id) =
         super::inflight::opt_message_id(state.effective_finalizer_turn_id())
@@ -246,8 +247,7 @@ async fn reregister_active_turn_from_inflight_inner(
         )
         .await;
         let durable_state_changed = if persist_durable_marker {
-            clear_inflight_state(&provider, state.channel_id);
-            true
+            clear_durable_state(&provider, state.channel_id)
         } else {
             tracing::warn!(
                 provider = %provider.as_str(),
@@ -380,7 +380,7 @@ pub(in crate::services::discord) async fn reregister_active_turn_from_inflight(
     shared: &Arc<SharedData>,
     state: &inflight::InflightTurnState,
 ) -> ActiveTurnReregisterOutcome {
-    reregister_active_turn_from_inflight_inner(shared, state, true).await
+    reregister_active_turn_from_inflight_inner(shared, state, true, clear_inflight_state).await
 }
 
 /// Automatic reattach holds the canonical episode flock across mailbox and
@@ -392,7 +392,7 @@ pub(in crate::services::discord) async fn reregister_active_turn_from_inflight_u
     shared: &Arc<SharedData>,
     state: &inflight::InflightTurnState,
 ) -> ActiveTurnReregisterOutcome {
-    reregister_active_turn_from_inflight_inner(shared, state, false).await
+    reregister_active_turn_from_inflight_inner(shared, state, false, clear_inflight_state).await
 }
 
 #[cfg(test)]
@@ -453,8 +453,13 @@ mod delivered_inflight_reregister_tests {
             .restore_active_turn(token, UserId::new(7), MessageId::new(state.user_msg_id))
             .await;
 
-        let outcome =
-            super::reregister_active_turn_from_inflight_inner(&shared, &state, false).await;
+        let outcome = super::reregister_active_turn_from_inflight_inner(
+            &shared,
+            &state,
+            false,
+            super::clear_inflight_state,
+        )
+        .await;
         assert!(!outcome.finish_mailbox_on_completion);
         assert!(
             outcome.mailbox_binding_changed,
@@ -465,6 +470,40 @@ mod delivered_inflight_reregister_tests {
                 .await
                 .cancel_token
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn committed_terminal_cleanup_does_not_report_failed_durable_clear() {
+        let shared = super::super::make_shared_data_for_tests_with_storage(None);
+        let mut state = inflight::InflightTurnState::new(
+            ProviderKind::Claude,
+            4_247,
+            Some("adk-cc".to_string()),
+            7,
+            9_303,
+            9_304,
+            "already delivered".to_string(),
+            Some("session-5".to_string()),
+            Some("AgentDesk-claude-adk-cc".to_string()),
+            Some("/tmp/claude-transcript.jsonl".to_string()),
+            None,
+            256,
+        );
+        state.terminal_delivery_committed = true;
+
+        let outcome = super::reregister_active_turn_from_inflight_inner(
+            &shared,
+            &state,
+            true,
+            |_provider, _channel_id| false,
+        )
+        .await;
+
+        assert!(!outcome.finish_mailbox_on_completion);
+        assert!(
+            !outcome.mailbox_binding_changed,
+            "a failed durable clear must not be reported as repaired state"
         );
     }
 

--- a/src/services/discord/recovery_engine/runtime.rs
+++ b/src/services/discord/recovery_engine/runtime.rs
@@ -223,6 +223,7 @@ async fn reregister_active_turn_from_inflight_inner(
             finalizer_turn_id,
             "inflight reregister skipped: terminal delivery already committed; clearing stale active turn state"
         );
+        let mailbox_binding_changed = snapshot.cancel_token.is_some();
         finish_recovered_turn_mailbox(
             shared,
             &provider,
@@ -230,34 +231,36 @@ async fn reregister_active_turn_from_inflight_inner(
             "recovery_terminal_delivery_already_committed",
         )
         .await;
-        if persist_durable_marker {
+        let durable_state_changed = if persist_durable_marker {
             clear_inflight_state(&provider, state.channel_id);
+            true
         } else {
             tracing::warn!(
                 provider = %provider.as_str(),
                 channel_id = state.channel_id,
                 "inflight reregister skipped recursive clear while exact-episode guard owns the sidecar flock"
             );
-        }
-        return ActiveTurnReregisterOutcome::default();
+            false
+        };
+        return ActiveTurnReregisterOutcome {
+            finish_mailbox_on_completion: false,
+            mailbox_binding_changed: mailbox_binding_changed || durable_state_changed,
+        };
     }
     if snapshot.cancel_token.is_some() {
         let restored = snapshot.active_user_message_id == Some(finalizer_msg_id);
-        let mailbox_binding_changed = if restored {
-            snapshot.cancel_token.as_ref().is_some_and(|token| {
-                token.tmux_session_name().as_deref() != state.tmux_session_name.as_deref()
-            })
-        } else {
-            false
-        };
+        let mut mailbox_binding_changed = false;
         if restored {
             if let Some(token) = snapshot.cancel_token.as_ref() {
+                let before = (token.tmux_session_name(), token.child_pid_value());
                 super::ensure_cancel_token_bound_from_inflight_state(
                     &provider,
                     state,
                     token,
                     "inflight reregister existing active turn",
                 );
+                mailbox_binding_changed =
+                    before != (token.tmux_session_name(), token.child_pid_value());
             }
             reseed_recovered_finalizer_ledger(
                 shared,
@@ -268,13 +271,16 @@ async fn reregister_active_turn_from_inflight_inner(
             );
             // #4370: a real-user turn re-bound to the mailbox across a restart.
             if readopted_ledger_record_allowed(state) {
-                let _ = mark_readopted_from_inflight(
+                let marker_changed = !state.readopted_from_inflight;
+                let marker_outcome = mark_readopted_from_inflight(
                     shared,
                     &provider,
                     channel_id,
                     state,
                     persist_durable_marker,
                 );
+                mailbox_binding_changed |=
+                    marker_changed && matches!(marker_outcome, inflight::GuardedSaveOutcome::Saved);
             }
         }
         return ActiveTurnReregisterOutcome {

--- a/src/services/discord/recovery_engine/runtime.rs
+++ b/src/services/discord/recovery_engine/runtime.rs
@@ -40,10 +40,18 @@ async fn reseed_recovered_finalizer_ledger(
     } else {
         super::turn_finalizer::CompletionAdmissionPlan::Immediate
     };
+    // Only watcher-owned entries create the deferred terminal-projection
+    // obligation this repair detector tracks. Bridge/standby registration below
+    // still restores finalization authority, but immediate admission makes that
+    // idempotent bookkeeping, not a relay repair.
     let changed = relay_owner == super::inflight::RelayOwnerKind::Watcher
         && !shared
             .turn_finalizer
-            .has_live_watcher_pending(channel_id, shared.restart.current_generation)
+            .has_exact_live_watcher_pending(super::turn_finalizer::TurnKey::new(
+                channel_id,
+                finalizer_turn_id,
+                shared.restart.current_generation,
+            ))
             .await;
     shared
         .turn_finalizer
@@ -334,7 +342,11 @@ async fn reregister_active_turn_from_inflight_inner(
     )
     .await;
     if started {
-        let _ = reseed_recovered_finalizer_ledger(
+        // Starting the mailbox is already an authoritative mutation, so the
+        // finalizer reseed cannot change this outcome from repaired to no-op.
+        // Keep the call for its ledger side effect without re-deriving repair
+        // from its return value.
+        reseed_recovered_finalizer_ledger(
             shared,
             channel_id,
             finalizer_turn_id,
@@ -367,10 +379,8 @@ async fn reregister_active_turn_from_inflight_inner(
 pub(in crate::services::discord) async fn reregister_active_turn_from_inflight(
     shared: &Arc<SharedData>,
     state: &inflight::InflightTurnState,
-) -> bool {
-    reregister_active_turn_from_inflight_inner(shared, state, true)
-        .await
-        .finish_mailbox_on_completion
+) -> ActiveTurnReregisterOutcome {
+    reregister_active_turn_from_inflight_inner(shared, state, true).await
 }
 
 /// Automatic reattach holds the canonical episode flock across mailbox and
@@ -458,6 +468,46 @@ mod delivered_inflight_reregister_tests {
         );
     }
 
+    #[tokio::test]
+    async fn exact_finalizer_reseed_is_counted_despite_other_watcher_entry() {
+        use serenity::model::id::ChannelId;
+
+        let shared = super::super::make_shared_data_for_tests_with_storage(None);
+        let channel = ChannelId::new(4_246);
+        let generation = shared.restart.current_generation;
+        shared.turn_finalizer.register_start(
+            super::super::turn_finalizer::TurnKey::new(channel, 8_001, generation),
+            ProviderKind::Claude,
+            inflight::RelayOwnerKind::Watcher,
+            &shared,
+        );
+        assert!(
+            shared
+                .turn_finalizer
+                .has_live_watcher_pending(channel, generation)
+                .await
+        );
+        assert!(
+            super::reseed_recovered_finalizer_ledger(
+                &shared,
+                channel,
+                8_002,
+                &ProviderKind::Claude,
+                inflight::RelayOwnerKind::Watcher,
+            )
+            .await,
+            "a different live watcher entry must not hide the exact turn's ledger repair"
+        );
+        assert!(
+            shared
+                .turn_finalizer
+                .has_exact_live_watcher_pending(super::super::turn_finalizer::TurnKey::new(
+                    channel, 8_002, generation,
+                ))
+                .await
+        );
+    }
+
     #[test]
     fn ordinary_inflight_still_recoverable_even_with_relayed_prefix() {
         let mut state = inflight::InflightTurnState::new(
@@ -537,7 +587,9 @@ mod reregister_ledger_reseed_tests {
             "ledger must start empty (simulating a post-restart in-memory ledger)"
         );
 
-        let restored = super::reregister_active_turn_from_inflight(&shared, &state).await;
+        let restored = super::reregister_active_turn_from_inflight(&shared, &state)
+            .await
+            .finish_mailbox_on_completion;
         assert!(
             restored,
             "an empty mailbox must let the reattach start the active turn"
@@ -565,10 +617,16 @@ mod reregister_ledger_reseed_tests {
         let mut state = active_turn_state(ch.get(), 9101);
         state.set_relay_owner_kind(super::inflight::RelayOwnerKind::Watcher);
 
-        assert!(super::reregister_active_turn_from_inflight(&shared, &state).await);
+        assert!(
+            super::reregister_active_turn_from_inflight(&shared, &state)
+                .await
+                .finish_mailbox_on_completion
+        );
         // Second call: the mailbox already holds the active turn, so this takes
         // the "existing active turn" rebind branch and re-seeds again.
-        let restored_again = super::reregister_active_turn_from_inflight(&shared, &state).await;
+        let restored_again = super::reregister_active_turn_from_inflight(&shared, &state)
+            .await
+            .finish_mailbox_on_completion;
         assert!(
             restored_again,
             "re-attaching an already-active turn re-binds (returns true) without panic"
@@ -604,7 +662,11 @@ mod reregister_ledger_reseed_tests {
             .restore_active_turn(token, UserId::new(7), MessageId::new(turn_id))
             .await;
 
-        assert!(super::reregister_active_turn_from_inflight(&shared, &state).await);
+        assert!(
+            super::reregister_active_turn_from_inflight(&shared, &state)
+                .await
+                .finish_mailbox_on_completion
+        );
         assert!(
             !shared
                 .turn_finalizer
@@ -653,7 +715,9 @@ mod reregister_ledger_reseed_tests {
         state.finalizer_turn_id = 9_010_777;
         state.set_relay_owner_kind(super::inflight::RelayOwnerKind::Watcher);
 
-        let restored = super::reregister_active_turn_from_inflight(&shared, &state).await;
+        let restored = super::reregister_active_turn_from_inflight(&shared, &state)
+            .await
+            .finish_mailbox_on_completion;
         assert!(
             restored,
             "a zero user_msg_id turn with a stable finalizer_turn_id is re-attached"
@@ -704,7 +768,9 @@ mod reregister_ledger_reseed_tests {
         state.current_msg_id = 0;
         state.set_relay_owner_kind(super::inflight::RelayOwnerKind::Watcher);
 
-        let restored = super::reregister_active_turn_from_inflight(&shared, &state).await;
+        let restored = super::reregister_active_turn_from_inflight(&shared, &state)
+            .await
+            .finish_mailbox_on_completion;
         assert!(
             !restored,
             "a zero-owner row must not report a mailbox re-registration"

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -368,8 +368,8 @@ fn relay_recovery_status_counts_as_applied(status: &'static str) -> bool {
 /// #5021: statuses that report a successful *apply* while performing no actual
 /// repair.
 ///
-/// `reuse_existing_live_watcher` means the claim found an already-live
-/// incumbent and changed nothing (`reattach_apply_status(false)`), so relay
+/// `reuse_existing_live_watcher` means the rebind reported no authoritative
+/// adoption, session, mailbox, runtime-binding, or watcher mutation. Relay
 /// delivery is left exactly as healthy — or as stalled — as it was before the
 /// attempt. Such a round still counts as applied for tick sequencing (it
 /// legitimately suppresses the destructive watchdog branches downstream of
@@ -383,18 +383,12 @@ fn relay_recovery_status_repaired_nothing(status: &str) -> bool {
     status == "reuse_existing_live_watcher"
 }
 
-/// #3277 verify-2: `rebind_inflight_for_channel` reports apply honestly through the claim
-/// (`claim_or_reuse_watcher`, source `"recovery_restore_inflight"`), which
-/// REPLACES a cancelled / heartbeat-stale / paused / output-path-changed
-/// same-session incumbent (`find_watcher_by_tmux_session` folds
-/// `heartbeat_stale()` into its replace predicate — see the lifecycle
-/// truth-table test) but NEVER a genuinely-live fresh-heartbeat handle (no
-/// duplicate-relay vector). When the claim reused such a live incumbent
-/// (`watcher_spawned == false` — e.g. the heartbeat recovered between the
-/// stale-handle decision and the apply, or a reused watcher owns the session
-/// under another channel), say so instead of claiming "reattached_watcher".
-fn reattach_apply_status(watcher_spawned: bool) -> &'static str {
-    if watcher_spawned {
+/// #3277/#5021: report a successful repair when any authoritative rebind
+/// mutation landed, even if the final watcher claim reused a live incumbent.
+/// `watcher_spawned` is only the last claim result; adoption and runtime/mailbox
+/// repair happen before it and are independently authoritative.
+fn reattach_apply_status(repaired_state: bool) -> &'static str {
+    if repaired_state {
         "reattached_watcher"
     } else {
         "reuse_existing_live_watcher"

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -365,6 +365,24 @@ fn relay_recovery_status_counts_as_applied(status: &'static str) -> bool {
     )
 }
 
+/// #5021: statuses that report a successful *apply* while performing no actual
+/// repair.
+///
+/// `reuse_existing_live_watcher` means the claim found an already-live
+/// incumbent and changed nothing (`reattach_apply_status(false)`), so relay
+/// delivery is left exactly as healthy — or as stalled — as it was before the
+/// attempt. Such a round still counts as applied for tick sequencing (it
+/// legitimately suppresses the destructive watchdog branches downstream of
+/// `relay_dead_reattach::try_apply`), but it must NOT settle as a *healed*
+/// round: committing it clears `consecutive_refunds` and `retry_not_before_ms`,
+/// which makes the escalating failure backoff in `refund_auto_heal_attempt`
+/// permanently unreachable. A stall classification that keeps re-firing then
+/// drives an unbounded reattach/redrive loop that never converges, never
+/// escalates, and never surfaces as a failure.
+fn relay_recovery_status_repaired_nothing(status: &str) -> bool {
+    status == "reuse_existing_live_watcher"
+}
+
 /// #3277 verify-2: `rebind_inflight_for_channel` reports apply honestly through the claim
 /// (`claim_or_reuse_watcher`, source `"recovery_restore_inflight"`), which
 /// REPLACES a cancelled / heartbeat-stale / paused / output-path-changed

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -381,6 +381,12 @@ fn relay_recovery_status_counts_as_applied(status: &'static str) -> bool {
 /// escalates, and never surfaces as a failure.
 fn relay_recovery_status_repaired_nothing(status: &str) -> bool {
     status == "reuse_existing_live_watcher"
+        || matches!(
+            status,
+            "skipped_idle_tmux_stale_turn_io_error"
+                | "skipped_idle_tmux_stale_turn_missing"
+                | "skipped_idle_tmux_stale_turn_pin_mismatch"
+        )
 }
 
 /// #3277/#5021: report a successful repair when any authoritative rebind

--- a/src/services/discord/relay_recovery/tests.rs
+++ b/src/services/discord/relay_recovery/tests.rs
@@ -470,12 +470,10 @@ fn reattach_eligibility_distinguishes_stale_attached_watcher_from_live() {
     assert!(detached.auto_heal.eligible);
 }
 
-/// #3277 verify-2: the reattach apply reports HONESTLY whether a watcher
-/// was actually spawned (dead incumbent replaced / fresh claim) or a live
-/// same-session incumbent was reused untouched — the latter must not be
-/// labelled "reattached_watcher".
+/// #3277/#5021: status follows authoritative repair, not just the last watcher
+/// claim. A reused watcher can still pick up a newly adopted episode.
 #[test]
-fn reattach_status_reports_live_incumbent_reuse_honestly() {
+fn reattach_status_reports_authoritative_repair_honestly() {
     assert_eq!(reattach_apply_status(true), "reattached_watcher");
     assert_eq!(reattach_apply_status(false), "reuse_existing_live_watcher");
 }

--- a/src/services/discord/relay_recovery/tests.rs
+++ b/src/services/discord/relay_recovery/tests.rs
@@ -470,6 +470,20 @@ fn reattach_eligibility_distinguishes_stale_attached_watcher_from_live() {
     assert!(detached.auto_heal.eligible);
 }
 
+#[test]
+fn idle_clear_skips_are_classified_as_repairing_nothing() {
+    for status in [
+        "skipped_idle_tmux_stale_turn_io_error",
+        "skipped_idle_tmux_stale_turn_missing",
+        "skipped_idle_tmux_stale_turn_pin_mismatch",
+    ] {
+        assert!(relay_recovery_status_repaired_nothing(status));
+    }
+    assert!(!relay_recovery_status_repaired_nothing(
+        "cleared_idle_tmux_stale_turn"
+    ));
+}
+
 /// #3277/#5021: status follows authoritative repair, not just the last watcher
 /// claim. A reused watcher can still pick up a newly adopted episode.
 #[test]
@@ -1578,11 +1592,13 @@ async fn auto_heal_attempts_are_rate_limited_per_window() {
     );
 
     assert_eq!(
-        reserve_auto_heal_attempt(&key, 1_000, AUTO_HEAL_DEFAULT_MAX_ATTEMPTS_PER_WINDOW),
+        reserve_auto_heal_attempt(&key, 1_000, AUTO_HEAL_DEFAULT_MAX_ATTEMPTS_PER_WINDOW)
+            .map(|(remaining, _)| remaining),
         Ok(0)
     );
     assert_eq!(
-        reserve_auto_heal_attempt(&key, 2_000, AUTO_HEAL_DEFAULT_MAX_ATTEMPTS_PER_WINDOW),
+        reserve_auto_heal_attempt(&key, 2_000, AUTO_HEAL_DEFAULT_MAX_ATTEMPTS_PER_WINDOW)
+            .map(|(remaining, _)| remaining),
         Err("auto_heal_rate_limited")
     );
     assert_eq!(
@@ -1590,7 +1606,8 @@ async fn auto_heal_attempts_are_rate_limited_per_window() {
             &key,
             1_000 + AUTO_HEAL_WINDOW_SECS * 1000,
             AUTO_HEAL_DEFAULT_MAX_ATTEMPTS_PER_WINDOW
-        ),
+        )
+        .map(|(remaining, _)| remaining),
         Ok(0)
     );
 }
@@ -1634,16 +1651,19 @@ async fn dead_frontier_reattach_gets_one_bounded_retry_only() {
     );
     assert_eq!(decision.auto_heal.remaining_attempts, 2);
     assert_eq!(
-        reserve_auto_heal_attempt(&key, 1_000, decision.auto_heal.max_attempts_per_window),
+        reserve_auto_heal_attempt(&key, 1_000, decision.auto_heal.max_attempts_per_window)
+            .map(|(remaining, _)| remaining),
         Ok(1)
     );
     assert_eq!(
-        reserve_auto_heal_attempt(&key, 2_000, decision.auto_heal.max_attempts_per_window),
+        reserve_auto_heal_attempt(&key, 2_000, decision.auto_heal.max_attempts_per_window)
+            .map(|(remaining, _)| remaining),
         Ok(0),
         "a still-dead relay frontier gets one bounded non-destructive reattach retry"
     );
     assert_eq!(
-        reserve_auto_heal_attempt(&key, 3_000, decision.auto_heal.max_attempts_per_window),
+        reserve_auto_heal_attempt(&key, 3_000, decision.auto_heal.max_attempts_per_window)
+            .map(|(remaining, _)| remaining),
         Err("auto_heal_rate_limited")
     );
 

--- a/src/services/discord/relay_recovery_auto_heal_apply.rs
+++ b/src/services/discord/relay_recovery_auto_heal_apply.rs
@@ -281,10 +281,17 @@ fn settle_auto_heal_confirmation(
             record_auto_heal_confirm_failure(&key, now_ms);
         }
         ReattachConfirmation::NotRequired | ReattachConfirmation::Confirmed => {
+            // #5021: `NotRequired` is "confirmation was skipped", not
+            // "confirmation passed" — `classify_reattach_confirmation` returns it
+            // whenever no watcher was spawned, so a no-op reuse never proves that
+            // delivery recovered. Settling a round that repaired nothing as a
+            // healed round would clear the consecutive-refund counter and the
+            // retry window, leaving the escalating backoff unreachable forever.
             if matches!(
                 apply_result.status,
                 "rebind_failed" | "provider_unavailable" | "reattach_episode_changed"
-            ) {
+            ) || relay_recovery_status_repaired_nothing(apply_result.status)
+            {
                 refund_auto_heal_attempt(&key, now_ms);
             } else {
                 commit_auto_heal_attempt(&key);
@@ -300,8 +307,8 @@ mod tests {
     use poise::serenity_prelude::{ChannelId, Http, MessageId, UserId};
 
     use super::super::auto_heal_attempts::{
-        auto_heal_key, auto_heal_test_lock, clear_auto_heal_attempts_for_tests,
-        reserve_auto_heal_attempt,
+        AUTO_HEAL_REFUND_BACKOFF_THRESHOLD, auto_heal_key, auto_heal_test_lock,
+        clear_auto_heal_attempts_for_tests, reserve_auto_heal_attempt,
     };
     use super::*;
     use crate::services::provider::CancelToken;
@@ -396,6 +403,111 @@ mod tests {
             reserve_auto_heal_attempt(&key, 3_000, 1),
             Err("auto_heal_rate_limited"),
             "in-flight relay must not refund an automatic reattach reservation before confirmed frontier progress"
+        );
+    }
+
+    /// A window budget deliberately larger than `AUTO_HEAL_REFUND_BACKOFF_THRESHOLD`
+    /// so the plain per-window rate limiter cannot mask the escalating backoff
+    /// this test is about.
+    const NOOP_REUSE_WINDOW_BUDGET: u32 = 8;
+
+    fn noop_reuse_apply_result() -> RelayRecoveryApplyResult {
+        RelayRecoveryApplyResult {
+            status: "reuse_existing_live_watcher",
+            removed_thread_proofs: 0,
+            removed_mailbox_token: false,
+            post_mailbox_has_cancel_token: None,
+            post_mailbox_queue_depth: None,
+            // `reattach_apply_status(false)`: the claim found a live incumbent
+            // and changed nothing.
+            reattach_watcher_spawned: Some(false),
+            reattach_watcher_replaced: Some(false),
+            reattach_initial_offset: None,
+            reattach_error: None,
+        }
+    }
+
+    /// #5021 regression: `reuse_existing_live_watcher` repairs nothing, so it must
+    /// not settle as a healed round.
+    ///
+    /// If such a round commits, `commit_auto_heal_attempt` clears
+    /// `consecutive_refunds` and `retry_not_before_ms` on every cycle, so the
+    /// escalating failure backoff can never engage. A stall classification that
+    /// keeps re-firing (for example a false-positive `tmux_alive_relay_dead`) then
+    /// drives an unbounded reattach/redrive loop that never converges, never
+    /// escalates, and never surfaces as a failure — observed live on channel
+    /// 1479671298497183835 as 340 recovery decisions with zero convergence.
+    #[tokio::test]
+    async fn repeated_noop_reuse_rounds_escalate_into_failure_backoff() {
+        let _guard = auto_heal_test_lock().lock().await;
+        clear_auto_heal_attempts_for_tests();
+        let key = auto_heal_key(
+            "claude",
+            1_479_671_298_497_183_835,
+            RelayRecoveryActionKind::ReattachWatcher,
+            RelayRecoveryApplySource::StallWatchdog,
+        );
+
+        let mut now_ms = 1_000_i64;
+        for _ in 0..AUTO_HEAL_REFUND_BACKOFF_THRESHOLD {
+            let _ = reserve_auto_heal_attempt(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET);
+            let mut apply_result = noop_reuse_apply_result();
+            settle_auto_heal_confirmation(
+                &mut apply_result,
+                ReattachConfirmation::NotRequired,
+                &key,
+                now_ms,
+            );
+            assert_eq!(apply_result.status, "reuse_existing_live_watcher");
+            now_ms += 1_000;
+        }
+
+        assert_eq!(
+            remaining_auto_heal_attempts(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET),
+            0,
+            "consecutive rounds that repaired nothing must open the escalating retry window"
+        );
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET),
+            Err("auto_heal_failure_backoff"),
+            "a reattach that repaired nothing must not keep resetting the failure backoff; \
+             otherwise a re-firing stall classification loops reattach/redrive forever"
+        );
+    }
+
+    /// Guards the opposite over-correction: a genuinely spawned and confirmed
+    /// reattach really did heal, so it must still commit and leave the retry
+    /// window closed.
+    #[tokio::test]
+    async fn confirmed_spawned_reattach_still_commits_without_opening_backoff() {
+        let _guard = auto_heal_test_lock().lock().await;
+        clear_auto_heal_attempts_for_tests();
+        let key = auto_heal_key(
+            "claude",
+            1_479_671_298_497_183_836,
+            RelayRecoveryActionKind::ReattachWatcher,
+            RelayRecoveryApplySource::StallWatchdog,
+        );
+
+        let mut now_ms = 1_000_i64;
+        for _ in 0..AUTO_HEAL_REFUND_BACKOFF_THRESHOLD {
+            let _ = reserve_auto_heal_attempt(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET);
+            let mut apply_result = noop_reuse_apply_result();
+            apply_result.status = "reattached_watcher";
+            apply_result.reattach_watcher_spawned = Some(true);
+            settle_auto_heal_confirmation(
+                &mut apply_result,
+                ReattachConfirmation::Confirmed,
+                &key,
+                now_ms,
+            );
+            now_ms += 1_000;
+        }
+
+        assert!(
+            reserve_auto_heal_attempt(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET).is_ok(),
+            "a confirmed reattach genuinely healed the relay, so it must not be \
+             penalised with the failure backoff"
         );
     }
 

--- a/src/services/discord/relay_recovery_auto_heal_apply.rs
+++ b/src/services/discord/relay_recovery_auto_heal_apply.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use super::auto_heal_attempts::{
-    auto_heal_key, cancel_unapplied_auto_heal_attempt, commit_auto_heal_attempt,
-    record_auto_heal_confirm_failure, refund_auto_heal_attempt, remaining_auto_heal_attempts,
-    reserve_auto_heal_attempt,
+    auto_heal_attempt_generation, auto_heal_key, cancel_unapplied_auto_heal_attempt_if_current,
+    commit_auto_heal_attempt_if_current, record_auto_heal_confirm_failure_if_current,
+    refund_auto_heal_attempt_if_current, remaining_auto_heal_attempts, reserve_auto_heal_attempt,
 };
 use super::auto_heal_confirm::{ReattachConfirmation, classify_reattach_confirmation};
 use super::*;
@@ -88,6 +88,8 @@ pub(super) async fn apply_relay_recovery_plan_with_seams(
             };
         }
     }
+    let attempt_generation = auto_heal_attempt_generation(&key)
+        .expect("successful auto-heal reservation must publish a generation");
 
     let mut reserved_episode = None;
     if circuit_breaker::should_use_durable_circuit(decision.action, source) {
@@ -99,6 +101,7 @@ pub(super) async fn apply_relay_recovery_plan_with_seams(
                     provider,
                     decision,
                     &key,
+                    attempt_generation,
                     reservation,
                     alert_enqueue,
                 )
@@ -156,6 +159,7 @@ pub(super) async fn apply_relay_recovery_plan_with_seams(
                     provider,
                     decision,
                     &key,
+                    attempt_generation,
                     reservation,
                     alert_enqueue,
                 )
@@ -198,7 +202,13 @@ pub(super) async fn apply_relay_recovery_plan_with_seams(
         chrono::Utc::now().timestamp(),
     )
     .await;
-    settle_auto_heal_confirmation(&mut apply_result, confirmation, &key, now_ms);
+    settle_auto_heal_confirmation(
+        &mut apply_result,
+        confirmation,
+        &key,
+        attempt_generation,
+        now_ms,
+    );
     let skipped = apply_result.status == "reattach_episode_changed";
     if skipped {
         decision.auto_heal.skipped_reason = Some("durable_reattach_confirmation_episode_changed");
@@ -234,10 +244,11 @@ async fn skipped_durable_reservation_response(
     provider: &ProviderKind,
     mut decision: RelayRecoveryDecision,
     key: &str,
+    attempt_generation: u64,
     reservation: circuit_breaker::CircuitReservation,
     alert_enqueue: &dyn circuit_breaker::CircuitAlertEnqueue,
 ) -> RelayRecoveryResponse {
-    cancel_unapplied_auto_heal_attempt(key);
+    cancel_unapplied_auto_heal_attempt_if_current(key, attempt_generation);
     decision.auto_heal.skipped_reason = Some(match reservation {
         circuit_breaker::CircuitReservation::Open {
             episode,
@@ -283,23 +294,24 @@ fn settle_auto_heal_confirmation(
     apply_result: &mut RelayRecoveryApplyResult,
     confirmation: ReattachConfirmation,
     key: &str,
+    attempt_generation: u64,
     now_ms: i64,
 ) {
     match confirmation {
         ReattachConfirmation::StartupGrace => {
             apply_result.status = "reattach_confirm_startup_grace";
-            commit_auto_heal_attempt(&key);
+            commit_auto_heal_attempt_if_current(key, attempt_generation);
         }
         ReattachConfirmation::RelayEmissionInFlight => {
             apply_result.status = "reattach_confirm_emission_in_flight";
-            commit_auto_heal_attempt(&key);
+            commit_auto_heal_attempt_if_current(key, attempt_generation);
         }
         ReattachConfirmation::Failed => {
             apply_result.status = "reattach_confirm_failed";
             apply_result.reattach_error = Some(
                 "spawned watcher did not confirm heartbeat or relay-frontier progress".to_string(),
             );
-            record_auto_heal_confirm_failure(&key, now_ms);
+            record_auto_heal_confirm_failure_if_current(key, attempt_generation, now_ms);
         }
         ReattachConfirmation::NotRequired | ReattachConfirmation::Confirmed => {
             // #5021: `NotRequired` is "confirmation was skipped", not
@@ -313,9 +325,9 @@ fn settle_auto_heal_confirmation(
                 "rebind_failed" | "provider_unavailable" | "reattach_episode_changed"
             ) || relay_recovery_status_repaired_nothing(apply_result.status)
             {
-                refund_auto_heal_attempt(&key, now_ms);
+                refund_auto_heal_attempt_if_current(key, attempt_generation, now_ms);
             } else {
-                commit_auto_heal_attempt(&key);
+                commit_auto_heal_attempt_if_current(key, attempt_generation);
             }
         }
     }
@@ -414,6 +426,7 @@ mod tests {
             &mut apply_result,
             ReattachConfirmation::RelayEmissionInFlight,
             &key,
+            auto_heal_attempt_generation(&key).expect("reservation generation"),
             2_000,
         );
 
@@ -476,6 +489,7 @@ mod tests {
                 &mut apply_result,
                 ReattachConfirmation::NotRequired,
                 &key,
+                auto_heal_attempt_generation(&key).expect("reservation generation"),
                 now_ms,
             );
             assert_eq!(apply_result.status, "reuse_existing_live_watcher");
@@ -519,6 +533,7 @@ mod tests {
                 &mut apply_result,
                 ReattachConfirmation::Confirmed,
                 &key,
+                auto_heal_attempt_generation(&key).expect("reservation generation"),
                 now_ms,
             );
             now_ms += 1_000;
@@ -640,6 +655,7 @@ mod tests {
             &mut apply_result,
             ReattachConfirmation::StartupGrace,
             &key,
+            auto_heal_attempt_generation(&key).expect("reservation generation"),
             2_000,
         );
 

--- a/src/services/discord/relay_recovery_auto_heal_apply.rs
+++ b/src/services/discord/relay_recovery_auto_heal_apply.rs
@@ -808,6 +808,47 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn relay_recovery_missing_writer_records_failure_instead_of_startup_grace() {
+        let _guard = auto_heal_test_lock().lock().await;
+        clear_auto_heal_attempts_for_tests();
+        let key = auto_heal_key(
+            "codex",
+            4_423_304,
+            RelayRecoveryActionKind::ReattachWatcher,
+            RelayRecoveryApplySource::ProbeAutoHeal,
+        );
+        let (_, generation) = reserve_auto_heal_attempt(&key, 1_000, 1)
+            .expect("reserve missing-writer confirmation attempt");
+        let mut apply_result = RelayRecoveryApplyResult {
+            status: "reattached_watcher",
+            removed_thread_proofs: 0,
+            removed_mailbox_token: false,
+            post_mailbox_has_cancel_token: None,
+            post_mailbox_queue_depth: None,
+            reattach_watcher_spawned: Some(true),
+            reattach_watcher_replaced: Some(false),
+            reattach_initial_offset: Some(0),
+            reattach_error: None,
+        };
+
+        settle_auto_heal_confirmation(
+            &mut apply_result,
+            ReattachConfirmation::Failed,
+            &key,
+            generation,
+            2_000,
+        );
+
+        assert_eq!(apply_result.status, "reattach_confirm_failed");
+        assert_eq!(
+            auto_heal_attempt_state(&key)
+                .map(|(_, refunds, retry_at, healed)| (refunds, retry_at, healed)),
+            Some((0, Some(2_000 + AUTO_HEAL_WINDOW_SECS * 1000), 0)),
+            "a disappeared writer must enter confirmation-failure backoff, not consume startup grace"
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn reserved_episode_replacement_at_apply_barrier_is_untouched() {
         let _guard = auto_heal_test_lock().lock().await;

--- a/src/services/discord/relay_recovery_auto_heal_apply.rs
+++ b/src/services/discord/relay_recovery_auto_heal_apply.rs
@@ -510,6 +510,88 @@ mod tests {
         );
     }
 
+    /// Production-wiring regression: this crosses the real apply adapter and
+    /// settlement call. The apply fails before mutation, so each round must refund
+    /// through the exact key reserved by the orchestration layer.
+    #[tokio::test]
+    async fn production_apply_failure_rounds_open_failure_backoff() {
+        let _guard = auto_heal_test_lock().lock().await;
+        clear_auto_heal_attempts_for_tests();
+        let provider = ProviderKind::Codex;
+        let registry = HealthRegistry::new();
+        let shared = super::super::super::make_shared_data_for_tests();
+        let channel_id = 5_021_001;
+        let mut decision = plan_relay_recovery(
+            &RelayHealthSnapshot {
+                provider: provider.as_str().to_string(),
+                channel_id,
+                active_turn: RelayActiveTurn::Foreground,
+                tmux_session: Some("AgentDesk-codex-5021-missing-runtime".to_string()),
+                tmux_alive: Some(true),
+                watcher_attached: false,
+                watcher_attached_stale: false,
+                watcher_owner_channel_id: None,
+                watcher_owns_live_relay: false,
+                bridge_inflight_present: true,
+                bridge_current_msg_id: Some(5_021_201),
+                mailbox_has_cancel_token: true,
+                mailbox_active_user_msg_id: Some(5_021_101),
+                mailbox_turn_started_at_ms: None,
+                queue_depth: 0,
+                pending_discord_callback_msg_id: None,
+                pending_thread_proof: false,
+                parent_channel_id: None,
+                thread_channel_id: None,
+                last_relay_ts_ms: None,
+                last_outbound_activity_ms: None,
+                last_capture_offset: Some(128),
+                last_relay_offset: 0,
+                unread_bytes: Some(128),
+                desynced: true,
+                stale_thread_proof: false,
+            },
+            RelayStallState::TmuxAliveRelayDead,
+            1_000,
+        );
+        decision.auto_heal.max_attempts_per_window = NOOP_REUSE_WINDOW_BUDGET;
+        let key = auto_heal_key(
+            provider.as_str(),
+            channel_id,
+            RelayRecoveryActionKind::ReattachWatcher,
+            RelayRecoveryApplySource::Manual,
+        );
+
+        let mut now_ms = 1_000_i64;
+        for _ in 0..AUTO_HEAL_REFUND_BACKOFF_THRESHOLD {
+            let response = apply_relay_recovery_plan_with_seams(
+                &registry,
+                &shared,
+                &provider,
+                decision.clone(),
+                now_ms,
+                RelayRecoveryApplySource::Manual,
+                &NeverAlert,
+                &ImmediateApplyBoundary,
+            )
+            .await;
+            assert_eq!(
+                response.apply_result.as_ref().map(|result| result.status),
+                Some("provider_unavailable")
+            );
+            now_ms += 1_000;
+        }
+
+        assert_eq!(
+            remaining_auto_heal_attempts(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET),
+            0,
+            "production orchestration must settle the exact reserved key"
+        );
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET),
+            Err("auto_heal_failure_backoff")
+        );
+    }
+
     #[tokio::test]
     async fn relay_recovery_startup_grace_consumes_budget_until_frontier_progress() {
         let _guard = auto_heal_test_lock().lock().await;

--- a/src/services/discord/relay_recovery_auto_heal_apply.rs
+++ b/src/services/discord/relay_recovery_auto_heal_apply.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::auto_heal_attempts::{
-    auto_heal_attempt_generation, auto_heal_key, cancel_unapplied_auto_heal_attempt_if_current,
+    auto_heal_key, cancel_unapplied_auto_heal_attempt_if_current,
     commit_auto_heal_attempt_if_current, record_auto_heal_confirm_failure_if_current,
     refund_auto_heal_attempt_if_current, remaining_auto_heal_attempts, reserve_auto_heal_attempt,
 };
@@ -72,24 +72,26 @@ pub(super) async fn apply_relay_recovery_plan_with_seams(
     );
     decision.auto_heal.remaining_attempts =
         remaining_auto_heal_attempts(&key, now_ms, decision.auto_heal.max_attempts_per_window);
-    match reserve_auto_heal_attempt(&key, now_ms, decision.auto_heal.max_attempts_per_window) {
-        Ok(remaining) => decision.auto_heal.remaining_attempts = remaining,
-        Err(reason) => {
-            decision.auto_heal.remaining_attempts = 0;
-            decision.auto_heal.skipped_reason = Some(reason);
-            trace_relay_recovery_skipped(&decision, Some(reason));
-            return RelayRecoveryResponse {
-                ok: false,
-                mode: "apply",
-                applied: false,
-                skipped: true,
-                decision,
-                apply_result: None,
-            };
-        }
-    }
-    let attempt_generation = auto_heal_attempt_generation(&key)
-        .expect("successful auto-heal reservation must publish a generation");
+    let attempt_generation =
+        match reserve_auto_heal_attempt(&key, now_ms, decision.auto_heal.max_attempts_per_window) {
+            Ok((remaining, generation)) => {
+                decision.auto_heal.remaining_attempts = remaining;
+                generation
+            }
+            Err(reason) => {
+                decision.auto_heal.remaining_attempts = 0;
+                decision.auto_heal.skipped_reason = Some(reason);
+                trace_relay_recovery_skipped(&decision, Some(reason));
+                return RelayRecoveryResponse {
+                    ok: false,
+                    mode: "apply",
+                    applied: false,
+                    skipped: true,
+                    decision,
+                    apply_result: None,
+                };
+            }
+        };
 
     let mut reserved_episode = None;
     if circuit_breaker::should_use_durable_circuit(decision.action, source) {
@@ -178,19 +180,24 @@ pub(super) async fn apply_relay_recovery_plan_with_seams(
         source,
     )
     .await;
-    if matches!(
-        apply_result.status,
-        "rebind_failed" | "provider_unavailable" | "reattach_episode_changed"
-    ) && let Some(episode) = reserved_episode.as_ref()
-    {
-        if !circuit_breaker::refund_unhanded_episode_attempt(provider, decision.channel_id, episode)
-        {
+    if let Some(episode) = reserved_episode.as_ref() {
+        let before_handoff = matches!(
+            apply_result.status,
+            "rebind_failed" | "provider_unavailable" | "reattach_episode_changed"
+        );
+        let settled = if before_handoff {
+            circuit_breaker::refund_unhanded_episode_attempt(provider, decision.channel_id, episode)
+        } else {
+            circuit_breaker::mark_episode_attempt_handed_off(provider, decision.channel_id, episode)
+        };
+        if !settled {
             tracing::warn!(
                 target: "agentdesk::discord::relay_recovery",
                 provider = provider.as_str(),
                 channel_id = decision.channel_id,
                 episode = episode.short_key(),
-                "failed to refund durable relay reattach attempt before watcher handoff"
+                before_handoff,
+                "failed to settle durable relay reattach reservation receipt"
             );
         }
     }
@@ -299,12 +306,20 @@ fn settle_auto_heal_confirmation(
 ) {
     match confirmation {
         ReattachConfirmation::StartupGrace => {
+            // Startup grace is inconclusive, but rebind already handed a watcher
+            // into the registry. Retrying immediately could replace that live
+            // writer and duplicate its range, so the reservation remains spent.
+            // Do not call `commit`: a failed probe is not a healed round and must
+            // not clear the existing consecutive-failure/backoff history.
             apply_result.status = "reattach_confirm_startup_grace";
-            commit_auto_heal_attempt_if_current(key, attempt_generation);
         }
         ReattachConfirmation::RelayEmissionInFlight => {
+            // The exact spawned watcher still owns an active emission. Retrying
+            // reattach concurrently could replace that writer and duplicate the
+            // range, so the reservation remains spent. Active emission is still
+            // not delivery confirmation and therefore must not clear failure
+            // history through the healed-round `commit` path.
             apply_result.status = "reattach_confirm_emission_in_flight";
-            commit_auto_heal_attempt_if_current(key, attempt_generation);
         }
         ReattachConfirmation::Failed => {
             apply_result.status = "reattach_confirm_failed";
@@ -340,13 +355,38 @@ mod tests {
     use poise::serenity_prelude::{ChannelId, Http, MessageId, UserId};
 
     use super::super::auto_heal_attempts::{
-        AUTO_HEAL_REFUND_BACKOFF_THRESHOLD, auto_heal_key, auto_heal_test_lock,
-        clear_auto_heal_attempts_for_tests, reserve_auto_heal_attempt,
+        AUTO_HEAL_REFUND_BACKOFF_THRESHOLD, auto_heal_attempt_generation, auto_heal_key,
+        auto_heal_test_lock, clear_auto_heal_attempts_for_tests, reserve_auto_heal_attempt,
     };
     use super::*;
     use crate::services::provider::CancelToken;
 
     struct NeverAlert;
+
+    struct CountingAlert {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl circuit_breaker::CircuitAlertEnqueue for CountingAlert {
+        async fn enqueue(
+            &self,
+            _pool: Option<&sqlx::PgPool>,
+            _request: &circuit_breaker::CircuitAlertRequest,
+        ) -> Result<i64, String> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(5023)
+        }
+
+        async fn activate(&self, _pool: Option<&sqlx::PgPool>, id: i64) -> Result<bool, String> {
+            assert_eq!(id, 5023);
+            Ok(true)
+        }
+
+        async fn cancel(&self, _pool: Option<&sqlx::PgPool>, _id: i64) -> Result<(), String> {
+            Ok(())
+        }
+    }
 
     #[async_trait::async_trait]
     impl circuit_breaker::CircuitAlertEnqueue for NeverAlert {
@@ -409,7 +449,10 @@ mod tests {
             RelayRecoveryActionKind::ReattachWatcher,
             RelayRecoveryApplySource::ProbeAutoHeal,
         );
-        assert_eq!(reserve_auto_heal_attempt(&key, 1_000, 1), Ok(0));
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, 1_000, 1).map(|(remaining, _)| remaining),
+            Ok(0)
+        );
         let mut apply_result = RelayRecoveryApplyResult {
             status: "reattached_watcher",
             removed_thread_proofs: 0,
@@ -434,7 +477,7 @@ mod tests {
         assert!(apply_result.reattach_error.is_none());
         assert!(relay_recovery_status_counts_as_applied(apply_result.status));
         assert_eq!(
-            reserve_auto_heal_attempt(&key, 3_000, 1),
+            reserve_auto_heal_attempt(&key, 3_000, 1).map(|(remaining, _)| remaining),
             Err("auto_heal_rate_limited"),
             "in-flight relay must not refund an automatic reattach reservation before confirmed frontier progress"
         );
@@ -483,7 +526,8 @@ mod tests {
 
         let mut now_ms = 1_000_i64;
         for _ in 0..AUTO_HEAL_REFUND_BACKOFF_THRESHOLD {
-            let _ = reserve_auto_heal_attempt(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET);
+            let _ = reserve_auto_heal_attempt(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET)
+                .map(|(remaining, _)| remaining);
             let mut apply_result = noop_reuse_apply_result();
             settle_auto_heal_confirmation(
                 &mut apply_result,
@@ -502,7 +546,8 @@ mod tests {
             "consecutive rounds that repaired nothing must open the escalating retry window"
         );
         assert_eq!(
-            reserve_auto_heal_attempt(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET),
+            reserve_auto_heal_attempt(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET)
+                .map(|(remaining, _)| remaining),
             Err("auto_heal_failure_backoff"),
             "a reattach that repaired nothing must not keep resetting the failure backoff; \
              otherwise a re-firing stall classification loops reattach/redrive forever"
@@ -525,7 +570,8 @@ mod tests {
 
         let mut now_ms = 1_000_i64;
         for _ in 0..AUTO_HEAL_REFUND_BACKOFF_THRESHOLD {
-            let _ = reserve_auto_heal_attempt(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET);
+            let _ = reserve_auto_heal_attempt(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET)
+                .map(|(remaining, _)| remaining);
             let mut apply_result = noop_reuse_apply_result();
             apply_result.status = "reattached_watcher";
             apply_result.reattach_watcher_spawned = Some(true);
@@ -623,13 +669,214 @@ mod tests {
             "production orchestration must settle the exact reserved key"
         );
         assert_eq!(
-            reserve_auto_heal_attempt(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET),
+            reserve_auto_heal_attempt(&key, now_ms, NOOP_REUSE_WINDOW_BUDGET)
+                .map(|(remaining, _)| remaining),
             Err("auto_heal_failure_backoff")
         );
     }
 
     #[tokio::test]
-    async fn relay_recovery_startup_grace_consumes_budget_until_frontier_progress() {
+    async fn production_internal_pre_handoff_failure_refunds_durable_attempt() {
+        let _guard = auto_heal_test_lock().lock().await;
+        clear_auto_heal_attempts_for_tests();
+        let root = tempfile::tempdir().expect("isolated AgentDesk root");
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
+        let provider = ProviderKind::Codex;
+        let registry = HealthRegistry::new();
+        let shared = super::super::super::make_shared_data_for_tests();
+        let channel_id = 5_023_201;
+        let tmux = "AgentDesk-codex-5023-pre-handoff";
+        let mut state = super::super::super::inflight::InflightTurnState::new(
+            provider.clone(),
+            channel_id,
+            None,
+            7,
+            channel_id + 1,
+            channel_id + 2,
+            "pre-handoff failure".to_string(),
+            Some("session-5023".to_string()),
+            Some(tmux.to_string()),
+            Some("/tmp/missing-5023.jsonl".to_string()),
+            None,
+            0,
+        );
+        state.finalizer_turn_id = state.user_msg_id;
+        state.turn_nonce = Some("nonce-5023".to_string());
+        super::super::super::inflight::save_inflight_state(&state).expect("seed inflight");
+        let mut decision = plan_relay_recovery(
+            &RelayHealthSnapshot {
+                provider: provider.as_str().to_string(),
+                channel_id,
+                active_turn: RelayActiveTurn::Foreground,
+                tmux_session: Some(tmux.to_string()),
+                tmux_alive: Some(true),
+                watcher_attached: false,
+                watcher_attached_stale: false,
+                watcher_owner_channel_id: None,
+                watcher_owns_live_relay: false,
+                bridge_inflight_present: true,
+                bridge_current_msg_id: Some(state.current_msg_id),
+                mailbox_has_cancel_token: true,
+                mailbox_active_user_msg_id: Some(state.user_msg_id),
+                mailbox_turn_started_at_ms: None,
+                queue_depth: 0,
+                pending_discord_callback_msg_id: None,
+                pending_thread_proof: false,
+                parent_channel_id: None,
+                thread_channel_id: None,
+                last_relay_ts_ms: None,
+                last_outbound_activity_ms: None,
+                last_capture_offset: Some(128),
+                last_relay_offset: 0,
+                unread_bytes: Some(128),
+                desynced: true,
+                stale_thread_proof: false,
+            },
+            RelayStallState::TmuxAliveRelayDead,
+            1_000,
+        );
+        decision.affected.finalizer_turn_id = Some(state.effective_finalizer_turn_id());
+        decision.auto_heal.eligible = true;
+        decision.auto_heal.skipped_reason = None;
+        decision.auto_heal.max_attempts_per_window = 2;
+
+        assert!(decision.auto_heal.eligible);
+        let first = apply_relay_recovery_plan_with_seams(
+            &registry,
+            &shared,
+            &provider,
+            decision.clone(),
+            1_000,
+            RelayRecoveryApplySource::ProbeAutoHeal,
+            &NeverAlert,
+            &ImmediateApplyBoundary,
+        )
+        .await;
+        assert_eq!(
+            first.apply_result.as_ref().map(|result| result.status),
+            Some("provider_unavailable"),
+            "unexpected response: {first:?}"
+        );
+        let expected = circuit_breaker::inspect_current_episode(&provider, &decision)
+            .expect("inspect refunded episode");
+        assert!(matches!(
+            circuit_breaker::reserve_inspected_episode(&provider, &decision, &expected, 2),
+            circuit_breaker::CircuitReservation::Reserved { attempt: 1, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn production_internal_crash_receipt_recovery_reaches_open_alert() {
+        let _guard = auto_heal_test_lock().lock().await;
+        clear_auto_heal_attempts_for_tests();
+        let root = tempfile::tempdir().expect("isolated AgentDesk root");
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
+        let provider = ProviderKind::Codex;
+        let registry = HealthRegistry::new();
+        let shared = super::super::super::make_shared_data_for_tests();
+        let channel_id = 5_023_202;
+        let tmux = "AgentDesk-codex-5023-crash-alert";
+        let mut state = super::super::super::inflight::InflightTurnState::new(
+            provider.clone(),
+            channel_id,
+            None,
+            7,
+            channel_id + 1,
+            channel_id + 2,
+            "crash alert".to_string(),
+            Some("session-5023-alert".to_string()),
+            Some(tmux.to_string()),
+            Some("/tmp/missing-5023-alert.jsonl".to_string()),
+            None,
+            0,
+        );
+        state.finalizer_turn_id = state.user_msg_id;
+        state.turn_nonce = Some("nonce-5023-alert".to_string());
+        super::super::super::inflight::save_inflight_state(&state).expect("seed inflight");
+        let mut decision = plan_relay_recovery(
+            &RelayHealthSnapshot {
+                provider: provider.as_str().to_string(),
+                channel_id,
+                active_turn: RelayActiveTurn::Foreground,
+                tmux_session: Some(tmux.to_string()),
+                tmux_alive: Some(true),
+                watcher_attached: false,
+                watcher_attached_stale: false,
+                watcher_owner_channel_id: None,
+                watcher_owns_live_relay: false,
+                bridge_inflight_present: true,
+                bridge_current_msg_id: Some(state.current_msg_id),
+                mailbox_has_cancel_token: true,
+                mailbox_active_user_msg_id: Some(state.user_msg_id),
+                mailbox_turn_started_at_ms: None,
+                queue_depth: 0,
+                pending_discord_callback_msg_id: None,
+                pending_thread_proof: false,
+                parent_channel_id: None,
+                thread_channel_id: None,
+                last_relay_ts_ms: None,
+                last_outbound_activity_ms: None,
+                last_capture_offset: Some(128),
+                last_relay_offset: 0,
+                unread_bytes: Some(128),
+                desynced: true,
+                stale_thread_proof: false,
+            },
+            RelayStallState::TmuxAliveRelayDead,
+            1_000,
+        );
+        decision.affected.finalizer_turn_id = Some(state.effective_finalizer_turn_id());
+        decision.auto_heal.eligible = true;
+        decision.auto_heal.skipped_reason = None;
+        decision.auto_heal.max_attempts_per_window = 1;
+        super::super::super::runtime_store::set_process_generation_for_tests(Some(61));
+        let expected = circuit_breaker::inspect_current_episode(&provider, &decision)
+            .expect("inspect crash episode");
+        assert!(matches!(
+            circuit_breaker::reserve_inspected_episode(&provider, &decision, &expected, 1),
+            circuit_breaker::CircuitReservation::Reserved { .. }
+        ));
+        super::super::super::runtime_store::set_process_generation_for_tests(Some(62));
+        let recovered = circuit_breaker::inspect_current_episode(&provider, &decision)
+            .expect("inspect recovered episode");
+        let circuit_breaker::CircuitReservation::Reserved { episode, .. } =
+            circuit_breaker::reserve_inspected_episode(&provider, &decision, &recovered, 1)
+        else {
+            panic!("replacement process must reclaim the crashed pre-handoff spend")
+        };
+        assert!(circuit_breaker::mark_episode_attempt_handed_off(
+            &provider, channel_id, &episode
+        ));
+        clear_auto_heal_attempts_for_tests();
+        let alert = CountingAlert {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        };
+        let response = apply_relay_recovery_plan_with_seams(
+            &registry,
+            &shared,
+            &provider,
+            decision,
+            2_000,
+            RelayRecoveryApplySource::ProbeAutoHeal,
+            &alert,
+            &ImmediateApplyBoundary,
+        )
+        .await;
+        assert!(response.skipped);
+        assert_eq!(
+            response.decision.auto_heal.skipped_reason,
+            Some("durable_reattach_circuit_open")
+        );
+        assert_eq!(
+            alert.calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the replacement process must reach the real circuit-open alert path"
+        );
+        super::super::super::runtime_store::set_process_generation_for_tests(None);
+    }
+
+    #[tokio::test]
+    async fn relay_recovery_startup_grace_spends_budget_without_committing_healed_round() {
         let _guard = auto_heal_test_lock().lock().await;
         clear_auto_heal_attempts_for_tests();
         let key = auto_heal_key(
@@ -638,7 +885,10 @@ mod tests {
             RelayRecoveryActionKind::ReattachWatcher,
             RelayRecoveryApplySource::ProbeAutoHeal,
         );
-        assert_eq!(reserve_auto_heal_attempt(&key, 1_000, 1), Ok(0));
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, 1_000, 1).map(|(remaining, _)| remaining),
+            Ok(0)
+        );
         let mut apply_result = RelayRecoveryApplyResult {
             status: "reattached_watcher",
             removed_thread_proofs: 0,
@@ -661,9 +911,9 @@ mod tests {
 
         assert_eq!(apply_result.status, "reattach_confirm_startup_grace");
         assert_eq!(
-            reserve_auto_heal_attempt(&key, 3_000, 1),
+            reserve_auto_heal_attempt(&key, 3_000, 1).map(|(remaining, _)| remaining),
             Err("auto_heal_rate_limited"),
-            "startup grace must not refund an automatic reattach reservation"
+            "an already handed-off watcher must consume the attempt even when startup grace makes its probe inconclusive"
         );
     }
 

--- a/src/services/discord/relay_recovery_auto_heal_apply.rs
+++ b/src/services/discord/relay_recovery_auto_heal_apply.rs
@@ -91,16 +91,35 @@ pub(super) async fn apply_relay_recovery_plan_with_seams(
 
     let mut reserved_episode = None;
     if circuit_breaker::should_use_durable_circuit(decision.action, source) {
-        match circuit_breaker::reserve_current_episode(
+        reserved_episode = match circuit_breaker::inspect_current_episode(provider, &decision) {
+            Ok(episode) => Some(episode),
+            Err(reservation) => {
+                return skipped_durable_reservation_response(
+                    shared,
+                    provider,
+                    decision,
+                    &key,
+                    reservation,
+                    alert_enqueue,
+                )
+                .await;
+            }
+        };
+    }
+
+    if let Some(episode) = reserved_episode.as_mut() {
+        match circuit_breaker::reserve_inspected_episode(
             provider,
             &decision,
+            episode,
             decision.auto_heal.max_attempts_per_window,
         ) {
             circuit_breaker::CircuitReservation::Reserved {
                 attempt,
-                episode,
+                episode: reserved,
                 orphaned_staged_alert_ids,
             } => {
+                *episode = reserved;
                 for staged_alert_id in orphaned_staged_alert_ids {
                     match alert_enqueue
                         .cancel(shared.pg_pool.as_ref(), staged_alert_id)
@@ -130,83 +149,19 @@ pub(super) async fn apply_relay_recovery_plan_with_seams(
                     episode = episode.short_key(),
                     "reserved durable relay reattach episode attempt"
                 );
-                reserved_episode = Some(episode);
             }
-            circuit_breaker::CircuitReservation::Open {
-                episode,
-                open,
-                alert_needed,
-                staged_alert_id,
-            } => {
-                cancel_unapplied_auto_heal_attempt(&key);
-                decision.auto_heal.remaining_attempts = 0;
-                decision.auto_heal.skipped_reason = Some("durable_reattach_circuit_open");
-                if alert_needed || staged_alert_id.is_some() {
-                    circuit_breaker::queue_or_resume_open_alert_with_enqueue(
-                        shared,
-                        provider,
-                        poise::serenity_prelude::ChannelId::new(decision.channel_id),
-                        &episode,
-                        &open,
-                        decision.auto_heal.max_attempts_per_window,
-                        staged_alert_id,
-                        alert_enqueue,
-                    )
-                    .await;
-                }
-                trace_relay_recovery_skipped(&decision, decision.auto_heal.skipped_reason);
-                return RelayRecoveryResponse {
-                    ok: false,
-                    mode: "apply",
-                    applied: false,
-                    skipped: true,
+            reservation => {
+                return skipped_durable_reservation_response(
+                    shared,
+                    provider,
                     decision,
-                    apply_result: None,
-                };
-            }
-            circuit_breaker::CircuitReservation::StaleIdentity => {
-                cancel_unapplied_auto_heal_attempt(&key);
-                decision.auto_heal.skipped_reason = Some("durable_reattach_stale_identity");
-                trace_relay_recovery_skipped(&decision, decision.auto_heal.skipped_reason);
-                return RelayRecoveryResponse {
-                    ok: false,
-                    mode: "apply",
-                    applied: false,
-                    skipped: true,
-                    decision,
-                    apply_result: None,
-                };
-            }
-            circuit_breaker::CircuitReservation::MissingInflight => {
-                cancel_unapplied_auto_heal_attempt(&key);
-                decision.auto_heal.skipped_reason = Some("durable_reattach_missing_inflight");
-                trace_relay_recovery_skipped(&decision, decision.auto_heal.skipped_reason);
-                return RelayRecoveryResponse {
-                    ok: false,
-                    mode: "apply",
-                    applied: false,
-                    skipped: true,
-                    decision,
-                    apply_result: None,
-                };
-            }
-            circuit_breaker::CircuitReservation::IoError => {
-                cancel_unapplied_auto_heal_attempt(&key);
-                decision.auto_heal.skipped_reason = Some("durable_reattach_store_unavailable");
-                trace_relay_recovery_skipped(&decision, decision.auto_heal.skipped_reason);
-                return RelayRecoveryResponse {
-                    ok: false,
-                    mode: "apply",
-                    applied: false,
-                    skipped: true,
-                    decision,
-                    apply_result: None,
-                };
+                    &key,
+                    reservation,
+                    alert_enqueue,
+                )
+                .await;
             }
         }
-    }
-
-    if let Some(episode) = reserved_episode.as_ref() {
         apply_boundary.after_reserve(episode).await;
     }
 
@@ -219,6 +174,22 @@ pub(super) async fn apply_relay_recovery_plan_with_seams(
         source,
     )
     .await;
+    if matches!(
+        apply_result.status,
+        "rebind_failed" | "provider_unavailable" | "reattach_episode_changed"
+    ) && let Some(episode) = reserved_episode.as_ref()
+    {
+        if !circuit_breaker::refund_unhanded_episode_attempt(provider, decision.channel_id, episode)
+        {
+            tracing::warn!(
+                target: "agentdesk::discord::relay_recovery",
+                provider = provider.as_str(),
+                channel_id = decision.channel_id,
+                episode = episode.short_key(),
+                "failed to refund durable relay reattach attempt before watcher handoff"
+            );
+        }
+    }
     let confirmation = classify_reattach_confirmation(
         shared,
         &decision,
@@ -255,6 +226,56 @@ pub(super) async fn apply_relay_recovery_plan_with_seams(
         skipped,
         decision,
         apply_result: Some(apply_result),
+    }
+}
+
+async fn skipped_durable_reservation_response(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    mut decision: RelayRecoveryDecision,
+    key: &str,
+    reservation: circuit_breaker::CircuitReservation,
+    alert_enqueue: &dyn circuit_breaker::CircuitAlertEnqueue,
+) -> RelayRecoveryResponse {
+    cancel_unapplied_auto_heal_attempt(key);
+    decision.auto_heal.skipped_reason = Some(match reservation {
+        circuit_breaker::CircuitReservation::Open {
+            episode,
+            open,
+            alert_needed,
+            staged_alert_id,
+        } => {
+            decision.auto_heal.remaining_attempts = 0;
+            if alert_needed || staged_alert_id.is_some() {
+                circuit_breaker::queue_or_resume_open_alert_with_enqueue(
+                    shared,
+                    provider,
+                    poise::serenity_prelude::ChannelId::new(decision.channel_id),
+                    &episode,
+                    &open,
+                    decision.auto_heal.max_attempts_per_window,
+                    staged_alert_id,
+                    alert_enqueue,
+                )
+                .await;
+            }
+            "durable_reattach_circuit_open"
+        }
+        circuit_breaker::CircuitReservation::StaleIdentity => "durable_reattach_stale_identity",
+        circuit_breaker::CircuitReservation::MissingInflight => "durable_reattach_missing_inflight",
+        circuit_breaker::CircuitReservation::IoError => "durable_reattach_store_unavailable",
+        circuit_breaker::CircuitReservation::Reserved { .. } => {
+            "durable_reattach_unexpected_reservation"
+        }
+    });
+    trace_relay_recovery_skipped(&decision, decision.auto_heal.skipped_reason);
+    RelayRecoveryResponse {
+        ok: false,
+        mode: "apply",
+        applied: false,
+        skipped: true,
+        decision,
+        apply_result: None,
     }
 }
 

--- a/src/services/discord/relay_recovery_auto_heal_apply.rs
+++ b/src/services/discord/relay_recovery_auto_heal_apply.rs
@@ -355,8 +355,9 @@ mod tests {
     use poise::serenity_prelude::{ChannelId, Http, MessageId, UserId};
 
     use super::super::auto_heal_attempts::{
-        AUTO_HEAL_REFUND_BACKOFF_THRESHOLD, auto_heal_attempt_generation, auto_heal_key,
-        auto_heal_test_lock, clear_auto_heal_attempts_for_tests, reserve_auto_heal_attempt,
+        AUTO_HEAL_REFUND_BACKOFF_THRESHOLD, auto_heal_attempt_generation, auto_heal_attempt_state,
+        auto_heal_key, auto_heal_test_lock, clear_auto_heal_attempts_for_tests,
+        reserve_auto_heal_attempt,
     };
     use super::*;
     use crate::services::provider::CancelToken;
@@ -910,6 +911,12 @@ mod tests {
         );
 
         assert_eq!(apply_result.status, "reattach_confirm_startup_grace");
+        assert_eq!(
+            auto_heal_attempt_state(&key)
+                .map(|(_, refunds, retry_at, healed)| (refunds, retry_at, healed)),
+            Some((0, None, 0)),
+            "an inconclusive probe must neither commit healed state nor manufacture failure history"
+        );
         assert_eq!(
             reserve_auto_heal_attempt(&key, 3_000, 1).map(|(remaining, _)| remaining),
             Err("auto_heal_rate_limited"),

--- a/src/services/discord/relay_recovery_auto_heal_apply.rs
+++ b/src/services/discord/relay_recovery_auto_heal_apply.rs
@@ -180,26 +180,20 @@ pub(super) async fn apply_relay_recovery_plan_with_seams(
         source,
     )
     .await;
-    if let Some(episode) = reserved_episode.as_ref() {
-        let before_handoff = matches!(
+    if let Some(episode) = reserved_episode.as_ref()
+        && matches!(
             apply_result.status,
             "rebind_failed" | "provider_unavailable" | "reattach_episode_changed"
+        )
+        && !circuit_breaker::refund_unhanded_episode_attempt(provider, decision.channel_id, episode)
+    {
+        tracing::warn!(
+            target: "agentdesk::discord::relay_recovery",
+            provider = provider.as_str(),
+            channel_id = decision.channel_id,
+            episode = episode.short_key(),
+            "failed to refund durable relay reattach attempt before watcher handoff"
         );
-        let settled = if before_handoff {
-            circuit_breaker::refund_unhanded_episode_attempt(provider, decision.channel_id, episode)
-        } else {
-            circuit_breaker::mark_episode_attempt_handed_off(provider, decision.channel_id, episode)
-        };
-        if !settled {
-            tracing::warn!(
-                target: "agentdesk::discord::relay_recovery",
-                provider = provider.as_str(),
-                channel_id = decision.channel_id,
-                episode = episode.short_key(),
-                before_handoff,
-                "failed to settle durable relay reattach reservation receipt"
-            );
-        }
     }
     let confirmation = classify_reattach_confirmation(
         shared,
@@ -764,116 +758,6 @@ mod tests {
             circuit_breaker::reserve_inspected_episode(&provider, &decision, &expected, 2),
             circuit_breaker::CircuitReservation::Reserved { attempt: 1, .. }
         ));
-    }
-
-    #[tokio::test]
-    async fn production_internal_crash_receipt_recovery_reaches_open_alert() {
-        let _guard = auto_heal_test_lock().lock().await;
-        clear_auto_heal_attempts_for_tests();
-        let root = tempfile::tempdir().expect("isolated AgentDesk root");
-        let _env = crate::config::set_agentdesk_root_for_test(root.path());
-        let provider = ProviderKind::Codex;
-        let registry = HealthRegistry::new();
-        let shared = super::super::super::make_shared_data_for_tests();
-        let channel_id = 5_023_202;
-        let tmux = "AgentDesk-codex-5023-crash-alert";
-        let mut state = super::super::super::inflight::InflightTurnState::new(
-            provider.clone(),
-            channel_id,
-            None,
-            7,
-            channel_id + 1,
-            channel_id + 2,
-            "crash alert".to_string(),
-            Some("session-5023-alert".to_string()),
-            Some(tmux.to_string()),
-            Some("/tmp/missing-5023-alert.jsonl".to_string()),
-            None,
-            0,
-        );
-        state.finalizer_turn_id = state.user_msg_id;
-        state.turn_nonce = Some("nonce-5023-alert".to_string());
-        super::super::super::inflight::save_inflight_state(&state).expect("seed inflight");
-        let mut decision = plan_relay_recovery(
-            &RelayHealthSnapshot {
-                provider: provider.as_str().to_string(),
-                channel_id,
-                active_turn: RelayActiveTurn::Foreground,
-                tmux_session: Some(tmux.to_string()),
-                tmux_alive: Some(true),
-                watcher_attached: false,
-                watcher_attached_stale: false,
-                watcher_owner_channel_id: None,
-                watcher_owns_live_relay: false,
-                bridge_inflight_present: true,
-                bridge_current_msg_id: Some(state.current_msg_id),
-                mailbox_has_cancel_token: true,
-                mailbox_active_user_msg_id: Some(state.user_msg_id),
-                mailbox_turn_started_at_ms: None,
-                queue_depth: 0,
-                pending_discord_callback_msg_id: None,
-                pending_thread_proof: false,
-                parent_channel_id: None,
-                thread_channel_id: None,
-                last_relay_ts_ms: None,
-                last_outbound_activity_ms: None,
-                last_capture_offset: Some(128),
-                last_relay_offset: 0,
-                unread_bytes: Some(128),
-                desynced: true,
-                stale_thread_proof: false,
-            },
-            RelayStallState::TmuxAliveRelayDead,
-            1_000,
-        );
-        decision.affected.finalizer_turn_id = Some(state.effective_finalizer_turn_id());
-        decision.auto_heal.eligible = true;
-        decision.auto_heal.skipped_reason = None;
-        decision.auto_heal.max_attempts_per_window = 1;
-        super::super::super::runtime_store::set_process_generation_for_tests(Some(61));
-        let expected = circuit_breaker::inspect_current_episode(&provider, &decision)
-            .expect("inspect crash episode");
-        assert!(matches!(
-            circuit_breaker::reserve_inspected_episode(&provider, &decision, &expected, 1),
-            circuit_breaker::CircuitReservation::Reserved { .. }
-        ));
-        super::super::super::runtime_store::set_process_generation_for_tests(Some(62));
-        let recovered = circuit_breaker::inspect_current_episode(&provider, &decision)
-            .expect("inspect recovered episode");
-        let circuit_breaker::CircuitReservation::Reserved { episode, .. } =
-            circuit_breaker::reserve_inspected_episode(&provider, &decision, &recovered, 1)
-        else {
-            panic!("replacement process must reclaim the crashed pre-handoff spend")
-        };
-        assert!(circuit_breaker::mark_episode_attempt_handed_off(
-            &provider, channel_id, &episode
-        ));
-        clear_auto_heal_attempts_for_tests();
-        let alert = CountingAlert {
-            calls: std::sync::atomic::AtomicUsize::new(0),
-        };
-        let response = apply_relay_recovery_plan_with_seams(
-            &registry,
-            &shared,
-            &provider,
-            decision,
-            2_000,
-            RelayRecoveryApplySource::ProbeAutoHeal,
-            &alert,
-            &ImmediateApplyBoundary,
-        )
-        .await;
-        assert!(response.skipped);
-        assert_eq!(
-            response.decision.auto_heal.skipped_reason,
-            Some("durable_reattach_circuit_open")
-        );
-        assert_eq!(
-            alert.calls.load(std::sync::atomic::Ordering::SeqCst),
-            1,
-            "the replacement process must reach the real circuit-open alert path"
-        );
-        super::super::super::runtime_store::set_process_generation_for_tests(None);
     }
 
     #[tokio::test]

--- a/src/services/discord/relay_recovery_auto_heal_apply.rs
+++ b/src/services/discord/relay_recovery_auto_heal_apply.rs
@@ -418,8 +418,7 @@ mod tests {
             removed_mailbox_token: false,
             post_mailbox_has_cancel_token: None,
             post_mailbox_queue_depth: None,
-            // `reattach_apply_status(false)`: the claim found a live incumbent
-            // and changed nothing.
+            // The rebind reported no authoritative state mutation.
             reattach_watcher_spawned: Some(false),
             reattach_watcher_replaced: Some(false),
             reattach_initial_offset: None,

--- a/src/services/discord/relay_recovery_auto_heal_attempts.rs
+++ b/src/services/discord/relay_recovery_auto_heal_attempts.rs
@@ -40,6 +40,7 @@ struct AttemptWindow {
     attempts: u32,
     consecutive_refunds: u32,
     retry_not_before_ms: Option<i64>,
+    generation: u64,
 }
 
 impl AttemptWindow {
@@ -49,6 +50,7 @@ impl AttemptWindow {
             attempts: 0,
             consecutive_refunds: 0,
             retry_not_before_ms: None,
+            generation: 0,
         }
     }
 
@@ -60,11 +62,13 @@ impl AttemptWindow {
             self.retry_not_before_ms = None;
             self.window_start_ms = now_ms;
             self.attempts = 0;
+            self.generation = self.generation.wrapping_add(1);
         } else if self.retry_not_before_ms.is_none()
             && now_ms.saturating_sub(self.window_start_ms) >= AUTO_HEAL_WINDOW_SECS * 1000
         {
             self.window_start_ms = now_ms;
             self.attempts = 0;
+            self.generation = self.generation.wrapping_add(1);
         }
     }
 
@@ -131,12 +135,49 @@ pub(super) fn reserve_auto_heal_attempt(
         return Err("auto_heal_rate_limited");
     }
     window.attempts += 1;
+    window.generation = window.generation.wrapping_add(1);
     Ok(max_attempts_per_window.saturating_sub(window.attempts))
 }
 
 /// Return a reservation consumed by a spawn/rebind failure. Consecutive
 /// refunds are retained across ordinary windows; the third failure opens a
 /// 1,200s retry window and later consecutive failures expand it exponentially.
+pub(super) fn auto_heal_attempt_generation(key: &str) -> Option<u64> {
+    auto_heal_attempts()
+        .lock()
+        .expect("relay recovery attempt map poisoned")
+        .get(key)
+        .map(|window| window.generation)
+}
+
+fn current_attempt_generation(key: &str, generation: u64) -> bool {
+    auto_heal_attempt_generation(key) == Some(generation)
+}
+
+pub(super) fn refund_auto_heal_attempt_if_current(key: &str, generation: u64, now_ms: i64) {
+    if current_attempt_generation(key, generation) {
+        refund_auto_heal_attempt(key, now_ms);
+    }
+}
+
+pub(super) fn cancel_unapplied_auto_heal_attempt_if_current(key: &str, generation: u64) {
+    if current_attempt_generation(key, generation) {
+        cancel_unapplied_auto_heal_attempt(key);
+    }
+}
+
+pub(super) fn record_auto_heal_confirm_failure_if_current(key: &str, generation: u64, now_ms: i64) {
+    if current_attempt_generation(key, generation) {
+        record_auto_heal_confirm_failure(key, now_ms);
+    }
+}
+
+pub(super) fn commit_auto_heal_attempt_if_current(key: &str, generation: u64) {
+    if current_attempt_generation(key, generation) {
+        commit_auto_heal_attempt(key);
+    }
+}
+
 pub(super) fn refund_auto_heal_attempt(key: &str, now_ms: i64) {
     let mut attempts = auto_heal_attempts()
         .lock()
@@ -317,6 +358,28 @@ mod tests {
             reserve_auto_heal_attempt(&internal, 2_000, 1),
             Ok(0),
             "manual exhaustion must not consume the internal budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn late_settlement_cannot_mutate_new_window_reservation() {
+        let _guard = auto_heal_test_lock().lock().await;
+        clear_auto_heal_attempts_for_tests();
+        let key = key();
+        assert_eq!(reserve_auto_heal_attempt(&key, 1_000, 1), Ok(0));
+        let stale_generation = auto_heal_attempt_generation(&key).expect("old generation");
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, 1_000 + AUTO_HEAL_WINDOW_SECS * 1000, 1),
+            Ok(0)
+        );
+        let current_generation = auto_heal_attempt_generation(&key).expect("new generation");
+        assert_ne!(stale_generation, current_generation);
+
+        refund_auto_heal_attempt_if_current(&key, stale_generation, 2_000);
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, 1_000 + AUTO_HEAL_WINDOW_SECS * 1000 + 1, 1),
+            Err("auto_heal_rate_limited"),
+            "late settlement from the old round must not refund the new reservation"
         );
     }
 

--- a/src/services/discord/relay_recovery_auto_heal_attempts.rs
+++ b/src/services/discord/relay_recovery_auto_heal_attempts.rs
@@ -41,6 +41,7 @@ struct AttemptWindow {
     consecutive_refunds: u32,
     retry_not_before_ms: Option<i64>,
     generation: u64,
+    healed_commits: u64,
 }
 
 impl AttemptWindow {
@@ -51,6 +52,7 @@ impl AttemptWindow {
             consecutive_refunds: 0,
             retry_not_before_ms: None,
             generation: 0,
+            healed_commits: 0,
         }
     }
 
@@ -143,12 +145,24 @@ pub(super) fn reserve_auto_heal_attempt(
 }
 
 #[cfg(test)]
-pub(super) fn auto_heal_attempt_generation(key: &str) -> Option<u64> {
+pub(super) fn auto_heal_attempt_state(key: &str) -> Option<(u64, u32, Option<i64>, u64)> {
     auto_heal_attempts()
         .lock()
         .expect("relay recovery attempt map poisoned")
         .get(key)
-        .map(|window| window.generation)
+        .map(|window| {
+            (
+                window.generation,
+                window.consecutive_refunds,
+                window.retry_not_before_ms,
+                window.healed_commits,
+            )
+        })
+}
+
+#[cfg(test)]
+pub(super) fn auto_heal_attempt_generation(key: &str) -> Option<u64> {
+    auto_heal_attempt_state(key).map(|(generation, _, _, _)| generation)
 }
 
 pub(super) fn refund_auto_heal_attempt_if_current(key: &str, generation: u64, now_ms: i64) {
@@ -258,6 +272,7 @@ pub(super) fn commit_auto_heal_attempt(key: &str) {
 }
 
 fn commit_auto_heal_attempt_in_window(window: &mut AttemptWindow) {
+    window.healed_commits = window.healed_commits.saturating_add(1);
     window.consecutive_refunds = 0;
     window.retry_not_before_ms = None;
 }

--- a/src/services/discord/relay_recovery_auto_heal_attempts.rs
+++ b/src/services/discord/relay_recovery_auto_heal_attempts.rs
@@ -120,7 +120,7 @@ pub(super) fn reserve_auto_heal_attempt(
     key: &str,
     now_ms: i64,
     max_attempts_per_window: u32,
-) -> Result<u32, &'static str> {
+) -> Result<(u32, u64), &'static str> {
     let mut attempts = auto_heal_attempts()
         .lock()
         .expect("relay recovery attempt map poisoned");
@@ -136,12 +136,13 @@ pub(super) fn reserve_auto_heal_attempt(
     }
     window.attempts += 1;
     window.generation = window.generation.wrapping_add(1);
-    Ok(max_attempts_per_window.saturating_sub(window.attempts))
+    Ok((
+        max_attempts_per_window.saturating_sub(window.attempts),
+        window.generation,
+    ))
 }
 
-/// Return a reservation consumed by a spawn/rebind failure. Consecutive
-/// refunds are retained across ordinary windows; the third failure opens a
-/// 1,200s retry window and later consecutive failures expand it exponentially.
+#[cfg(test)]
 pub(super) fn auto_heal_attempt_generation(key: &str) -> Option<u64> {
     auto_heal_attempts()
         .lock()
@@ -150,31 +151,47 @@ pub(super) fn auto_heal_attempt_generation(key: &str) -> Option<u64> {
         .map(|window| window.generation)
 }
 
-fn current_attempt_generation(key: &str, generation: u64) -> bool {
-    auto_heal_attempt_generation(key) == Some(generation)
-}
-
 pub(super) fn refund_auto_heal_attempt_if_current(key: &str, generation: u64, now_ms: i64) {
-    if current_attempt_generation(key, generation) {
-        refund_auto_heal_attempt(key, now_ms);
+    let mut attempts = auto_heal_attempts()
+        .lock()
+        .expect("relay recovery attempt map poisoned");
+    if let Some(window) = attempts.get_mut(key)
+        && window.generation == generation
+    {
+        refund_auto_heal_attempt_in_window(window, now_ms);
     }
 }
 
 pub(super) fn cancel_unapplied_auto_heal_attempt_if_current(key: &str, generation: u64) {
-    if current_attempt_generation(key, generation) {
-        cancel_unapplied_auto_heal_attempt(key);
+    let mut attempts = auto_heal_attempts()
+        .lock()
+        .expect("relay recovery attempt map poisoned");
+    if let Some(window) = attempts.get_mut(key)
+        && window.generation == generation
+    {
+        window.attempts = window.attempts.saturating_sub(1);
     }
 }
 
 pub(super) fn record_auto_heal_confirm_failure_if_current(key: &str, generation: u64, now_ms: i64) {
-    if current_attempt_generation(key, generation) {
-        record_auto_heal_confirm_failure(key, now_ms);
+    let mut attempts = auto_heal_attempts()
+        .lock()
+        .expect("relay recovery attempt map poisoned");
+    if let Some(window) = attempts.get_mut(key)
+        && window.generation == generation
+    {
+        record_auto_heal_confirm_failure_in_window(window, now_ms);
     }
 }
 
 pub(super) fn commit_auto_heal_attempt_if_current(key: &str, generation: u64) {
-    if current_attempt_generation(key, generation) {
-        commit_auto_heal_attempt(key);
+    let mut attempts = auto_heal_attempts()
+        .lock()
+        .expect("relay recovery attempt map poisoned");
+    if let Some(window) = attempts.get_mut(key)
+        && window.generation == generation
+    {
+        commit_auto_heal_attempt_in_window(window);
     }
 }
 
@@ -185,6 +202,10 @@ pub(super) fn refund_auto_heal_attempt(key: &str, now_ms: i64) {
     let Some(window) = attempts.get_mut(key) else {
         return;
     };
+    refund_auto_heal_attempt_in_window(window, now_ms);
+}
+
+fn refund_auto_heal_attempt_in_window(window: &mut AttemptWindow, now_ms: i64) {
     window.attempts = window.attempts.saturating_sub(1);
     window.consecutive_refunds = window.consecutive_refunds.saturating_add(1);
     if window.consecutive_refunds < AUTO_HEAL_REFUND_BACKOFF_THRESHOLD {
@@ -201,7 +222,8 @@ pub(super) fn refund_auto_heal_attempt(key: &str, now_ms: i64) {
 
 /// Return a reservation when a fail-closed pre-apply gate refused the action.
 /// This is deliberately narrower than confirmation settlement: once rebind was
-/// attempted, StartupGrace and RelayEmissionInFlight consume their reservation.
+/// attempted, confirmation policy decides whether to consume or refund it.
+#[cfg(test)]
 pub(super) fn cancel_unapplied_auto_heal_attempt(key: &str) {
     let mut attempts = auto_heal_attempts()
         .lock()
@@ -218,6 +240,10 @@ pub(super) fn record_auto_heal_confirm_failure(key: &str, now_ms: i64) {
     let window = attempts
         .entry(key.to_string())
         .or_insert_with(|| AttemptWindow::new(now_ms));
+    record_auto_heal_confirm_failure_in_window(window, now_ms);
+}
+
+fn record_auto_heal_confirm_failure_in_window(window: &mut AttemptWindow, now_ms: i64) {
     window.consecutive_refunds = 0;
     window.retry_not_before_ms = Some(now_ms.saturating_add(AUTO_HEAL_WINDOW_SECS * 1000));
 }
@@ -227,9 +253,13 @@ pub(super) fn commit_auto_heal_attempt(key: &str) {
         .lock()
         .expect("relay recovery attempt map poisoned");
     if let Some(window) = attempts.get_mut(key) {
-        window.consecutive_refunds = 0;
-        window.retry_not_before_ms = None;
+        commit_auto_heal_attempt_in_window(window);
     }
+}
+
+fn commit_auto_heal_attempt_in_window(window: &mut AttemptWindow) {
+    window.consecutive_refunds = 0;
+    window.retry_not_before_ms = None;
 }
 
 pub(super) fn max_attempts_per_window_for_snapshot(
@@ -323,14 +353,17 @@ mod tests {
             RelayRecoveryApplySource::Manual,
         );
 
-        assert_eq!(reserve_auto_heal_attempt(&probe, 1_000, 1), Ok(0));
         assert_eq!(
-            reserve_auto_heal_attempt(&watchdog, 2_000, 1),
+            reserve_auto_heal_attempt(&probe, 1_000, 1).map(|(remaining, _)| remaining),
+            Ok(0)
+        );
+        assert_eq!(
+            reserve_auto_heal_attempt(&watchdog, 2_000, 1).map(|(remaining, _)| remaining),
             Err("auto_heal_rate_limited"),
             "probe and watchdog must consume the same internal budget"
         );
         assert_eq!(
-            reserve_auto_heal_attempt(&manual, 2_000, 1),
+            reserve_auto_heal_attempt(&manual, 2_000, 1).map(|(remaining, _)| remaining),
             Ok(0),
             "internal exhaustion must not consume the manual budget"
         );
@@ -353,9 +386,12 @@ mod tests {
             RelayRecoveryApplySource::ProbeAutoHeal,
         );
 
-        assert_eq!(reserve_auto_heal_attempt(&manual, 1_000, 1), Ok(0));
         assert_eq!(
-            reserve_auto_heal_attempt(&internal, 2_000, 1),
+            reserve_auto_heal_attempt(&manual, 1_000, 1).map(|(remaining, _)| remaining),
+            Ok(0)
+        );
+        assert_eq!(
+            reserve_auto_heal_attempt(&internal, 2_000, 1).map(|(remaining, _)| remaining),
             Ok(0),
             "manual exhaustion must not consume the internal budget"
         );
@@ -366,10 +402,14 @@ mod tests {
         let _guard = auto_heal_test_lock().lock().await;
         clear_auto_heal_attempts_for_tests();
         let key = key();
-        assert_eq!(reserve_auto_heal_attempt(&key, 1_000, 1), Ok(0));
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, 1_000, 1).map(|(remaining, _)| remaining),
+            Ok(0)
+        );
         let stale_generation = auto_heal_attempt_generation(&key).expect("old generation");
         assert_eq!(
-            reserve_auto_heal_attempt(&key, 1_000 + AUTO_HEAL_WINDOW_SECS * 1000, 1),
+            reserve_auto_heal_attempt(&key, 1_000 + AUTO_HEAL_WINDOW_SECS * 1000, 1)
+                .map(|(remaining, _)| remaining),
             Ok(0)
         );
         let current_generation = auto_heal_attempt_generation(&key).expect("new generation");
@@ -377,7 +417,8 @@ mod tests {
 
         refund_auto_heal_attempt_if_current(&key, stale_generation, 2_000);
         assert_eq!(
-            reserve_auto_heal_attempt(&key, 1_000 + AUTO_HEAL_WINDOW_SECS * 1000 + 1, 1),
+            reserve_auto_heal_attempt(&key, 1_000 + AUTO_HEAL_WINDOW_SECS * 1000 + 1, 1)
+                .map(|(remaining, _)| remaining),
             Err("auto_heal_rate_limited"),
             "late settlement from the old round must not refund the new reservation"
         );
@@ -388,11 +429,17 @@ mod tests {
         let _guard = auto_heal_test_lock().lock().await;
         clear_auto_heal_attempts_for_tests();
         let key = key();
-        assert_eq!(reserve_auto_heal_attempt(&key, 1_000, 1), Ok(0));
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, 1_000, 1).map(|(remaining, _)| remaining),
+            Ok(0)
+        );
 
         refund_auto_heal_attempt(&key, 2_000);
 
-        assert_eq!(reserve_auto_heal_attempt(&key, 3_000, 1), Ok(0));
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, 3_000, 1).map(|(remaining, _)| remaining),
+            Ok(0)
+        );
     }
 
     #[tokio::test]
@@ -401,16 +448,19 @@ mod tests {
         clear_auto_heal_attempts_for_tests();
         let key = key();
         for now_ms in [1_000, 2_000, 3_000] {
-            assert_eq!(reserve_auto_heal_attempt(&key, now_ms, 1), Ok(0));
+            assert_eq!(
+                reserve_auto_heal_attempt(&key, now_ms, 1).map(|(remaining, _)| remaining),
+                Ok(0)
+            );
             refund_auto_heal_attempt(&key, now_ms);
         }
 
         assert_eq!(
-            reserve_auto_heal_attempt(&key, 4_000, 1),
+            reserve_auto_heal_attempt(&key, 4_000, 1).map(|(remaining, _)| remaining),
             Err("auto_heal_failure_backoff")
         );
         assert_eq!(
-            reserve_auto_heal_attempt(&key, 3_000 + 1_200_000, 1),
+            reserve_auto_heal_attempt(&key, 3_000 + 1_200_000, 1).map(|(remaining, _)| remaining),
             Ok(0),
             "the third consecutive refund must expand the base 600s window to 1200s"
         );
@@ -421,16 +471,20 @@ mod tests {
         let _guard = auto_heal_test_lock().lock().await;
         clear_auto_heal_attempts_for_tests();
         let key = key();
-        assert_eq!(reserve_auto_heal_attempt(&key, 1_000, 2), Ok(1));
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, 1_000, 2).map(|(remaining, _)| remaining),
+            Ok(1)
+        );
 
         record_auto_heal_confirm_failure(&key, 2_000);
 
         assert_eq!(
-            reserve_auto_heal_attempt(&key, 3_000, 2),
+            reserve_auto_heal_attempt(&key, 3_000, 2).map(|(remaining, _)| remaining),
             Err("auto_heal_failure_backoff")
         );
         assert_eq!(
-            reserve_auto_heal_attempt(&key, 2_000 + AUTO_HEAL_WINDOW_SECS * 1000, 2),
+            reserve_auto_heal_attempt(&key, 2_000 + AUTO_HEAL_WINDOW_SECS * 1000, 2)
+                .map(|(remaining, _)| remaining),
             Ok(1)
         );
     }

--- a/src/services/discord/relay_recovery_auto_heal_confirm.rs
+++ b/src/services/discord/relay_recovery_auto_heal_confirm.rs
@@ -51,13 +51,11 @@ pub(super) async fn classify_reattach_confirmation(
     }
     let probe_result = match decision.affected.tmux_session.as_deref() {
         Some(tmux_session) if !tmux_session.is_empty() => {
-            confirm_spawned_watcher(
-                shared,
-                decision.channel_id,
-                tmux_session,
-                decision.evidence.last_relay_offset,
-            )
-            .await
+            let baseline_frontier = shared
+                .committed_relay_offset(ChannelId::new(decision.channel_id))
+                .max(decision.evidence.last_relay_offset);
+            confirm_spawned_watcher(shared, decision.channel_id, tmux_session, baseline_frontier)
+                .await
         }
         _ => SpawnedWatcherConfirmation::Failed,
     };
@@ -202,6 +200,70 @@ mod tests {
             SpawnedWatcherConfirmation::Confirmed
         );
         advance.await.expect("heartbeat task");
+    }
+
+    #[tokio::test]
+    async fn channel_frontier_existing_before_probe_is_not_spawn_confirmation() {
+        let shared = make_shared_data_for_tests();
+        let channel = ChannelId::new(4_423_207);
+        let tmux_session = "AgentDesk-codex-4423-frontier-baseline";
+        shared
+            .tmux_relay_coord(channel)
+            .confirmed_end_offset
+            .store(512, Ordering::Release);
+        shared.tmux_watchers.insert(
+            channel,
+            watcher_handle(tmux_session, Arc::new(AtomicI64::new(100))),
+        );
+        let decision = super::super::plan_relay_recovery(
+            &super::super::RelayHealthSnapshot {
+                provider: "codex".to_string(),
+                channel_id: channel.get(),
+                active_turn: super::super::RelayActiveTurn::Foreground,
+                tmux_session: Some(tmux_session.to_string()),
+                tmux_alive: Some(true),
+                watcher_attached: false,
+                watcher_attached_stale: false,
+                watcher_owner_channel_id: None,
+                watcher_owns_live_relay: false,
+                bridge_inflight_present: true,
+                bridge_current_msg_id: Some(4_423_217),
+                mailbox_has_cancel_token: true,
+                mailbox_active_user_msg_id: Some(4_423_227),
+                mailbox_turn_started_at_ms: None,
+                queue_depth: 0,
+                pending_discord_callback_msg_id: None,
+                pending_thread_proof: false,
+                parent_channel_id: None,
+                thread_channel_id: None,
+                last_relay_ts_ms: None,
+                last_outbound_activity_ms: None,
+                last_capture_offset: Some(512),
+                last_relay_offset: 0,
+                unread_bytes: Some(512),
+                desynced: true,
+                stale_thread_proof: false,
+            },
+            super::super::RelayStallState::TmuxAliveRelayDead,
+            1_000,
+        );
+        let apply_result = RelayRecoveryApplyResult {
+            status: "reattached_watcher",
+            removed_thread_proofs: 0,
+            removed_mailbox_token: false,
+            post_mailbox_has_cancel_token: None,
+            post_mailbox_queue_depth: None,
+            reattach_watcher_spawned: Some(true),
+            reattach_watcher_replaced: Some(false),
+            reattach_initial_offset: Some(0),
+            reattach_error: None,
+        };
+
+        assert_ne!(
+            classify_reattach_confirmation(&shared, &decision, &apply_result, 0, 1_000).await,
+            ReattachConfirmation::Confirmed,
+            "frontier committed before this probe must not confirm the spawned watcher"
+        );
     }
 
     #[test]

--- a/src/services/discord/relay_recovery_auto_heal_confirm.rs
+++ b/src/services/discord/relay_recovery_auto_heal_confirm.rs
@@ -24,7 +24,8 @@ pub(super) enum ReattachConfirmation {
 enum SpawnedWatcherConfirmation {
     Confirmed,
     RelayEmissionInFlight,
-    Failed,
+    Unconfirmed,
+    WatcherGone,
 }
 
 #[derive(Clone)]
@@ -57,7 +58,7 @@ pub(super) async fn classify_reattach_confirmation(
             confirm_spawned_watcher(shared, decision.channel_id, tmux_session, baseline_frontier)
                 .await
         }
-        _ => SpawnedWatcherConfirmation::Failed,
+        _ => SpawnedWatcherConfirmation::WatcherGone,
     };
     confirmation_after_probe(probe_result, process_started_at_unix, now_unix)
 }
@@ -72,12 +73,14 @@ fn confirmation_after_probe(
         SpawnedWatcherConfirmation::RelayEmissionInFlight => {
             ReattachConfirmation::RelayEmissionInFlight
         }
-        SpawnedWatcherConfirmation::Failed
+        SpawnedWatcherConfirmation::Unconfirmed
             if startup_confirm_grace_active(process_started_at_unix, now_unix) =>
         {
             ReattachConfirmation::StartupGrace
         }
-        SpawnedWatcherConfirmation::Failed => ReattachConfirmation::Failed,
+        SpawnedWatcherConfirmation::Unconfirmed | SpawnedWatcherConfirmation::WatcherGone => {
+            ReattachConfirmation::Failed
+        }
     }
 }
 
@@ -93,16 +96,20 @@ async fn confirm_spawned_watcher(
 ) -> SpawnedWatcherConfirmation {
     let Some(probe) = spawned_watcher_probe(shared, ChannelId::new(channel_id), tmux_session)
     else {
-        return SpawnedWatcherConfirmation::Failed;
+        return SpawnedWatcherConfirmation::WatcherGone;
     };
     let deadline = Instant::now() + AUTO_HEAL_CONFIRM_TIMEOUT;
     let mut heartbeat_stable_since = None;
     loop {
+        if !spawned_watcher_still_current(shared, &probe) {
+            return SpawnedWatcherConfirmation::WatcherGone;
+        }
+        // The frontier is channel-scoped rather than watcher/episode-scoped. The
+        // current check prevents an already replaced watcher from taking credit,
+        // but another relay actor can still advance it while this watcher remains
+        // current. Exact attribution belongs to #5022.
         if shared.committed_relay_offset(ChannelId::new(channel_id)) > baseline_frontier {
             return SpawnedWatcherConfirmation::Confirmed;
-        }
-        if !spawned_watcher_still_current(shared, &probe) {
-            return SpawnedWatcherConfirmation::Failed;
         }
         if probe.heartbeat.load(Ordering::Acquire) > probe.baseline_heartbeat_ms {
             let stable_since = heartbeat_stable_since.get_or_insert_with(Instant::now);
@@ -122,10 +129,12 @@ fn confirmation_at_deadline(
     channel_id: ChannelId,
     probe: &SpawnedWatcherProbe,
 ) -> SpawnedWatcherConfirmation {
-    if spawned_watcher_still_current(shared, probe) && shared.relay_emission_in_flight(channel_id) {
+    if !spawned_watcher_still_current(shared, probe) {
+        SpawnedWatcherConfirmation::WatcherGone
+    } else if shared.relay_emission_in_flight(channel_id) {
         SpawnedWatcherConfirmation::RelayEmissionInFlight
     } else {
-        SpawnedWatcherConfirmation::Failed
+        SpawnedWatcherConfirmation::Unconfirmed
     }
 }
 
@@ -359,7 +368,7 @@ mod tests {
 
         assert_eq!(
             confirmation_at_deadline(&shared, channel, &probe),
-            SpawnedWatcherConfirmation::Failed
+            SpawnedWatcherConfirmation::Unconfirmed
         );
     }
 
@@ -381,7 +390,12 @@ mod tests {
 
         assert_eq!(
             confirmation_at_deadline(&shared, channel, &probe),
-            SpawnedWatcherConfirmation::Failed
+            SpawnedWatcherConfirmation::WatcherGone
+        );
+        assert_eq!(
+            confirmation_after_probe(SpawnedWatcherConfirmation::WatcherGone, 10_000, 10_001),
+            ReattachConfirmation::Failed,
+            "startup grace must not consume a round after the writer disappeared"
         );
     }
 
@@ -406,7 +420,7 @@ mod tests {
 
         assert_eq!(
             confirmation_at_deadline(&shared, channel, &probe),
-            SpawnedWatcherConfirmation::Failed
+            SpawnedWatcherConfirmation::WatcherGone
         );
     }
 
@@ -415,7 +429,7 @@ mod tests {
         let started_at = 10_000;
         assert_eq!(
             confirmation_after_probe(
-                SpawnedWatcherConfirmation::Failed,
+                SpawnedWatcherConfirmation::Unconfirmed,
                 started_at,
                 started_at + 119
             ),
@@ -423,7 +437,7 @@ mod tests {
         );
         assert_eq!(
             confirmation_after_probe(
-                SpawnedWatcherConfirmation::Failed,
+                SpawnedWatcherConfirmation::Unconfirmed,
                 started_at,
                 started_at + 120
             ),

--- a/src/services/discord/relay_recovery_auto_heal_confirm.rs
+++ b/src/services/discord/relay_recovery_auto_heal_confirm.rs
@@ -45,7 +45,7 @@ pub(super) async fn classify_reattach_confirmation(
     now_unix: i64,
 ) -> ReattachConfirmation {
     if decision.action != super::RelayRecoveryActionKind::ReattachWatcher
-        || apply_result.reattach_watcher_spawned != Some(true)
+        || apply_result.status != "reattached_watcher"
     {
         return ReattachConfirmation::NotRequired;
     }
@@ -222,6 +222,65 @@ mod tests {
         assert_eq!(
             confirmation_at_deadline(&shared, channel, &probe),
             SpawnedWatcherConfirmation::RelayEmissionInFlight
+        );
+    }
+
+    #[tokio::test]
+    async fn relay_recovery_repaired_round_without_spawn_still_requires_probe() {
+        let shared = make_shared_data_for_tests();
+        let channel = ChannelId::new(4_423_206);
+        let tmux_session = "AgentDesk-codex-4423-repaired-reuse";
+        shared.tmux_watchers.insert(
+            channel,
+            watcher_handle(tmux_session, Arc::new(AtomicI64::new(100))),
+        );
+        let decision = super::super::plan_relay_recovery(
+            &super::super::RelayHealthSnapshot {
+                provider: "codex".to_string(),
+                channel_id: channel.get(),
+                active_turn: super::super::RelayActiveTurn::Foreground,
+                tmux_session: Some(tmux_session.to_string()),
+                tmux_alive: Some(true),
+                watcher_attached: false,
+                watcher_attached_stale: false,
+                watcher_owner_channel_id: None,
+                watcher_owns_live_relay: false,
+                bridge_inflight_present: true,
+                bridge_current_msg_id: Some(4_423_216),
+                mailbox_has_cancel_token: true,
+                mailbox_active_user_msg_id: Some(4_423_226),
+                mailbox_turn_started_at_ms: None,
+                queue_depth: 0,
+                pending_discord_callback_msg_id: None,
+                pending_thread_proof: false,
+                parent_channel_id: None,
+                thread_channel_id: None,
+                last_relay_ts_ms: None,
+                last_outbound_activity_ms: None,
+                last_capture_offset: Some(128),
+                last_relay_offset: 0,
+                unread_bytes: Some(128),
+                desynced: true,
+                stale_thread_proof: false,
+            },
+            super::super::RelayStallState::TmuxAliveRelayDead,
+            1_000,
+        );
+        let apply_result = RelayRecoveryApplyResult {
+            status: "reattached_watcher",
+            removed_thread_proofs: 0,
+            removed_mailbox_token: false,
+            post_mailbox_has_cancel_token: None,
+            post_mailbox_queue_depth: None,
+            reattach_watcher_spawned: Some(false),
+            reattach_watcher_replaced: Some(false),
+            reattach_initial_offset: Some(0),
+            reattach_error: None,
+        };
+
+        assert_eq!(
+            classify_reattach_confirmation(&shared, &decision, &apply_result, 0, 200).await,
+            ReattachConfirmation::Failed
         );
     }
 

--- a/src/services/discord/relay_recovery_auto_heal_confirm.rs
+++ b/src/services/discord/relay_recovery_auto_heal_confirm.rs
@@ -101,15 +101,13 @@ async fn confirm_spawned_watcher(
     let deadline = Instant::now() + AUTO_HEAL_CONFIRM_TIMEOUT;
     let mut heartbeat_stable_since = None;
     loop {
-        if !spawned_watcher_still_current(shared, &probe) {
-            return SpawnedWatcherConfirmation::WatcherGone;
-        }
-        // The frontier is channel-scoped rather than watcher/episode-scoped. The
-        // current check prevents an already replaced watcher from taking credit,
-        // but another relay actor can still advance it while this watcher remains
-        // current. Exact attribution belongs to #5022.
-        if shared.committed_relay_offset(ChannelId::new(channel_id)) > baseline_frontier {
-            return SpawnedWatcherConfirmation::Confirmed;
+        if let Some(result) = current_watcher_frontier_confirmation(
+            shared,
+            ChannelId::new(channel_id),
+            &probe,
+            baseline_frontier,
+        ) {
+            return result;
         }
         if probe.heartbeat.load(Ordering::Acquire) > probe.baseline_heartbeat_ms {
             let stable_since = heartbeat_stable_since.get_or_insert_with(Instant::now);
@@ -122,6 +120,23 @@ async fn confirm_spawned_watcher(
         }
         tokio::time::sleep(AUTO_HEAL_CONFIRM_POLL).await;
     }
+}
+
+fn current_watcher_frontier_confirmation(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    probe: &SpawnedWatcherProbe,
+    baseline_frontier: u64,
+) -> Option<SpawnedWatcherConfirmation> {
+    if !spawned_watcher_still_current(shared, probe) {
+        return Some(SpawnedWatcherConfirmation::WatcherGone);
+    }
+    // The frontier is channel-scoped rather than watcher/episode-scoped. The
+    // current check prevents an already replaced watcher from taking credit,
+    // but another relay actor can still advance it while this watcher remains
+    // current. Exact attribution belongs to #5022.
+    (shared.committed_relay_offset(channel_id) > baseline_frontier)
+        .then_some(SpawnedWatcherConfirmation::Confirmed)
 }
 
 fn confirmation_at_deadline(
@@ -373,7 +388,7 @@ mod tests {
     }
 
     #[test]
-    fn relay_recovery_cancelled_watcher_fails_even_with_channel_emission() {
+    fn relay_recovery_cancelled_watcher_fails_even_with_frontier_progress() {
         let shared = make_shared_data_for_tests();
         let channel = ChannelId::new(4_423_204);
         let tmux_session = "AgentDesk-codex-4423-cancelled-emitting";
@@ -385,12 +400,13 @@ mod tests {
         probe.cancel.store(true, Ordering::Release);
         shared
             .tmux_relay_coord(channel)
-            .relay_slot
+            .confirmed_end_offset
             .store(128, Ordering::Release);
 
         assert_eq!(
-            confirmation_at_deadline(&shared, channel, &probe),
-            SpawnedWatcherConfirmation::WatcherGone
+            current_watcher_frontier_confirmation(&shared, channel, &probe, 0),
+            Some(SpawnedWatcherConfirmation::WatcherGone),
+            "current identity must be checked before channel-scoped frontier progress"
         );
         assert_eq!(
             confirmation_after_probe(SpawnedWatcherConfirmation::WatcherGone, 10_000, 10_001),

--- a/src/services/discord/relay_recovery_circuit_breaker.rs
+++ b/src/services/discord/relay_recovery_circuit_breaker.rs
@@ -2,10 +2,10 @@
 //!
 //! The ordinary auto-heal limiter is intentionally process-local and windowed.
 //! That is useful for burst control, but it cannot bound a dead relay frontier
-//! across dcserver restarts or successive windows. This sidecar records a
-//! lifetime budget for one exact inflight episode without writing the inflight
-//! row itself: circuit bookkeeping must not advance `updated_at` or
-//! `save_generation` and masquerade as producer liveness.
+//! across successive windows within one process lifetime. This sidecar records
+//! a budget for one exact inflight episode without writing the inflight row
+//! itself: circuit bookkeeping must not advance `updated_at` or `save_generation`
+//! and masquerade as producer liveness. Crash-orphan recovery is tracked in #5045.
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/services/discord/relay_recovery_circuit_breaker.rs
+++ b/src/services/discord/relay_recovery_circuit_breaker.rs
@@ -24,6 +24,7 @@ pub(super) struct RelayReattachEpisode {
     key: String,
     owner_user_id: u64,
     pin: super::super::inflight::InflightEpisodePin,
+    reservation_generation: Option<u64>,
 }
 
 impl RelayReattachEpisode {
@@ -59,6 +60,7 @@ impl RelayReattachEpisode {
             key: hasher.finalize().to_hex().to_string(),
             owner_user_id: state.request_owner_user_id,
             pin: super::super::inflight::InflightEpisodePin::from_state(state),
+            reservation_generation: None,
         }
     }
 
@@ -291,8 +293,10 @@ fn reserve_in_root(
     if persist_record(&path, &record).is_err() {
         return CircuitReservation::IoError;
     }
+    let mut reserved_episode = expected.clone();
+    reserved_episode.reservation_generation = Some(record.open_generation);
     CircuitReservation::Reserved {
-        episode: expected.clone(),
+        episode: reserved_episode,
         attempt: record.attempts,
         orphaned_staged_alert_ids: record.orphaned_staged_alert_ids.clone(),
     }
@@ -305,15 +309,14 @@ pub(super) fn should_use_durable_circuit(
     action == RelayRecoveryActionKind::ReattachWatcher && source != RelayRecoveryApplySource::Manual
 }
 
-pub(super) fn reserve_current_episode(
+pub(super) fn inspect_current_episode(
     provider: &ProviderKind,
     decision: &RelayRecoveryDecision,
-    max_attempts: u32,
-) -> CircuitReservation {
+) -> Result<RelayReattachEpisode, CircuitReservation> {
     let Some(state) =
         super::super::inflight::load_inflight_state_read_only(provider, decision.channel_id)
     else {
-        return CircuitReservation::MissingInflight;
+        return Err(CircuitReservation::MissingInflight);
     };
     if decision.provider != provider.as_str()
         || decision.affected.provider != provider.as_str()
@@ -323,9 +326,22 @@ pub(super) fn reserve_current_episode(
             && decision.affected.mailbox_active_user_msg_id != Some(state.user_msg_id))
         || decision.affected.tmux_session != state.tmux_session_name
     {
-        return CircuitReservation::StaleIdentity;
+        return Err(CircuitReservation::StaleIdentity);
     }
-    let expected = RelayReattachEpisode::from_state(&state);
+    Ok(RelayReattachEpisode::from_state(&state))
+}
+
+pub(super) fn reserve_inspected_episode(
+    provider: &ProviderKind,
+    decision: &RelayRecoveryDecision,
+    expected: &RelayReattachEpisode,
+    max_attempts: u32,
+) -> CircuitReservation {
+    let Some(state) =
+        super::super::inflight::load_inflight_state_read_only(provider, decision.channel_id)
+    else {
+        return CircuitReservation::MissingInflight;
+    };
     let Some(root) = super::super::runtime_store::runtime_root()
         .map(|root| root.join("discord_relay_recovery_circuit"))
     else {
@@ -334,10 +350,53 @@ pub(super) fn reserve_current_episode(
     reserve_in_root(
         &root,
         &state,
-        &expected,
+        expected,
         decision.evidence.last_relay_offset,
         max_attempts,
     )
+}
+
+pub(super) fn reserve_current_episode(
+    provider: &ProviderKind,
+    decision: &RelayRecoveryDecision,
+    max_attempts: u32,
+) -> CircuitReservation {
+    let expected = match inspect_current_episode(provider, decision) {
+        Ok(expected) => expected,
+        Err(reservation) => return reservation,
+    };
+    reserve_inspected_episode(provider, decision, &expected, max_attempts)
+}
+
+pub(super) fn refund_unhanded_episode_attempt(
+    provider: &ProviderKind,
+    channel_id: u64,
+    episode: &RelayReattachEpisode,
+) -> bool {
+    let Some(generation) = episode.reservation_generation else {
+        return false;
+    };
+    let Some(root) = super::super::runtime_store::runtime_root()
+        .map(|root| root.join("discord_relay_recovery_circuit"))
+    else {
+        return false;
+    };
+    let path = circuit_path(&root, provider, channel_id);
+    let Ok(_lock) = lock_path(&path) else {
+        return false;
+    };
+    let Ok(Some(mut record)) = load_record(&path) else {
+        return false;
+    };
+    if record.version != CIRCUIT_VERSION
+        || record.episode_key != episode.key
+        || record.open_generation != generation
+        || record.attempts == 0
+    {
+        return false;
+    }
+    record.attempts -= 1;
+    persist_record(&path, &record).is_ok()
 }
 
 fn open_alert_cas_in_root(
@@ -909,6 +968,36 @@ mod tests {
         );
         decision.affected.finalizer_turn_id = Some(state.effective_finalizer_turn_id());
         decision
+    }
+
+    #[test]
+    fn unhanded_attempt_refund_prevents_no_watcher_frontier_deadlock() {
+        let temp = tempfile::tempdir().expect("circuit root");
+        let _env = crate::config::set_agentdesk_root_for_test(temp.path());
+        let provider = ProviderKind::Codex;
+        let state = state(44_649);
+        let decision = decision_for_state(&state);
+        super::super::super::inflight::save_inflight_state(&state)
+            .expect("seed authoritative inflight");
+
+        for _ in 0..2 {
+            let expected = inspect_current_episode(&provider, &decision).expect("inspect episode");
+            let CircuitReservation::Reserved { episode, .. } =
+                reserve_inspected_episode(&provider, &decision, &expected, 2)
+            else {
+                panic!("a pre-handoff failure must be allowed to retry")
+            };
+            assert!(
+                refund_unhanded_episode_attempt(&provider, state.channel_id, &episode),
+                "failure before watcher handoff must release the durable spend"
+            );
+        }
+
+        let expected = inspect_current_episode(&provider, &decision).expect("inspect episode");
+        assert!(matches!(
+            reserve_inspected_episode(&provider, &decision, &expected, 2),
+            CircuitReservation::Reserved { attempt: 1, .. }
+        ));
     }
 
     #[test]

--- a/src/services/discord/relay_recovery_circuit_breaker.rs
+++ b/src/services/discord/relay_recovery_circuit_breaker.rs
@@ -420,7 +420,7 @@ fn open_alert_cas_in_root(
     else {
         return false;
     };
-    if RelayReattachEpisode::from_state(&authoritative) != *expected
+    if RelayReattachEpisode::from_state(&authoritative).key() != expected.key()
         || record.version != CIRCUIT_VERSION
         || record.episode_key != open.episode_key
         || record.baseline_relay_offset != open.baseline_relay_offset
@@ -722,8 +722,8 @@ pub(super) async fn queue_or_resume_open_alert_with_enqueue(
         )
         .is_ok_and(|locked_episode| {
             debug_assert_eq!(
-                RelayReattachEpisode::from_state(locked_episode.state()),
-                validate_episode
+                RelayReattachEpisode::from_state(locked_episode.state()).key(),
+                validate_episode.key()
             );
             open_alert_cas_in_root(
                 &validate_root,

--- a/src/services/discord/relay_recovery_circuit_breaker.rs
+++ b/src/services/discord/relay_recovery_circuit_breaker.rs
@@ -25,7 +25,6 @@ pub(super) struct RelayReattachEpisode {
     owner_user_id: u64,
     pin: super::super::inflight::InflightEpisodePin,
     reservation_generation: Option<u64>,
-    reserved_process_generation: Option<u64>,
 }
 
 impl RelayReattachEpisode {
@@ -62,7 +61,6 @@ impl RelayReattachEpisode {
             owner_user_id: state.request_owner_user_id,
             pin: super::super::inflight::InflightEpisodePin::from_state(state),
             reservation_generation: None,
-            reserved_process_generation: None,
         }
     }
 
@@ -138,11 +136,6 @@ struct CircuitRecord {
     orphaned_staged_alert_ids: Vec<i64>,
     #[serde(default)]
     open_generation: u64,
-    /// Process generation that reserved the newest pre-handoff attempt. Zero
-    /// means handed off/settled or legacy data. A later process may reclaim one
-    /// nonzero stale receipt before applying the durable limit.
-    #[serde(default)]
-    unhanded_process_generation: u64,
 }
 
 struct CircuitFileLock {
@@ -214,24 +207,6 @@ fn reserve_in_root(
     observed_relay_offset: u64,
     max_attempts: u32,
 ) -> CircuitReservation {
-    reserve_in_root_for_process_generation(
-        root,
-        snapshot,
-        expected,
-        observed_relay_offset,
-        max_attempts,
-        super::super::runtime_store::process_generation(),
-    )
-}
-
-fn reserve_in_root_for_process_generation(
-    root: &Path,
-    snapshot: &super::super::inflight::InflightTurnState,
-    expected: &RelayReattachEpisode,
-    observed_relay_offset: u64,
-    max_attempts: u32,
-    current_process_generation: u64,
-) -> CircuitReservation {
     let current = RelayReattachEpisode::from_state(snapshot);
     if &current != expected {
         return CircuitReservation::StaleIdentity;
@@ -273,24 +248,11 @@ fn reserve_in_root_for_process_generation(
             staged_alert_id: None,
             orphaned_staged_alert_ids: Vec::new(),
             open_generation: 1,
-            unhanded_process_generation: 0,
         },
         Err(_) => return CircuitReservation::IoError,
     };
     if record.version != CIRCUIT_VERSION {
         return CircuitReservation::IoError;
-    }
-    // A receipt owned by an older dcserver generation can only be a
-    // reservation whose stack disappeared before watcher handoff. Reclaim it
-    // under the circuit flock before testing the lifetime cap. The receipt is
-    // cleared at the handoff boundary; crash after handoff intentionally spends.
-    if current_process_generation != 0
-        && record.episode_key == expected.key
-        && record.unhanded_process_generation != 0
-        && record.unhanded_process_generation != current_process_generation
-    {
-        record.attempts = record.attempts.saturating_sub(1);
-        record.unhanded_process_generation = 0;
     }
     if record.episode_key != expected.key {
         if let Some(id) = record.staged_alert_id.take()
@@ -303,7 +265,6 @@ fn reserve_in_root_for_process_generation(
         record.attempts = 0;
         record.alert_queued = false;
         record.open_generation = 1;
-        record.unhanded_process_generation = 0;
     } else if frontier > record.baseline_relay_offset {
         if let Some(id) = record.staged_alert_id.take()
             && !record.orphaned_staged_alert_ids.contains(&id)
@@ -314,7 +275,6 @@ fn reserve_in_root_for_process_generation(
         record.attempts = 0;
         record.alert_queued = false;
         record.open_generation = record.open_generation.saturating_add(1).max(1);
-        record.unhanded_process_generation = 0;
     } else if record.open_generation == 0 {
         record.open_generation = 1;
     }
@@ -330,13 +290,11 @@ fn reserve_in_root_for_process_generation(
         };
     }
     record.attempts = record.attempts.saturating_add(1);
-    record.unhanded_process_generation = current_process_generation;
     if persist_record(&path, &record).is_err() {
         return CircuitReservation::IoError;
     }
     let mut reserved_episode = expected.clone();
     reserved_episode.reservation_generation = Some(record.open_generation);
-    reserved_episode.reserved_process_generation = Some(current_process_generation);
     CircuitReservation::Reserved {
         episode: reserved_episode,
         attempt: record.attempts,
@@ -410,32 +368,12 @@ pub(super) fn reserve_current_episode(
     reserve_inspected_episode(provider, decision, &expected, max_attempts)
 }
 
-pub(super) fn mark_episode_attempt_handed_off(
-    provider: &ProviderKind,
-    channel_id: u64,
-    episode: &RelayReattachEpisode,
-) -> bool {
-    settle_unhanded_episode_attempt(provider, channel_id, episode, false)
-}
-
 pub(super) fn refund_unhanded_episode_attempt(
     provider: &ProviderKind,
     channel_id: u64,
     episode: &RelayReattachEpisode,
 ) -> bool {
-    settle_unhanded_episode_attempt(provider, channel_id, episode, true)
-}
-
-fn settle_unhanded_episode_attempt(
-    provider: &ProviderKind,
-    channel_id: u64,
-    episode: &RelayReattachEpisode,
-    refund: bool,
-) -> bool {
-    let (Some(generation), Some(process_generation)) = (
-        episode.reservation_generation,
-        episode.reserved_process_generation,
-    ) else {
+    let Some(generation) = episode.reservation_generation else {
         return false;
     };
     let Some(root) = super::super::runtime_store::runtime_root()
@@ -453,15 +391,11 @@ fn settle_unhanded_episode_attempt(
     if record.version != CIRCUIT_VERSION
         || record.episode_key != episode.key
         || record.open_generation != generation
-        || record.unhanded_process_generation != process_generation
         || record.attempts == 0
     {
         return false;
     }
-    if refund {
-        record.attempts -= 1;
-    }
-    record.unhanded_process_generation = 0;
+    record.attempts -= 1;
     persist_record(&path, &record).is_ok()
 }
 
@@ -486,7 +420,7 @@ fn open_alert_cas_in_root(
     else {
         return false;
     };
-    if RelayReattachEpisode::from_state(&authoritative).key() != expected.key()
+    if RelayReattachEpisode::from_state(&authoritative) != *expected
         || record.version != CIRCUIT_VERSION
         || record.episode_key != open.episode_key
         || record.baseline_relay_offset != open.baseline_relay_offset
@@ -788,8 +722,8 @@ pub(super) async fn queue_or_resume_open_alert_with_enqueue(
         )
         .is_ok_and(|locked_episode| {
             debug_assert_eq!(
-                RelayReattachEpisode::from_state(locked_episode.state()).key(),
-                validate_episode.key()
+                RelayReattachEpisode::from_state(locked_episode.state()),
+                validate_episode
             );
             open_alert_cas_in_root(
                 &validate_root,
@@ -1037,7 +971,7 @@ mod tests {
     }
 
     #[test]
-    fn same_process_unhanded_attempt_refund_restores_budget() {
+    fn unhanded_attempt_refund_prevents_no_watcher_frontier_deadlock() {
         let temp = tempfile::tempdir().expect("circuit root");
         let _env = crate::config::set_agentdesk_root_for_test(temp.path());
         let provider = ProviderKind::Codex;
@@ -1063,87 +997,6 @@ mod tests {
         assert!(matches!(
             reserve_inspected_episode(&provider, &decision, &expected, 2),
             CircuitReservation::Reserved { attempt: 1, .. }
-        ));
-    }
-
-    #[test]
-    fn crashed_pre_handoff_receipt_is_reclaimed_by_next_process() {
-        let temp = tempfile::tempdir().expect("circuit root");
-        let _env = crate::config::set_agentdesk_root_for_test(temp.path());
-        let provider = ProviderKind::Codex;
-        let state = state(44_648);
-        let decision = decision_for_state(&state);
-        super::super::super::inflight::save_inflight_state(&state)
-            .expect("seed authoritative inflight");
-
-        let expected = inspect_current_episode(&provider, &decision).expect("inspect episode");
-        assert!(matches!(
-            reserve_in_root_for_process_generation(
-                temp.path(),
-                &state,
-                &expected,
-                decision.evidence.last_relay_offset,
-                1,
-                41,
-            ),
-            CircuitReservation::Reserved { attempt: 1, .. }
-        ));
-
-        let expected =
-            inspect_current_episode(&provider, &decision).expect("inspect after restart");
-        assert!(matches!(
-            reserve_in_root_for_process_generation(
-                temp.path(),
-                &state,
-                &expected,
-                decision.evidence.last_relay_offset,
-                1,
-                42,
-            ),
-            CircuitReservation::Reserved { attempt: 1, .. }
-        ));
-    }
-
-    #[test]
-    fn handed_off_attempt_survives_restart_until_frontier_progress() {
-        let temp = tempfile::tempdir().expect("circuit root");
-        let _env = crate::config::set_agentdesk_root_for_test(temp.path());
-        let provider = ProviderKind::Codex;
-        let state = state(44_647);
-        let decision = decision_for_state(&state);
-        super::super::super::inflight::save_inflight_state(&state)
-            .expect("seed authoritative inflight");
-
-        let expected = inspect_current_episode(&provider, &decision).expect("inspect episode");
-        let CircuitReservation::Reserved { episode, .. } = reserve_in_root_for_process_generation(
-            temp.path(),
-            &state,
-            &expected,
-            decision.evidence.last_relay_offset,
-            1,
-            51,
-        ) else {
-            panic!("reserve handed-off attempt")
-        };
-        let record_path = circuit_path(temp.path(), &provider, state.channel_id);
-        let mut record = load_record(&record_path)
-            .expect("load handed-off receipt")
-            .expect("handed-off receipt");
-        assert_eq!(record.unhanded_process_generation, 51);
-        record.unhanded_process_generation = 0;
-        persist_record(&record_path, &record).expect("mark receipt handed off");
-        let expected =
-            inspect_current_episode(&provider, &decision).expect("inspect after restart");
-        assert!(matches!(
-            reserve_in_root_for_process_generation(
-                temp.path(),
-                &state,
-                &expected,
-                decision.evidence.last_relay_offset,
-                1,
-                52,
-            ),
-            CircuitReservation::Open { .. }
         ));
     }
 
@@ -1590,11 +1443,6 @@ mod tests {
         else {
             panic!("first attempt must reserve");
         };
-        assert!(mark_episode_attempt_handed_off(
-            &provider,
-            channel.get(),
-            &episode
-        ));
         let circuit_root = super::super::super::runtime_store::runtime_root()
             .expect("runtime root")
             .join("discord_relay_recovery_circuit");

--- a/src/services/discord/relay_recovery_circuit_breaker.rs
+++ b/src/services/discord/relay_recovery_circuit_breaker.rs
@@ -214,6 +214,24 @@ fn reserve_in_root(
     observed_relay_offset: u64,
     max_attempts: u32,
 ) -> CircuitReservation {
+    reserve_in_root_for_process_generation(
+        root,
+        snapshot,
+        expected,
+        observed_relay_offset,
+        max_attempts,
+        super::super::runtime_store::process_generation(),
+    )
+}
+
+fn reserve_in_root_for_process_generation(
+    root: &Path,
+    snapshot: &super::super::inflight::InflightTurnState,
+    expected: &RelayReattachEpisode,
+    observed_relay_offset: u64,
+    max_attempts: u32,
+    current_process_generation: u64,
+) -> CircuitReservation {
     let current = RelayReattachEpisode::from_state(snapshot);
     if &current != expected {
         return CircuitReservation::StaleIdentity;
@@ -262,12 +280,12 @@ fn reserve_in_root(
     if record.version != CIRCUIT_VERSION {
         return CircuitReservation::IoError;
     }
-    let current_process_generation = super::super::runtime_store::process_generation();
-    // A nonzero receipt owned by an older dcserver generation can only be a
+    // A receipt owned by an older dcserver generation can only be a
     // reservation whose stack disappeared before watcher handoff. Reclaim it
     // under the circuit flock before testing the lifetime cap. The receipt is
     // cleared at the handoff boundary; crash after handoff intentionally spends.
-    if record.episode_key == expected.key
+    if current_process_generation != 0
+        && record.episode_key == expected.key
         && record.unhanded_process_generation != 0
         && record.unhanded_process_generation != current_process_generation
     {
@@ -468,7 +486,7 @@ fn open_alert_cas_in_root(
     else {
         return false;
     };
-    if RelayReattachEpisode::from_state(&authoritative) != *expected
+    if RelayReattachEpisode::from_state(&authoritative).key() != expected.key()
         || record.version != CIRCUIT_VERSION
         || record.episode_key != open.episode_key
         || record.baseline_relay_offset != open.baseline_relay_offset
@@ -770,8 +788,8 @@ pub(super) async fn queue_or_resume_open_alert_with_enqueue(
         )
         .is_ok_and(|locked_episode| {
             debug_assert_eq!(
-                RelayReattachEpisode::from_state(locked_episode.state()),
-                validate_episode
+                RelayReattachEpisode::from_state(locked_episode.state()).key(),
+                validate_episode.key()
             );
             open_alert_cas_in_root(
                 &validate_root,
@@ -1052,7 +1070,6 @@ mod tests {
     fn crashed_pre_handoff_receipt_is_reclaimed_by_next_process() {
         let temp = tempfile::tempdir().expect("circuit root");
         let _env = crate::config::set_agentdesk_root_for_test(temp.path());
-        super::super::super::runtime_store::set_process_generation_for_tests(Some(41));
         let provider = ProviderKind::Codex;
         let state = state(44_648);
         let decision = decision_for_state(&state);
@@ -1061,25 +1078,36 @@ mod tests {
 
         let expected = inspect_current_episode(&provider, &decision).expect("inspect episode");
         assert!(matches!(
-            reserve_inspected_episode(&provider, &decision, &expected, 1),
+            reserve_in_root_for_process_generation(
+                temp.path(),
+                &state,
+                &expected,
+                decision.evidence.last_relay_offset,
+                1,
+                41,
+            ),
             CircuitReservation::Reserved { attempt: 1, .. }
         ));
-        super::super::super::runtime_store::set_process_generation_for_tests(Some(42));
 
         let expected =
             inspect_current_episode(&provider, &decision).expect("inspect after restart");
         assert!(matches!(
-            reserve_inspected_episode(&provider, &decision, &expected, 1),
+            reserve_in_root_for_process_generation(
+                temp.path(),
+                &state,
+                &expected,
+                decision.evidence.last_relay_offset,
+                1,
+                42,
+            ),
             CircuitReservation::Reserved { attempt: 1, .. }
         ));
-        super::super::super::runtime_store::set_process_generation_for_tests(None);
     }
 
     #[test]
     fn handed_off_attempt_survives_restart_until_frontier_progress() {
         let temp = tempfile::tempdir().expect("circuit root");
         let _env = crate::config::set_agentdesk_root_for_test(temp.path());
-        super::super::super::runtime_store::set_process_generation_for_tests(Some(51));
         let provider = ProviderKind::Codex;
         let state = state(44_647);
         let decision = decision_for_state(&state);
@@ -1087,25 +1115,36 @@ mod tests {
             .expect("seed authoritative inflight");
 
         let expected = inspect_current_episode(&provider, &decision).expect("inspect episode");
-        let CircuitReservation::Reserved { episode, .. } =
-            reserve_inspected_episode(&provider, &decision, &expected, 1)
-        else {
+        let CircuitReservation::Reserved { episode, .. } = reserve_in_root_for_process_generation(
+            temp.path(),
+            &state,
+            &expected,
+            decision.evidence.last_relay_offset,
+            1,
+            51,
+        ) else {
             panic!("reserve handed-off attempt")
         };
-        assert!(mark_episode_attempt_handed_off(
-            &provider,
-            state.channel_id,
-            &episode
-        ));
-        super::super::super::runtime_store::set_process_generation_for_tests(Some(52));
-
+        let record_path = circuit_path(temp.path(), &provider, state.channel_id);
+        let mut record = load_record(&record_path)
+            .expect("load handed-off receipt")
+            .expect("handed-off receipt");
+        assert_eq!(record.unhanded_process_generation, 51);
+        record.unhanded_process_generation = 0;
+        persist_record(&record_path, &record).expect("mark receipt handed off");
         let expected =
             inspect_current_episode(&provider, &decision).expect("inspect after restart");
         assert!(matches!(
-            reserve_inspected_episode(&provider, &decision, &expected, 1),
+            reserve_in_root_for_process_generation(
+                temp.path(),
+                &state,
+                &expected,
+                decision.evidence.last_relay_offset,
+                1,
+                52,
+            ),
             CircuitReservation::Open { .. }
         ));
-        super::super::super::runtime_store::set_process_generation_for_tests(None);
     }
 
     #[test]
@@ -1551,6 +1590,11 @@ mod tests {
         else {
             panic!("first attempt must reserve");
         };
+        assert!(mark_episode_attempt_handed_off(
+            &provider,
+            channel.get(),
+            &episode
+        ));
         let circuit_root = super::super::super::runtime_store::runtime_root()
             .expect("runtime root")
             .join("discord_relay_recovery_circuit");

--- a/src/services/discord/relay_recovery_circuit_breaker.rs
+++ b/src/services/discord/relay_recovery_circuit_breaker.rs
@@ -25,6 +25,7 @@ pub(super) struct RelayReattachEpisode {
     owner_user_id: u64,
     pin: super::super::inflight::InflightEpisodePin,
     reservation_generation: Option<u64>,
+    reserved_process_generation: Option<u64>,
 }
 
 impl RelayReattachEpisode {
@@ -61,6 +62,7 @@ impl RelayReattachEpisode {
             owner_user_id: state.request_owner_user_id,
             pin: super::super::inflight::InflightEpisodePin::from_state(state),
             reservation_generation: None,
+            reserved_process_generation: None,
         }
     }
 
@@ -136,6 +138,11 @@ struct CircuitRecord {
     orphaned_staged_alert_ids: Vec<i64>,
     #[serde(default)]
     open_generation: u64,
+    /// Process generation that reserved the newest pre-handoff attempt. Zero
+    /// means handed off/settled or legacy data. A later process may reclaim one
+    /// nonzero stale receipt before applying the durable limit.
+    #[serde(default)]
+    unhanded_process_generation: u64,
 }
 
 struct CircuitFileLock {
@@ -248,11 +255,24 @@ fn reserve_in_root(
             staged_alert_id: None,
             orphaned_staged_alert_ids: Vec::new(),
             open_generation: 1,
+            unhanded_process_generation: 0,
         },
         Err(_) => return CircuitReservation::IoError,
     };
     if record.version != CIRCUIT_VERSION {
         return CircuitReservation::IoError;
+    }
+    let current_process_generation = super::super::runtime_store::process_generation();
+    // A nonzero receipt owned by an older dcserver generation can only be a
+    // reservation whose stack disappeared before watcher handoff. Reclaim it
+    // under the circuit flock before testing the lifetime cap. The receipt is
+    // cleared at the handoff boundary; crash after handoff intentionally spends.
+    if record.episode_key == expected.key
+        && record.unhanded_process_generation != 0
+        && record.unhanded_process_generation != current_process_generation
+    {
+        record.attempts = record.attempts.saturating_sub(1);
+        record.unhanded_process_generation = 0;
     }
     if record.episode_key != expected.key {
         if let Some(id) = record.staged_alert_id.take()
@@ -265,6 +285,7 @@ fn reserve_in_root(
         record.attempts = 0;
         record.alert_queued = false;
         record.open_generation = 1;
+        record.unhanded_process_generation = 0;
     } else if frontier > record.baseline_relay_offset {
         if let Some(id) = record.staged_alert_id.take()
             && !record.orphaned_staged_alert_ids.contains(&id)
@@ -275,6 +296,7 @@ fn reserve_in_root(
         record.attempts = 0;
         record.alert_queued = false;
         record.open_generation = record.open_generation.saturating_add(1).max(1);
+        record.unhanded_process_generation = 0;
     } else if record.open_generation == 0 {
         record.open_generation = 1;
     }
@@ -290,11 +312,13 @@ fn reserve_in_root(
         };
     }
     record.attempts = record.attempts.saturating_add(1);
+    record.unhanded_process_generation = current_process_generation;
     if persist_record(&path, &record).is_err() {
         return CircuitReservation::IoError;
     }
     let mut reserved_episode = expected.clone();
     reserved_episode.reservation_generation = Some(record.open_generation);
+    reserved_episode.reserved_process_generation = Some(current_process_generation);
     CircuitReservation::Reserved {
         episode: reserved_episode,
         attempt: record.attempts,
@@ -368,12 +392,32 @@ pub(super) fn reserve_current_episode(
     reserve_inspected_episode(provider, decision, &expected, max_attempts)
 }
 
+pub(super) fn mark_episode_attempt_handed_off(
+    provider: &ProviderKind,
+    channel_id: u64,
+    episode: &RelayReattachEpisode,
+) -> bool {
+    settle_unhanded_episode_attempt(provider, channel_id, episode, false)
+}
+
 pub(super) fn refund_unhanded_episode_attempt(
     provider: &ProviderKind,
     channel_id: u64,
     episode: &RelayReattachEpisode,
 ) -> bool {
-    let Some(generation) = episode.reservation_generation else {
+    settle_unhanded_episode_attempt(provider, channel_id, episode, true)
+}
+
+fn settle_unhanded_episode_attempt(
+    provider: &ProviderKind,
+    channel_id: u64,
+    episode: &RelayReattachEpisode,
+    refund: bool,
+) -> bool {
+    let (Some(generation), Some(process_generation)) = (
+        episode.reservation_generation,
+        episode.reserved_process_generation,
+    ) else {
         return false;
     };
     let Some(root) = super::super::runtime_store::runtime_root()
@@ -391,11 +435,15 @@ pub(super) fn refund_unhanded_episode_attempt(
     if record.version != CIRCUIT_VERSION
         || record.episode_key != episode.key
         || record.open_generation != generation
+        || record.unhanded_process_generation != process_generation
         || record.attempts == 0
     {
         return false;
     }
-    record.attempts -= 1;
+    if refund {
+        record.attempts -= 1;
+    }
+    record.unhanded_process_generation = 0;
     persist_record(&path, &record).is_ok()
 }
 
@@ -971,7 +1019,7 @@ mod tests {
     }
 
     #[test]
-    fn unhanded_attempt_refund_prevents_no_watcher_frontier_deadlock() {
+    fn same_process_unhanded_attempt_refund_restores_budget() {
         let temp = tempfile::tempdir().expect("circuit root");
         let _env = crate::config::set_agentdesk_root_for_test(temp.path());
         let provider = ProviderKind::Codex;
@@ -998,6 +1046,66 @@ mod tests {
             reserve_inspected_episode(&provider, &decision, &expected, 2),
             CircuitReservation::Reserved { attempt: 1, .. }
         ));
+    }
+
+    #[test]
+    fn crashed_pre_handoff_receipt_is_reclaimed_by_next_process() {
+        let temp = tempfile::tempdir().expect("circuit root");
+        let _env = crate::config::set_agentdesk_root_for_test(temp.path());
+        super::super::super::runtime_store::set_process_generation_for_tests(Some(41));
+        let provider = ProviderKind::Codex;
+        let state = state(44_648);
+        let decision = decision_for_state(&state);
+        super::super::super::inflight::save_inflight_state(&state)
+            .expect("seed authoritative inflight");
+
+        let expected = inspect_current_episode(&provider, &decision).expect("inspect episode");
+        assert!(matches!(
+            reserve_inspected_episode(&provider, &decision, &expected, 1),
+            CircuitReservation::Reserved { attempt: 1, .. }
+        ));
+        super::super::super::runtime_store::set_process_generation_for_tests(Some(42));
+
+        let expected =
+            inspect_current_episode(&provider, &decision).expect("inspect after restart");
+        assert!(matches!(
+            reserve_inspected_episode(&provider, &decision, &expected, 1),
+            CircuitReservation::Reserved { attempt: 1, .. }
+        ));
+        super::super::super::runtime_store::set_process_generation_for_tests(None);
+    }
+
+    #[test]
+    fn handed_off_attempt_survives_restart_until_frontier_progress() {
+        let temp = tempfile::tempdir().expect("circuit root");
+        let _env = crate::config::set_agentdesk_root_for_test(temp.path());
+        super::super::super::runtime_store::set_process_generation_for_tests(Some(51));
+        let provider = ProviderKind::Codex;
+        let state = state(44_647);
+        let decision = decision_for_state(&state);
+        super::super::super::inflight::save_inflight_state(&state)
+            .expect("seed authoritative inflight");
+
+        let expected = inspect_current_episode(&provider, &decision).expect("inspect episode");
+        let CircuitReservation::Reserved { episode, .. } =
+            reserve_inspected_episode(&provider, &decision, &expected, 1)
+        else {
+            panic!("reserve handed-off attempt")
+        };
+        assert!(mark_episode_attempt_handed_off(
+            &provider,
+            state.channel_id,
+            &episode
+        ));
+        super::super::super::runtime_store::set_process_generation_for_tests(Some(52));
+
+        let expected =
+            inspect_current_episode(&provider, &decision).expect("inspect after restart");
+        assert!(matches!(
+            reserve_inspected_episode(&provider, &decision, &expected, 1),
+            CircuitReservation::Open { .. }
+        ));
+        super::super::super::runtime_store::set_process_generation_for_tests(None);
     }
 
     #[test]

--- a/src/services/discord/relay_recovery_reattach_apply.rs
+++ b/src/services/discord/relay_recovery_reattach_apply.rs
@@ -23,7 +23,7 @@ pub(super) async fn apply_rebind(
         .await
     {
         Some(Ok(outcome)) => RelayRecoveryApplyResult {
-            status: reattach_apply_status(outcome.watcher_spawned),
+            status: reattach_apply_status(outcome.repaired_state),
             removed_thread_proofs: 0,
             removed_mailbox_token: false,
             post_mailbox_has_cancel_token: None,

--- a/src/services/discord/tui_prompt_relay/synthetic_start.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start.rs
@@ -1192,7 +1192,8 @@ mod tests {
                 crate::services::discord::recovery::reregister_active_turn_from_inflight(
                     &shared, &pre,
                 )
-                .await;
+                .await
+                .finish_mailbox_on_completion;
             assert!(readopted, "{label}: restart must re-adopt the live turn");
 
             // Transition #1: the REAL user owns the mailbox post-restart.
@@ -1302,7 +1303,8 @@ mod tests {
         inflight::save_inflight_state(&pre).expect("seed pre-restart inflight");
         let readopted =
             crate::services::discord::recovery::reregister_active_turn_from_inflight(&shared, &pre)
-                .await;
+                .await
+                .finish_mailbox_on_completion;
         assert!(readopted, "restart must re-adopt the live turn");
         shared.restart.global_active.store(1, Ordering::Relaxed);
         // Capture the mailbox cancel token the re-adopt bound, to prove the reclaim

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -183,10 +183,12 @@ fn ledger_has_live_watcher_pending(
     ledger: &HashMap<LedgerKey, LedgerEntry>,
     channel_id: ChannelId,
     generation: u64,
+    user_msg_id: Option<u64>,
 ) -> bool {
     ledger.iter().any(|(lk, entry)| {
         lk.channel_id == channel_id
             && lk.generation == generation
+            && user_msg_id.is_none_or(|expected| lk.user_msg_id == expected)
             && entry.phase != Phase::Finalized
             && entry.relay_owner == RelayOwnerKind::Watcher
     })
@@ -567,6 +569,27 @@ impl TurnFinalizer {
             .send(FinalizeMsg::QueryWatcherPending {
                 channel_id,
                 generation,
+                user_msg_id: None,
+                ack,
+            })
+            .is_err()
+        {
+            return false;
+        }
+        rx.await.unwrap_or(false)
+    }
+
+    pub(in crate::services::discord) async fn has_exact_live_watcher_pending(
+        &self,
+        key: TurnKey,
+    ) -> bool {
+        let (ack, rx) = oneshot::channel();
+        if self
+            .tx
+            .send(FinalizeMsg::QueryWatcherPending {
+                channel_id: key.channel_id,
+                generation: key.generation,
+                user_msg_id: Some(key.user_msg_id),
                 ack,
             })
             .is_err()
@@ -798,10 +821,15 @@ async fn actor_loop(mut rx: mpsc::UnboundedReceiver<FinalizeMsg>) {
                     FinalizeMsg::QueryWatcherPending {
                         channel_id,
                         generation,
+                        user_msg_id,
                         ack,
                     } => {
-                        let pending =
-                            ledger_has_live_watcher_pending(&ledger, channel_id, generation);
+                        let pending = ledger_has_live_watcher_pending(
+                            &ledger,
+                            channel_id,
+                            generation,
+                            user_msg_id,
+                        );
                         let _ = ack.send(pending);
                     }
                 }

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -181,14 +181,13 @@ pub(super) fn resolve_ledger_key(
 /// (wired into the `bridge_handoff_finds_watcher_handle` invariant).
 fn ledger_has_live_watcher_pending(
     ledger: &HashMap<LedgerKey, LedgerEntry>,
-    channel_id: ChannelId,
-    generation: u64,
-    user_msg_id: Option<u64>,
+    key: TurnKey,
+    exact: bool,
 ) -> bool {
     ledger.iter().any(|(lk, entry)| {
-        lk.channel_id == channel_id
-            && lk.generation == generation
-            && user_msg_id.is_none_or(|expected| lk.user_msg_id == expected)
+        lk.channel_id == key.channel_id
+            && lk.generation == key.generation
+            && (!exact || lk.user_msg_id == key.user_msg_id)
             && entry.phase != Phase::Finalized
             && entry.relay_owner == RelayOwnerKind::Watcher
     })
@@ -563,35 +562,22 @@ impl TurnFinalizer {
         channel_id: ChannelId,
         generation: u64,
     ) -> bool {
-        let (ack, rx) = oneshot::channel();
-        if self
-            .tx
-            .send(FinalizeMsg::QueryWatcherPending {
-                channel_id,
-                generation,
-                user_msg_id: None,
-                ack,
-            })
-            .is_err()
-        {
-            return false;
-        }
-        rx.await.unwrap_or(false)
+        self.query_live_watcher_pending(TurnKey::new(channel_id, 0, generation), false)
+            .await
     }
 
     pub(in crate::services::discord) async fn has_exact_live_watcher_pending(
         &self,
         key: TurnKey,
     ) -> bool {
+        self.query_live_watcher_pending(key, true).await
+    }
+
+    async fn query_live_watcher_pending(&self, key: TurnKey, exact: bool) -> bool {
         let (ack, rx) = oneshot::channel();
         if self
             .tx
-            .send(FinalizeMsg::QueryWatcherPending {
-                channel_id: key.channel_id,
-                generation: key.generation,
-                user_msg_id: Some(key.user_msg_id),
-                ack,
-            })
+            .send(FinalizeMsg::QueryWatcherPending { key, exact, ack })
             .is_err()
         {
             return false;
@@ -818,19 +804,8 @@ async fn actor_loop(mut rx: mpsc::UnboundedReceiver<FinalizeMsg>) {
                         let _ = ack.send(released);
                     }
                     // #3016 S1: pure read of the actor-owned ledger — no mutation.
-                    FinalizeMsg::QueryWatcherPending {
-                        channel_id,
-                        generation,
-                        user_msg_id,
-                        ack,
-                    } => {
-                        let pending = ledger_has_live_watcher_pending(
-                            &ledger,
-                            channel_id,
-                            generation,
-                            user_msg_id,
-                        );
-                        let _ = ack.send(pending);
+                    FinalizeMsg::QueryWatcherPending { key, exact, ack } => {
+                        let _ = ack.send(ledger_has_live_watcher_pending(&ledger, key, exact));
                     }
                 }
             }

--- a/src/services/discord/turn_finalizer/actor_state.rs
+++ b/src/services/discord/turn_finalizer/actor_state.rs
@@ -92,9 +92,8 @@ pub(super) enum FinalizeMsg {
         ack: oneshot::Sender<bool>,
     },
     QueryWatcherPending {
-        channel_id: ChannelId,
-        generation: u64,
-        user_msg_id: Option<u64>,
+        key: TurnKey,
+        exact: bool,
         ack: oneshot::Sender<bool>,
     },
 }

--- a/src/services/discord/turn_finalizer/actor_state.rs
+++ b/src/services/discord/turn_finalizer/actor_state.rs
@@ -94,6 +94,7 @@ pub(super) enum FinalizeMsg {
     QueryWatcherPending {
         channel_id: ChannelId,
         generation: u64,
+        user_msg_id: Option<u64>,
         ack: oneshot::Sender<bool>,
     },
 }

--- a/src/services/discord/watchers/lifecycle/restore.rs
+++ b/src/services/discord/watchers/lifecycle/restore.rs
@@ -485,7 +485,8 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
                     super::super::super::recovery::reregister_active_turn_from_inflight(
                         &shared, &state,
                     )
-                    .await;
+                    .await
+                    .finish_mailbox_on_completion;
                 restored_turn = Some(RestoredWatcherTurn {
                     finish_mailbox_on_completion,
                     ..restored_tmux

--- a/src/services/tui_prompt_dedupe/runtime_binding.rs
+++ b/src/services/tui_prompt_dedupe/runtime_binding.rs
@@ -123,7 +123,6 @@ pub(crate) fn register_rehydrated_tmux_runtime_binding(
         tmux_session_name,
         channel_id,
         binding,
-        false,
     );
 }
 
@@ -133,21 +132,14 @@ pub(crate) fn merge_rehydrated_tmux_runtime_binding(
     channel_id: u64,
     binding: TuiRuntimeBinding,
 ) -> Option<(Option<TuiRuntimeBinding>, TuiRuntimeBinding, Option<u64>)> {
-    register_rehydrated_tmux_runtime_binding_inner(
-        provider,
-        tmux_session_name,
-        channel_id,
-        binding,
-        true,
-    )
+    register_rehydrated_tmux_runtime_binding_inner(provider, tmux_session_name, channel_id, binding)
 }
 
 fn register_rehydrated_tmux_runtime_binding_inner(
     provider: &str,
     tmux_session_name: &str,
     channel_id: u64,
-    mut binding: TuiRuntimeBinding,
-    preserve_same_path_cursor: bool,
+    binding: TuiRuntimeBinding,
 ) -> Option<(Option<TuiRuntimeBinding>, TuiRuntimeBinding, Option<u64>)> {
     let provider = normalize_provider(provider);
     let tmux_session_name = tmux_session_name.trim();
@@ -169,17 +161,6 @@ fn register_rehydrated_tmux_runtime_binding_inner(
         .channel_by_tmux
         .get(tmux_session_name)
         .map(|entry| entry.value);
-    // Rehydration may race a live reader that advances the same transcript
-    // cursor after recovery sampled it. Merge under the registry lock so a
-    // stale whole-binding insert cannot move that cursor backwards. A changed
-    // output path is a new transcript and deliberately keeps its supplied
-    // restart offset (including zero after truncate/recreate).
-    if preserve_same_path_cursor
-        && let Some(previous) = state.runtime_by_tmux.get(tmux_session_name)
-        && previous.value.output_path == binding.output_path
-    {
-        binding.last_offset = binding.last_offset.max(previous.value.last_offset);
-    }
     let session_id = binding.session_id.clone();
     let installed_binding = binding.clone();
     state.runtime_by_tmux.insert(

--- a/src/services/tui_prompt_dedupe/runtime_binding.rs
+++ b/src/services/tui_prompt_dedupe/runtime_binding.rs
@@ -118,6 +118,37 @@ pub(crate) fn register_rehydrated_tmux_runtime_binding(
     channel_id: u64,
     binding: TuiRuntimeBinding,
 ) {
+    let _ = register_rehydrated_tmux_runtime_binding_inner(
+        provider,
+        tmux_session_name,
+        channel_id,
+        binding,
+        false,
+    );
+}
+
+pub(crate) fn merge_rehydrated_tmux_runtime_binding(
+    provider: &str,
+    tmux_session_name: &str,
+    channel_id: u64,
+    binding: TuiRuntimeBinding,
+) -> Option<(Option<TuiRuntimeBinding>, TuiRuntimeBinding, Option<u64>)> {
+    register_rehydrated_tmux_runtime_binding_inner(
+        provider,
+        tmux_session_name,
+        channel_id,
+        binding,
+        true,
+    )
+}
+
+fn register_rehydrated_tmux_runtime_binding_inner(
+    provider: &str,
+    tmux_session_name: &str,
+    channel_id: u64,
+    mut binding: TuiRuntimeBinding,
+    preserve_same_path_cursor: bool,
+) -> Option<(Option<TuiRuntimeBinding>, TuiRuntimeBinding, Option<u64>)> {
     let provider = normalize_provider(provider);
     let tmux_session_name = tmux_session_name.trim();
     if provider.is_empty()
@@ -126,11 +157,31 @@ pub(crate) fn register_rehydrated_tmux_runtime_binding(
         || binding.output_path.trim().is_empty()
         || binding.relay_output_path().trim().is_empty()
     {
-        return;
+        return None;
     }
-    let session_id = binding.session_id.clone();
     let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
     state.purge_expired();
+    let previous_binding = state
+        .runtime_by_tmux
+        .get(tmux_session_name)
+        .map(|entry| entry.value.clone());
+    let previous_channel = state
+        .channel_by_tmux
+        .get(tmux_session_name)
+        .map(|entry| entry.value);
+    // Rehydration may race a live reader that advances the same transcript
+    // cursor after recovery sampled it. Merge under the registry lock so a
+    // stale whole-binding insert cannot move that cursor backwards. A changed
+    // output path is a new transcript and deliberately keeps its supplied
+    // restart offset (including zero after truncate/recreate).
+    if preserve_same_path_cursor
+        && let Some(previous) = state.runtime_by_tmux.get(tmux_session_name)
+        && previous.value.output_path == binding.output_path
+    {
+        binding.last_offset = binding.last_offset.max(previous.value.last_offset);
+    }
+    let session_id = binding.session_id.clone();
+    let installed_binding = binding.clone();
     state.runtime_by_tmux.insert(
         tmux_session_name.to_string(),
         TimedValue {
@@ -158,6 +209,7 @@ pub(crate) fn register_rehydrated_tmux_runtime_binding(
             },
         );
     }
+    Some((previous_binding, installed_binding, previous_channel))
 }
 
 /// #3018: DIAGNOSTIC / MIRROR USE ONLY.

--- a/src/services/tui_prompt_dedupe/tests.rs
+++ b/src/services/tui_prompt_dedupe/tests.rs
@@ -908,50 +908,6 @@ fn advances_runtime_binding_offset_for_same_output_path() {
 }
 
 #[test]
-fn rehydrated_same_path_binding_preserves_newer_live_cursor_atomically() {
-    let _guard = TEST_LOCK.lock().unwrap();
-    reset_state();
-    let tmux = "tmux-rehydrate-monotonic";
-    register_tmux_runtime_binding(
-        tmux,
-        TuiRuntimeBinding {
-            runtime_kind: RuntimeHandoffKind::ClaudeTui,
-            output_path: "/tmp/rehydrate-monotonic.jsonl".to_string(),
-            relay_output_path: None,
-            input_fifo_path: None,
-            session_id: Some("session-live".to_string()),
-            last_offset: 256,
-            relay_last_offset: None,
-        },
-    );
-
-    let merged = merge_rehydrated_tmux_runtime_binding(
-        "claude",
-        tmux,
-        42,
-        TuiRuntimeBinding {
-            runtime_kind: RuntimeHandoffKind::ClaudeTui,
-            output_path: "/tmp/rehydrate-monotonic.jsonl".to_string(),
-            relay_output_path: None,
-            input_fifo_path: None,
-            session_id: Some("session-live".to_string()),
-            last_offset: 128,
-            relay_last_offset: None,
-        },
-    )
-    .expect("merge binding");
-
-    assert_eq!(merged.0.expect("previous binding").last_offset, 256);
-    assert_eq!(merged.1.last_offset, 256);
-    assert_eq!(
-        runtime_binding_for_tmux_session(tmux)
-            .expect("installed binding")
-            .last_offset,
-        256
-    );
-}
-
-#[test]
 fn advances_runtime_binding_relay_offset_separately_from_runtime_path() {
     let _guard = TEST_LOCK.lock().unwrap();
     reset_state();

--- a/src/services/tui_prompt_dedupe/tests.rs
+++ b/src/services/tui_prompt_dedupe/tests.rs
@@ -908,6 +908,50 @@ fn advances_runtime_binding_offset_for_same_output_path() {
 }
 
 #[test]
+fn rehydrated_same_path_binding_preserves_newer_live_cursor_atomically() {
+    let _guard = TEST_LOCK.lock().unwrap();
+    reset_state();
+    let tmux = "tmux-rehydrate-monotonic";
+    register_tmux_runtime_binding(
+        tmux,
+        TuiRuntimeBinding {
+            runtime_kind: RuntimeHandoffKind::ClaudeTui,
+            output_path: "/tmp/rehydrate-monotonic.jsonl".to_string(),
+            relay_output_path: None,
+            input_fifo_path: None,
+            session_id: Some("session-live".to_string()),
+            last_offset: 256,
+            relay_last_offset: None,
+        },
+    );
+
+    let merged = merge_rehydrated_tmux_runtime_binding(
+        "claude",
+        tmux,
+        42,
+        TuiRuntimeBinding {
+            runtime_kind: RuntimeHandoffKind::ClaudeTui,
+            output_path: "/tmp/rehydrate-monotonic.jsonl".to_string(),
+            relay_output_path: None,
+            input_fifo_path: None,
+            session_id: Some("session-live".to_string()),
+            last_offset: 128,
+            relay_last_offset: None,
+        },
+    )
+    .expect("merge binding");
+
+    assert_eq!(merged.0.expect("previous binding").last_offset, 256);
+    assert_eq!(merged.1.last_offset, 256);
+    assert_eq!(
+        runtime_binding_for_tmux_session(tmux)
+            .expect("installed binding")
+            .last_offset,
+        256
+    );
+}
+
+#[test]
 fn advances_runtime_binding_relay_offset_separately_from_runtime_path() {
     let _guard = TEST_LOCK.lock().unwrap();
     reset_state();


### PR DESCRIPTION
Closes #5021

## 문제와 범위

2026-07-30 라이브 장애에서 `reuse_existing_live_watcher` 라운드가 `commit_auto_heal_attempt`로 정산되어 `consecutive_refunds`와 `retry_not_before_ms`를 매번 초기화했다. 그 결과 연속 실패 백오프가 열리지 않았고 reattach/redrive가 반복됐다.

루프의 촉발 조건 자체는 #4999가 제거했다. 이 PR은 **이 수정만으로 당시 루프를 멈췄다고 주장하지 않는다.** 대신 이후 어떤 원인으로 같은 stall 분류가 재발하더라도, 실제로 아무것도 수리하지 않은 라운드는 refund되어 자력으로 백오프에 진입하도록 회계를 고친다.

## authoritative mutation 판정

`watcher_spawned`는 rebind 마지막 단계의 watcher claim 결과일 뿐이다. claim 전에 durable inflight adoption, relay-owner 교정, session/mailbox readoption, runtime binding 복구가 이미 일어날 수 있다. 따라서 `watcher_spawned=false`를 곧바로 no-op으로 취급하면 실제 치유를 실패로 회계하는 반대 방향 결함이 된다.

이 PR은 `RebindOutcome::repaired_state`를 추가하고 다음 실제 mutation을 집계한다.

- durable inflight adoption 또는 synthetic row 생성
- Discord session binding 복원
- mailbox/cancel-token binding 및 readoption marker 복원
- Claude TUI runtime binding 복원
- watcher spawn/replacement

`relay_recovery_reattach_apply::apply_rebind`는 이제 `outcome.repaired_state`로 status를 결정한다. **위 mutation이 하나도 없을 때만** `reuse_existing_live_watcher`가 되고 settlement에서 refund된다. 그 회차의 `response.applied == true`는 유지하여 watchdog의 후속 파괴 분기로 떨어지지 않게 한다.

## durable circuit 실측

리뷰에서 제시된 “durable circuit이 예산 2회 후 먼저 열려 루프를 멈춘다”는 전제는 실측과 달랐다. 자세한 증거는 #5028에 기록했다.

- 거부 77/77건이 모두 local `auto_heal_rate_limited`
- durable circuit 거부 0건
- 디스크 record는 `attempts=2`로 이미 open 임계였지만 local limiter가 먼저 선점

따라서 local 회계가 no-op마다 성공으로 초기화되는 결함을 직접 고쳐야 한다.

## 테스트 및 뮤테이션 증명

- `reused_watcher_still_reports_prior_authoritative_repair`
  - 판정을 `watcher_spawned`/`watcher_replaced` 단독으로 회귀: **FAILED, rc=101**
  - authoritative mutation 집계 복원: **ok, rc=0**
- `production_apply_failure_rounds_open_failure_backoff`
  - `apply_relay_recovery_plan_with_seams`를 실제 호출하여 reserve → apply adapter → confirmation → settlement → 같은 key 회계를 횡단
  - production `settle_auto_heal_confirmation(...)` 호출 제거: **FAILED, rc=101**
  - settlement 호출 복원: **ok, rc=0**
- 기존 no-op/반대방향 테스트
  - `repeated_noop_reuse_rounds_escalate_into_failure_backoff`
  - `confirmed_spawned_reattach_still_commits_without_opening_backoff`

## 게이트

- `cargo fmt --all` — rc=0
- `cargo fmt --all --check` — rc=0
- `cargo check --lib` — rc=0
- `env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery` — 82 passed, rc=0
- `env -u AGENTDESK_ROOT_DIR cargo test --lib recovery_engine` — 161 passed, rc=0
- `python3 scripts/generate_inventory_docs.py` — rc=0
- `python3 scripts/check_agent_maintenance_docs.py` — `agent-maintenance freshness check passed`, rc=0
- `TEST_LANE_BASELINE_REF=origin/main bash scripts/ci-script-checks.sh` — rc=0
- baseline / `giant_file_registry.toml` / cap 변경 없음
- 4대 핫파일 무접촉

## 인접 이슈

- #4999 — 당시 루프의 촉발 조건 제거
- #5022 — 미시딩과 실제 정지를 구분하는 분류기 입력 문제
- #5028 — local limiter가 durable circuit을 선점한 라이브 실측
