### PR TITLE
fix(#5044): assert typed phase-gate verdict instead of formatted tracing output

### DIFF
--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -1392,24 +1392,18 @@ fn complete_dispatch_inner_with_backends(
     Ok(dispatch)
 }
 
-/// #699 / #4884: inject `verdict = context.phase_gate.pass_verdict` into a
-/// phase-gate dispatch result when every declared `checks.*` entry passed but
-/// the caller forgot the explicit verdict field.
-///
-/// Returns `Some(enriched)` only when an injection happened — callers should
-/// fall back to the original `result` otherwise.
-///
-/// The pass/fail decision itself is delegated to
-/// `crate::db::auto_queue::phase_gate_verdict`, the single Rust authority also
-/// used by the durable reconciler that runs for CRUD / watcher / bridge
-/// recovery completions. This path only owns the *side effect* of persisting
-/// the inferred verdict onto the result payload; it must never reach a
-/// different verdict than the reconciler would for the same evidence.
-fn infer_phase_gate_verdict(
-    dispatch_id: &str,
+/// Typed phase-gate inference result shared by production logging and tests.
+struct InferredPhaseGateVerdict {
+    enriched_result: serde_json::Value,
+    pass_verdict: String,
+    declared_check_count: usize,
+    reported_check_count: usize,
+}
+
+fn infer_phase_gate_verdict_details(
     context: &serde_json::Value,
     result: &serde_json::Value,
-) -> Option<serde_json::Value> {
+) -> Option<InferredPhaseGateVerdict> {
     let phase_gate_ctx = context.get("phase_gate")?;
     let phase_gate_verdict::VerdictResolution::Inferred(pass_verdict) =
         phase_gate_verdict::resolve_verdict(Some(context), result)
@@ -1417,11 +1411,11 @@ fn infer_phase_gate_verdict(
         return None;
     };
 
-    let mut enriched = result.clone();
-    if !enriched.is_object() {
-        enriched = serde_json::Value::Object(serde_json::Map::new());
+    let mut enriched_result = result.clone();
+    if !enriched_result.is_object() {
+        enriched_result = serde_json::Value::Object(serde_json::Map::new());
     }
-    if let Some(obj) = enriched.as_object_mut() {
+    if let Some(obj) = enriched_result.as_object_mut() {
         obj.insert(
             "verdict".to_string(),
             serde_json::Value::String(pass_verdict.clone()),
@@ -1440,15 +1434,43 @@ fn infer_phase_gate_verdict(
         .get("checks")
         .and_then(serde_json::Value::as_object)
         .map_or(0, serde_json::Map::len);
-    tracing::info!(
-        dispatch_id = %dispatch_id,
-        pass_verdict = %pass_verdict,
+
+    Some(InferredPhaseGateVerdict {
+        enriched_result,
+        pass_verdict,
         declared_check_count,
         reported_check_count,
+    })
+}
+
+/// #699 / #4884: inject `verdict = context.phase_gate.pass_verdict` into a
+/// phase-gate dispatch result when every declared `checks.*` entry passed but
+/// the caller forgot the explicit verdict field.
+///
+/// Returns `Some(enriched)` only when an injection happened — callers should
+/// fall back to the original `result` otherwise.
+///
+/// The pass/fail decision itself is delegated to
+/// `crate::db::auto_queue::phase_gate_verdict`, the single Rust authority also
+/// used by the durable reconciler that runs for CRUD / watcher / bridge
+/// recovery completions. This path only owns the *side effect* of persisting
+/// the inferred verdict onto the result payload; it must never reach a
+/// different verdict than the reconciler would for the same evidence.
+fn infer_phase_gate_verdict(
+    dispatch_id: &str,
+    context: &serde_json::Value,
+    result: &serde_json::Value,
+) -> Option<serde_json::Value> {
+    let details = infer_phase_gate_verdict_details(context, result)?;
+    tracing::info!(
+        dispatch_id = %dispatch_id,
+        pass_verdict = %details.pass_verdict,
+        declared_check_count = details.declared_check_count,
+        reported_check_count = details.reported_check_count,
         "[dispatch] #699 inferred phase-gate verdict because all declared checks passed",
     );
 
-    Some(enriched)
+    Some(details.enriched_result)
 }
 
 #[cfg(test)]
@@ -1648,61 +1670,13 @@ mod auto_queue_terminal_sync_policy_tests {
 #[cfg(test)]
 mod auto_queue_phase_gate_finalize_wrapper_tests {
     use super::{
-        infer_effective_completion_result, infer_phase_gate_verdict, log_phase_gate_reconciliation,
-        maybe_inject_phase_gate_verdict_pg, set_dispatch_status_on_pg_async,
+        infer_effective_completion_result, infer_phase_gate_verdict,
+        infer_phase_gate_verdict_details, maybe_inject_phase_gate_verdict_pg,
+        set_dispatch_status_on_pg_async,
     };
     use crate::db::auto_queue::test_support::TestPostgresDb;
     use serde_json::{Value, json};
     use sqlx::{PgPool, Row};
-    use std::io::{self, Write};
-    use std::sync::{Arc, Mutex};
-    use tracing_subscriber::fmt::writer::MakeWriter;
-
-    #[derive(Clone)]
-    struct CapturingWriter {
-        buffer: Arc<Mutex<Vec<u8>>>,
-    }
-
-    impl Write for CapturingWriter {
-        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-            match self.buffer.lock() {
-                Ok(mut buffer) => buffer.extend_from_slice(bytes),
-                Err(poisoned) => poisoned.into_inner().extend_from_slice(bytes),
-            }
-            Ok(bytes.len())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    impl<'a> MakeWriter<'a> for CapturingWriter {
-        type Writer = CapturingWriter;
-
-        fn make_writer(&'a self) -> Self::Writer {
-            self.clone()
-        }
-    }
-
-    fn capture_info_logs(emit: impl FnOnce()) -> Result<String, std::string::FromUtf8Error> {
-        let buffer = Arc::new(Mutex::new(Vec::new()));
-        let subscriber = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::INFO)
-            .with_ansi(false)
-            .without_time()
-            .with_target(false)
-            .with_writer(CapturingWriter {
-                buffer: buffer.clone(),
-            })
-            .finish();
-        tracing::subscriber::with_default(subscriber, emit);
-        let bytes = match buffer.lock() {
-            Ok(buffer) => buffer.clone(),
-            Err(poisoned) => poisoned.into_inner().clone(),
-        };
-        String::from_utf8(bytes)
-    }
 
     fn gate() -> serde_json::Value {
         json!({
@@ -2148,73 +2122,18 @@ mod auto_queue_phase_gate_finalize_wrapper_tests {
     }
 
     #[test]
-    fn failed_reconciliation_log_does_not_emit_verdict_payload() {
-        let result = json!({
-            "verdict": {"authorization": "Bearer secret"},
-            "checks": {"build_passed": "fail"},
-        });
-        let resolution = crate::db::auto_queue::phase_gate_verdict::resolve_verdict(None, &result);
-        assert_eq!(
-            resolution,
-            crate::db::auto_queue::phase_gate_verdict::VerdictResolution::Missing
-        );
-        let failed_reason = match crate::db::auto_queue::phase_gate_verdict::diagnostic_verdict(
-            &result,
-            &resolution,
-        ) {
-            Some(diagnostic) => format!("expected verdict gate_ok, got {diagnostic}"),
-            None => "expected verdict gate_ok, got none".to_string(),
-        };
-        let outcome = crate::db::auto_queue::PhaseGateReconciliation::MarkedFailed {
-            run_id: "run-log-redaction".to_string(),
-            phase: 0,
-            failed_dispatch_id: "dsp-log-redaction".to_string(),
-            failed_reason,
-        };
-        let logs = capture_info_logs(|| {
-            log_phase_gate_reconciliation("dsp-log-redaction", &outcome);
-        });
-
-        assert!(
-            logs.as_ref()
-                .is_ok_and(|logs| logs.contains("<non-string:object>")),
-            "{logs:?}"
-        );
-        assert!(
-            logs.as_ref().is_ok_and(|logs| {
-                !logs.contains("authorization") && !logs.contains("Bearer secret")
-            }),
-            "failed reconciliation log leaked verdict payload: {logs:?}"
-        );
-    }
-
-    #[test]
-    fn inferred_verdict_log_preserves_check_cardinality_fields() {
+    fn inferred_verdict_preserves_check_cardinality_fields() {
         let result = json!({ "checks": passing_checks() });
-        let logs = capture_info_logs(|| {
-            let injected = infer_phase_gate_verdict("dsp-log-fields", &gate(), &result);
-            assert!(injected.is_some());
-        });
+        let details = infer_phase_gate_verdict_details(&gate(), &result)
+            .expect("passing declared checks should infer a verdict");
 
-        assert!(
-            logs.as_ref()
-                .is_ok_and(|logs| logs.contains("dispatch_id=dsp-log-fields")),
-            "{logs:?}"
-        );
-        assert!(
-            logs.as_ref()
-                .is_ok_and(|logs| logs.contains("pass_verdict=phase_gate_passed")),
-            "{logs:?}"
-        );
-        assert!(
-            logs.as_ref()
-                .is_ok_and(|logs| logs.contains("declared_check_count=3")),
-            "{logs:?}"
-        );
-        assert!(
-            logs.as_ref()
-                .is_ok_and(|logs| logs.contains("reported_check_count=3")),
-            "{logs:?}"
+        assert_eq!(details.pass_verdict, "phase_gate_passed");
+        assert_eq!(details.declared_check_count, 3);
+        assert_eq!(details.reported_check_count, 3);
+        assert_eq!(details.enriched_result["verdict"], "phase_gate_passed");
+        assert_eq!(
+            details.enriched_result["verdict_inferred"],
+            serde_json::Value::Bool(true)
         );
     }
 

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -2125,7 +2125,7 @@ mod auto_queue_phase_gate_finalize_wrapper_tests {
     fn inferred_verdict_preserves_check_cardinality_fields() {
         let result = json!({ "checks": passing_checks() });
         let details = infer_phase_gate_verdict_details(&gate(), &result)
-            .expect("passing declared checks should infer a verdict");
+            .expect("passing declared checks should infer a verdict"); // agentdesk-audit: allow-unwrap — deterministic typed-verdict assertion in #[cfg(test)] module (#5044)
 
         assert_eq!(details.pass_verdict, "phase_gate_passed");
         assert_eq!(details.declared_check_count, 3);


### PR DESCRIPTION
## 요약
auto_queue phase-gate 테스트가 self-hosted 러너에서 flaky했던 근본원인을 제거한다 (#5044).

## 근본원인 (스카우트 확정)
- 프로덕션 verdict 계산은 결정적·무결 (`phase_gate_verdict.rs:70`, 시간·순서·환경 의존 없음).
- 실패는 테스트가 **formatted tracing INFO 문자열을 correctness oracle**로 삼아 프로세스 전역 tracing callsite interest cache와 경쟁했기 때문 (실패 시 `logs == Ok("")`인데 closure 내 verdict assert는 통과 — verdict 정상, INFO만 writer 미도달).
- 이슈 본문의 "낮은 max-level subscriber가 INFO를 never로 고정" 메커니즘은 tracing-core 0.1.36 소스 대조로 기각 (상이한 interest는 `sometimes`로 결합).

## 변경 (src/dispatch/dispatch_status.rs만, +59/−140)
- `infer_phase_gate_verdict`의 순수 계산을 private `InferredPhaseGateVerdict` + `infer_phase_gate_verdict_details`로 분리. 기존 함수는 wrapper로서 **동일 INFO 로그**(필드명·값·메시지 보존) 후 `enriched_result`만 반환 — 프로덕션 API·로그 동작 무변경 (리뷰에서 main과 라인 대조 동치 확정).
- flaky 테스트를 typed 결과 직접 검증(`inferred_verdict_preserves_check_cardinality_fields`)으로 전환, tracing 캡처 헬퍼 삭제.
- redaction 테스트는 기존 typed/durable 검증(phase_gate_verdict.rs:290, phase_gates.rs:2355)과 중복 확인 후 제거.

## 검증
- 배터리: fmt --check / check --lib / test --lib dispatch_status·auto_queue / **대상 테스트 반복 10회 flake 0** / docs freshness / audit --check / audit_state_lint / ci-script-checks 전부 rc=0.
- Dual review @6dad23067: Claude Opus leg CLEAN + GPT sol fresh leg CLEAN (r1 Opus 지적 P1 마커는 반영 완료, P2 "wrapper INFO 발생 증명 부재"는 수용된 트레이드오프 — in-process 로그 문자열 단언 자체가 유효 oracle이 아님).

Refs #5044 (T0 blocker ④, #5071)

🤖 Generated with [Claude Code](https://claude.com/claude-code)