### PR TITLE
fix(#5003): route nightly multinode_regression lane to --lib target

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -262,7 +262,7 @@ jobs:
 
       - name: Rust multinode invariants
         timeout-minutes: 15
-        run: "cargo test --bin agentdesk multinode_regression:: -- --nocapture --test-threads=1"
+        run: "cargo test --lib multinode_regression:: -- --nocapture --test-threads=1"
 
       - name: Merge gate policy invariants
         run: node --test policies/__tests__/merge-automation.test.js

--- a/scripts/pg_test_lane_baseline.txt
+++ b/scripts/pg_test_lane_baseline.txt
@@ -17,11 +17,6 @@ db::intake_outbox::migration_tests::migration_0080_recovers_provider_from_claim_
 engine::ops::config_ops::tests::policy_engine_config_get_preserves_types_precedence_and_fail_closed_contract
 engine::ops::db_ops::tests::policy_db_query_json_returns_typed_json_columns_and_query_keeps_strings
 server::issue_specs::tests::upsert_issue_spec_persists_parsed_contract
-server::multinode_regression::tests::multinode_dispatch_claims_exactly_once_then_reclaims_expired_lease
-server::multinode_regression::tests::multinode_dispatch_claims_prefer_label_but_fallback_when_preferred_node_offline
-server::multinode_regression::tests::multinode_dispatch_claims_route_mixed_required_and_preferred_to_best_online_node
-server::multinode_regression::tests::multinode_single_leader_lock_allows_one_holder
-server::multinode_regression::tests::multinode_unreal_resource_lock_is_exclusive
 server::resource_locks::tests::resource_lock_allows_only_one_active_holder
 server::resource_locks::tests::resource_lock_reclaims_expired_holder
 server::routes::dispatches::crud::tests::dispatch_delivery_events_route_returns_typed_rows_newest_first


### PR DESCRIPTION
## 요약
#5003 사례1(빈 타깃 필터 rc=0 green) 4곳 중 마지막 잔존 수리. `ci-nightly.yml`의 `multinode_regression` 레인이 `cargo test --bin agentdesk multinode_regression::`으로 **0개 매칭 rc=0**이었던 것을 `--lib`로 전환 (#5002가 고친 high_risk_recovery 3곳과 동일 형태).

## 변경
- `.github/workflows/ci-nightly.yml`: `--bin agentdesk` → `--lib` (1줄)
- `scripts/pg_test_lane_baseline.txt`: rule1 stale 5건 제거 (118→113, shrink-only) — `--lib` 전환으로 nightly PG-backed multinode 잡이 이 5개 테스트를 실제 커버하게 되어 S1 게이트가 stale로 판정

## 근거
- `multinode_regression`은 lib 전용 모듈: `src/lib.rs:128` → `src/server/mod.rs:8`. `src/main.rs\)에는 mod 선언 0건 (0매칭의 근본 원인)
- 해당 nightly 잡은 PG 기동함 (`ci-nightly.yml:223` env + postgres-service.sh start 스텝)

## 게이트
- `ci-script-checks.sh` (TEST_LANE_BASELINE_REF=origin/main) rc=0
- Rust prod 무변경

## 리뷰
- Claude Opus fresh 세션 적대 리뷰 @ `873618823`: **VERDICT: CLEAN** (P0/P1 0건, P2 관찰 3건 — 기존 부채)
- 간단수정 예외(단일 관심사 CI wiring, 핫파일 비접촉) 적용, 1 leg

EPIC #5071 T0 ① 트랙.

🤖 Generated with [Claude Code](https://claude.com/claude-code)