### PR TITLE
fix(#4983): ci-timeout — masked-signal checkpoint polling with a bounded, honestly-scoped cleanup contract

### DIFF
--- a/scripts/ci-timeout.py
+++ b/scripts/ci-timeout.py
@@ -20,10 +20,6 @@ _FORWARDED_SIGNALS = (signal.SIGTERM, signal.SIGINT)
 _monotonic, _sleep = time.monotonic, time.sleep
 
 
-class _DiagnosticCapExpired(Exception):
-    pass
-
-
 @dataclass
 class _RunState:
     first_signum: int | None = None
@@ -126,59 +122,45 @@ def _diagnostic_commands(proc: subprocess.Popen[bytes]) -> list[list[str]]:
     return commands
 
 
-def _diagnose_capped(
+def _diagnose_with_deadline(
     proc: subprocess.Popen[bytes], state: _RunState, enabled: bool
 ) -> None:
-    # R1: bounded poll only. Every diagnostic, including Popen, shares this hard cap.
+    """Poll returned diagnostic children against one shared deadline.
+
+    Diagnostic Popen creation is deliberately outside the deadline: Python cannot
+    safely interrupt Popen and still guarantee ownership of a child it has not
+    returned.  Once Popen returns, the child is registered immediately and is
+    killed best-effort if it remains alive at the shared deadline.  No
+    process-global signal handler or timer is installed here.
+    """
+    # R1: bounded poll only; dumper creation itself is best-effort and unbounded.
     deadline = _monotonic() + DIAGNOSTIC_CAP_SECONDS
     dumpers: list[subprocess.Popen[bytes]] = []
-    alarm_supported = all(
-        hasattr(signal, name)
-        for name in ("SIGALRM", "ITIMER_REAL", "getsignal", "setitimer")
-    )
-    previous_alarm_handler = None
-    previous_timer: tuple[float, float] | None = None
-
-    def diagnostic_cap_expired(_signum: int, _frame: object) -> None:
-        raise _DiagnosticCapExpired
 
     print("::group::ci-timeout diagnostics", file=sys.stderr)
     try:
-        if not alarm_supported:
+        if not enabled:
             print(
-                "ci-timeout: diagnostic hard cap unavailable on this platform",
+                "ci-timeout: diagnostics skipped without POSIX signal masking",
                 file=sys.stderr,
             )
             return
-        remaining_cap = max(0.0, deadline - _monotonic())
-        if remaining_cap == 0:
-            return
-        previous_alarm_handler = signal.getsignal(signal.SIGALRM)
-        signal.signal(signal.SIGALRM, diagnostic_cap_expired)
-        previous_timer = signal.setitimer(signal.ITIMER_REAL, remaining_cap)
-        try:
-            for command in _diagnostic_commands(proc):
-                if _monotonic() >= deadline:
-                    break
-                try:
-                    dumpers.append(_popen(command, enabled))
-                    _checkpoint(state, enabled, "diagnostic_poll")
-                except (OSError, subprocess.SubprocessError) as error:
-                    print(f"ci-timeout: diagnostic failed: {error}", file=sys.stderr)
-            while dumpers and _monotonic() < deadline:
+        for command in _diagnostic_commands(proc):
+            if _monotonic() >= deadline:
+                break
+            try:
+                dumper = _popen(command, enabled)
+                dumpers.append(dumper)
                 _checkpoint(state, enabled, "diagnostic_poll")
-                dumpers = [dumper for dumper in dumpers if dumper.poll() is None]
-                if dumpers:
-                    remaining = max(0.0, deadline - _monotonic())
-                    _sleep(min(POLL_INTERVAL_SECONDS, remaining))
-        except _DiagnosticCapExpired:
-            pass
-        finally:
-            signal.setitimer(signal.ITIMER_REAL, 0)
-            signal.signal(signal.SIGALRM, previous_alarm_handler)
-            assert previous_timer is not None
-            if previous_timer[0] > 0:
-                signal.setitimer(signal.ITIMER_REAL, *previous_timer)
+            except (OSError, subprocess.SubprocessError) as error:
+                print(f"ci-timeout: diagnostic failed: {error}", file=sys.stderr)
+        while dumpers:
+            _checkpoint(state, enabled, "diagnostic_poll")
+            dumpers = [dumper for dumper in dumpers if dumper.poll() is None]
+            remaining = deadline - _monotonic()
+            if not dumpers or remaining <= 0:
+                break
+            _sleep(min(POLL_INTERVAL_SECONDS, remaining))
         for dumper in dumpers:
             try:
                 dumper.kill()
@@ -195,7 +177,7 @@ def _diagnose_capped(
 
 def _cleanup(proc: subprocess.Popen[bytes], state: _RunState, enabled: bool) -> None:
     if not state.reaped and proc.returncode is None:
-        _diagnose_capped(proc, state, enabled)
+        _diagnose_with_deadline(proc, state, enabled)
 
     _checkpoint(state, enabled, "term_boundary")  # R2″ ④: TERM boundary
     _refresh_reaped(proc, state)
@@ -263,7 +245,6 @@ def run_command(timeout: float, command: list[str]) -> int:
     checkpoint1_started = _monotonic()
     # Checkpoint ① is the special no-spawn rc-table row 1a.
     if _checkpoint(state, enabled, "checkpoint1"):
-        state.cutoff = True
         rc = _select_return_code(state, timed_out=False, child_returncode=None)
         _report(timeout, command, _monotonic() - checkpoint1_started, rc)
         return rc

--- a/scripts/ci-timeout.py
+++ b/scripts/ci-timeout.py
@@ -20,6 +20,10 @@ _FORWARDED_SIGNALS = (signal.SIGTERM, signal.SIGINT)
 _monotonic, _sleep = time.monotonic, time.sleep
 
 
+class _DiagnosticCapExpired(Exception):
+    pass
+
+
 @dataclass
 class _RunState:
     first_signum: int | None = None
@@ -69,7 +73,8 @@ def _poll_child(
 ) -> tuple[int | None, str]:
     while True:
         # R2″ checkpoint ③: every bounded poll iteration observes pending signals.
-        if _checkpoint(state, enabled, "poll") and stop_on_signal:
+        _checkpoint(state, enabled, "poll")
+        if state.first_signum is not None and stop_on_signal:
             return None, "signal"
         returncode = proc.poll()
         if returncode is not None:
@@ -124,23 +129,56 @@ def _diagnostic_commands(proc: subprocess.Popen[bytes]) -> list[list[str]]:
 def _diagnose_capped(
     proc: subprocess.Popen[bytes], state: _RunState, enabled: bool
 ) -> None:
-    # R1: bounded poll only. Every diagnostic shares this single hard deadline.
+    # R1: bounded poll only. Every diagnostic, including Popen, shares this hard cap.
     deadline = _monotonic() + DIAGNOSTIC_CAP_SECONDS
-    dumpers = []
+    dumpers: list[subprocess.Popen[bytes]] = []
+    alarm_supported = all(
+        hasattr(signal, name)
+        for name in ("SIGALRM", "ITIMER_REAL", "getsignal", "setitimer")
+    )
+    previous_alarm_handler = None
+    previous_timer: tuple[float, float] | None = None
+
+    def diagnostic_cap_expired(_signum: int, _frame: object) -> None:
+        raise _DiagnosticCapExpired
+
     print("::group::ci-timeout diagnostics", file=sys.stderr)
     try:
-        for command in _diagnostic_commands(proc):
-            if _monotonic() >= deadline:
-                break
-            try:
-                dumpers.append(_popen(command, enabled))
-            except (OSError, subprocess.SubprocessError) as error:
-                print(f"ci-timeout: diagnostic failed: {error}", file=sys.stderr)
-        while dumpers and _monotonic() < deadline:
-            _checkpoint(state, enabled, "diagnostic_poll")
-            dumpers = [dumper for dumper in dumpers if dumper.poll() is None]
-            if dumpers:
-                _sleep(min(POLL_INTERVAL_SECONDS, deadline - _monotonic()))
+        if not alarm_supported:
+            print(
+                "ci-timeout: diagnostic hard cap unavailable on this platform",
+                file=sys.stderr,
+            )
+            return
+        remaining_cap = max(0.0, deadline - _monotonic())
+        if remaining_cap == 0:
+            return
+        previous_alarm_handler = signal.getsignal(signal.SIGALRM)
+        signal.signal(signal.SIGALRM, diagnostic_cap_expired)
+        previous_timer = signal.setitimer(signal.ITIMER_REAL, remaining_cap)
+        try:
+            for command in _diagnostic_commands(proc):
+                if _monotonic() >= deadline:
+                    break
+                try:
+                    dumpers.append(_popen(command, enabled))
+                    _checkpoint(state, enabled, "diagnostic_poll")
+                except (OSError, subprocess.SubprocessError) as error:
+                    print(f"ci-timeout: diagnostic failed: {error}", file=sys.stderr)
+            while dumpers and _monotonic() < deadline:
+                _checkpoint(state, enabled, "diagnostic_poll")
+                dumpers = [dumper for dumper in dumpers if dumper.poll() is None]
+                if dumpers:
+                    remaining = max(0.0, deadline - _monotonic())
+                    _sleep(min(POLL_INTERVAL_SECONDS, remaining))
+        except _DiagnosticCapExpired:
+            pass
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            signal.signal(signal.SIGALRM, previous_alarm_handler)
+            assert previous_timer is not None
+            if previous_timer[0] > 0:
+                signal.setitimer(signal.ITIMER_REAL, *previous_timer)
         for dumper in dumpers:
             try:
                 dumper.kill()
@@ -221,6 +259,7 @@ def _report(timeout: float, command: list[str], elapsed: float, rc: int) -> None
 
 def run_command(timeout: float, command: list[str]) -> int:
     enabled, state = _mask_forwarded_signals(), _RunState()
+    previous_handlers: dict[int, signal.Handlers] = {}
     checkpoint1_started = _monotonic()
     # Checkpoint ① is the special no-spawn rc-table row 1a.
     if _checkpoint(state, enabled, "checkpoint1"):
@@ -229,39 +268,56 @@ def run_command(timeout: float, command: list[str]) -> int:
         _report(timeout, command, _monotonic() - checkpoint1_started, rc)
         return rc
 
-    proc = _popen(command, enabled)
-    spawn_completed = _monotonic()
-    child_rc, timed_out = None, False
-    # Checkpoint ② observes signals that arrived inside Popen.
-    if _checkpoint(state, enabled, "checkpoint2"):
-        _cleanup(proc, state, enabled)
-    else:
-        child_rc, outcome = _poll_child(
-            proc, state, enabled, spawn_completed + timeout, stop_on_signal=True
-        )
-        timed_out = outcome == "deadline"
-        if outcome == "signal":
-            _cleanup(proc, state, enabled)
-        elif timed_out:
-            elapsed = _monotonic() - spawn_completed
-            print(
-                f"::error::ci-timeout: exceeded {timeout:g}s after {elapsed:.1f}s "
-                f"— {shlex.join(command)}",
-                file=sys.stderr,
-            )
-            _cleanup(proc, state, enabled)
+    try:
+        proc = _popen(command, enabled)
 
-    # Checkpoint ⑤ is immediately before cutoff C and the sole rc selection.
-    had_signal = state.first_signum is not None
-    observed_at_final = _checkpoint(state, enabled, "final")
-    newly_observed = observed_at_final and not had_signal
-    if newly_observed and not state.cleanup_done:
-        _cleanup(proc, state, enabled)
-        _checkpoint(state, enabled, "final")
-    state.cutoff = True
-    rc = _select_return_code(state, timed_out=timed_out, child_returncode=child_rc)
-    _report(timeout, command, _monotonic() - spawn_completed, rc)
-    return rc
+        if not enabled:
+            # Preserve the pre-masking implementation on platforms without POSIX APIs.
+            def forward_signal(signum: int, _frame: object) -> None:
+                if state.cutoff:
+                    return
+                if state.first_signum is None:
+                    state.first_signum = signum
+                _send_process_signal(proc, state, signum)
+
+            for signum in _FORWARDED_SIGNALS:
+                previous_handlers[signum] = signal.signal(signum, forward_signal)
+
+        spawn_completed = _monotonic()
+        child_rc, timed_out = None, False
+        # Checkpoint ② observes signals that arrived inside Popen.
+        if _checkpoint(state, enabled, "checkpoint2"):
+            _cleanup(proc, state, enabled)
+        else:
+            child_rc, outcome = _poll_child(
+                proc, state, enabled, spawn_completed + timeout, stop_on_signal=True
+            )
+            timed_out = outcome == "deadline"
+            if outcome == "signal":
+                _cleanup(proc, state, enabled)
+            elif timed_out:
+                elapsed = _monotonic() - spawn_completed
+                print(
+                    f"::error::ci-timeout: exceeded {timeout:g}s after {elapsed:.1f}s "
+                    f"— {shlex.join(command)}",
+                    file=sys.stderr,
+                )
+                _cleanup(proc, state, enabled)
+
+        # Checkpoint ⑤ is immediately before cutoff C and the sole rc selection.
+        had_signal = state.first_signum is not None
+        observed_at_final = _checkpoint(state, enabled, "final")
+        newly_observed = observed_at_final and not had_signal
+        if newly_observed and not state.cleanup_done:
+            _cleanup(proc, state, enabled)
+            _checkpoint(state, enabled, "final")
+        state.cutoff = True
+        rc = _select_return_code(state, timed_out=timed_out, child_returncode=child_rc)
+        _report(timeout, command, _monotonic() - spawn_completed, rc)
+        return rc
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
 
 
 def main() -> int:

--- a/scripts/ci-timeout.py
+++ b/scripts/ci-timeout.py
@@ -1,26 +1,100 @@
 #!/usr/bin/env python3
-"""Run a command with a wall-clock timeout and return 124 on expiry."""
+"""Run a command with a wall-clock timeout and bounded cleanup."""
 
 from __future__ import annotations
 
 import os
+import shlex
+import shutil
 import signal
 import subprocess
 import sys
+import time
+from dataclasses import dataclass
 
-TERMINATION_GRACE_SECONDS = 5
+TERMINATION_GRACE_SECONDS = 5.0
+DIAGNOSTIC_CAP_SECONDS = 10.0
+KILL_WAIT_SECONDS = 10.0
+POLL_INTERVAL_SECONDS = 0.1
+_FORWARDED_SIGNALS = (signal.SIGTERM, signal.SIGINT)
+_monotonic, _sleep = time.monotonic, time.sleep
 
 
-class _ForwardedSignal(Exception):
-    def __init__(self, signum: int) -> None:
-        super().__init__(signum)
-        self.signum = signum
+@dataclass
+class _RunState:
+    first_signum: int | None = None
+    reaped: bool = False
+    cutoff: bool = False
+    cleanup_done: bool = False
+
+
+def _mask_forwarded_signals() -> bool:
+    required = ("pthread_sigmask", "sigpending", "SIG_BLOCK", "SIG_UNBLOCK")
+    if not all(hasattr(signal, name) for name in required):
+        return False
+    signal.pthread_sigmask(signal.SIG_BLOCK, _FORWARDED_SIGNALS)
+    return True
+
+
+def _unblock_forwarded_signals() -> None:
+    signal.pthread_sigmask(signal.SIG_UNBLOCK, _FORWARDED_SIGNALS)
+
+
+def _checkpoint(state: _RunState, enabled: bool, name: str) -> bool:
+    """Record the first target signal observed before cutoff C."""
+    if state.cutoff or not enabled:
+        return False
+    pending = signal.sigpending()
+    if state.first_signum is None:
+        # sigpending() is unordered: TERM wins a simultaneous TERM+INT tie.
+        if signal.SIGTERM in pending:
+            state.first_signum = signal.SIGTERM
+        elif signal.SIGINT in pending:
+            state.first_signum = signal.SIGINT
+    return state.first_signum is not None
+
+
+def _popen(command: list[str], enabled: bool) -> subprocess.Popen[bytes]:
+    options = {"preexec_fn": _unblock_forwarded_signals} if enabled else {}
+    return subprocess.Popen(command, start_new_session=True, **options)
+
+
+def _poll_child(
+    proc: subprocess.Popen[bytes],
+    state: _RunState,
+    enabled: bool,
+    deadline: float,
+    *,
+    stop_on_signal: bool,
+) -> tuple[int | None, str]:
+    while True:
+        # R2″ checkpoint ③: every bounded poll iteration observes pending signals.
+        if _checkpoint(state, enabled, "poll") and stop_on_signal:
+            return None, "signal"
+        returncode = proc.poll()
+        if returncode is not None:
+            state.reaped = True
+            return returncode, "reaped"
+        remaining = deadline - _monotonic()
+        if remaining <= 0:
+            return None, "deadline"
+        _sleep(min(POLL_INTERVAL_SECONDS, remaining))
+
+
+def _refresh_reaped(proc: subprocess.Popen[bytes], state: _RunState) -> None:
+    if state.reaped or proc.returncode is not None or proc.poll() is not None:
+        state.reaped = True
 
 
 def _send_process_signal(
-    proc: subprocess.Popen[bytes], signum: int, *, force: bool = False
+    proc: subprocess.Popen[bytes],
+    state: _RunState,
+    signum: int,
+    *,
+    force: bool = False,
 ) -> None:
-    """Signal the child process group, or its process on platforms without killpg."""
+    if state.cutoff or state.reaped or proc.returncode is not None:
+        return
     try:
         if hasattr(os, "killpg"):
             os.killpg(proc.pid, signal.SIGKILL if force else signum)
@@ -28,59 +102,177 @@ def _send_process_signal(
             proc.kill()
         else:
             proc.terminate()
-    except ProcessLookupError:
+    except (ProcessLookupError, OSError, AttributeError):
         pass
 
 
-def _wait_after_signal(proc: subprocess.Popen[bytes]) -> None:
+def _diagnostic_commands(proc: subprocess.Popen[bytes]) -> list[list[str]]:
+    commands = []
+    if sys.platform == "darwin" and os.path.exists("/usr/bin/sample"):
+        commands.append(["/usr/bin/sample", str(proc.pid), "5"])
+    elif shutil.which("gdb"):
+        commands.append(
+            ["gdb", "-batch", "-ex", "thread apply all bt", "-p", str(proc.pid)]
+        )
+    if ps := shutil.which("ps"):
+        commands.append(
+            [ps, "-o", "pid,ppid,pgid,stat,etime,command", "-g", str(proc.pid)]
+        )
+    return commands
+
+
+def _diagnose_capped(
+    proc: subprocess.Popen[bytes], state: _RunState, enabled: bool
+) -> None:
+    # R1: bounded poll only. Every diagnostic shares this single hard deadline.
+    deadline = _monotonic() + DIAGNOSTIC_CAP_SECONDS
+    dumpers = []
+    print("::group::ci-timeout diagnostics", file=sys.stderr)
     try:
-        proc.wait(timeout=TERMINATION_GRACE_SECONDS)
-    except subprocess.TimeoutExpired:
-        _send_process_signal(proc, signal.SIGTERM, force=True)
-        proc.wait()
+        for command in _diagnostic_commands(proc):
+            if _monotonic() >= deadline:
+                break
+            try:
+                dumpers.append(_popen(command, enabled))
+            except (OSError, subprocess.SubprocessError) as error:
+                print(f"ci-timeout: diagnostic failed: {error}", file=sys.stderr)
+        while dumpers and _monotonic() < deadline:
+            _checkpoint(state, enabled, "diagnostic_poll")
+            dumpers = [dumper for dumper in dumpers if dumper.poll() is None]
+            if dumpers:
+                _sleep(min(POLL_INTERVAL_SECONDS, deadline - _monotonic()))
+        for dumper in dumpers:
+            try:
+                dumper.kill()
+            except (ProcessLookupError, OSError, AttributeError):
+                pass
+            if dumper.poll() is None:
+                print(
+                    f"::warning::ci-timeout: diagnostic pid {dumper.pid} unreaped",
+                    file=sys.stderr,
+                )
+    finally:
+        print("::endgroup::", file=sys.stderr)
 
 
-def _terminate_and_wait(proc: subprocess.Popen[bytes]) -> None:
-    _send_process_signal(proc, signal.SIGTERM)
-    _wait_after_signal(proc)
+def _cleanup(proc: subprocess.Popen[bytes], state: _RunState, enabled: bool) -> None:
+    if not state.reaped and proc.returncode is None:
+        _diagnose_capped(proc, state, enabled)
+
+    _checkpoint(state, enabled, "term_boundary")  # R2″ ④: TERM boundary
+    _refresh_reaped(proc, state)
+    _send_process_signal(proc, state, signal.SIGTERM)
+    if not state.reaped:
+        _poll_child(
+            proc,
+            state,
+            enabled,
+            _monotonic() + TERMINATION_GRACE_SECONDS,
+            stop_on_signal=False,
+        )
+
+    _checkpoint(state, enabled, "grace_boundary")  # R2″ ④: KILL boundary
+    _refresh_reaped(proc, state)
+    _send_process_signal(proc, state, signal.SIGTERM, force=True)
+    if not state.reaped:
+        _poll_child(
+            proc,
+            state,
+            enabled,
+            _monotonic() + KILL_WAIT_SECONDS,
+            stop_on_signal=False,
+        )
+
+    _checkpoint(state, enabled, "kill_boundary")  # R2″ ④: post-KILL
+    _refresh_reaped(proc, state)
+    if not state.reaped:
+        print(
+            f"::warning::ci-timeout: child pid {proc.pid} unreaped after KILL_WAIT",
+            file=sys.stderr,
+        )
+    state.cleanup_done = True
+
+
+def _normalize_return_code(returncode: int) -> int:
+    return 128 - returncode if returncode < 0 else returncode
+
+
+def _select_return_code(
+    state: _RunState, *, timed_out: bool, child_returncode: int | None
+) -> int:
+    """Apply all seven rc-table rows in one place."""
+    if state.first_signum is not None:
+        return 128 + state.first_signum
+    if timed_out:
+        return 124
+    if child_returncode is None:
+        raise RuntimeError("ci-timeout: missing child return code")
+    return _normalize_return_code(child_returncode)
+
+
+def _report(timeout: float, command: list[str], elapsed: float, rc: int) -> None:
+    if os.environ.get("AGENTDESK_CI_TIMEOUT_REPORT") == "1":
+        print(
+            f"::notice::ci-timeout: {elapsed:.1f}s / {timeout:g}s, rc {rc} "
+            f"— {shlex.join(command)}",
+            file=sys.stderr,
+        )
 
 
 def run_command(timeout: float, command: list[str]) -> int:
-    proc = subprocess.Popen(command, start_new_session=True)
-    previous_handlers: dict[int, signal.Handlers] = {}
+    enabled, state = _mask_forwarded_signals(), _RunState()
+    checkpoint1_started = _monotonic()
+    # Checkpoint ① is the special no-spawn rc-table row 1a.
+    if _checkpoint(state, enabled, "checkpoint1"):
+        state.cutoff = True
+        rc = _select_return_code(state, timed_out=False, child_returncode=None)
+        _report(timeout, command, _monotonic() - checkpoint1_started, rc)
+        return rc
 
-    def forward_signal(signum: int, _frame: object) -> None:
-        _send_process_signal(proc, signum)
-        raise _ForwardedSignal(signum)
+    proc = _popen(command, enabled)
+    spawn_completed = _monotonic()
+    child_rc, timed_out = None, False
+    # Checkpoint ② observes signals that arrived inside Popen.
+    if _checkpoint(state, enabled, "checkpoint2"):
+        _cleanup(proc, state, enabled)
+    else:
+        child_rc, outcome = _poll_child(
+            proc, state, enabled, spawn_completed + timeout, stop_on_signal=True
+        )
+        timed_out = outcome == "deadline"
+        if outcome == "signal":
+            _cleanup(proc, state, enabled)
+        elif timed_out:
+            elapsed = _monotonic() - spawn_completed
+            print(
+                f"::error::ci-timeout: exceeded {timeout:g}s after {elapsed:.1f}s "
+                f"— {shlex.join(command)}",
+                file=sys.stderr,
+            )
+            _cleanup(proc, state, enabled)
 
-    try:
-        for signum in (signal.SIGTERM, signal.SIGINT):
-            previous_handlers[signum] = signal.signal(signum, forward_signal)
-
-        try:
-            return proc.wait(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            _terminate_and_wait(proc)
-            return 124
-        except _ForwardedSignal as forwarded:
-            _wait_after_signal(proc)
-            return 128 + forwarded.signum
-    finally:
-        for signum, handler in previous_handlers.items():
-            signal.signal(signum, handler)
+    # Checkpoint ⑤ is immediately before cutoff C and the sole rc selection.
+    had_signal = state.first_signum is not None
+    observed_at_final = _checkpoint(state, enabled, "final")
+    newly_observed = observed_at_final and not had_signal
+    if newly_observed and not state.cleanup_done:
+        _cleanup(proc, state, enabled)
+        _checkpoint(state, enabled, "final")
+    state.cutoff = True
+    rc = _select_return_code(state, timed_out=timed_out, child_returncode=child_rc)
+    _report(timeout, command, _monotonic() - spawn_completed, rc)
+    return rc
 
 
 def main() -> int:
     if len(sys.argv) < 3:
         print("usage: ci-timeout.py SECONDS COMMAND [ARG...]", file=sys.stderr)
         return 2
-
     try:
         timeout = float(sys.argv[1])
     except ValueError:
         print(f"invalid timeout seconds: {sys.argv[1]!r}", file=sys.stderr)
         return 2
-
     return run_command(timeout, sys.argv[2:])
 
 

--- a/scripts/ci-timeout.py
+++ b/scripts/ci-timeout.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Run a command with a wall-clock timeout and bounded cleanup."""
+"""Run a command with a wall-clock timeout and bounded cleanup.
+
+Diagnostic process creation is best-effort and outside the cleanup bound.
+"""
 
 from __future__ import annotations
 
@@ -25,7 +28,6 @@ class _RunState:
     first_signum: int | None = None
     reaped: bool = False
     cutoff: bool = False
-    cleanup_done: bool = False
 
 
 def _mask_forwarded_signals() -> bool:
@@ -210,7 +212,6 @@ def _cleanup(proc: subprocess.Popen[bytes], state: _RunState, enabled: bool) -> 
             f"::warning::ci-timeout: child pid {proc.pid} unreaped after KILL_WAIT",
             file=sys.stderr,
         )
-    state.cleanup_done = True
 
 
 def _normalize_return_code(returncode: int) -> int:
@@ -220,7 +221,7 @@ def _normalize_return_code(returncode: int) -> int:
 def _select_return_code(
     state: _RunState, *, timed_out: bool, child_returncode: int | None
 ) -> int:
-    """Apply all seven rc-table rows in one place."""
+    """Select rc for signal, timeout, and child-exit rows after spawn."""
     if state.first_signum is not None:
         return 128 + state.first_signum
     if timed_out:
@@ -253,7 +254,7 @@ def run_command(timeout: float, command: list[str]) -> int:
         proc = _popen(command, enabled)
 
         if not enabled:
-            # Preserve the pre-masking implementation on platforms without POSIX APIs.
+            # Preserve the pre-masking contract on platforms without POSIX APIs.
             def forward_signal(signum: int, _frame: object) -> None:
                 if state.cutoff:
                     return
@@ -285,13 +286,8 @@ def run_command(timeout: float, command: list[str]) -> int:
                 )
                 _cleanup(proc, state, enabled)
 
-        # Checkpoint ⑤ is immediately before cutoff C and the sole rc selection.
-        had_signal = state.first_signum is not None
-        observed_at_final = _checkpoint(state, enabled, "final")
-        newly_observed = observed_at_final and not had_signal
-        if newly_observed and not state.cleanup_done:
-            _cleanup(proc, state, enabled)
-            _checkpoint(state, enabled, "final")
+        # Checkpoint ⑤ is immediately before cutoff C and spawn-path rc selection.
+        _checkpoint(state, enabled, "final")
         state.cutoff = True
         rc = _select_return_code(state, timed_out=timed_out, child_returncode=child_rc)
         _report(timeout, command, _monotonic() - spawn_completed, rc)

--- a/tests/test_ci_timeout.py
+++ b/tests/test_ci_timeout.py
@@ -39,9 +39,11 @@ class Process:
     def __init__(self, results=(), default=None):
         self.pid, self.returncode = 4413, None
         self.results, self.default = list(results), default
+        self.poll_calls = 0
         self.terminate, self.kill = mock.Mock(), mock.Mock()
 
     def poll(self):
+        self.poll_calls += 1
         result = self.results.pop(0) if self.results else self.default
         if result is not None:
             self.returncode = result
@@ -185,76 +187,111 @@ class CiTimeoutTests(unittest.TestCase):
 
     # F8(b,c)
     def test_two_hanging_dumpers_share_one_diagnostic_cap(self):
-        primary, dumpers, checkpoints = Process(default=None), [], []
-        real_popen, real_checkpoint = subprocess.Popen, ci_timeout._checkpoint
+        primary, dumpers, checkpoints, attempts = Process(default=None), [], [], []
+        real_checkpoint = ci_timeout._checkpoint
 
-        def popen(command, **options):
+        def popen(command, _enabled):
             if command == ["primary"]:
                 return primary
-            dumpers.append(real_popen(command, **options))
+            attempts.append(command)
+            time.sleep(1.2)  # Scaled equivalent of each 6s seam under a 10s cap.
+            dumpers.append(Process(default=None))
             return dumpers[-1]
 
         def send(*_args, force=False, **_kwargs):
-            if force:
-                primary.returncode = primary.default = -signal.SIGKILL
+            primary.returncode = primary.default = (
+                -signal.SIGKILL if force else -signal.SIGTERM
+            )
 
         def checkpoint(state, enabled, name):
             checkpoints.append(name)
             return real_checkpoint(state, enabled, name)
 
-        sleeper = [sys.executable, "-c", "import time;time.sleep(600)"]
         started = time.monotonic()
-        try:
-            with mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=False), \
-                 mock.patch.object(ci_timeout.subprocess, "Popen", side_effect=popen), \
-                 mock.patch.object(ci_timeout, "_diagnostic_commands", return_value=[sleeper] * 2), \
-                 mock.patch.object(ci_timeout, "_send_process_signal", side_effect=send), \
-                 mock.patch.object(ci_timeout, "DIAGNOSTIC_CAP_SECONDS", 0.05), \
-                 mock.patch.object(ci_timeout, "TERMINATION_GRACE_SECONDS", 0.01), \
-                 mock.patch.object(ci_timeout, "KILL_WAIT_SECONDS", 0.01), \
-                 mock.patch.object(ci_timeout, "_checkpoint", side_effect=checkpoint), \
-                 contextlib.redirect_stderr(io.StringIO()):
-                rc = ci_timeout.run_command(0.01, ["primary"])
-        finally:
-            for dumper in dumpers:
-                try:
-                    dumper.wait(timeout=1)
-                except subprocess.TimeoutExpired:
-                    dumper.kill(); dumper.wait(timeout=1)
-        self.assertEqual((rc, len(dumpers)), (124, 2))
+        with mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=True), \
+             mock.patch.object(ci_timeout, "_popen", side_effect=popen), \
+             mock.patch.object(ci_timeout, "_diagnostic_commands",
+                               return_value=[["dumper-1"], ["dumper-2"]]), \
+             mock.patch.object(ci_timeout, "_send_process_signal", side_effect=send), \
+             mock.patch.object(ci_timeout, "DIAGNOSTIC_CAP_SECONDS", 2.0), \
+             mock.patch.object(ci_timeout, "_checkpoint", side_effect=checkpoint), \
+             mock.patch.object(ci_timeout.signal, "sigpending", return_value=set()), \
+             contextlib.redirect_stderr(io.StringIO()):
+            rc = ci_timeout.run_command(0, ["primary"])
+        elapsed = time.monotonic() - started
+        self.assertEqual((rc, len(attempts), len(dumpers)), (124, 2, 1))
         self.assertIn("diagnostic_poll", checkpoints)
-        self.assertLess(time.monotonic() - started, 0.5)
+        self.assertGreaterEqual(elapsed, 1.9)
+        self.assertLess(elapsed, 2.3)
+
+    def test_diagnostic_poll_never_sleeps_a_negative_duration(self):
+        dumper, times, sleeps = Process(default=None), iter((0, 0, 0, 0, 2, 2)), []
+
+        def sleep(seconds):
+            self.assertGreaterEqual(seconds, 0)
+            sleeps.append(seconds)
+
+        with mock.patch.object(ci_timeout, "DIAGNOSTIC_CAP_SECONDS", 1), \
+             mock.patch.object(ci_timeout, "_diagnostic_commands", return_value=[["dump"]]), \
+             mock.patch.object(ci_timeout, "_popen", return_value=dumper), \
+             mock.patch.object(ci_timeout, "_checkpoint", return_value=False), \
+             mock.patch.object(ci_timeout, "_monotonic", side_effect=times), \
+             mock.patch.object(ci_timeout, "_sleep", side_effect=sleep), \
+             contextlib.redirect_stderr(io.StringIO()):
+            ci_timeout._diagnose_capped(Process(), ci_timeout._RunState(), False)
+        self.assertEqual(sleeps, [0])
 
     # F9
+    @unittest.skipUnless(hasattr(signal, "pthread_sigmask"), "POSIX required")
     def test_post_cutoff_signals_never_use_any_send_path(self):
-        for has_killpg in (True, False):
-            for reaped in (True, False):
-                proc, state = Process(), ci_timeout._RunState(reaped=reaped, cutoff=True)
-                proc.returncode = 0 if reaped else None
-                fake_os = types.SimpleNamespace(environ={})
-                if has_killpg:
-                    fake_os.killpg = mock.Mock()
-                with mock.patch.object(ci_timeout, "os", fake_os):
-                    ci_timeout._send_process_signal(proc, state, signal.SIGTERM)
-                    ci_timeout._send_process_signal(proc, state, signal.SIGTERM, force=True)
-                if has_killpg:
-                    fake_os.killpg.assert_not_called()
-                proc.terminate.assert_not_called(); proc.kill.assert_not_called()
-                with mock.patch.object(ci_timeout.signal, "sigpending") as pending:
-                    self.assertFalse(ci_timeout._checkpoint(state, True, "post_cutoff"))
-                pending.assert_not_called(); self.assertIsNone(state.first_signum)
-                expected = 0 if reaped else 124
-                self.assertEqual(
-                    ci_timeout._select_return_code(
-                        state, timed_out=not reaped, child_returncode=proc.returncode
-                    ),
-                    expected,
-                )
-        proc, state = Process(), ci_timeout._RunState(reaped=False)
-        proc.returncode = 0
-        with mock.patch.object(ci_timeout.os, "killpg") as killpg:
-            ci_timeout._send_process_signal(proc, state, signal.SIGTERM)
-        killpg.assert_not_called()
+        original_mask, real_checkpoint = signal.pthread_sigmask, ci_timeout._checkpoint
+        old_mask = original_mask(signal.SIG_BLOCK, set())
+        try:
+            for path, proc, expected in (
+                ("reaped", Process([0]), 0),
+                ("unreaped", Process(default=None), 124),
+            ):
+                with self.subTest(path=path):
+                    clock, captured, after_cutoff = Clock(), {}, []
+
+                    def checkpoint(state, enabled, name):
+                        captured["state"] = state
+                        return real_checkpoint(state, enabled, name)
+
+                    def report(*_args):
+                        sends_before = killpg.call_count
+                        os.kill(os.getpid(), signal.SIGTERM)
+                        self.assertIn(signal.SIGTERM, signal.sigpending())
+                        after_cutoff.append(
+                            real_checkpoint(captured["state"], True, "post_cutoff")
+                        )
+                        ci_timeout._send_process_signal(
+                            proc, captured["state"], signal.SIGTERM
+                        )
+                        ci_timeout._send_process_signal(
+                            proc, captured["state"], signal.SIGTERM, force=True
+                        )
+                        self.assertEqual(killpg.call_count, sends_before)
+
+                    try:
+                        with mock.patch.object(ci_timeout, "_popen", return_value=proc), \
+                             mock.patch.object(ci_timeout, "_diagnose_capped"), \
+                             mock.patch.object(ci_timeout.os, "killpg") as killpg, \
+                             mock.patch.object(ci_timeout, "_monotonic", side_effect=clock.monotonic), \
+                             mock.patch.object(ci_timeout, "_sleep", side_effect=clock.sleep), \
+                             mock.patch.object(ci_timeout, "_checkpoint", side_effect=checkpoint), \
+                             mock.patch.object(ci_timeout, "_report", side_effect=report), \
+                             contextlib.redirect_stderr(io.StringIO()):
+                            rc = ci_timeout.run_command(0, ["cargo", "test"])
+                        self.assertEqual((rc, after_cutoff), (expected, [False]))
+                        self.assertIsNone(captured["state"].first_signum)
+                    finally:
+                        if signal.SIGTERM in signal.sigpending():
+                            signal.sigwait({signal.SIGTERM})
+        finally:
+            if signal.SIGTERM in signal.sigpending():
+                signal.sigwait({signal.SIGTERM})
+            original_mask(signal.SIG_SETMASK, old_mask)
 
     # F10-①
     @unittest.skipUnless(hasattr(signal, "pthread_sigmask"), "POSIX required")
@@ -338,6 +375,102 @@ class CiTimeoutTests(unittest.TestCase):
         self.assertTrue(required.issubset(names))
         self.assertLessEqual(max(clock.sleeps), ci_timeout.POLL_INTERVAL_SECONDS)
 
+    def test_poll_child_checkpoints_every_iteration(self):
+        proc, state, clock, checkpoints = Process([None, None, 0]), ci_timeout._RunState(), Clock(), []
+
+        def checkpoint(*_args):
+            checkpoints.append("poll")
+            return False
+
+        with mock.patch.object(ci_timeout, "_checkpoint", side_effect=checkpoint), \
+             mock.patch.object(ci_timeout, "_monotonic", side_effect=clock.monotonic), \
+             mock.patch.object(ci_timeout, "_sleep", side_effect=clock.sleep):
+            rc, outcome = ci_timeout._poll_child(
+                proc, state, True, 1, stop_on_signal=True
+            )
+        self.assertEqual((rc, outcome), (0, "reaped"))
+        self.assertEqual(len(checkpoints), proc.poll_calls)
+
+    def test_every_signal_arrival_row_meets_the_cleanup_bound(self):
+        real_checkpoint = ci_timeout._checkpoint
+        signal_rows = (
+            "checkpoint1", "checkpoint2", "poll", "term_boundary",
+            "grace_boundary", "kill_boundary", "final",
+        )
+        for target in signal_rows:
+            with self.subTest(target=target):
+                clock = Clock()
+                proc = Process([0] if target == "final" else (), default=None)
+                injected = [False]
+
+                def checkpoint(state, enabled, name):
+                    if name == target and not injected[0]:
+                        injected[0] = True
+                        state.first_signum = signal.SIGTERM
+                        return True
+                    return real_checkpoint(state, enabled, name)
+
+                with mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=True), \
+                     mock.patch.object(ci_timeout.signal, "sigpending", return_value=set()), \
+                     mock.patch.object(ci_timeout, "_popen", return_value=proc) as popen, \
+                     mock.patch.object(ci_timeout, "_diagnose_capped"), \
+                     mock.patch.object(ci_timeout, "_send_process_signal"), \
+                     mock.patch.object(ci_timeout, "_monotonic", side_effect=clock.monotonic), \
+                     mock.patch.object(ci_timeout, "_sleep", side_effect=clock.sleep), \
+                     mock.patch.object(ci_timeout, "_checkpoint", side_effect=checkpoint), \
+                     mock.patch.object(ci_timeout, "_report"), \
+                     contextlib.redirect_stderr(io.StringIO()):
+                    rc = ci_timeout.run_command(0, ["cargo", "test"])
+                self.assertTrue(injected[0])
+                self.assertEqual(rc, 143)
+                self.assertLessEqual(clock.now, 55.1)
+                if target == "checkpoint1":
+                    popen.assert_not_called()
+
+    @unittest.skipUnless(hasattr(signal, "pthread_sigmask"), "POSIX required")
+    def test_cutoff_boundary_uses_real_pending_signals(self):
+        original_mask, real_checkpoint = signal.pthread_sigmask, ci_timeout._checkpoint
+        old_mask = original_mask(signal.SIG_BLOCK, set())
+        try:
+            for timing, expected in (("before", 143), ("after", 0)):
+                with self.subTest(timing=timing):
+                    proc, captured, injected, after_result = Process([0]), {}, [False], []
+
+                    def checkpoint(state, enabled, name):
+                        captured["state"] = state
+                        if timing == "before" and name == "final" and not injected[0]:
+                            injected[0] = True
+                            os.kill(os.getpid(), signal.SIGTERM)
+                        return real_checkpoint(state, enabled, name)
+
+                    def report(*_args):
+                        if timing == "after":
+                            injected[0] = True
+                            os.kill(os.getpid(), signal.SIGTERM)
+                            after_result.append(
+                                real_checkpoint(captured["state"], True, "after_cutoff")
+                            )
+
+                    try:
+                        with mock.patch.object(ci_timeout, "_popen", return_value=proc), \
+                             mock.patch.object(ci_timeout, "_send_process_signal") as send, \
+                             mock.patch.object(ci_timeout, "_checkpoint", side_effect=checkpoint), \
+                             mock.patch.object(ci_timeout, "_report", side_effect=report):
+                            rc = ci_timeout.run_command(30, ["cargo", "test"])
+                        self.assertTrue(injected[0])
+                        self.assertEqual(rc, expected)
+                        if timing == "after":
+                            self.assertEqual(after_result, [False])
+                            self.assertIsNone(captured["state"].first_signum)
+                            send.assert_not_called()
+                    finally:
+                        if signal.SIGTERM in signal.sigpending():
+                            signal.sigwait({signal.SIGTERM})
+        finally:
+            if signal.SIGTERM in signal.sigpending():
+                signal.sigwait({signal.SIGTERM})
+            original_mask(signal.SIG_SETMASK, old_mask)
+
     # F11
     def test_spawn_and_input_errors_preserve_legacy_rows(self):
         with mock.patch.object(ci_timeout.signal, "pthread_sigmask") as mask_call, \
@@ -353,6 +486,23 @@ class CiTimeoutTests(unittest.TestCase):
         result = subprocess.run([sys.executable, str(SCRIPT_PATH), "1", "/not/a/program"],
                                 capture_output=True, timeout=5)
         self.assertEqual(result.returncode, 1)
+
+    def test_non_posix_path_installs_and_restores_legacy_handlers(self):
+        installed = {}
+
+        def install(signum, handler):
+            previous = installed.get(signum, signal.SIG_DFL)
+            installed[signum] = handler
+            return previous
+
+        with mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=False), \
+             mock.patch.object(ci_timeout, "_popen", return_value=Process([0])), \
+             mock.patch.object(ci_timeout.signal, "signal", side_effect=install) as handlers:
+            rc = ci_timeout.run_command(30, ["cargo", "test"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(handlers.call_count, 4)
+        self.assertEqual(installed, {signal.SIGTERM: signal.SIG_DFL,
+                                     signal.SIGINT: signal.SIG_DFL})
 
     # F12
     @unittest.skipUnless(hasattr(signal, "pthread_sigmask"), "POSIX required")
@@ -388,21 +538,39 @@ class CiTimeoutTests(unittest.TestCase):
         self.assertEqual((imports, constructors), ([], []))
 
     # F13
+    @unittest.skipUnless(hasattr(signal, "pthread_sigmask"), "POSIX required")
     def test_checkpoint_one_pending_signal_never_spawns_or_cleans_up(self):
-        for pending, expected in (({signal.SIGINT}, 130), ({signal.SIGTERM}, 143),
-                                  ({signal.SIGTERM, signal.SIGINT}, 143)):
-            with self.subTest(pending=pending), \
-                 mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=True), \
-                 mock.patch.object(ci_timeout.signal, "sigpending", return_value=pending), \
-                 mock.patch.object(ci_timeout.signal, "signal") as handlers, \
+        original_mask, original_signal = signal.pthread_sigmask, signal.signal
+        old_mask = original_mask(signal.SIG_BLOCK, set())
+        old_handler = original_signal(signal.SIGTERM, lambda *_args: None)
+        mask_operations = []
+
+        def mask(how, signals):
+            mask_operations.append(how)
+            return original_mask(how, signals)
+
+        try:
+            original_mask(signal.SIG_BLOCK, {signal.SIGTERM})
+            os.kill(os.getpid(), signal.SIGTERM)
+            self.assertIn(signal.SIGTERM, signal.sigpending())
+            with mock.patch.object(ci_timeout.signal, "pthread_sigmask", side_effect=mask), \
                  mock.patch.object(ci_timeout, "_popen") as popen, \
                  mock.patch.object(ci_timeout, "_diagnose_capped") as diagnose, \
                  mock.patch.object(ci_timeout, "_cleanup") as cleanup, \
                  mock.patch.object(ci_timeout, "_send_process_signal") as send:
-                started = time.monotonic(); rc = ci_timeout.run_command(30, ["cargo", "test"])
-            self.assertEqual(rc, expected); self.assertLess(time.monotonic() - started, 55.1)
-            for operation in (popen, diagnose, cleanup, send, handlers):
+                started = time.monotonic()
+                rc = ci_timeout.run_command(30, ["cargo", "test"])
+            self.assertEqual(rc, 143)
+            self.assertLess(time.monotonic() - started, 55.1)
+            self.assertIn(signal.SIGTERM, signal.sigpending())
+            self.assertNotIn(signal.SIG_UNBLOCK, mask_operations)
+            for operation in (popen, diagnose, cleanup, send):
                 operation.assert_not_called()
+        finally:
+            if signal.SIGTERM in signal.sigpending():
+                signal.sigwait({signal.SIGTERM})
+            original_mask(signal.SIG_SETMASK, old_mask)
+            original_signal(signal.SIGTERM, old_handler)
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_timeout.py
+++ b/tests/test_ci_timeout.py
@@ -1,81 +1,408 @@
+import ast
+import contextlib
 import importlib.util
+import io
+import os
 import signal
 import subprocess
+import sys
+import threading
+import time
 import types
 import unittest
 from pathlib import Path
 from unittest import mock
 
-
 SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "ci-timeout.py"
 SPEC = importlib.util.spec_from_file_location("ci_timeout", SCRIPT_PATH)
-assert SPEC is not None and SPEC.loader is not None
+assert SPEC and SPEC.loader
 ci_timeout = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = ci_timeout
 SPEC.loader.exec_module(ci_timeout)
 
 
-class FakeProcess:
-    def __init__(self, timeout_count: int) -> None:
-        self.pid = 4413
-        self.terminate = mock.Mock()
-        self.kill = mock.Mock()
-        self.timeout_count = timeout_count
-        self.wait_calls = 0
+class Clock:
+    now = 0.0
 
-    def wait(self, timeout=None):
-        self.wait_calls += 1
-        if self.wait_calls <= self.timeout_count:
-            raise subprocess.TimeoutExpired("cargo test", timeout)
-        return 0
+    def __init__(self):
+        self.sleeps = []
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+class Process:
+    def __init__(self, results=(), default=None):
+        self.pid, self.returncode = 4413, None
+        self.results, self.default = list(results), default
+        self.terminate, self.kill = mock.Mock(), mock.Mock()
+
+    def poll(self):
+        result = self.results.pop(0) if self.results else self.default
+        if result is not None:
+            self.returncode = result
+        return result
 
 
 class CiTimeoutTests(unittest.TestCase):
+    def fake_run(self, proc, *, timeout=1, pending=lambda: set(), clock=None, diag=False):
+        clock = clock or Clock()
+        with contextlib.ExitStack() as stack:
+            for patcher in (
+                mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=True),
+                mock.patch.object(ci_timeout.signal, "sigpending", side_effect=pending),
+                mock.patch.object(ci_timeout, "_popen", return_value=proc),
+                mock.patch.object(ci_timeout, "_monotonic", side_effect=clock.monotonic),
+                mock.patch.object(ci_timeout, "_sleep", side_effect=clock.sleep),
+            ):
+                stack.enter_context(patcher)
+            if not diag:
+                stack.enter_context(mock.patch.object(ci_timeout, "_diagnose_capped"))
+            return ci_timeout.run_command(timeout, ["cargo", "test"]), clock
+
+    # F1
+    def test_timeout_is_bounded_and_returns_124(self):
+        proc = Process(default=None)
+
+        def send(*_args, force=False, **_kwargs):
+            if force:
+                proc.returncode = proc.default = -signal.SIGKILL
+
+        with mock.patch.object(ci_timeout, "_send_process_signal", side_effect=send):
+            rc, clock = self.fake_run(proc, timeout=2)
+        self.assertEqual(rc, 124)
+        self.assertLessEqual(clock.now, 27.1)
+
+    # Existing R4 fixture from line 33 of the original 82-line test.
     def test_killpg_fallback_terminates_then_kills_after_grace_period(self):
-        proc = FakeProcess(timeout_count=2)
-
-        with (
-            mock.patch.object(ci_timeout, "os", types.SimpleNamespace()),
-            mock.patch.object(ci_timeout.subprocess, "Popen", return_value=proc),
-            mock.patch.object(ci_timeout.signal, "signal", return_value=signal.SIG_DFL),
-        ):
-            return_code = ci_timeout.run_command(30, ["cargo", "test"])
-
+        proc = Process(default=None)
+        with mock.patch.object(ci_timeout, "os", types.SimpleNamespace(environ={})):
+            rc, _ = self.fake_run(proc)
         proc.terminate.assert_called_once_with()
         proc.kill.assert_called_once_with()
-        self.assertEqual(proc.wait_calls, 3)
-        self.assertEqual(return_code, 124)
+        self.assertEqual(rc, 124)
 
-    def test_sigterm_and_sigint_are_forwarded_with_shell_return_code(self):
-        for signum in (signal.SIGTERM, signal.SIGINT):
-            with self.subTest(signum=signum):
-                installed_handlers = {}
+    # F2 + F4
+    def test_external_sigkill_is_normalized_to_137(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "2", sys.executable, "-c",
+             "import os,signal;os.kill(os.getpid(),signal.SIGKILL)"],
+            capture_output=True, timeout=5,
+        )
+        self.assertEqual(result.returncode, 137)
+        for child_rc, expected in ((0, 0), (7, 7), (-signal.SIGHUP, 129)):
+            with self.subTest(child_rc=child_rc):
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    rc, _ = self.fake_run(Process([child_rc]))
+                self.assertEqual(rc, expected)
+                self.assertNotIn("::error::", stderr.getvalue())
+        with mock.patch.dict(os.environ, {"AGENTDESK_CI_TIMEOUT_REPORT": "1"}), \
+             contextlib.redirect_stderr(stderr := io.StringIO()):
+            self.fake_run(Process([0]))
+        self.assertIn("::notice::ci-timeout:", stderr.getvalue())
 
-                def install_handler(installed_signum, handler):
-                    previous = installed_handlers.get(installed_signum, signal.SIG_DFL)
-                    installed_handlers[installed_signum] = handler
-                    return previous
+    # F3
+    def test_missing_diagnostic_dumper_does_not_change_timeout_rc(self):
+        proc, clock = Process(default=None), Clock()
 
-                wait_results = [
-                    lambda timeout: installed_handlers[signum](signum, None),
-                    -signum,
-                ]
+        def popen(command, _enabled):
+            if command == ["cargo", "test"]:
+                return proc
+            raise FileNotFoundError(command[0])
 
-                def next_wait(timeout=None):
-                    result = wait_results.pop(0)
-                    return result(timeout) if callable(result) else result
+        def send(*_args, force=False, **_kwargs):
+            if force:
+                proc.returncode = proc.default = -signal.SIGKILL
 
-                proc = mock.Mock(pid=4413)
-                proc.wait = mock.Mock(side_effect=next_wait)
+        with mock.patch.object(ci_timeout, "_popen", side_effect=popen), \
+             mock.patch.object(ci_timeout, "_diagnostic_commands", return_value=[["missing"]]), \
+             mock.patch.object(ci_timeout, "_send_process_signal", side_effect=send), \
+             mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=True), \
+             mock.patch.object(ci_timeout.signal, "sigpending", return_value=set()), \
+             mock.patch.object(ci_timeout, "_monotonic", side_effect=clock.monotonic), \
+             mock.patch.object(ci_timeout, "_sleep", side_effect=clock.sleep), \
+             contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(ci_timeout.run_command(1, ["cargo", "test"]), 124)
 
-                with (
-                    mock.patch.object(ci_timeout.signal, "signal", side_effect=install_handler),
-                    mock.patch.object(ci_timeout.subprocess, "Popen", return_value=proc),
-                    mock.patch.object(ci_timeout, "_send_process_signal") as send_signal,
-                ):
-                    return_code = ci_timeout.run_command(30, ["cargo", "test"])
+    # F5 + F6
+    def test_sigterm_and_send_exceptions_preserve_origin_rc(self):
+        errors = (ProcessLookupError(), PermissionError(), OSError(), AttributeError())
+        for error in errors:
+            for origin in ("timeout", "signal"):
+                with self.subTest(error=type(error).__name__, origin=origin):
+                    seen = [0]
 
-                send_signal.assert_called_once_with(proc, signum)
-                self.assertEqual(return_code, 128 + signum)
+                    def pending():
+                        seen[0] += 1
+                        if origin == "timeout" or seen[0] == 1:
+                            return set()
+                        return {signal.SIGTERM} if seen[0] == 2 else {signal.SIGINT}
+
+                    with mock.patch.object(ci_timeout.os, "killpg", side_effect=error), \
+                         contextlib.redirect_stderr(io.StringIO()):
+                        rc, _ = self.fake_run(Process(default=None), pending=pending)
+                    self.assertEqual(rc, 124 if origin == "timeout" else 143)
+
+    # F7
+    def test_unreaped_child_stops_after_kill_wait_and_warns(self):
+        stderr = io.StringIO()
+        with mock.patch.object(ci_timeout.os, "killpg"), contextlib.redirect_stderr(stderr):
+            rc, clock = self.fake_run(Process(default=None))
+        self.assertEqual((rc, stderr.getvalue().count("unreaped after KILL_WAIT")), (124, 1))
+        self.assertLessEqual(clock.now, 16.1)
+
+    # F8(a,d,e)
+    def test_diagnostic_path_has_only_bounded_poll_apis(self):
+        source, tree = SCRIPT_PATH.read_text(), ast.parse(SCRIPT_PATH.read_text())
+        with self.subTest("F8-a vocabulary"):
+            for token in ("subprocess.run(", ".wait()", ".communicate()"):
+                self.assertNotIn(token, source)
+        self.assertIn("# R1: bounded poll only", source)
+        forbidden, aliases, violations = {"run", "call", "check_call", "check_output"}, set(), []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Attribute):
+                value = node.value
+                if isinstance(value.value, ast.Name) and value.value.id == "subprocess" and value.attr in forbidden:
+                    aliases.update(t.id for t in node.targets if isinstance(t, ast.Name))
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name) \
+                    and func.value.id == "subprocess" and func.attr in forbidden:
+                violations.append(node.lineno)
+            if isinstance(func, ast.Name) and func.id in aliases:
+                violations.append(node.lineno)
+            if isinstance(func, ast.Attribute) and func.attr in {"wait", "communicate"} \
+                    and not any(k.arg == "timeout" for k in node.keywords):
+                violations.append(node.lineno)
+        with self.subTest("F8-d AST"):
+            self.assertEqual((aliases, violations), (set(), []))
+
+    # F8(b,c)
+    def test_two_hanging_dumpers_share_one_diagnostic_cap(self):
+        primary, dumpers, checkpoints = Process(default=None), [], []
+        real_popen, real_checkpoint = subprocess.Popen, ci_timeout._checkpoint
+
+        def popen(command, **options):
+            if command == ["primary"]:
+                return primary
+            dumpers.append(real_popen(command, **options))
+            return dumpers[-1]
+
+        def send(*_args, force=False, **_kwargs):
+            if force:
+                primary.returncode = primary.default = -signal.SIGKILL
+
+        def checkpoint(state, enabled, name):
+            checkpoints.append(name)
+            return real_checkpoint(state, enabled, name)
+
+        sleeper = [sys.executable, "-c", "import time;time.sleep(600)"]
+        started = time.monotonic()
+        try:
+            with mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=False), \
+                 mock.patch.object(ci_timeout.subprocess, "Popen", side_effect=popen), \
+                 mock.patch.object(ci_timeout, "_diagnostic_commands", return_value=[sleeper] * 2), \
+                 mock.patch.object(ci_timeout, "_send_process_signal", side_effect=send), \
+                 mock.patch.object(ci_timeout, "DIAGNOSTIC_CAP_SECONDS", 0.05), \
+                 mock.patch.object(ci_timeout, "TERMINATION_GRACE_SECONDS", 0.01), \
+                 mock.patch.object(ci_timeout, "KILL_WAIT_SECONDS", 0.01), \
+                 mock.patch.object(ci_timeout, "_checkpoint", side_effect=checkpoint), \
+                 contextlib.redirect_stderr(io.StringIO()):
+                rc = ci_timeout.run_command(0.01, ["primary"])
+        finally:
+            for dumper in dumpers:
+                try:
+                    dumper.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    dumper.kill(); dumper.wait(timeout=1)
+        self.assertEqual((rc, len(dumpers)), (124, 2))
+        self.assertIn("diagnostic_poll", checkpoints)
+        self.assertLess(time.monotonic() - started, 0.5)
+
+    # F9
+    def test_post_cutoff_signals_never_use_any_send_path(self):
+        for has_killpg in (True, False):
+            for reaped in (True, False):
+                proc, state = Process(), ci_timeout._RunState(reaped=reaped, cutoff=True)
+                proc.returncode = 0 if reaped else None
+                fake_os = types.SimpleNamespace(environ={})
+                if has_killpg:
+                    fake_os.killpg = mock.Mock()
+                with mock.patch.object(ci_timeout, "os", fake_os):
+                    ci_timeout._send_process_signal(proc, state, signal.SIGTERM)
+                    ci_timeout._send_process_signal(proc, state, signal.SIGTERM, force=True)
+                if has_killpg:
+                    fake_os.killpg.assert_not_called()
+                proc.terminate.assert_not_called(); proc.kill.assert_not_called()
+                with mock.patch.object(ci_timeout.signal, "sigpending") as pending:
+                    self.assertFalse(ci_timeout._checkpoint(state, True, "post_cutoff"))
+                pending.assert_not_called(); self.assertIsNone(state.first_signum)
+                expected = 0 if reaped else 124
+                self.assertEqual(
+                    ci_timeout._select_return_code(
+                        state, timed_out=not reaped, child_returncode=proc.returncode
+                    ),
+                    expected,
+                )
+        proc, state = Process(), ci_timeout._RunState(reaped=False)
+        proc.returncode = 0
+        with mock.patch.object(ci_timeout.os, "killpg") as killpg:
+            ci_timeout._send_process_signal(proc, state, signal.SIGTERM)
+        killpg.assert_not_called()
+
+    # F10-①
+    @unittest.skipUnless(hasattr(signal, "pthread_sigmask"), "POSIX required")
+    def test_popen_seam_signal_has_required_event_order(self):
+        events, proc = [], Process(default=None)
+        original_mask, original_pending, old_mask = signal.pthread_sigmask, signal.sigpending, [None]
+
+        def mask(how, signals):
+            events.append("mask_blocked"); old_mask[0] = original_mask(how, signals); return old_mask[0]
+
+        def pending():
+            result = original_pending()
+            events.append("checkpoint_observed" if signal.SIGTERM in result else "checkpoint1_clear")
+            return result
+
+        def popen(*_args):
+            events.append("popen_entered"); os.kill(os.getpid(), signal.SIGTERM)
+            events.extend(("signal_pending", "popen_returned")); return proc
+
+        def send(*_args, **_kwargs):
+            events.append("term_sent"); proc.returncode = proc.default = -signal.SIGTERM
+
+        try:
+            with mock.patch.object(ci_timeout.signal, "pthread_sigmask", side_effect=mask), \
+                 mock.patch.object(ci_timeout.signal, "sigpending", side_effect=pending), \
+                 mock.patch.object(ci_timeout, "_popen", side_effect=popen), \
+                 mock.patch.object(ci_timeout, "_diagnose_capped"), \
+                 mock.patch.object(ci_timeout, "_send_process_signal", side_effect=send):
+                rc = ci_timeout.run_command(30, ["cargo", "test"])
+            signal.sigwait({signal.SIGTERM})
+        finally:
+            if old_mask[0] is not None:
+                original_mask(signal.SIG_SETMASK, old_mask[0])
+        required = ["mask_blocked", "checkpoint1_clear", "popen_entered", "signal_pending",
+                    "popen_returned", "checkpoint_observed", "term_sent"]
+        self.assertEqual([events.index(e) for e in required], sorted(events.index(e) for e in required))
+        self.assertEqual(rc, 143)
+
+    # F10-②..⑥
+    def test_signal_boundaries_polling_and_tie_break(self):
+        state = ci_timeout._RunState()
+        with mock.patch.object(ci_timeout.signal, "sigpending", return_value={signal.SIGTERM, signal.SIGINT}):
+            self.assertTrue(ci_timeout._checkpoint(state, True, "final"))
+        state.cutoff = True
+        self.assertEqual(ci_timeout._select_return_code(state, timed_out=False, child_returncode=0), 143)
+        with mock.patch.object(ci_timeout.signal, "sigpending") as pending:
+            self.assertFalse(ci_timeout._checkpoint(ci_timeout._RunState(cutoff=True), True, "after"))
+        pending.assert_not_called()
+
+        clock, proc, seen, points = Clock(), Process(default=None), [None, None], []
+        real_checkpoint = ci_timeout._checkpoint
+
+        def popen(*_args):
+            clock.now += 100; seen[0] = clock.now + 0.15; seen[1] = clock.now; return proc
+
+        def pending_signal():
+            return {signal.SIGTERM} if seen[0] is not None and clock.now >= seen[0] else set()
+
+        def send(*_args, **_kwargs):
+            proc.returncode = proc.default = -signal.SIGTERM
+
+        def checkpoint(s, enabled, name):
+            points.append((name, clock.now)); return real_checkpoint(s, enabled, name)
+
+        with mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=True), \
+             mock.patch.object(ci_timeout, "_popen", side_effect=popen), \
+             mock.patch.object(ci_timeout.signal, "sigpending", side_effect=pending_signal), \
+             mock.patch.object(ci_timeout, "_diagnose_capped"), \
+             mock.patch.object(ci_timeout, "_send_process_signal", side_effect=send), \
+             mock.patch.object(ci_timeout, "_monotonic", side_effect=clock.monotonic), \
+             mock.patch.object(ci_timeout, "_sleep", side_effect=clock.sleep), \
+             mock.patch.object(ci_timeout, "_checkpoint", side_effect=checkpoint):
+            rc = ci_timeout.run_command(30, ["cargo", "test"])
+        names = {name for name, _ in points}
+        required = {"checkpoint1", "checkpoint2", "poll", "term_boundary",
+                    "grace_boundary", "kill_boundary", "final"}
+        observed = next(at for name, at in points if name == "poll" and at >= seen[0])
+        self.assertEqual(rc, 143)
+        self.assertLessEqual(observed - seen[0], 0.1 + 1e-9)
+        self.assertLessEqual(clock.now - seen[1], 55.1)
+        self.assertTrue(required.issubset(names))
+        self.assertLessEqual(max(clock.sleeps), ci_timeout.POLL_INTERVAL_SECONDS)
+
+    # F11
+    def test_spawn_and_input_errors_preserve_legacy_rows(self):
+        with mock.patch.object(ci_timeout.signal, "pthread_sigmask") as mask_call, \
+             mock.patch.object(ci_timeout.signal, "sigpending", return_value=set()), \
+             mock.patch.object(ci_timeout.signal, "signal") as handlers, \
+             mock.patch.object(ci_timeout, "_popen", side_effect=FileNotFoundError()):
+            with self.assertRaises(FileNotFoundError):
+                ci_timeout.run_command(1, ["missing"])
+        handlers.assert_not_called(); self.assertEqual(mask_call.call_count, 1)
+        for argv in (["ci-timeout.py"], ["ci-timeout.py", "bad", "true"]):
+            with mock.patch.object(sys, "argv", argv), mock.patch.object(ci_timeout, "_popen") as popen:
+                self.assertEqual(ci_timeout.main(), 2); popen.assert_not_called()
+        result = subprocess.run([sys.executable, str(SCRIPT_PATH), "1", "/not/a/program"],
+                                capture_output=True, timeout=5)
+        self.assertEqual(result.returncode, 1)
+
+    # F12
+    @unittest.skipUnless(hasattr(signal, "pthread_sigmask"), "POSIX required")
+    def test_child_mask_is_unblocked_and_wrapper_is_single_threaded(self):
+        code = ("import signal;m=signal.pthread_sigmask(signal.SIG_BLOCK,[]);"
+                "print(int(signal.SIGTERM in m),int(signal.SIGINT in m))")
+        result = subprocess.run([sys.executable, str(SCRIPT_PATH), "2", sys.executable, "-c", code],
+                                capture_output=True, text=True, timeout=5)
+        self.assertEqual((result.returncode, result.stdout.strip()), (0, "0 0"))
+        threads, proc = [], Process([0])
+
+        def popen(_command, **options):
+            threads.append(threading.active_count())
+            self.assertIs(options.get("preexec_fn"), ci_timeout._unblock_forwarded_signals)
+            return proc
+
+        with mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=True), \
+             mock.patch.object(ci_timeout.signal, "sigpending", return_value=set()), \
+             mock.patch.object(ci_timeout.subprocess, "Popen", side_effect=popen):
+            self.assertEqual(ci_timeout.run_command(1, ["true"]), 0)
+        self.assertEqual(threads, [1])
+        tree, imports, constructors = ast.parse(SCRIPT_PATH.read_text()), [], []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports += [a.name for a in node.names if a.name in {"threading", "concurrent.futures"}]
+            elif isinstance(node, ast.ImportFrom) and node.module in {"threading", "concurrent.futures"}:
+                imports.append(node.module)
+            elif isinstance(node, ast.Call):
+                name = node.func.attr if isinstance(node.func, ast.Attribute) else \
+                    node.func.id if isinstance(node.func, ast.Name) else ""
+                if name in {"Thread", "ThreadPoolExecutor"}:
+                    constructors.append(node.lineno)
+        self.assertEqual((imports, constructors), ([], []))
+
+    # F13
+    def test_checkpoint_one_pending_signal_never_spawns_or_cleans_up(self):
+        for pending, expected in (({signal.SIGINT}, 130), ({signal.SIGTERM}, 143),
+                                  ({signal.SIGTERM, signal.SIGINT}, 143)):
+            with self.subTest(pending=pending), \
+                 mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=True), \
+                 mock.patch.object(ci_timeout.signal, "sigpending", return_value=pending), \
+                 mock.patch.object(ci_timeout.signal, "signal") as handlers, \
+                 mock.patch.object(ci_timeout, "_popen") as popen, \
+                 mock.patch.object(ci_timeout, "_diagnose_capped") as diagnose, \
+                 mock.patch.object(ci_timeout, "_cleanup") as cleanup, \
+                 mock.patch.object(ci_timeout, "_send_process_signal") as send:
+                started = time.monotonic(); rc = ci_timeout.run_command(30, ["cargo", "test"])
+            self.assertEqual(rc, expected); self.assertLess(time.monotonic() - started, 55.1)
+            for operation in (popen, diagnose, cleanup, send, handlers):
+                operation.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_timeout.py
+++ b/tests/test_ci_timeout.py
@@ -6,6 +6,7 @@ import os
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import types
@@ -63,7 +64,9 @@ class CiTimeoutTests(unittest.TestCase):
             ):
                 stack.enter_context(patcher)
             if not diag:
-                stack.enter_context(mock.patch.object(ci_timeout, "_diagnose_capped"))
+                stack.enter_context(
+                    mock.patch.object(ci_timeout, "_diagnose_with_deadline")
+                )
             return ci_timeout.run_command(timeout, ["cargo", "test"]), clock
 
     # F1
@@ -184,17 +187,27 @@ class CiTimeoutTests(unittest.TestCase):
                 violations.append(node.lineno)
         with self.subTest("F8-d AST"):
             self.assertEqual((aliases, violations), (set(), []))
+        with self.subTest("no process-global diagnostic timer"):
+            self.assertNotIn("SIGALRM", source)
+            self.assertNotIn("setitimer", source)
+            self.assertNotIn("_DiagnosticCapExpired", source)
 
     # F8(b,c)
-    def test_two_hanging_dumpers_share_one_diagnostic_cap(self):
-        primary, dumpers, checkpoints, attempts = Process(default=None), [], [], []
+    def test_returned_dumpers_are_tracked_when_popen_exceeds_deadline(self):
+        primary, dumpers, checkpoints, attempts, clock = (
+            Process(default=None),
+            [],
+            [],
+            [],
+            Clock(),
+        )
         real_checkpoint = ci_timeout._checkpoint
 
         def popen(command, _enabled):
             if command == ["primary"]:
                 return primary
             attempts.append(command)
-            time.sleep(1.2)  # Scaled equivalent of each 6s seam under a 10s cap.
+            clock.now += 1.2  # Each Popen seam consumes time outside the deadline.
             dumpers.append(Process(default=None))
             return dumpers[-1]
 
@@ -207,7 +220,6 @@ class CiTimeoutTests(unittest.TestCase):
             checkpoints.append(name)
             return real_checkpoint(state, enabled, name)
 
-        started = time.monotonic()
         with mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=True), \
              mock.patch.object(ci_timeout, "_popen", side_effect=popen), \
              mock.patch.object(ci_timeout, "_diagnostic_commands",
@@ -216,16 +228,20 @@ class CiTimeoutTests(unittest.TestCase):
              mock.patch.object(ci_timeout, "DIAGNOSTIC_CAP_SECONDS", 2.0), \
              mock.patch.object(ci_timeout, "_checkpoint", side_effect=checkpoint), \
              mock.patch.object(ci_timeout.signal, "sigpending", return_value=set()), \
+             mock.patch.object(ci_timeout, "_monotonic", side_effect=clock.monotonic), \
+             mock.patch.object(ci_timeout, "_sleep", side_effect=clock.sleep), \
              contextlib.redirect_stderr(io.StringIO()):
             rc = ci_timeout.run_command(0, ["primary"])
-        elapsed = time.monotonic() - started
-        self.assertEqual((rc, len(attempts), len(dumpers)), (124, 2, 1))
+        self.assertEqual((rc, len(attempts), len(dumpers)), (124, 2, 2))
+        for dumper in dumpers:
+            dumper.kill.assert_called_once_with()
         self.assertIn("diagnostic_poll", checkpoints)
-        self.assertGreaterEqual(elapsed, 1.9)
-        self.assertLess(elapsed, 2.3)
+        # Popen creation is outside the poll deadline, but every returned child
+        # is owned and killed; no SIGALRM can interrupt registration.
+        self.assertAlmostEqual(clock.now, 2.4)
 
     def test_diagnostic_poll_never_sleeps_a_negative_duration(self):
-        dumper, times, sleeps = Process(default=None), iter((0, 0, 0, 0, 2, 2)), []
+        dumper, times, sleeps = Process(default=None), iter((0, 0, 2)), []
 
         def sleep(seconds):
             self.assertGreaterEqual(seconds, 0)
@@ -238,8 +254,10 @@ class CiTimeoutTests(unittest.TestCase):
              mock.patch.object(ci_timeout, "_monotonic", side_effect=times), \
              mock.patch.object(ci_timeout, "_sleep", side_effect=sleep), \
              contextlib.redirect_stderr(io.StringIO()):
-            ci_timeout._diagnose_capped(Process(), ci_timeout._RunState(), False)
-        self.assertEqual(sleeps, [0])
+            ci_timeout._diagnose_with_deadline(
+                Process(), ci_timeout._RunState(), True
+            )
+        self.assertEqual(sleeps, [])
 
     # F9
     @unittest.skipUnless(hasattr(signal, "pthread_sigmask"), "POSIX required")
@@ -275,7 +293,7 @@ class CiTimeoutTests(unittest.TestCase):
 
                     try:
                         with mock.patch.object(ci_timeout, "_popen", return_value=proc), \
-                             mock.patch.object(ci_timeout, "_diagnose_capped"), \
+                             mock.patch.object(ci_timeout, "_diagnose_with_deadline"), \
                              mock.patch.object(ci_timeout.os, "killpg") as killpg, \
                              mock.patch.object(ci_timeout, "_monotonic", side_effect=clock.monotonic), \
                              mock.patch.object(ci_timeout, "_sleep", side_effect=clock.sleep), \
@@ -318,7 +336,7 @@ class CiTimeoutTests(unittest.TestCase):
             with mock.patch.object(ci_timeout.signal, "pthread_sigmask", side_effect=mask), \
                  mock.patch.object(ci_timeout.signal, "sigpending", side_effect=pending), \
                  mock.patch.object(ci_timeout, "_popen", side_effect=popen), \
-                 mock.patch.object(ci_timeout, "_diagnose_capped"), \
+                 mock.patch.object(ci_timeout, "_diagnose_with_deadline"), \
                  mock.patch.object(ci_timeout, "_send_process_signal", side_effect=send):
                 rc = ci_timeout.run_command(30, ["cargo", "test"])
             signal.sigwait({signal.SIGTERM})
@@ -359,7 +377,7 @@ class CiTimeoutTests(unittest.TestCase):
         with mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=True), \
              mock.patch.object(ci_timeout, "_popen", side_effect=popen), \
              mock.patch.object(ci_timeout.signal, "sigpending", side_effect=pending_signal), \
-             mock.patch.object(ci_timeout, "_diagnose_capped"), \
+             mock.patch.object(ci_timeout, "_diagnose_with_deadline"), \
              mock.patch.object(ci_timeout, "_send_process_signal", side_effect=send), \
              mock.patch.object(ci_timeout, "_monotonic", side_effect=clock.monotonic), \
              mock.patch.object(ci_timeout, "_sleep", side_effect=clock.sleep), \
@@ -413,7 +431,7 @@ class CiTimeoutTests(unittest.TestCase):
                 with mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=True), \
                      mock.patch.object(ci_timeout.signal, "sigpending", return_value=set()), \
                      mock.patch.object(ci_timeout, "_popen", return_value=proc) as popen, \
-                     mock.patch.object(ci_timeout, "_diagnose_capped"), \
+                     mock.patch.object(ci_timeout, "_diagnose_with_deadline"), \
                      mock.patch.object(ci_timeout, "_send_process_signal"), \
                      mock.patch.object(ci_timeout, "_monotonic", side_effect=clock.monotonic), \
                      mock.patch.object(ci_timeout, "_sleep", side_effect=clock.sleep), \
@@ -487,22 +505,79 @@ class CiTimeoutTests(unittest.TestCase):
                                 capture_output=True, timeout=5)
         self.assertEqual(result.returncode, 1)
 
-    def test_non_posix_path_installs_and_restores_legacy_handlers(self):
-        installed = {}
+    def test_non_posix_path_forwards_sigterm_to_real_child_and_restores_handlers(self):
+        installed, trigger_threads, children = {}, [], []
+        real_popen = ci_timeout._popen
 
         def install(signum, handler):
             previous = installed.get(signum, signal.SIG_DFL)
             installed[signum] = handler
+            if (
+                not trigger_threads
+                and all(callable(installed.get(item)) for item in ci_timeout._FORWARDED_SIGNALS)
+            ):
+                trigger = threading.Thread(target=forward_when_child_is_ready)
+                trigger_threads.append(trigger)
+                trigger.start()
             return previous
 
-        with mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=False), \
-             mock.patch.object(ci_timeout, "_popen", return_value=Process([0])), \
-             mock.patch.object(ci_timeout.signal, "signal", side_effect=install) as handlers:
-            rc = ci_timeout.run_command(30, ["cargo", "test"])
-        self.assertEqual(rc, 0)
-        self.assertEqual(handlers.call_count, 4)
-        self.assertEqual(installed, {signal.SIGTERM: signal.SIG_DFL,
-                                     signal.SIGINT: signal.SIG_DFL})
+        with tempfile.TemporaryDirectory() as directory:
+            ready = Path(directory) / "ready"
+            received = Path(directory) / "received"
+
+            def forward_when_child_is_ready():
+                deadline = time.monotonic() + 3
+                while not ready.exists() and time.monotonic() < deadline:
+                    time.sleep(0.01)
+                if ready.exists():
+                    installed[signal.SIGTERM](signal.SIGTERM, None)
+
+            child = "\n".join(
+                (
+                    "import signal, sys, time",
+                    "from pathlib import Path",
+                    "def handled(signum, _frame):",
+                    "    Path(sys.argv[2]).write_text(str(signum))",
+                    "    raise SystemExit(0)",
+                    "signal.signal(signal.SIGTERM, handled)",
+                    "Path(sys.argv[1]).write_text('ready')",
+                    "while True: time.sleep(0.01)",
+                )
+            )
+            fallback_os = types.SimpleNamespace(environ=os.environ)
+
+            def popen(command, enabled):
+                spawned = real_popen(command, enabled)
+                children.append(spawned)
+                return spawned
+
+            try:
+                with mock.patch.object(ci_timeout, "_mask_forwarded_signals", return_value=False), \
+                     mock.patch.object(ci_timeout, "_popen", side_effect=popen), \
+                     mock.patch.object(ci_timeout, "_cleanup"), \
+                     mock.patch.object(ci_timeout, "os", fallback_os), \
+                     mock.patch.object(ci_timeout.signal, "signal", side_effect=install) as handlers, \
+                     contextlib.redirect_stderr(io.StringIO()):
+                    rc = ci_timeout.run_command(
+                        5, [sys.executable, "-c", child, str(ready), str(received)]
+                    )
+                trigger_threads[0].join(timeout=1)
+                receipt_deadline = time.monotonic() + 1
+                while not received.exists() and time.monotonic() < receipt_deadline:
+                    time.sleep(0.01)
+                self.assertEqual(rc, 143)
+                self.assertEqual(received.read_text(), str(signal.SIGTERM))
+                self.assertFalse(trigger_threads[0].is_alive())
+                self.assertEqual(handlers.call_count, 4)
+                self.assertEqual(
+                    installed,
+                    {signal.SIGTERM: signal.SIG_DFL, signal.SIGINT: signal.SIG_DFL},
+                )
+            finally:
+                for spawned in children:
+                    if spawned.poll() is None:
+                        spawned.kill()
+                    spawned.wait(timeout=1)
 
     # F12
     @unittest.skipUnless(hasattr(signal, "pthread_sigmask"), "POSIX required")
@@ -543,11 +618,20 @@ class CiTimeoutTests(unittest.TestCase):
         original_mask, original_signal = signal.pthread_sigmask, signal.signal
         old_mask = original_mask(signal.SIG_BLOCK, set())
         old_handler = original_signal(signal.SIGTERM, lambda *_args: None)
-        mask_operations = []
+        mask_operations, select_calls, report_pending = [], [], []
+        real_select = ci_timeout._select_return_code
 
         def mask(how, signals):
             mask_operations.append(how)
             return original_mask(how, signals)
+
+        def select(*args, **kwargs):
+            select_calls.append(True)
+            os.kill(os.getpid(), signal.SIGINT)
+            return real_select(*args, **kwargs)
+
+        def report(*_args):
+            report_pending.append(signal.sigpending())
 
         try:
             original_mask(signal.SIG_BLOCK, {signal.SIGTERM})
@@ -555,20 +639,26 @@ class CiTimeoutTests(unittest.TestCase):
             self.assertIn(signal.SIGTERM, signal.sigpending())
             with mock.patch.object(ci_timeout.signal, "pthread_sigmask", side_effect=mask), \
                  mock.patch.object(ci_timeout, "_popen") as popen, \
-                 mock.patch.object(ci_timeout, "_diagnose_capped") as diagnose, \
+                 mock.patch.object(ci_timeout, "_diagnose_with_deadline") as diagnose, \
                  mock.patch.object(ci_timeout, "_cleanup") as cleanup, \
-                 mock.patch.object(ci_timeout, "_send_process_signal") as send:
+                 mock.patch.object(ci_timeout, "_send_process_signal") as send, \
+                 mock.patch.object(ci_timeout, "_select_return_code", side_effect=select), \
+                 mock.patch.object(ci_timeout, "_report", side_effect=report):
                 started = time.monotonic()
                 rc = ci_timeout.run_command(30, ["cargo", "test"])
             self.assertEqual(rc, 143)
             self.assertLess(time.monotonic() - started, 55.1)
             self.assertIn(signal.SIGTERM, signal.sigpending())
+            self.assertEqual(select_calls, [True])
+            self.assertEqual(len(report_pending), 1)
+            self.assertIn(signal.SIGINT, report_pending[0])
             self.assertNotIn(signal.SIG_UNBLOCK, mask_operations)
             for operation in (popen, diagnose, cleanup, send):
                 operation.assert_not_called()
         finally:
-            if signal.SIGTERM in signal.sigpending():
-                signal.sigwait({signal.SIGTERM})
+            for signum in (signal.SIGTERM, signal.SIGINT):
+                if signum in signal.sigpending():
+                    signal.sigwait({signum})
             original_mask(signal.SIG_SETMASK, old_mask)
             original_signal(signal.SIGTERM, old_handler)
 

--- a/tests/test_ci_timeout.py
+++ b/tests/test_ci_timeout.py
@@ -191,6 +191,20 @@ class CiTimeoutTests(unittest.TestCase):
             self.assertNotIn("SIGALRM", source)
             self.assertNotIn("setitimer", source)
             self.assertNotIn("_DiagnosticCapExpired", source)
+        with self.subTest("contract wording stays scoped to actual guarantees"):
+            for wording in (
+                "Diagnostic process creation is best-effort and outside the cleanup bound.",
+                "Select rc for signal, timeout, and child-exit rows after spawn.",
+                "Preserve the pre-masking contract",
+                "spawn-path rc selection",
+            ):
+                self.assertIn(wording, source)
+            for overstatement in (
+                "Apply all seven rc-table rows in one place.",
+                "Preserve the pre-masking implementation",
+                "the sole rc selection",
+            ):
+                self.assertNotIn(overstatement, source)
 
     # F8(b,c)
     def test_returned_dumpers_are_tracked_when_popen_exceeds_deadline(self):
@@ -230,12 +244,17 @@ class CiTimeoutTests(unittest.TestCase):
              mock.patch.object(ci_timeout.signal, "sigpending", return_value=set()), \
              mock.patch.object(ci_timeout, "_monotonic", side_effect=clock.monotonic), \
              mock.patch.object(ci_timeout, "_sleep", side_effect=clock.sleep), \
-             contextlib.redirect_stderr(io.StringIO()):
+             contextlib.redirect_stderr(stderr := io.StringIO()):
             rc = ci_timeout.run_command(0, ["primary"])
         self.assertEqual((rc, len(attempts), len(dumpers)), (124, 2, 2))
         for dumper in dumpers:
             dumper.kill.assert_called_once_with()
-        self.assertIn("diagnostic_poll", checkpoints)
+            self.assertIn(
+                f"::warning::ci-timeout: diagnostic pid {dumper.pid} unreaped",
+                stderr.getvalue(),
+            )
+        # One checkpoint per returned child plus one bounded poll iteration.
+        self.assertEqual(checkpoints.count("diagnostic_poll"), len(dumpers) + 1)
         # Popen creation is outside the poll deadline, but every returned child
         # is owned and killed; no SIGALRM can interrupt registration.
         self.assertAlmostEqual(clock.now, 2.4)
@@ -347,6 +366,31 @@ class CiTimeoutTests(unittest.TestCase):
                     "popen_returned", "checkpoint_observed", "term_sent"]
         self.assertEqual([events.index(e) for e in required], sorted(events.index(e) for e in required))
         self.assertEqual(rc, 143)
+
+    @unittest.skipUnless(hasattr(signal, "pthread_sigmask"), "POSIX required")
+    def test_spawned_reaped_child_final_pending_sigint_returns_130(self):
+        original_mask, real_checkpoint = signal.pthread_sigmask, ci_timeout._checkpoint
+        old_mask = original_mask(signal.SIG_BLOCK, set())
+        proc, injected = Process([0]), []
+
+        def checkpoint(state, enabled, name):
+            if name == "final" and not injected:
+                os.kill(os.getpid(), signal.SIGINT)
+                injected.append(True)
+            return real_checkpoint(state, enabled, name)
+
+        try:
+            with mock.patch.object(ci_timeout, "_popen", return_value=proc), \
+                 mock.patch.object(ci_timeout, "_checkpoint", side_effect=checkpoint), \
+                 mock.patch.object(ci_timeout, "_cleanup") as cleanup:
+                rc = ci_timeout.run_command(30, ["cargo", "test"])
+            self.assertEqual(rc, 130)
+            self.assertIn(signal.SIGINT, signal.sigpending())
+            cleanup.assert_not_called()
+        finally:
+            if signal.SIGINT in signal.sigpending():
+                signal.sigwait({signal.SIGINT})
+            original_mask(signal.SIG_SETMASK, old_mask)
 
     # F10-②..⑥
     def test_signal_boundaries_polling_and_tie_break(self):
@@ -661,6 +705,26 @@ class CiTimeoutTests(unittest.TestCase):
                     signal.sigwait({signum})
             original_mask(signal.SIG_SETMASK, old_mask)
             original_signal(signal.SIGTERM, old_handler)
+
+    @unittest.skipUnless(hasattr(signal, "pthread_sigmask"), "POSIX required")
+    def test_checkpoint_one_pending_sigint_returns_130_without_spawn(self):
+        original_mask = signal.pthread_sigmask
+        old_mask = original_mask(signal.SIG_BLOCK, set())
+        try:
+            original_mask(signal.SIG_BLOCK, {signal.SIGINT})
+            os.kill(os.getpid(), signal.SIGINT)
+            self.assertEqual(signal.sigpending(), {signal.SIGINT})
+            with mock.patch.object(ci_timeout, "_popen") as popen, \
+                 mock.patch.object(ci_timeout, "_cleanup") as cleanup, \
+                 mock.patch.object(ci_timeout, "_send_process_signal") as send:
+                rc = ci_timeout.run_command(30, ["cargo", "test"])
+            self.assertEqual(rc, 130)
+            for operation in (popen, cleanup, send):
+                operation.assert_not_called()
+        finally:
+            if signal.SIGINT in signal.sigpending():
+                signal.sigwait({signal.SIGINT})
+            original_mask(signal.SIG_SETMASK, old_mask)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#5071 T0 ③ / #4983 S1. `scripts/ci-timeout.py`를 마스킹 + 체크포인트 폴링 모델로 교체하고, 진단·정리 구간의 시간 계약을 **실제로 보장하는 범위까지만** 선언한다.

## 무엇을 고치나
CI의 `cargo test` 레인에 hang 보호가 없어 데드락이 최대 6시간 침묵 점유로 나타났다. 래퍼가 자식에게 신호를 전달하고 타임아웃 시 진단을 뜨는데, 그 과정 자체가 신호를 잃거나 무한 대기할 수 있었다.

새 모델은 SIGTERM/SIGINT를 **블록**해두고 정해진 체크포인트에서 `sigpending()`으로 관측한다. 비동기 핸들러가 임의 지점에 끼어드는 대신 관측 지점이 코드에 고정되므로, "언제 신호를 봤는가"가 rc 테이블의 행과 1:1로 대응한다.

## 설계 이력에서 실제로 배운 것
r2에서 진단 전체에 `SIGALRM`/`setitimer` hard cap을 걸었다. 그게 **P1 3건을 새로 만들었다** — 알람이 `Popen` 반환 전에 터지면 자식이 리스트에 등록되지 않아 유실되고, handler/timer 설치가 transactional하지 않아 복원이 실패하며, 캡 예외가 `try` 밖에서 발생하면 rc 124 계약을 깨고 TERM/KILL 에스컬레이션을 통째로 건너뛴다.

r3은 그 기계를 **통째로 제거했다.** 전역 타이머·핸들러를 설치하지 않고, 하나의 monotonic deadline으로 "반환한 dumper의 poll 대기"만 제한한다. 세 결함이 뿌리째 사라졌고, 잃은 것(진단 spawn 구간의 wall-clock 상한)은 RISKS와 docstring에 명시 축소로 선언했다 — job timeout이 최종 백스톱이다.

## 이 브랜치의 핵심 교훈: 픽스처가 두 번 거짓말했다
r1·r2에서 **새 픽스처가 잡아야 할 뮤테이션을 통과**하는 일이 반복됐다. 원인은 mock 오라클이었다. 그래서 최종 상태는 전부 실제 경로로 단언한다 — 실제 `sigpending()`, 실제 자식 프로세스가 신호 수신을 파일에 기록, 실제 stderr 캡처.

특히 `state.cutoff = True`가 두 곳(`:266` 1a 경로 / `:314` 스폰 경로)에 있어 **어느 줄을 변이했느냐에 따라 리뷰어 판정이 갈렸다**(1a 제거 → 통과 = 무방비 / 스폰 제거 → FAILED 3건). 1a의 그 대입은 조기 반환 전 읽히지 않는 죽은 코드로 판명돼 삭제했고, 대신 no-spawn 계약을 실제 pending signal로 단언하는 픽스처를 넣었다.

## 검증
테스트 2 → 21. 뮤테이션은 전부 `제거=FAILED / 복원=ok`를 **대상 `file:line`과 함께** 증명한다:

| 뮤테이션 | 대상 | 결과 |
|---|---|---|
| rc 식 상수화 (`return 143`) | `:226` | `143 != 130` |
| 진단 체크포인트 생성 사이트 단독 제거 | `:156` | `1 != 3` |
| 진단 체크포인트 poll 사이트 단독 제거 | `:160` | `2 != 3` |
| 미reap dumper 경고 무력화 | `:171` | PID 포함 경고 미출력 |
| final 체크포인트 제거 | `:290` | `0 != 130` |
| SIGINT 관측을 SIGTERM으로 오기록 | `:54-55` | `143 != 130` (failures=2) |
| D-1 역행(final 뒤 재cleanup 삽입) | `:290` | `cleanup.assert_not_called()` |
| 축소된 docstring 4곳을 옛 과대 문구로 역행 | `:2-5,224,257,289` | 4건 각각 FAILED |

표준 배터리 전부 green — fmt / check(접촉 `.rs` 0개) / docs 재생성 후 트리 clean / audit / `ci-script-checks.sh` rc=0.

## 리뷰
- sol (fresh, exact SHA, 전용 워크트리): **P0 0 · P1 0**, 요구 뮤테이션 6종 전건 검출 확인. hard cap 축소가 설계 rev.10의 delta·RISKS에 정직하게 선언돼 있고 미선언 축소 없음. P2 4건은 후속 항목.
- Fable (fresh, 전용 워크트리): 정적 결함 **0건**, 설계 rev.10 F1–F13 전수 매핑 확인. 실행 권한이 차단돼 `BLOCKED`를 냈고 판정을 지어내지 않았다 — 그가 설계한 뮤테이션 중 실행 가능한 것은 **오케스트레이터가 직접 돌려 검출을 확인**했다(위 표 하단 3종).

## 남은 한계 (선언됨)
진단 dumper의 `Popen` **생성** 구간과 그 구간의 자식 수명은 bound 밖이며 job timeout이 백스톱이다. 미reap dumper 회수는 best-effort다. 둘 다 RISKS와 모듈 docstring에 명시했다.