### PR TITLE
fix(#5059): authenticate loopback gateway catalog fetch with OCX admin token

### DIFF
--- a/src/services/claude_compact_context.rs
+++ b/src/services/claude_compact_context.rs
@@ -646,8 +646,11 @@ async fn fetch_catalog(proxy_url: &str) -> Result<GatewayCatalog, String> {
             .build()
             .expect("build Claude context-window HTTP client")
     });
-    let response = client
-        .get(&endpoint)
+    let mut request = client.get(&endpoint);
+    if let Some(token) = local_gateway_admin_token(&endpoint) {
+        request = request.header("x-opencodex-api-key", token);
+    }
+    let response = request
         .send()
         .await
         .map_err(|error| format!("GET {endpoint}: {error}"))?
@@ -709,6 +712,40 @@ fn ocx_auto_compact_window(value: &Value) -> Option<u64> {
         })
         .unwrap_or(OCX_AUTO_COMPACT_WINDOW_DEFAULT_TOKENS);
     Some(window)
+}
+
+/// OCX gates its whole management API (`/api/*`, including the catalog
+/// endpoint) behind an admin token: `OPENCODEX_ADMIN_AUTH_TOKEN` env first,
+/// else the token file in its config dir (`$OPENCODEX_HOME`, default
+/// `~/.opencodex`). Mirror that resolution — but only for loopback endpoints:
+/// the file token is a host-local secret and must never be sent to a remote
+/// gateway. Absent token → no header (pre-auth gateways keep working).
+fn local_gateway_admin_token(endpoint: &str) -> Option<String> {
+    let host = reqwest::Url::parse(endpoint).ok()?.host_str()?.to_string();
+    if !matches!(host.as_str(), "127.0.0.1" | "localhost" | "::1" | "[::1]") {
+        return None;
+    }
+    if let Ok(token) = std::env::var("OPENCODEX_ADMIN_AUTH_TOKEN") {
+        let token = token.trim();
+        if !token.is_empty() {
+            return Some(token.to_string());
+        }
+    }
+    let config_dir = std::env::var("OPENCODEX_HOME")
+        .ok()
+        .map(|raw| raw.trim().to_string())
+        .filter(|raw| !raw.is_empty())
+        .map(std::path::PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".opencodex")))?;
+    let path = config_dir.join("admin-api-token");
+    let metadata = std::fs::symlink_metadata(&path).ok()?;
+    // Mirror OCX's own read guard: regular file, bounded size.
+    if !metadata.is_file() || metadata.len() > 512 {
+        return None;
+    }
+    let token = std::fs::read_to_string(&path).ok()?;
+    let token = token.trim();
+    (!token.is_empty()).then(|| token.to_string())
 }
 
 fn collect_catalog_windows(value: &Value, windows: &mut HashMap<String, u64>) {
@@ -1020,6 +1057,19 @@ mod tests {
             None,
             "scrubbed launches use native selectors whose [1m] windows are genuinely 1M"
         );
+    }
+
+    #[test]
+    fn gateway_admin_token_is_never_sent_to_non_loopback_hosts() {
+        assert_eq!(
+            local_gateway_admin_token("http://10.0.0.5:10100/api/claude-code"),
+            None
+        );
+        assert_eq!(
+            local_gateway_admin_token("http://gateway.example:10100/api/claude-code"),
+            None
+        );
+        assert_eq!(local_gateway_admin_token("not a url"), None);
     }
 
     #[test]
@@ -1359,5 +1409,36 @@ mod tests {
         assert!(enabled_command.get_envs().any(|(key, value)| {
             key == OsStr::new(CLAUDE_AUTO_COMPACT_WINDOW_ENV) && value == Some(OsStr::new("700000"))
         }));
+    }
+}
+
+/// Operator diagnostic against a live local gateway; never runs in CI.
+/// `cargo test --lib live_probe_tui_launch_window -- --ignored --nocapture`
+/// prints the launch decision, the raw fetch result (window count + policy),
+/// and the committed cache entry for `http://127.0.0.1:10100`.
+#[cfg(test)]
+mod live_probe_tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "live gateway probe: requires an opencodex gateway on 127.0.0.1:10100"]
+    fn live_probe_tui_launch_window() {
+        let _guard = state_test_guard();
+        let decision = tui_launch_auto_compact_window(&ClaudeGatewayProxyEnv::Inject {
+            base_url: "http://127.0.0.1:10100".to_string(),
+        });
+        eprintln!("LIVE_PROBE decision={decision:?}");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let raw = runtime.block_on(fetch_catalog("http://127.0.0.1:10100"));
+        eprintln!(
+            "LIVE_PROBE raw_fetch={:?}",
+            raw.as_ref()
+                .map(|catalog| (catalog.windows.len(), catalog.auto_compact_window))
+        );
+        let cached = cached_gateway_auto_compact_window("http://127.0.0.1:10100");
+        eprintln!("LIVE_PROBE cached={cached:?}");
     }
 }

--- a/src/services/claude_compact_context.rs
+++ b/src/services/claude_compact_context.rs
@@ -1410,16 +1410,11 @@ mod tests {
             key == OsStr::new(CLAUDE_AUTO_COMPACT_WINDOW_ENV) && value == Some(OsStr::new("700000"))
         }));
     }
-}
 
-/// Operator diagnostic against a live local gateway; never runs in CI.
-/// `cargo test --lib live_probe_tui_launch_window -- --ignored --nocapture`
-/// prints the launch decision, the raw fetch result (window count + policy),
-/// and the committed cache entry for `http://127.0.0.1:10100`.
-#[cfg(test)]
-mod live_probe_tests {
-    use super::*;
-
+    /// Operator diagnostic against a live local gateway; never runs in CI.
+    /// `cargo test --lib live_probe_tui_launch_window -- --ignored --nocapture`
+    /// prints the launch decision, the raw fetch result (window count +
+    /// policy), and the committed cache entry for `http://127.0.0.1:10100`.
     #[test]
     #[ignore = "live gateway probe: requires an opencodex gateway on 127.0.0.1:10100"]
     fn live_probe_tui_launch_window() {


### PR DESCRIPTION
Follow-up to #5060 (post-deploy 실측 검증에서 발견).

## 발견 경위
#5060 배포 후 새 TUI launch 스크립트에 export가 안 붙는 것을 실물 검증으로 확인 → live probe로 재현 → 카탈로그 fetch가 **401 Unauthorized**. opencodex가 management API(`/api/*`, 카탈로그 endpoint 포함)를 admin 토큰으로 게이트하기 시작했고, ADK fetch는 토큰을 안 보냄. 이로 인해 신규 TUI env 주입뿐 아니라 기존 compact steering의 proven-window 경로도 조용히 `fallback_max`로 degraded 상태였음 (dcserver 로그 확인).

## 변경
- `fetch_catalog`가 OCX의 토큰 해석 순서를 미러링해 `x-opencodex-api-key` 헤더 첨부: `OPENCODEX_ADMIN_AUTH_TOKEN` env → `$OPENCODEX_HOME/admin-api-token` → `~/.opencodex/admin-api-token` (regular file, ≤512B 가드 동일 미러)
- **loopback 호스트 한정** — host-local secret이 리모트 게이트웨이로 유출되지 않도록 127.0.0.1/localhost/::1 외에는 헤더 미첨부
- 토큰 부재 시 기존 동작(무헤더) 유지 — 인증 없는 구버전 게이트웨이 호환
- ignored live-probe 진단 테스트 추가 (`cargo test --lib live_probe_tui_launch_window -- --ignored --nocapture`)

## 검증
- live probe: 401 재현 → 토큰 첨부 후 `decision=Some(350000)`, 27 windows 캐시 커밋 확인
- `cargo test --lib claude_compact_context` 21 passed (신규: non-loopback 토큰 미전송 가드)
- `cargo fmt --check` 클린, docs freshness gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)