### PR TITLE
fix(#5059): arm gateway-policy auto-compact window for TUI launches

### DIFF
--- a/src/services/claude_compact_context.rs
+++ b/src/services/claude_compact_context.rs
@@ -27,6 +27,10 @@ const MAX_CATALOGS: usize = 32;
 const MAX_LAUNCH_PROVENANCE: usize = 512;
 const TMUX_LAUNCH_PROVENANCE_OPTION: &str = "@agentdesk_claude_compact_provenance";
 pub(crate) const CLAUDE_AUTO_COMPACT_WINDOW_ENV: &str = "CLAUDE_CODE_AUTO_COMPACT_WINDOW";
+/// OCX's own auto-context default (`AUTO_COMPACT_WINDOW_DEFAULT` in opencodex
+/// `context-windows.ts`). Mirrored so an ADK-hosted TUI receives the exact env
+/// an `ocx claude` launch would have injected for the same gateway policy.
+const OCX_AUTO_COMPACT_WINDOW_DEFAULT_TOKENS: u64 = 350_000;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ClaudeLaunchProvenance {
@@ -61,7 +65,18 @@ struct PersistedLaunchProvenance {
 #[derive(Clone, Debug)]
 struct CatalogEntry {
     windows: HashMap<String, u64>,
+    /// The gateway's own effective `CLAUDE_CODE_AUTO_COMPACT_WINDOW` decision
+    /// (`None` when its auto-context policy is off or unreported).
+    auto_compact_window: Option<u64>,
     refreshed_at: Instant,
+}
+
+/// One fetched snapshot of the gateway's `/api/claude-code` surface: the
+/// model-window map plus the gateway's own auto-context decision.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct GatewayCatalog {
+    pub(crate) windows: HashMap<String, u64>,
+    pub(crate) auto_compact_window: Option<u64>,
 }
 
 #[derive(Default)]
@@ -247,6 +262,87 @@ pub(crate) fn launch_auto_compact_window_for_session(
             gateway_proxy_env,
         )
     })
+}
+
+/// Absolute Claude Code launch knob for a mutable interactive TUI (#4591
+/// revision). Unlike the immutable headless knob above, this value is NOT
+/// derived from the launch model: it replicates the model-independent env the
+/// gateway itself injects into `ocx claude` launches, so mid-session model
+/// switches cannot make it stale. Without it, gateway-generated subagent
+/// definitions carrying a `[1m]` marker are accounted at 1M by Claude Code
+/// while the routed backend enforces a smaller real window — their internal
+/// loops overflow before compaction arms, and ADK's own compact steering can
+/// never reach a CLI-internal subagent loop. Scrubbed launches use only native
+/// selectors, whose `[1m]` windows are genuinely 1M, so they need no knob.
+pub(crate) fn tui_launch_auto_compact_window(
+    gateway_proxy_env: &ClaudeGatewayProxyEnv,
+) -> Option<u64> {
+    let ClaudeGatewayProxyEnv::Inject { base_url } = gateway_proxy_env else {
+        return None;
+    };
+    let proxy_url = normalize_proxy_url(base_url);
+    if proxy_url.is_empty() {
+        return None;
+    }
+    if let Some(decision) = cached_gateway_auto_compact_window(&proxy_url) {
+        return decision;
+    }
+    // Cold cache: a TUI pane launch is rare and not latency-critical, while a
+    // pane that misses this knob keeps the hazard for its whole lifetime. Run
+    // one bounded fetch on a dedicated thread (the HTTP client enforces its
+    // own 2s timeout) so this works from both async and blocking callers.
+    let fetch_url = proxy_url.clone();
+    let fetched = std::thread::Builder::new()
+        .name("claude-catalog-launch-fetch".to_string())
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .ok()?;
+            Some(runtime.block_on(fetch_catalog(&fetch_url)))
+        })
+        .ok()?
+        .join()
+        .ok()??;
+    match fetched {
+        Ok(catalog) if !catalog.windows.is_empty() => {
+            let decision = catalog.auto_compact_window;
+            let mut state = CATALOG_STATE
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            commit_catalog_entry(&mut state, &proxy_url, catalog);
+            decision
+        }
+        Ok(_) => {
+            tracing::warn!(
+                proxy_url,
+                "Claude launch catalog fetch returned an empty window map; TUI launches without an absolute compact window"
+            );
+            None
+        }
+        Err(error) => {
+            tracing::debug!(
+                proxy_url,
+                %error,
+                "Claude launch catalog fetch failed; TUI launches without an absolute compact window"
+            );
+            None
+        }
+    }
+}
+
+/// Fresh-cache read of the gateway's auto-compact decision. Outer `None` means
+/// the cache is cold or stale; inner `None` means a fresh gateway reported its
+/// auto-context policy as off.
+fn cached_gateway_auto_compact_window(proxy_url: &str) -> Option<Option<u64>> {
+    let state = CATALOG_STATE
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    state
+        .by_proxy_url
+        .get(proxy_url)
+        .filter(|entry| entry.refreshed_at.elapsed() < CATALOG_TTL)
+        .map(|entry| entry.auto_compact_window)
 }
 
 /// Render an isolation fence for shell-based launches. An inherited absolute
@@ -508,24 +604,31 @@ fn spawn_catalog_refresh(proxy_url: String) {
     });
 }
 
+/// Commit one fetched catalog snapshot without touching the in-flight refresh
+/// marker. Shared by the background refresh path and the bounded launch fetch.
+fn commit_catalog_entry(state: &mut CatalogState, proxy_url: &str, catalog: GatewayCatalog) {
+    state.by_proxy_url.insert(
+        proxy_url.to_string(),
+        CatalogEntry {
+            windows: catalog.windows,
+            auto_compact_window: catalog.auto_compact_window,
+            refreshed_at: Instant::now(),
+        },
+    );
+    trim_oldest_catalogs(state);
+}
+
 /// Commit a catalog refresh. Failed or empty refreshes deliberately retain a
 /// stale map for diagnostics/retry, but callers can never consume that map:
 /// [`cached_catalog_and_schedule_refresh`] returns only fresh entries.
-fn finish_catalog_refresh(proxy_url: &str, result: Result<HashMap<String, u64>, String>) {
+fn finish_catalog_refresh(proxy_url: &str, result: Result<GatewayCatalog, String>) {
     let mut state = CATALOG_STATE
         .lock()
         .unwrap_or_else(|error| error.into_inner());
     state.refreshing.remove(proxy_url);
     match result {
-        Ok(windows) if !windows.is_empty() => {
-            state.by_proxy_url.insert(
-                proxy_url.to_string(),
-                CatalogEntry {
-                    windows,
-                    refreshed_at: Instant::now(),
-                },
-            );
-            trim_oldest_catalogs(&mut state);
+        Ok(catalog) if !catalog.windows.is_empty() => {
+            commit_catalog_entry(&mut state, proxy_url, catalog);
         }
         Ok(_) => tracing::warn!(proxy_url, "Claude context-window catalog was empty"),
         Err(error) => {
@@ -534,7 +637,7 @@ fn finish_catalog_refresh(proxy_url: &str, result: Result<HashMap<String, u64>, 
     }
 }
 
-async fn fetch_catalog(proxy_url: &str) -> Result<HashMap<String, u64>, String> {
+async fn fetch_catalog(proxy_url: &str) -> Result<GatewayCatalog, String> {
     let endpoint = catalog_endpoint(proxy_url)
         .ok_or_else(|| "Claude context-window proxy URL is empty".to_string())?;
     let client = CONTEXT_WINDOW_CLIENT.get_or_init(|| {
@@ -554,7 +657,7 @@ async fn fetch_catalog(proxy_url: &str) -> Result<HashMap<String, u64>, String> 
         .text()
         .await
         .map_err(|error| format!("read {endpoint}: {error}"))?;
-    parse_context_window_catalog(&body).map_err(|error| format!("parse {endpoint}: {error}"))
+    parse_gateway_catalog(&body).map_err(|error| format!("parse {endpoint}: {error}"))
 }
 
 /// Parses both OCX's `contextWindows` map and array/object compatibility
@@ -562,10 +665,50 @@ async fn fetch_catalog(proxy_url: &str) -> Result<HashMap<String, u64>, String> 
 /// compatibility entries must name a model and its context-window field so
 /// root response metadata cannot poison the conservative unknown-model fallback.
 pub(crate) fn parse_context_window_catalog(body: &str) -> Result<HashMap<String, u64>, String> {
+    parse_gateway_catalog(body).map(|catalog| catalog.windows)
+}
+
+/// Full gateway snapshot: the window map plus the gateway's own auto-context
+/// decision derived from the same response body.
+pub(crate) fn parse_gateway_catalog(body: &str) -> Result<GatewayCatalog, String> {
     let value: Value = serde_json::from_str(body).map_err(|error| error.to_string())?;
     let mut windows = HashMap::new();
     collect_catalog_windows(&value, &mut windows);
-    Ok(windows)
+    Ok(GatewayCatalog {
+        windows,
+        auto_compact_window: ocx_auto_compact_window(&value),
+    })
+}
+
+/// Mirror OCX's `resolveAutoContext` (opencodex `context-windows.ts`): the
+/// gateway injects `CLAUDE_CODE_AUTO_COMPACT_WINDOW` into its own `ocx claude`
+/// launches exactly when its auto-context policy is on and the legacy
+/// `maxContextTokens` override is absent. An out-of-range or missing
+/// `autoCompactWindow` config value falls back to the 350k default, matching
+/// the gateway's own fallback. Absent policy fields fail closed.
+fn ocx_auto_compact_window(value: &Value) -> Option<u64> {
+    let object = value.as_object()?;
+    if object.get("enabled").and_then(Value::as_bool) != Some(true) {
+        return None;
+    }
+    if object.get("autoContext").and_then(Value::as_bool) != Some(true) {
+        return None;
+    }
+    if object
+        .get("maxContextTokens")
+        .and_then(Value::as_u64)
+        .is_some_and(|tokens| tokens > 0)
+    {
+        return None;
+    }
+    let window = object
+        .get("autoCompactWindow")
+        .and_then(Value::as_u64)
+        .filter(|window| {
+            (CLAUDE_AUTO_COMPACT_MIN_TOKENS..=CLAUDE_AUTO_COMPACT_MAX_TOKENS).contains(window)
+        })
+        .unwrap_or(OCX_AUTO_COMPACT_WINDOW_DEFAULT_TOKENS);
+    Some(window)
 }
 
 fn collect_catalog_windows(value: &Value, windows: &mut HashMap<String, u64>) {
@@ -689,6 +832,15 @@ fn reset_for_test() {
 
 #[cfg(test)]
 pub(crate) fn put_catalog_for_test(proxy_url: &str, windows: HashMap<String, u64>) {
+    put_catalog_with_auto_compact_for_test(proxy_url, windows, None);
+}
+
+#[cfg(test)]
+pub(crate) fn put_catalog_with_auto_compact_for_test(
+    proxy_url: &str,
+    windows: HashMap<String, u64>,
+    auto_compact_window: Option<u64>,
+) {
     CATALOG_STATE
         .lock()
         .unwrap_or_else(|error| error.into_inner())
@@ -697,6 +849,7 @@ pub(crate) fn put_catalog_for_test(proxy_url: &str, windows: HashMap<String, u64
             normalize_proxy_url(proxy_url),
             CatalogEntry {
                 windows,
+                auto_compact_window,
                 refreshed_at: Instant::now(),
             },
         );
@@ -786,6 +939,100 @@ mod tests {
         )
         .unwrap();
         assert_eq!(parsed, HashMap::from([("gpt".to_string(), 372_000)]));
+    }
+
+    #[test]
+    fn gateway_auto_compact_mirrors_ocx_resolve_auto_context() {
+        let decide = |body: &str| parse_gateway_catalog(body).unwrap().auto_compact_window;
+        // Policy on, explicit in-range window.
+        assert_eq!(
+            decide(
+                r#"{"enabled":true,"autoContext":true,"autoCompactWindow":700000,"contextWindows":{}}"#
+            ),
+            Some(700_000)
+        );
+        // Policy on, null/missing window falls back to OCX's 350k default.
+        assert_eq!(
+            decide(
+                r#"{"enabled":true,"autoContext":true,"autoCompactWindow":null,"contextWindows":{}}"#
+            ),
+            Some(350_000)
+        );
+        // Out-of-range config values also fall back to the default, matching
+        // OCX's own hand-edit guard.
+        assert_eq!(
+            decide(
+                r#"{"enabled":true,"autoContext":true,"autoCompactWindow":5,"contextWindows":{}}"#
+            ),
+            Some(350_000)
+        );
+        // Auto-context off, gateway disabled, or the legacy maxContextTokens
+        // override all disable the knob; absent fields fail closed.
+        assert_eq!(
+            decide(r#"{"enabled":true,"autoContext":false,"contextWindows":{}}"#),
+            None
+        );
+        assert_eq!(
+            decide(r#"{"enabled":false,"autoContext":true,"contextWindows":{}}"#),
+            None
+        );
+        assert_eq!(
+            decide(
+                r#"{"enabled":true,"autoContext":true,"maxContextTokens":180000,"contextWindows":{}}"#
+            ),
+            None
+        );
+        assert_eq!(decide(r#"{"contextWindows":{"gpt":372000}}"#), None);
+        assert_eq!(decide(r#"[{"id":"gpt","context_window":372000}]"#), None);
+    }
+
+    #[test]
+    fn tui_launch_window_uses_fresh_gateway_policy_and_scrub_stays_disarmed() {
+        let _guard = state_test_guard();
+        let proxy = "http://tui-policy.test";
+        put_catalog_with_auto_compact_for_test(
+            proxy,
+            HashMap::from([("gpt".to_string(), 372_000)]),
+            Some(350_000),
+        );
+        assert_eq!(
+            tui_launch_auto_compact_window(&ClaudeGatewayProxyEnv::Inject {
+                base_url: proxy.to_string(),
+            }),
+            Some(350_000)
+        );
+
+        put_catalog_with_auto_compact_for_test(
+            proxy,
+            HashMap::from([("gpt".to_string(), 372_000)]),
+            None,
+        );
+        assert_eq!(
+            tui_launch_auto_compact_window(&ClaudeGatewayProxyEnv::Inject {
+                base_url: proxy.to_string(),
+            }),
+            None,
+            "a fresh gateway reporting auto-context off must not arm the knob"
+        );
+
+        assert_eq!(
+            tui_launch_auto_compact_window(&ClaudeGatewayProxyEnv::Scrub),
+            None,
+            "scrubbed launches use native selectors whose [1m] windows are genuinely 1M"
+        );
+    }
+
+    #[test]
+    fn tui_launch_window_cold_cache_fetch_failure_fails_closed() {
+        let _guard = state_test_guard();
+        // 127.0.0.1:9 (discard) refuses immediately; the bounded launch fetch
+        // must fail closed without arming the knob.
+        assert_eq!(
+            tui_launch_auto_compact_window(&ClaudeGatewayProxyEnv::Inject {
+                base_url: "http://127.0.0.1:9".to_string(),
+            }),
+            None
+        );
     }
 
     #[test]

--- a/src/services/claude_tui/session.rs
+++ b/src/services/claude_tui/session.rs
@@ -415,12 +415,20 @@ fn write_launch_script(
     let mut gateway_exports = String::new();
     // Chokepoint base: resolved gateway launch env (#4559).
     config.launch_env.append_shell_env(&mut gateway_exports);
-    // Compact-window overlay (#4591): interactive TUI sessions can change model
-    // after launch, so they never inherit an absolute compact window from
-    // dcserver/tmux.
+    // Compact-window overlay (#4591 revision): interactive TUI sessions can
+    // change model after launch, so a launch-model-derived absolute window
+    // would go stale. The gateway-policy value below is model-independent —
+    // it replicates the exact env an `ocx claude` launch injects — and is the
+    // only compact safety net that reaches CLI-internal subagent loops
+    // running `[1m]`-marked routed models. Scrubbed launches still export
+    // nothing beyond the isolation fence.
+    let auto_compact_window =
+        crate::services::claude_compact_context::tui_launch_auto_compact_window(
+            config.launch_env.gateway_proxy_env(),
+        );
     crate::services::claude_compact_context::append_auto_compact_window_shell_env(
         &mut gateway_exports,
-        None,
+        auto_compact_window,
     );
     let mut escaped_claude_bin = String::new();
     config
@@ -568,7 +576,7 @@ mod tests {
     }
 
     #[test]
-    fn launch_script_never_exports_absolute_compact_window_and_gates_gateway_proxy() {
+    fn launch_script_exports_gateway_policy_compact_window_and_gates_gateway_proxy() {
         let _context_guard = context_state_guard();
         let dir = tempfile::tempdir().unwrap();
         let mut config = sample_config();
@@ -576,6 +584,13 @@ mod tests {
         config.launch_env = ClaudeLaunchEnv::inject_for_test("http://proxy.example/it's-ready");
         let launch_script_path = dir.path().join("launch.sh");
 
+        // A fresh gateway catalog whose auto-context policy is OFF: the launch
+        // still exports only the isolation fence.
+        crate::services::claude_compact_context::put_catalog_with_auto_compact_for_test(
+            "http://proxy.example/it's-ready",
+            std::collections::HashMap::from([("gpt-x".to_string(), 372_000)]),
+            None,
+        );
         write_launch_script(
             &launch_script_path,
             &config,
@@ -587,13 +602,33 @@ mod tests {
         assert!(script.contains("unset CLAUDE_CODE_AUTO_COMPACT_WINDOW\n"));
         assert!(
             !script.contains("export CLAUDE_CODE_AUTO_COMPACT_WINDOW="),
-            "a long-lived interactive Claude TUI must not pin auto-compact to its launch model"
+            "gateway auto-context off must leave the exact-token steering path as the sole compact authority"
         );
         assert!(
             script.contains("export ANTHROPIC_BASE_URL='http://proxy.example/it'\\''s-ready'\n")
         );
         assert!(script.contains("export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1\n"));
         assert!(!script.contains("CLAUDE_CODE_EXTENDED_CACHE_TTL"));
+
+        // The same gateway with auto-context ON: the launch replicates the env
+        // an `ocx claude` launch would inject.
+        crate::services::claude_compact_context::put_catalog_with_auto_compact_for_test(
+            "http://proxy.example/it's-ready",
+            std::collections::HashMap::from([("gpt-x".to_string(), 372_000)]),
+            Some(350_000),
+        );
+        write_launch_script(
+            &launch_script_path,
+            &config,
+            Path::new("/tmp/settings.json"),
+        )
+        .unwrap();
+        let armed_script = std::fs::read_to_string(&launch_script_path).unwrap();
+        assert!(armed_script.contains("unset CLAUDE_CODE_AUTO_COMPACT_WINDOW\n"));
+        assert!(
+            armed_script.contains("export CLAUDE_CODE_AUTO_COMPACT_WINDOW=350000\n"),
+            "gateway auto-context on must arm the CLI-internal compact safety net for [1m]-marked subagent models"
+        );
 
         config.launch_env = ClaudeLaunchEnv::scrub_for_test();
         write_launch_script(
@@ -616,6 +651,8 @@ mod tests {
         let mut config = sample_config();
         let launch_script_path = dir.path().join("launch.sh");
 
+        // Scrubbed launches use only native selectors, whose `[1m]` windows
+        // are genuinely 1M: no absolute window is ever exported.
         write_launch_script(
             &launch_script_path,
             &config,
@@ -628,9 +665,24 @@ mod tests {
         assert!(!sonnet_script.contains("export CLAUDE_CODE_AUTO_COMPACT_WINDOW="));
 
         // `/model` can change the live TUI's model after this script has
-        // launched. Rewriting the artifact with a different launch selector
-        // must still leave the exact-token steering path as the sole compact
-        // authority.
+        // launched. The gateway-policy window is model-independent, so a
+        // different launch selector must produce the identical export — the
+        // value can never go stale against the session's current model.
+        crate::services::claude_compact_context::put_catalog_with_auto_compact_for_test(
+            "http://proxy.example/gateway",
+            std::collections::HashMap::from([("gpt-x".to_string(), 372_000)]),
+            Some(350_000),
+        );
+        config.launch_env = ClaudeLaunchEnv::inject_for_test("http://proxy.example/gateway");
+        write_launch_script(
+            &launch_script_path,
+            &config,
+            Path::new("/tmp/settings.json"),
+        )
+        .unwrap();
+        let sonnet_injected = std::fs::read_to_string(&launch_script_path).unwrap();
+        assert!(sonnet_injected.contains("export CLAUDE_CODE_AUTO_COMPACT_WINDOW=350000\n"));
+
         config.model = Some("opus".to_string());
         write_launch_script(
             &launch_script_path,
@@ -641,8 +693,7 @@ mod tests {
         let opus_script = std::fs::read_to_string(&launch_script_path).unwrap();
         assert!(opus_script.contains("'--model' 'opus'"));
         assert!(!opus_script.contains("'--model' 'sonnet'"));
-        assert!(opus_script.contains("unset CLAUDE_CODE_AUTO_COMPACT_WINDOW\n"));
-        assert!(!opus_script.contains("export CLAUDE_CODE_AUTO_COMPACT_WINDOW="));
+        assert!(opus_script.contains("export CLAUDE_CODE_AUTO_COMPACT_WINDOW=350000\n"));
         assert!(!opus_script.contains("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"));
     }
 


### PR DESCRIPTION
Closes #5059

## 변경 요약
- `claude_compact_context.rs`: 게이트웨이 `/api/claude-code` 응답에서 auto-context 정책(`enabled`/`autoContext`/`maxContextTokens`/`autoCompactWindow`, 350k 기본값)을 파싱해 카탈로그 캐시에 함께 저장. 신규 `tui_launch_auto_compact_window()`가 Inject launch에서 이 모델 무관 정책 값을 반환하고, cold cache일 때는 전용 스레드에서 1회 bounded fetch(클라이언트 2s 타임아웃) 수행. Scrub launch는 항상 None.
- `claude_tui/session.rs`: launch 스크립트가 isolation fence(unset) 뒤에 게이트웨이 정책 값을 export. #4591의 stale 우려는 launch-model 파생 값에만 성립 — 이 값은 모델 전환과 무관하므로 안전하며, `ocx claude`가 주입하는 env와 동일한 검증된 구성을 복제한다.

## 왜
`[1m]` 마커가 붙은 ocx 서브에이전트 모델(gpt-5.6 계열, 실윈도우 372k)을 TUI 세션에서 호출하면 CLI가 1M 기준으로 compact 임계치를 잡아 백엔드 실한도에서 compact 없이 즉사. ADK exact-token steering은 CLI 내부 서브에이전트 루프에 도달 불가하므로 이 env가 유일한 안전망이다.

## 검증
- `cargo test --lib claude_compact_context` 20 passed (신규: 정책 파싱 미러링, fresh/off/scrub, cold-fetch fail-closed)
- `cargo test --lib claude_tui::session` 11 passed (export/unset 시나리오 + 모델 전환 불변성 재작성)
- `cargo test --lib claude_compact_trigger` 20 passed
- `cargo fmt --check` 클린, docs freshness gate passed (rebase 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)