### PR TITLE
refactor(#4979): S3 B0 canary — migrate outbox_claiming PG tests into the postgres lane

### DIFF
--- a/justfile
+++ b/justfile
@@ -44,6 +44,8 @@ test-non-pg:
     cargo test --lib server::claude_oauth_usage_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib tui_task_card::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib server::routes::message_outbox::tests -- --skip _pg --skip pg_ --skip postgres
+    # Keep the non-PostgreSQL unit tests covered after outbox_claiming's PG split.
+    cargo test --lib services::dispatches::outbox_claiming::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib discord_thread_create -- --test-threads=1
     # #4599: queue reaction fallback and persisted-v1 promotion contracts.
     cargo test --lib reaction_control::tests -- --skip _pg --skip pg_ --skip postgres

--- a/scripts/pg_test_lane_baseline.txt
+++ b/scripts/pg_test_lane_baseline.txt
@@ -74,8 +74,6 @@ services::dispatches::discord_delivery::guard::tests::failed_delivery_retry_shad
 services::dispatches::discord_delivery::guard::tests::finalize_delivery_guard_shadow_updates_failed_event_without_notified_marker
 services::dispatches::discord_delivery::guard::tests::finalize_delivery_guard_shadow_updates_sent_event_and_kv_meta
 services::dispatches::discord_delivery::guard::tests::kv_meta_markers_remain_authoritative_when_typed_shadow_missing
-services::dispatches::outbox_claiming::tests::reassign_stale_claim_owner_clears_owner_when_no_live_candidate_matches
-services::dispatches::outbox_claiming::tests::reassign_stale_claim_owners_moves_100_pending_rows_to_live_label_match
 services::maintenance::jobs::db_retention::tests::db_retention_context_snapshot_terminal_reclaim
 services::maintenance::jobs::db_retention::tests::db_retention_keeps_skill_usage_rows_with_null_used_at
 services::maintenance::jobs::db_retention::tests::db_retention_preserves_permanent_outbox_dedupe_sentinels
@@ -309,8 +307,6 @@ services::dispatches::discord_delivery::guard::tests::failed_delivery_retry_shad
 services::dispatches::discord_delivery::guard::tests::finalize_delivery_guard_shadow_updates_failed_event_without_notified_marker
 services::dispatches::discord_delivery::guard::tests::finalize_delivery_guard_shadow_updates_sent_event_and_kv_meta
 services::dispatches::discord_delivery::guard::tests::kv_meta_markers_remain_authoritative_when_typed_shadow_missing
-services::dispatches::outbox_claiming::tests::reassign_stale_claim_owner_clears_owner_when_no_live_candidate_matches
-services::dispatches::outbox_claiming::tests::reassign_stale_claim_owners_moves_100_pending_rows_to_live_label_match
 services::maintenance::jobs::db_retention::tests::db_retention_context_snapshot_terminal_reclaim
 services::maintenance::jobs::db_retention::tests::db_retention_keeps_skill_usage_rows_with_null_used_at
 services::maintenance::jobs::db_retention::tests::db_retention_preserves_permanent_outbox_dedupe_sentinels

--- a/scripts/pg_test_lane_manifest.txt
+++ b/scripts/pg_test_lane_manifest.txt
@@ -129,7 +129,7 @@ services::discord::tmux::watcher_lifecycle::restore_tests::restored_session_cwd_
 services::discord::turn_bridge::completion_guard::completion_postgres::dispatch_failure_pg_tests
 services::discord::turn_bridge::recovery_text::tests
 services::dispatches::discord_delivery::guard::tests
-services::dispatches::outbox_claiming::tests
+services::dispatches::outbox_claiming::tests::outbox_claiming_pg_tests
 services::dispatches::wait_queue::tests
 services::maintenance::jobs::db_retention::tests
 services::maintenance::jobs::worktree_orphan_sweep::active_dispatch_worktree_keep_set_tests
@@ -495,8 +495,8 @@ services::dispatches::discord_delivery::guard::tests::failed_delivery_retry_shad
 services::dispatches::discord_delivery::guard::tests::finalize_delivery_guard_shadow_updates_failed_event_without_notified_marker
 services::dispatches::discord_delivery::guard::tests::finalize_delivery_guard_shadow_updates_sent_event_and_kv_meta
 services::dispatches::discord_delivery::guard::tests::kv_meta_markers_remain_authoritative_when_typed_shadow_missing
-services::dispatches::outbox_claiming::tests::reassign_stale_claim_owner_clears_owner_when_no_live_candidate_matches
-services::dispatches::outbox_claiming::tests::reassign_stale_claim_owners_moves_100_pending_rows_to_live_label_match
+services::dispatches::outbox_claiming::tests::outbox_claiming_pg_tests::reassign_stale_claim_owner_clears_owner_when_no_live_candidate_matches
+services::dispatches::outbox_claiming::tests::outbox_claiming_pg_tests::reassign_stale_claim_owners_moves_100_pending_rows_to_live_label_match
 services::dispatches::wait_queue::tests::wake_waiting_dispatch_outbox_pg_reassigns_wait_rows_fifo
 services::maintenance::jobs::db_retention::tests::db_retention_context_snapshot_pg_reference_gate
 services::maintenance::jobs::db_retention::tests::db_retention_context_snapshot_terminal_reclaim

--- a/scripts/test_lane_coverage_baseline.txt
+++ b/scripts/test_lane_coverage_baseline.txt
@@ -532,7 +532,6 @@ services::dispatched_sessions::kill_tmux_resume_tests
 services::dispatches::discord_delivery::guard::tests
 services::dispatches::discord_delivery::orchestration::slot_routing_pure_tests
 services::dispatches::discord_delivery::transport::tests
-services::dispatches::outbox_claiming::tests
 services::dispatches::outbox_route::tests
 services::dispatches::result_header::tests
 services::dispatches::routing_constraint::tests

--- a/src/services/dispatches/outbox_claiming.rs
+++ b/src/services/dispatches/outbox_claiming.rs
@@ -705,9 +705,14 @@ mod tests {
     // 지우면 안 된다 — `check_test_lane_coverage.py`가 test fn을 가장 안쪽
     // `cfg(test)` 모듈에 귀속시키므로, 빼면 PG 2건이 부모 `…::tests`로 귀속되고
     // 그 부모는 `--skip _pg` 탓에 어떤 curated 호출로도 커버되지 않게 된다.
-    // 반면 `*_pg_tests` 접미사는 어떤 게이트도 강제하지 않는 사람 규약이다
-    // (bare `pg_tests` 모듈이 이미 3건 존재) — 후속 이관은 이름을 게이트가
-    // 지켜준다고 가정하지 말 것.
+    // 이름 계약은 두 층으로 갈린다. `*_pg_tests`라는 **접미사 형태**는 어떤
+    // 게이트도 강제하지 않는 사람 규약이고(bare `pg_tests` 모듈이 이미 4건
+    // 있다), 실제로 강제되는 것은 정규화된 테스트 경로가 `_pg`·`pg_`·`postgres`
+    // 중 하나를 부분문자열로 포함해야 한다는 것뿐이다 — `justfile`의
+    // `cargo test --lib -- _pg pg_ postgres`(rule1)와 비PG 레인의 `--skip _pg
+    // --skip pg_ --skip postgres`(rule2)에서 나오며, 둘 다 one-way ratchet이라
+    // 위반하면 CI가 red다. 즉 `mod db_backed_tests` 같은 이름은 규약 위반이
+    // 아니라 게이트 위반이다.
     #[cfg(test)]
     mod outbox_claiming_pg_tests {
         use super::*;

--- a/src/services/dispatches/outbox_claiming.rs
+++ b/src/services/dispatches/outbox_claiming.rs
@@ -699,10 +699,18 @@ mod tests {
             None
         );
     }
+
+    // #4979 B0: PG 테스트를 `*_pg_tests` 하위 모듈로 이관해 `just test-postgres`의
+    // `_pg` 선택자에 걸리게 한다. 아래 `#[cfg(test)]`는 컴파일상 중복이지만
+    // 지우면 안 된다 — `check_test_lane_coverage.py`가 test fn을 가장 안쪽
+    // `cfg(test)` 모듈에 귀속시키므로, 빼면 PG 2건이 부모 `…::tests`로 귀속되고
+    // 그 부모는 `--skip _pg` 탓에 어떤 curated 호출로도 커버되지 않게 된다.
+    // 반면 `*_pg_tests` 접미사는 어떤 게이트도 강제하지 않는 사람 규약이다
+    // (bare `pg_tests` 모듈이 이미 3건 존재) — 후속 이관은 이름을 게이트가
+    // 지켜준다고 가정하지 말 것.
     #[cfg(test)]
     mod outbox_claiming_pg_tests {
         use super::*;
-        use serde_json::json;
         use sqlx::PgPool;
         use uuid::Uuid;
 

--- a/src/services/dispatches/outbox_claiming.rs
+++ b/src/services/dispatches/outbox_claiming.rs
@@ -520,133 +520,6 @@ mod tests {
     use crate::db::dispatches::outbox::DispatchOutboxClaimCandidate;
     use crate::services::dispatches::routing_constraint::{NoOpConstraint, RoutingEngine};
     use serde_json::json;
-    use sqlx::PgPool;
-    use uuid::Uuid;
-
-    struct TestPostgresDb {
-        _lock: crate::db::postgres::PostgresTestLifecycleGuard,
-        admin_url: String,
-        database_name: String,
-        database_url: String,
-    }
-
-    impl TestPostgresDb {
-        async fn create() -> Option<Self> {
-            let lock = crate::db::postgres::lock_test_lifecycle();
-            let admin_url = postgres_admin_database_url();
-            let database_name = format!("agentdesk_outbox_claiming_{}", Uuid::new_v4().simple());
-            let database_url = format!("{}/{}", postgres_base_database_url(), database_name);
-            if let Err(error) = crate::db::postgres::create_test_database(
-                &admin_url,
-                &database_name,
-                "outbox claiming tests",
-            )
-            .await
-            {
-                eprintln!("skipping outbox claiming postgres test: {error}");
-                return None;
-            }
-
-            Some(Self {
-                _lock: lock,
-                admin_url,
-                database_name,
-                database_url,
-            })
-        }
-
-        async fn connect_and_migrate(&self) -> PgPool {
-            crate::db::postgres::connect_test_pool_and_migrate(
-                &self.database_url,
-                "outbox claiming tests",
-            )
-            .await
-            .expect("connect and migrate outbox claiming postgres test database")
-        }
-
-        async fn drop(self) {
-            crate::db::postgres::drop_test_database(
-                &self.admin_url,
-                &self.database_name,
-                "outbox claiming tests",
-            )
-            .await
-            .expect("drop outbox claiming postgres test database");
-        }
-    }
-
-    fn postgres_base_database_url() -> String {
-        if let Ok(base) = std::env::var("POSTGRES_TEST_DATABASE_URL_BASE") {
-            let trimmed = base.trim();
-            if !trimmed.is_empty() {
-                return trimmed.trim_end_matches('/').to_string();
-            }
-        }
-
-        let user = std::env::var("PGUSER")
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-            .or_else(|| {
-                std::env::var("USER")
-                    .ok()
-                    .filter(|value| !value.trim().is_empty())
-            })
-            .unwrap_or_else(|| "postgres".to_string());
-        let password = std::env::var("PGPASSWORD")
-            .ok()
-            .filter(|value| !value.trim().is_empty());
-        let host = std::env::var("PGHOST")
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or_else(|| "localhost".to_string());
-        let port = std::env::var("PGPORT")
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or_else(|| "5432".to_string());
-
-        match password {
-            Some(password) => format!("postgres://{user}:{password}@{host}:{port}"),
-            None => format!("postgres://{user}@{host}:{port}"),
-        }
-    }
-
-    fn postgres_admin_database_url() -> String {
-        if let Ok(url) = std::env::var("POSTGRES_TEST_ADMIN_URL") {
-            let trimmed = url.trim();
-            if !trimmed.is_empty() {
-                return trimmed.to_string();
-            }
-        }
-        let admin_db = std::env::var("POSTGRES_TEST_ADMIN_DB")
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or_else(|| "postgres".to_string());
-        format!("{}/{}", postgres_base_database_url(), admin_db)
-    }
-
-    async fn seed_worker_node(
-        pool: &PgPool,
-        instance_id: &str,
-        labels: serde_json::Value,
-        heartbeat_age_secs: i64,
-    ) {
-        sqlx::query(
-            "INSERT INTO worker_nodes (
-                instance_id, hostname, process_id, role, effective_role, status,
-                labels, capabilities, last_heartbeat_at, started_at, updated_at
-             ) VALUES (
-                $1, $1, 100, 'auto', 'worker', 'online',
-                $2, '{\"providers\":[\"codex\"]}'::jsonb,
-                NOW() - ($3::BIGINT * INTERVAL '1 second'), NOW(), NOW()
-             )",
-        )
-        .bind(instance_id)
-        .bind(labels)
-        .bind(heartbeat_age_secs)
-        .execute(pool)
-        .await
-        .expect("seed worker node");
-    }
 
     #[test]
     fn non_empty_required_capabilities_handles_null_and_empty_object() {
@@ -826,108 +699,241 @@ mod tests {
             None
         );
     }
+    #[cfg(test)]
+    mod outbox_claiming_pg_tests {
+        use super::*;
+        use serde_json::json;
+        use sqlx::PgPool;
+        use uuid::Uuid;
 
-    #[tokio::test]
-    async fn reassign_stale_claim_owners_moves_100_pending_rows_to_live_label_match() {
-        let Some(pg_db) = TestPostgresDb::create().await else {
-            return;
-        };
-        let pool = pg_db.connect_and_migrate().await;
-        seed_worker_node(&pool, "stale-node", json!(["mac-book"]), 45).await;
-        seed_worker_node(&pool, "mac-mini-release", json!(["mac-mini"]), 0).await;
+        struct TestPostgresDb {
+            _lock: crate::db::postgres::PostgresTestLifecycleGuard,
+            admin_url: String,
+            database_name: String,
+            database_url: String,
+        }
 
-        sqlx::query(
-            "INSERT INTO dispatch_outbox (
+        impl TestPostgresDb {
+            async fn create() -> Option<Self> {
+                let lock = crate::db::postgres::lock_test_lifecycle();
+                let admin_url = postgres_admin_database_url();
+                let database_name =
+                    format!("agentdesk_outbox_claiming_{}", Uuid::new_v4().simple());
+                let database_url = format!("{}/{}", postgres_base_database_url(), database_name);
+                if let Err(error) = crate::db::postgres::create_test_database(
+                    &admin_url,
+                    &database_name,
+                    "outbox claiming tests",
+                )
+                .await
+                {
+                    eprintln!("skipping outbox claiming postgres test: {error}");
+                    return None;
+                }
+
+                Some(Self {
+                    _lock: lock,
+                    admin_url,
+                    database_name,
+                    database_url,
+                })
+            }
+
+            async fn connect_and_migrate(&self) -> PgPool {
+                crate::db::postgres::connect_test_pool_and_migrate(
+                    &self.database_url,
+                    "outbox claiming tests",
+                )
+                .await
+                .expect("connect and migrate outbox claiming postgres test database")
+            }
+
+            async fn drop(self) {
+                crate::db::postgres::drop_test_database(
+                    &self.admin_url,
+                    &self.database_name,
+                    "outbox claiming tests",
+                )
+                .await
+                .expect("drop outbox claiming postgres test database");
+            }
+        }
+
+        fn postgres_base_database_url() -> String {
+            if let Ok(base) = std::env::var("POSTGRES_TEST_DATABASE_URL_BASE") {
+                let trimmed = base.trim();
+                if !trimmed.is_empty() {
+                    return trimmed.trim_end_matches('/').to_string();
+                }
+            }
+
+            let user = std::env::var("PGUSER")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .or_else(|| {
+                    std::env::var("USER")
+                        .ok()
+                        .filter(|value| !value.trim().is_empty())
+                })
+                .unwrap_or_else(|| "postgres".to_string());
+            let password = std::env::var("PGPASSWORD")
+                .ok()
+                .filter(|value| !value.trim().is_empty());
+            let host = std::env::var("PGHOST")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| "localhost".to_string());
+            let port = std::env::var("PGPORT")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| "5432".to_string());
+
+            match password {
+                Some(password) => format!("postgres://{user}:{password}@{host}:{port}"),
+                None => format!("postgres://{user}@{host}:{port}"),
+            }
+        }
+
+        fn postgres_admin_database_url() -> String {
+            if let Ok(url) = std::env::var("POSTGRES_TEST_ADMIN_URL") {
+                let trimmed = url.trim();
+                if !trimmed.is_empty() {
+                    return trimmed.to_string();
+                }
+            }
+            let admin_db = std::env::var("POSTGRES_TEST_ADMIN_DB")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| "postgres".to_string());
+            format!("{}/{}", postgres_base_database_url(), admin_db)
+        }
+
+        async fn seed_worker_node(
+            pool: &PgPool,
+            instance_id: &str,
+            labels: serde_json::Value,
+            heartbeat_age_secs: i64,
+        ) {
+            sqlx::query(
+                "INSERT INTO worker_nodes (
+                instance_id, hostname, process_id, role, effective_role, status,
+                labels, capabilities, last_heartbeat_at, started_at, updated_at
+             ) VALUES (
+                $1, $1, 100, 'auto', 'worker', 'online',
+                $2, '{\"providers\":[\"codex\"]}'::jsonb,
+                NOW() - ($3::BIGINT * INTERVAL '1 second'), NOW(), NOW()
+             )",
+            )
+            .bind(instance_id)
+            .bind(labels)
+            .bind(heartbeat_age_secs)
+            .execute(pool)
+            .await
+            .expect("seed worker node");
+        }
+
+        #[tokio::test]
+        async fn reassign_stale_claim_owners_moves_100_pending_rows_to_live_label_match() {
+            let Some(pg_db) = TestPostgresDb::create().await else {
+                return;
+            };
+            let pool = pg_db.connect_and_migrate().await;
+            seed_worker_node(&pool, "stale-node", json!(["mac-book"]), 45).await;
+            seed_worker_node(&pool, "mac-mini-release", json!(["mac-mini"]), 0).await;
+
+            sqlx::query(
+                "INSERT INTO dispatch_outbox (
                 dispatch_id, action, status, claim_owner, required_capabilities
              )
              SELECT 'dispatch-stale-' || gs, 'notify', 'pending', 'stale-node', $1
                FROM generate_series(1, 100) gs",
-        )
-        .bind(json!({"preferred": {"labels": ["mac-book", "mac-mini"]}}))
-        .execute(&pool)
-        .await
-        .expect("seed stale claim-owner outbox rows");
+            )
+            .bind(json!({"preferred": {"labels": ["mac-book", "mac-mini"]}}))
+            .execute(&pool)
+            .await
+            .expect("seed stale claim-owner outbox rows");
 
-        let mut config = crate::config::ClusterConfig::default();
-        config.heartbeat_interval_secs = 10;
-        let reassigned =
-            reassign_stale_dispatch_outbox_claim_owners_with_cluster_config_pg(&pool, &config)
-                .await
-                .expect("reassign stale claim owners");
-        assert_eq!(reassigned, 100);
+            let mut config = crate::config::ClusterConfig::default();
+            config.heartbeat_interval_secs = 10;
+            let reassigned =
+                reassign_stale_dispatch_outbox_claim_owners_with_cluster_config_pg(&pool, &config)
+                    .await
+                    .expect("reassign stale claim owners");
+            assert_eq!(reassigned, 100);
 
-        let new_owner_count: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*)::BIGINT
+            let new_owner_count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*)::BIGINT
                FROM dispatch_outbox
               WHERE claim_owner = 'mac-mini-release'",
-        )
-        .fetch_one(&pool)
-        .await
-        .unwrap();
-        assert_eq!(new_owner_count, 100);
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(new_owner_count, 100);
 
-        let diagnostics: serde_json::Value = sqlx::query_scalar(
-            "SELECT routing_diagnostics
+            let diagnostics: serde_json::Value = sqlx::query_scalar(
+                "SELECT routing_diagnostics
                FROM dispatch_outbox
               WHERE dispatch_id = 'dispatch-stale-1'",
-        )
-        .fetch_one(&pool)
-        .await
-        .unwrap();
-        assert_eq!(diagnostics["event"], "stale_claim_owner_reassigned");
-        assert_eq!(diagnostics["previous_claim_owner"], "stale-node");
-        assert_eq!(diagnostics["new_claim_owner"], "mac-mini-release");
-        assert_eq!(
-            diagnostics["selected"]["decision"]["instance_id"],
-            "mac-mini-release"
-        );
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(diagnostics["event"], "stale_claim_owner_reassigned");
+            assert_eq!(diagnostics["previous_claim_owner"], "stale-node");
+            assert_eq!(diagnostics["new_claim_owner"], "mac-mini-release");
+            assert_eq!(
+                diagnostics["selected"]["decision"]["instance_id"],
+                "mac-mini-release"
+            );
 
-        pool.close().await;
-        pg_db.drop().await;
-    }
+            pool.close().await;
+            pg_db.drop().await;
+        }
 
-    #[tokio::test]
-    async fn reassign_stale_claim_owner_clears_owner_when_no_live_candidate_matches() {
-        let Some(pg_db) = TestPostgresDb::create().await else {
-            return;
-        };
-        let pool = pg_db.connect_and_migrate().await;
-        seed_worker_node(&pool, "stale-node", json!(["mac-book"]), 45).await;
-        seed_worker_node(&pool, "mac-mini-release", json!(["mac-mini"]), 0).await;
+        #[tokio::test]
+        async fn reassign_stale_claim_owner_clears_owner_when_no_live_candidate_matches() {
+            let Some(pg_db) = TestPostgresDb::create().await else {
+                return;
+            };
+            let pool = pg_db.connect_and_migrate().await;
+            seed_worker_node(&pool, "stale-node", json!(["mac-book"]), 45).await;
+            seed_worker_node(&pool, "mac-mini-release", json!(["mac-mini"]), 0).await;
 
-        sqlx::query(
-            "INSERT INTO dispatch_outbox (
+            sqlx::query(
+                "INSERT INTO dispatch_outbox (
                 dispatch_id, action, status, claim_owner, required_capabilities
              ) VALUES (
                 'dispatch-no-candidate', 'notify', 'pending', 'stale-node', $1
              )",
-        )
-        .bind(json!({"required": {"labels": ["linux"]}}))
-        .execute(&pool)
-        .await
-        .expect("seed no-candidate stale claim-owner outbox row");
+            )
+            .bind(json!({"required": {"labels": ["linux"]}}))
+            .execute(&pool)
+            .await
+            .expect("seed no-candidate stale claim-owner outbox row");
 
-        let config = crate::config::ClusterConfig::default();
-        let reassigned =
-            reassign_stale_dispatch_outbox_claim_owners_with_cluster_config_pg(&pool, &config)
-                .await
-                .expect("clear stale claim owner");
-        assert_eq!(reassigned, 1);
+            let config = crate::config::ClusterConfig::default();
+            let reassigned =
+                reassign_stale_dispatch_outbox_claim_owners_with_cluster_config_pg(&pool, &config)
+                    .await
+                    .expect("clear stale claim owner");
+            assert_eq!(reassigned, 1);
 
-        let (claim_owner, diagnostics): (Option<String>, serde_json::Value) = sqlx::query_as(
-            "SELECT claim_owner, routing_diagnostics
+            let (claim_owner, diagnostics): (Option<String>, serde_json::Value) = sqlx::query_as(
+                "SELECT claim_owner, routing_diagnostics
                FROM dispatch_outbox
               WHERE dispatch_id = 'dispatch-no-candidate'",
-        )
-        .fetch_one(&pool)
-        .await
-        .unwrap();
-        assert!(claim_owner.is_none());
-        assert_eq!(diagnostics["previous_claim_owner"], "stale-node");
-        assert!(diagnostics["new_claim_owner"].is_null());
-        assert!(diagnostics["selected"].is_null());
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert!(claim_owner.is_none());
+            assert_eq!(diagnostics["previous_claim_owner"], "stale-node");
+            assert!(diagnostics["new_claim_owner"].is_null());
+            assert!(diagnostics["selected"].is_null());
 
-        pool.close().await;
-        pg_db.drop().await;
+            pool.close().await;
+            pg_db.drop().await;
+        }
     }
 }

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -39,6 +39,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --lib server::claude_oauth_usage_tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib tui_task_card::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib server::routes::message_outbox::tests -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib services::dispatches::outbox_claiming::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib discord_thread_create -- --test-threads=1",
     "cargo test --lib reaction_control::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib intake_queue_transaction::tests -- --skip _pg --skip pg_ --skip postgres",


### PR DESCRIPTION
#5071 T0 / #4979 S3 — **B0 카나리**. 이관 메커니즘이 실제로 작동하는지를 PG 테스트 2건으로 먼저 증명한다. 나머지 112건(S4~S7)은 이 카나리가 통과한 뒤 같은 방식으로 전개한다.

## 배경
`services::dispatches::outbox_claiming::tests`의 PG 테스트 2건이 모듈 경로에 PG 마커가 없어 **어떤 CI 레인에서도 실행되지 않고 있었다**. S1(게이트)·S2(경화)는 이미 머지됐고, S3가 첫 실제 이관이다.

## 변경
기존 `tests` 안에 `outbox_claiming_pg_tests` 하위 모듈을 만들어 PG 테스트 2건만 이관했다. `_pg` 선택자를 만족시키면서 비-PG 테스트 9건이 PG 레인으로 오염되지 않는다.

```
이관 전: …::outbox_claiming::tests::reassign_…      (test-postgres 필터에 항목 없음)
이관 후: …::outbox_claiming::tests::outbox_claiming_pg_tests::reassign_…   (--list 533건에 포함, 실제 2 passed)
```

레인 배선 5단계가 전부 이어짐을 양 리뷰어가 독립 확인했다: `ci-pr.yml`의 `pg_db` 필터 → `src/services/dispatches/**` → job 조건 → `just test-postgres` → `_pg pg_ postgres` 필터 → 새 경로 2건.

부채 3건 상환(pg baseline stale 2 + coverage debt 1). **이 감소가 탐지 회귀가 아님을 별도로 실증했다** — 삭제된 baseline 항목이 새 중첩 경로로 manifest·`--list`에 실재한다(같은 배치에서 "부채 감소"가 실은 탐지 회귀였던 P0 전례가 있어 이번엔 리뷰어에게 독립 재현을 요구했다).

## 후속 배치를 위한 주석
이관 규약 중 **게이트가 강제하는 것과 사람 규약인 것**이 갈린다는 사실을 코드 주석으로 고정했다:
- 중첩 모듈의 `#[cfg(test)]`는 컴파일상 중복이지만 **load-bearing** — `check_test_lane_coverage.py`가 test fn을 가장 안쪽 `cfg(test)` 모듈에 귀속시키므로, 지우면 PG 2건이 부모로 귀속되고 그 부모는 `--skip _pg` 탓에 커버 불가가 된다.
- `*_pg_tests` **접미사 형태**는 게이트가 강제하지 않는다(bare `pg_tests` 모듈이 이미 4건 존재). 실제 강제되는 것은 정규화 경로에 `_pg`·`pg_`·`postgres` 중 하나가 부분문자열로 들어가야 한다는 것뿐이며, 이는 rule1/rule2 one-way ratchet이라 위반 시 CI red다.

## 검증
표준 배터리 전부 green — fmt / check(접촉 파일 신규 경고 0) / clippy / 타겟 테스트 / docs 재생성 후 트리 clean / audit / `ci-script-checks.sh` rc=0. PG membership rc=0. 로컬 PG 환경에서 이관된 2건 실제 통과.

## 리뷰
- sol (fresh, exact SHA `624eb4af1`): **VERDICT: CLEAN** — 이관 전후 본문 공백제거 해시 동일, 배선 5단계 추적, 부채 감소 정당성 독립 재현, 비-PG 9건 잔존 실행 확인.
- Opus (fresh, 같은 SHA): P0/P1 **0**, P2만 — 그중 두 건(중첩 `cfg(test)`의 숨은 불변식, 이름 규칙이 게이트로 강제되지 않음)은 후속 112건 이관의 근거가 되므로 주석으로 반영했다. 나머지(헬퍼 공유 케이스 미검증, 모듈당 고정비용)는 S4~S7 착수 시 확인할 항목으로 이월.

Closes 없음 — #4979는 S4~S7·S8 잔여로 open 유지.