### PR TITLE
fix(ci): avoid PostgreSQL lane binary test link OOM (#5043)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -199,16 +199,9 @@ jobs:
           CARGO_PROFILE_TEST_DEBUG: "0"
           CARGO_PROFILE_DEV_DEBUG: "0"
 
-      - name: Stop PostgreSQL lane resource diagnostics
+      - name: Show PostgreSQL lane resource diagnostics
         if: always() && inputs.resource_diagnostics == true
-        run: |
-          kill "$sample_pid" 2>/dev/null || true
-          wait "$sample_pid" 2>/dev/null || true
-          cat "$RUNNER_TEMP/pg-resource-samples.log" || true
-
-      - name: PostgreSQL lane OOM evidence
-        if: failure()
-        run: dmesg | grep -i -E 'out of memory|oom|killed process' || true
+        run: cat "$RUNNER_TEMP/pg-resource-samples.log" || true
 
       - name: Stop PostgreSQL service
         if: always()

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ci-main-${{ github.ref }}
@@ -170,12 +171,33 @@ jobs:
 
       - name: just test-postgres
         timeout-minutes: 20
-        run: just test-postgres
+        run: |
+          resource_sample() {
+            while true; do
+              printf 'PG_RESOURCE_SAMPLE '
+              date --iso-8601=seconds
+              free -m | awk '/Mem:/ { printf "mem_total_mib=%s mem_used_mib=%s mem_available_mib=%s ", $2, $3, $7 }'
+              printf 'cgroup_max_bytes='
+              cat /sys/fs/cgroup/memory.max || true
+              printf 'cgroup_current_bytes='
+              cat /sys/fs/cgroup/memory.current || true
+              docker stats --no-stream --format 'pg_mem={{.MemUsage}}' agentdesk-postgres || true
+              sleep 5
+            done
+          }
+          resource_sample &
+          sample_pid=$!
+          trap 'kill "$sample_pid" 2>/dev/null || true; wait "$sample_pid" 2>/dev/null || true' EXIT
+          just test-postgres
         env:
           # #4245: see Full tests lane — keep test debuginfo off so the build
           # and serial PostgreSQL suite retain headroom in the bounded step.
           CARGO_PROFILE_TEST_DEBUG: "0"
           CARGO_PROFILE_DEV_DEBUG: "0"
+
+      - name: PostgreSQL lane OOM evidence
+        if: failure()
+        run: dmesg | grep -i -E 'out of memory|oom|killed process' || true
 
       - name: Stop PostgreSQL service
         if: always()

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -141,8 +141,8 @@ jobs:
       PGUSER: postgres
       PGPASSWORD: postgres
       # The PostgreSQL service shares the hosted runner with a cold Rust build.
-      # Two rustc jobs keep the peak below the runner's 16 GiB memory limit.
-      CARGO_BUILD_JOBS: "2"
+      # A single rustc job keeps the cold-build peak below its 16 GiB limit.
+      CARGO_BUILD_JOBS: "1"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      resource_diagnostics:
+        description: Emit PostgreSQL lane memory samples every five seconds
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ci-main-${{ github.ref }}
@@ -172,31 +178,36 @@ jobs:
           shared-key: cargo-dependencies-v2
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: just test-postgres
-        timeout-minutes: 20
+      - name: PostgreSQL lane resource diagnostics
+        if: ${{ inputs.resource_diagnostics == true }}
         run: |
           resource_sample() {
             while true; do
               printf 'PG_RESOURCE_SAMPLE '
               date --iso-8601=seconds
               free -m | awk '/Mem:/ { printf "mem_total_mib=%s mem_used_mib=%s mem_available_mib=%s ", $2, $3, $7 }'
-              printf 'cgroup_max_bytes='
-              cat /sys/fs/cgroup/memory.max || true
-              printf 'cgroup_current_bytes='
-              cat /sys/fs/cgroup/memory.current || true
               docker stats --no-stream --format 'pg_mem={{.MemUsage}}' agentdesk-postgres || true
               sleep 5
             done
           }
-          resource_sample &
-          sample_pid=$!
-          trap 'kill "$sample_pid" 2>/dev/null || true; wait "$sample_pid" 2>/dev/null || true' EXIT
-          just test-postgres
+          resource_sample > "$RUNNER_TEMP/pg-resource-samples.log" 2>&1 &
+          echo "sample_pid=$!" >> "$GITHUB_ENV"
+
+      - name: just test-postgres
+        timeout-minutes: 20
+        run: just test-postgres
         env:
           # #4245: see Full tests lane — keep test debuginfo off so the build
           # and serial PostgreSQL suite retain headroom in the bounded step.
           CARGO_PROFILE_TEST_DEBUG: "0"
           CARGO_PROFILE_DEV_DEBUG: "0"
+
+      - name: Stop PostgreSQL lane resource diagnostics
+        if: always() && inputs.resource_diagnostics == true
+        run: |
+          kill "$sample_pid" 2>/dev/null || true
+          wait "$sample_pid" 2>/dev/null || true
+          cat "$RUNNER_TEMP/pg-resource-samples.log" || true
 
       - name: PostgreSQL lane OOM evidence
         if: failure()

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -187,8 +187,9 @@ jobs:
               sleep 5
             done
           }
+          # No PID handoff: a later step runs in a different shell, so it cannot
+          # `wait` on this sampler. The hosted VM reclaims it when the job ends.
           resource_sample > "$RUNNER_TEMP/pg-resource-samples.log" 2>&1 &
-          echo "sample_pid=$!" >> "$GITHUB_ENV"
 
       - name: just test-postgres
         timeout-minutes: 20

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -140,6 +140,9 @@ jobs:
       PGPORT: "5432"
       PGUSER: postgres
       PGPASSWORD: postgres
+      # The PostgreSQL service shares the hosted runner with a cold Rust build.
+      # Two rustc jobs keep the peak below the runner's 16 GiB memory limit.
+      CARGO_BUILD_JOBS: "2"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -146,11 +146,6 @@ jobs:
       PGPORT: "5432"
       PGUSER: postgres
       PGPASSWORD: postgres
-      # A cold PostgreSQL test build links the full PG-selected test binary.
-      # Splitting LLVM work across 256 codegen units lowers rustc's peak RSS;
-      # two cargo jobs retain adequate timeout headroom on hosted runners.
-      CARGO_BUILD_JOBS: "2"
-      CARGO_PROFILE_TEST_CODEGEN_UNITS: "256"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -146,9 +146,11 @@ jobs:
       PGPORT: "5432"
       PGUSER: postgres
       PGPASSWORD: postgres
-      # The PostgreSQL service shares the hosted runner with a cold Rust build.
-      # A single rustc job keeps the cold-build peak below its 16 GiB limit.
-      CARGO_BUILD_JOBS: "1"
+      # A cold PostgreSQL test build links the full PG-selected test binary.
+      # Splitting LLVM work across 256 codegen units lowers rustc's peak RSS;
+      # two cargo jobs retain adequate timeout headroom on hosted runners.
+      CARGO_BUILD_JOBS: "2"
+      CARGO_PROFILE_TEST_CODEGEN_UNITS: "256"
     steps:
       - uses: actions/checkout@v4
 

--- a/justfile
+++ b/justfile
@@ -112,6 +112,6 @@ test-non-pg:
     cargo test --doc ClaudeBinary
 
 test-postgres:
-    cargo test -- _pg pg_ postgres --nocapture --test-threads=1
+    cargo test --lib -- _pg pg_ postgres --nocapture --test-threads=1
 
 check: fmt-check lint cargo-check test

--- a/justfile
+++ b/justfile
@@ -111,6 +111,8 @@ test-non-pg:
     # Filter the real rustdoc harness to this public capability contract.
     cargo test --doc ClaudeBinary
 
+# PostgreSQL tests belong in the library harness. Integration and doctest targets
+# are intentionally excluded; add a separate PG lane command if either gains PG coverage.
 test-postgres:
     cargo test --lib -- _pg pg_ postgres --nocapture --test-threads=1
 


### PR DESCRIPTION
## Summary

Fixes #5043.

`just test-postgres` selected every default test target because its `cargo test` invocation omitted `--lib`. AgentDesk has a `[[bin]] agentdesk` target (`src/main.rs`), so the PostgreSQL lane cold-built and linked both the library test harness and the binary harness. The extra binary link pushed the hosted runner over its 16 GiB memory limit.

The recipe now uses `cargo test --lib -- _pg pg_ postgres --nocapture --test-threads=1`, preserving the PostgreSQL library suite while avoiding the unrelated binary harness. The recipe documents that new PostgreSQL coverage in integration or doctest targets requires a separate lane command.

## Evidence

- Diagnostic run: PostgreSQL job sampled `mem_total_mib=15988 mem_used_mib=15944 mem_available_mib=44` immediately before runner shutdown / exit 143. The PostgreSQL Docker container held only 10–25 MiB, ruling it out as the material memory consumer.
- The recipe lacked `--lib` from its original 2026-05-31 introduction; its three commands were combined in `88a5bc143` on 2026-07-10 without adding it. Neither commit supplies a rationale for exercising the binary harness.
- Coverage parity: the former command ran 527 PostgreSQL library tests and passed all 527. The corrected `--lib` command also runs and passes exactly 527 PostgreSQL library tests. The existing `tests/e2e` integration target has three tests, none matches `_pg`, `pg_`, or `postgres` (one is ignored); nine doctests likewise match none of these filters. The removed binary harness reported zero tests.
- Rejected alternative: `CARGO_BUILD_JOBS=1` did avoid OOM, but took 19m33s against a 20-minute timeout—only 27 seconds (2.25%) headroom.

## Sequential CI validation

All runs use SHA `7bd02c9ffff5cf26d90619076ec0bb4912ed31e2` and were dispatched serially:

1. https://github.com/itismyfield/AgentDesk/actions/runs/30565477530 — PostgreSQL tests: 9m39s
2. https://github.com/itismyfield/AgentDesk/actions/runs/30566478491 — PostgreSQL tests: 11m13s
3. https://github.com/itismyfield/AgentDesk/actions/runs/30567435070 — PostgreSQL tests: 10m08s

The workflow retains an opt-in `workflow_dispatch` `resource_diagnostics` input for five-second memory sampling during future incidents. The samples are shown from the same job after the test command. No post-failure OOM probe remains because a runner shutdown cannot execute a later step.

## Verification

- `TEST_LANE_BASELINE_REF=$(git rev-parse origin/main) bash scripts/ci-script-checks.sh` (rc=0)
- Opt-in diagnostics dispatch: https://github.com/itismyfield/AgentDesk/actions/runs/30570389054
- `job_sha256` pin update: not applicable; `ci-main.yml` has no such pin.
