### PR TITLE
feat(discord): add fable[1m] to the curated Claude model catalog

### DIFF
--- a/src/services/discord/model_catalog/claude.rs
+++ b/src/services/discord/model_catalog/claude.rs
@@ -72,6 +72,11 @@ const CURATED_ALIASES: &[CuratedAlias] = &[
         metadata_fallback_id: "claude-haiku-4-5-20251001",
     },
     CuratedAlias {
+        selector: "fable[1m]",
+        label: "Fable 1M",
+        metadata_fallback_id: "claude-fable-5",
+    },
+    CuratedAlias {
         selector: "sonnet[1m]",
         label: "Sonnet 1M",
         metadata_fallback_id: "claude-sonnet-5",
@@ -880,7 +885,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(&values[..4], ["fable", "opus", "sonnet", "haiku"]);
-        for selector in ["sonnet[1m]", "opus[1m]", "opusplan"] {
+        for selector in ["fable[1m]", "sonnet[1m]", "opus[1m]", "opusplan"] {
             assert!(
                 values.contains(&selector),
                 "runtime-only selector {selector} must survive without caches"


### PR DESCRIPTION
## 문제

`/model` 피커의 Claude 카탈로그(`CURATED_ALIASES`)에 1M 컨텍스트 셀렉터가 `sonnet[1m]`, `opus[1m]`만 있고 Fable용이 없었다. 그래서 Fable은 200k 셀렉터(`fable`)로만 선택 가능했다.

`ANTHROPIC_BASE_URL`이 `api.anthropic.com`이 아닌 환경(로컬 opencodex 게이트웨이 등)에서는 Claude Code가 native-1M 경로를 끈다 — 컨텍스트 창 계산이 다음 순서라서:

1. 모델 문자열에 `[1m]` 접미사 → 1M
2. 1M 베타 헤더 → 1M
3. native 1M (`firstParty` **and** base URL이 `api.anthropic.com`일 것) → 1M
4. 그 외 → **200k**

`claude-fable-5`는 카탈로그상 `native_1m: true`지만 3번 조건에서 탈락하고(`native_1m_3p`도 없어 gateway 경로 불가), `fable` alias는 `claude-fable-5`(접미사 없음)로 해석되므로 200k로 떨어진다. 즉 그 환경에서 Fable로 1M을 쓰려면 `fable[1m]` 셀렉터가 유일한 경로인데, 피커에 항목이 없어 수동 오버라이드에 의존해야 했고 피커를 한 번 쓰면 200k로 되돌아갔다.

## 변경

- `CURATED_ALIASES`에 `fable[1m]` (label `Fable 1M`, fallback id `claude-fable-5`) 추가 — 게이트웨이/API 캐시가 없어도 셀렉터가 살아남는다.
- `invariant_claude_model_catalog_curated_aliases_remain_evergreen_runtime_selectors`의 runtime-only 셀렉터 목록에 `fable[1m]` 추가.

기존 `values[..4] == ["fable","opus","sonnet","haiku"]` 불변식은 유지되도록 haiku 뒤 1M 그룹 선두에 넣었다.

## 검증

- `cargo fmt --all --check` 클린
- `cargo check --lib` 클린
- `cargo test --lib model_catalog` — 28 passed, 0 failed
- `python3 scripts/generate_inventory_docs.py` → `check_agent_maintenance_docs.py` = `agent-maintenance freshness check passed` (generated docs 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)