### PR TITLE
fix(#5026): make the post-deploy relay round-trip actually reachable

### DIFF
--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -2822,27 +2822,63 @@ _post_deploy_smoke_check_fail_closed_warn_rate() {
     fi
 }
 
-_post_deploy_smoke_check_relay_round_trip() {
-    local cluster_standby channel_id relay_output relay_log resolve_rc cell_busy cell_guard_rc
-    local config_path="$ADK_REL/config/agentdesk.yaml"
-    if [ -z "$POST_DEPLOY_SMOKE_HEALTH_BODY" ] || [ ! -s "$POST_DEPLOY_SMOKE_HEALTH_BODY" ]; then
-        _post_deploy_smoke_fail "relay E-1: /api/health body unavailable for standby gate" || true
+# #5026: resolve the `cluster_standby` flag as a *value*, never through `jq -e`.
+#
+# `jq -e` sets exit status 1 whenever the last output value is `false` or
+# `null`, and `false` is exactly the healthy non-standby value. The previous
+# `-e` spelling therefore reported "could not prove non-standby" on every
+# normal node even though it had extracted the flag correctly. Combined with
+# the deliberate skip on `cluster_standby=true`, no input value could ever
+# reach the round-trip below — the relay check was unreachable on every
+# deploy, which is why it never caught a relay regression.
+#
+# Echoes `true`/`false` on stdout and returns non-zero only when the flag is
+# genuinely unreadable (missing body, malformed JSON, non-boolean field).
+# jq stderr is left to the caller's redirect so evidence capture is unchanged.
+_post_deploy_smoke_resolve_cluster_standby() {
+    local health_body="$1" value
+    if [ -z "$health_body" ] || [ ! -s "$health_body" ]; then
         return 1
     fi
-    if ! cluster_standby=$(jq -er '
+    if ! value=$(jq -r '
         if (.cluster_standby | type) == "boolean" then
             .cluster_standby
         else
             error("cluster_standby is not boolean")
         end
-    ' "$POST_DEPLOY_SMOKE_HEALTH_BODY" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"); then
-        _post_deploy_smoke_fail "relay E-1: could not prove node is non-standby; round-trip skipped" || true
+    ' "$health_body"); then
+        return 1
+    fi
+    case "$value" in
+        true | false)
+            printf '%s\n' "$value"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+_post_deploy_smoke_check_relay_round_trip() {
+    local cluster_standby channel_id relay_output relay_log resolve_rc cell_busy cell_guard_rc
+    local config_path="$ADK_REL/config/agentdesk.yaml"
+    if [ -z "$POST_DEPLOY_SMOKE_HEALTH_BODY" ] || [ ! -s "$POST_DEPLOY_SMOKE_HEALTH_BODY" ]; then
+        _post_deploy_smoke_fail "relay E-1 NOT VERIFIED: /api/health body unavailable for standby gate; round-trip did not run (smoke coverage gap, not a relay failure)" || true
+        return 1
+    fi
+    if ! cluster_standby=$(_post_deploy_smoke_resolve_cluster_standby \
+        "$POST_DEPLOY_SMOKE_HEALTH_BODY" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"); then
+        _post_deploy_smoke_fail "relay E-1 NOT VERIFIED: cluster_standby missing or non-boolean in /api/health; round-trip did not run (smoke coverage gap, not a relay failure)" || true
         return 1
     fi
     if [ "$cluster_standby" = "true" ]; then
         _post_deploy_smoke_note "relay E-1=skipped cluster_standby=true (no standby injection)" || return 1
         return 0
     fi
+    # Positive breadcrumb (#5026): the standby gate passed and the round-trip is
+    # actually executing. Absence of this line in a deploy log means the relay
+    # check did not run, which is what silently held for every prior deploy.
+    _post_deploy_smoke_note "relay E-1=round-trip proceeding cluster_standby=false" || return 1
 
     # Reuse the #3729 wrapper's config resolver: channel ids remain
     # machine-local agentdesk.yaml data and are never hard-coded here.

--- a/tests/test_deploy_smoke_standby_gate_5026.sh
+++ b/tests/test_deploy_smoke_standby_gate_5026.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Regression test for #5026: the post-deploy relay round-trip must actually run
+# on a healthy (non-standby) node.
+#
+# `jq -e` sets exit status 1 whenever the last output value is `false` or
+# `null`, and `false` is exactly the healthy non-standby value of
+# `.cluster_standby`. The previous `jq -er` standby gate therefore reported
+# "could not prove node is non-standby" on every normal node even though it had
+# extracted the flag correctly. Combined with the deliberate skip on
+# `cluster_standby=true`, no input value could reach the round-trip at all: the
+# relay check was unreachable on every deploy and silently caught nothing.
+#
+# The defect is "a gate that quietly never ran", so this suite asserts the
+# positive: on a non-standby node the round-trip path is actually entered.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPLOY_SH="$REPO_ROOT/scripts/deploy-release.sh"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agentdesk-smoke-standby-test.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+extract_function() {
+    local function_name="$1"
+    awk -v start="^${function_name}[(][)] [{]$" '
+        $0 ~ start { printing = 1 }
+        printing { print }
+        printing && /^}$/ { exit }
+    ' "$DEPLOY_SH"
+}
+
+# Exercise the production functions without executing the deploy script.
+eval "$(extract_function _post_deploy_smoke_note)"
+eval "$(extract_function _post_deploy_smoke_fail)"
+eval "$(extract_function _post_deploy_smoke_resolve_cluster_standby)"
+eval "$(extract_function _post_deploy_smoke_check_relay_round_trip)"
+
+POST_DEPLOY_SMOKE_EVIDENCE="$TMP_ROOT/evidence.log"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+ADK_REL="$TMP_ROOT/release"
+REPO="$REPO_ROOT"
+POST_DEPLOY_SMOKE_RELAY_CELL="claude/adk-cc"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$TMP_ROOT/health-detail.json"
+POST_DEPLOY_SMOKE_SESSIONS_BODY="$TMP_ROOT/sessions.json"
+POST_DEPLOY_SMOKE_HEALTH_BODY=""
+# The production functions loaded through eval consume these test globals, so
+# the linter cannot see the uses; exporting them states the contract. An array
+# cannot be exported, hence the targeted directive below.
+export POST_DEPLOY_SMOKE_EVIDENCE ADK_REL REPO POST_DEPLOY_SMOKE_RELAY_CELL
+export POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY POST_DEPLOY_SMOKE_SESSIONS_BODY
+export POST_DEPLOY_SMOKE_HEALTH_BODY
+# shellcheck disable=SC2034  # consumed by the eval'd _post_deploy_smoke_fail
+POST_DEPLOY_SMOKE_FAILURES=()
+mkdir -p "$ADK_REL/config"
+printf '{}\n' > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+printf '{}\n' > "$POST_DEPLOY_SMOKE_SESSIONS_BODY"
+
+failures=0
+fail_test() {
+    printf 'FAIL: %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+health_body_with() {
+    local body="$1" path="$TMP_ROOT/health.json"
+    printf '%s\n' "$body" > "$path"
+    printf '%s' "$path"
+}
+
+# --- 1. `false` is a legitimate VALUE, not a resolution failure -------------
+# This is the exact regression: `jq -e` conflates the boolean `false` with
+# "no output", so a perfectly readable non-standby node looked unreadable.
+rc=0
+value=$(_post_deploy_smoke_resolve_cluster_standby \
+    "$(health_body_with '{"cluster_standby": false}')") || rc=$?
+if [ "$rc" -ne 0 ]; then
+    fail_test "cluster_standby=false must resolve successfully, got rc=$rc (jq -e exit-status regression)"
+elif [ "$value" != "false" ]; then
+    fail_test "cluster_standby=false must resolve to 'false', got '$value'"
+fi
+
+# --- 2. `true` still resolves (standby nodes skip by design) ----------------
+rc=0
+value=$(_post_deploy_smoke_resolve_cluster_standby \
+    "$(health_body_with '{"cluster_standby": true}')") || rc=$?
+if [ "$rc" -ne 0 ]; then
+    fail_test "cluster_standby=true must resolve successfully, got rc=$rc"
+elif [ "$value" != "true" ]; then
+    fail_test "cluster_standby=true must resolve to 'true', got '$value'"
+fi
+
+# --- 3. genuinely unreadable input is the ONLY failure mode -----------------
+rc=0
+_post_deploy_smoke_resolve_cluster_standby \
+    "$(health_body_with '{"cluster_standby": "false"}')" >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 0 ]; then
+    fail_test "a non-boolean cluster_standby must not resolve"
+fi
+
+rc=0
+_post_deploy_smoke_resolve_cluster_standby \
+    "$(health_body_with '{}')" >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 0 ]; then
+    fail_test "a missing cluster_standby must not resolve"
+fi
+
+rc=0
+_post_deploy_smoke_resolve_cluster_standby "$TMP_ROOT/does-not-exist.json" >/dev/null || rc=$?
+if [ "$rc" -eq 0 ]; then
+    fail_test "an absent health body must not resolve"
+fi
+
+# --- 4. the round-trip is actually ENTERED on a non-standby node ------------
+# The downstream round-trip needs a live deploy environment and is expected to
+# fail here; only the gate decision is under test, so the call runs in a
+# subshell and just the emitted breadcrumbs are asserted.
+POST_DEPLOY_SMOKE_HEALTH_BODY="$(health_body_with '{"cluster_standby": false}')"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+( _post_deploy_smoke_check_relay_round_trip ) > "$TMP_ROOT/roundtrip.out" 2>&1 || true
+
+if ! grep -q 'relay E-1=round-trip proceeding' "$TMP_ROOT/roundtrip.out"; then
+    fail_test "non-standby node never entered the relay round-trip; the standby gate rejected it"
+fi
+if grep -q 'NOT VERIFIED' "$TMP_ROOT/roundtrip.out"; then
+    fail_test "non-standby node reported the standby gate as unverifiable"
+fi
+
+# --- 5. a standby node still skips without claiming a failure --------------
+POST_DEPLOY_SMOKE_HEALTH_BODY="$(health_body_with '{"cluster_standby": true}')"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+( _post_deploy_smoke_check_relay_round_trip ) > "$TMP_ROOT/standby.out" 2>&1 || true
+
+if ! grep -q 'relay E-1=skipped cluster_standby=true' "$TMP_ROOT/standby.out"; then
+    fail_test "standby node must record the deliberate skip"
+fi
+if grep -q 'relay E-1=round-trip proceeding' "$TMP_ROOT/standby.out"; then
+    fail_test "standby node must not enter the round-trip"
+fi
+
+# --- 6. unreadable standby state is reported as NOT VERIFIED, not a failure -
+POST_DEPLOY_SMOKE_HEALTH_BODY="$(health_body_with '{}')"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+( _post_deploy_smoke_check_relay_round_trip ) > "$TMP_ROOT/unreadable.out" 2>&1 || true
+
+if ! grep -q 'relay E-1 NOT VERIFIED' "$TMP_ROOT/unreadable.out"; then
+    fail_test "an unreadable standby flag must be reported as NOT VERIFIED (coverage gap), distinct from a relay failure"
+fi
+
+if [ "$failures" -ne 0 ]; then
+    printf '%s\n' "test_deploy_smoke_standby_gate_5026: $failures assertion(s) failed" >&2
+    exit 1
+fi
+
+printf '%s\n' "test_deploy_smoke_standby_gate_5026: all assertions passed"


### PR DESCRIPTION
Closes #5026

## 무엇이 문제였나

`jq -e` 는 **마지막 출력이 `false` 또는 `null` 이면 종료코드 1** 을 반환한다. 그런데 정상(비스탠바이) 노드의 `.cluster_standby` 값이 정확히 `false` 다.

`scripts/deploy-release.sh` 의 standby 게이트는 `jq -er` 를 썼으므로, **플래그를 정확히 추출하고도** "could not prove node is non-standby" 로 판정하고 라운드트립 전에 return 했다.

여기에 `cluster_standby=true` 의 의도적 skip 이 겹치면서 **어떤 입력값도 릴레이 왕복 검사에 도달하지 못했다**:

| `cluster_standby` | jq rc | 결과 | 왕복 검사 |
|---|---|---|---|
| `false` (모든 정상 배포) | 1 | `_post_deploy_smoke_fail` | **실행 안 됨** |
| `true` (스탠바이) | 0 | 의도적 skip | **실행 안 됨** |

즉 릴레이 왕복 검사는 **모든 배포에서 단 한 번도 실행된 적이 없다.** 2026-07-30 릴레이 장애(#5021 / #5022 계열)가 스모크에 걸리지 않고 프로덕션에 도달한 이유다.

## 무엇을 고쳤나

standby 판정을 작은 전용 함수로 분리하고 `jq -r` 로 **값** 을 해석한다. 진짜로 읽을 수 없는 경우(본문 없음 / 파싱 실패 / boolean 아님)만 실패로 분류한다.

추가로 코디네이터 요청대로 **"검증 못 함" 과 "검증 실패" 를 분리**했다:
- 읽을 수 없는 standby 플래그 → `relay E-1 NOT VERIFIED: ... (smoke coverage gap, not a relay failure)`
- 라운드트립에 실제 진입하면 양성 breadcrumb `relay E-1=round-trip proceeding cluster_standby=false` 를 남긴다. 배포 로그에 이 줄이 없으면 검사가 안 돌았다는 뜻이며, 이전에는 그 사실을 로그에서 구분할 방법이 없었다

## 테스트 (`tests/test_deploy_smoke_standby_gate_5026.sh`)

기존 `tests/test_deploy_smoke_warn_scope_4511.sh` 의 `extract_function` 패턴을 그대로 따른다 — awk 로 프로덕션 함수만 뽑아 eval 하므로 **배포 스크립트를 실행하지 않는다.**

이 결함의 본질이 "게이트가 조용히 안 돌았다" 이므로 **양성** 을 단언한다:

1. `cluster_standby=false` 가 rc=0 으로 해석되는가 (핵심 회귀)
2. `cluster_standby=true` 도 해석되는가
3. 비-boolean / 필드 없음 / 본문 없음만 실패하는가
4. **비스탠바이 노드에서 라운드트립 경로에 실제로 진입하는가** (`round-trip proceeding` breadcrumb 관측)
5. 스탠바이 노드는 skip 하고 라운드트립에 진입하지 않는가
6. 읽을 수 없는 경우 `NOT VERIFIED` 로 보고되는가

`ci-script-checks.sh:272` 의 `for shell_test in tests/*.sh` 루프가 자동으로 실행한다 (확인함).

## 뮤테이션 증명

`jq -r` 을 `jq -er` 로 되돌려 결함을 재도입했다.

**복원 상태 — rc=0**
```
test_deploy_smoke_standby_gate_5026: all assertions passed
```

**결함 재도입 — rc=1**
```
FAIL: cluster_standby=false must resolve successfully, got rc=1 (jq -e exit-status regression)
FAIL: non-standby node never entered the relay round-trip; the standby gate rejected it
FAIL: non-standby node reported the standby gate as unverifiable
test_deploy_smoke_standby_gate_5026: 3 assertion(s) failed
```

**구문 에러 사망이 아님**: 뮤테이션 상태에서 `bash -n scripts/deploy-release.sh` 와 `bash -n tests/...` 모두 rc=0. 테스트는 자기 assert 로만 죽었다.

**복원 후 재확인 — rc=0**

## 게이트

| 게이트 | rc |
|---|---|
| `bash -n scripts/deploy-release.sh` (파싱만, 실행 아님) | **0** |
| `shellcheck -S warning scripts/deploy-release.sh` | **0** |
| `shellcheck -S warning tests/test_deploy_smoke_standby_gate_5026.sh` | **0** |
| `bash tests/test_deploy_smoke_standby_gate_5026.sh` | **0** |

## 안전성 주의

배포 스크립트 변경이라 각별히 보수적으로 다뤘다. **`deploy-release.sh` 를 실행하지 않았다** — 검증은 전부 `bash -n` 파싱과 함수 추출 후 eval 로만 했다. 제어 흐름은 그대로이고, 추가된 것은 순수 함수 하나와 메시지 문구, 그리고 note 한 줄이다.
