### PR TITLE
test(#4996): deterministic pg_tunnel signal harness + a narrowed, honestly-scoped static trap contract

### DIFF
--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -196,23 +196,31 @@ class DeploymentWiringTests(unittest.TestCase):
         This guard intentionally does no bash parsing: every physical line that
         starts with trap is compared as a full-line ordered multiset.  It also
         pins unique cleanup definitions, relative reset/registration order, and
-        the preflight-call strip set.  Indirect registrations through the
-        builtin trap command or eval are outside this static guard; the
-        real-signal INT/TERM harness is the behavioral backstop.  A query such
-        as trap -p INT is still a trap line and therefore fails the exact
+        the preflight-call strip set.  Trap tokens that are not at line start
+        (for example after ``;`` in a compound command), indirect registrations
+        through the builtin trap command, and registrations assembled by eval
+        are outside this static guard; the real-signal INT/TERM harness is the
+        behavioral backstop.  The EXIT-leg harness executes this production
+        slice on normal exit and injects INT during cleanup, so a registration
+        hidden in a heredoc is caught behaviorally even though this exact-line
+        guard deliberately does not parse shell syntax.  A query such as
+        ``trap -p INT`` is still a trap line and therefore fails the exact
         contract.
         """
         deploy = DEPLOY.read_text(encoding="utf-8")
         deploy_lines = deploy.splitlines()
 
         trap_rows = [
-            (line_number, line.strip())
+            (line_number, line)
             for line_number, line in enumerate(deploy_lines, 1)
             if re.match(r"^[ \t]*trap[ \t]", line)
         ]
+        # The reset commands are deliberately indented as function-body lines;
+        # all five rows remain raw exact matches, while the three top-level
+        # registrations below are required to stay at column 0.
         expected_traps = [
-            "trap - EXIT",
-            "trap '' INT TERM",
+            "    trap - EXIT",
+            "    trap '' INT TERM",
             "trap _cleanup_on_exit EXIT",
             "trap '_handle_cleanup_signal 130' INT",
             "trap '_handle_cleanup_signal 143' TERM",
@@ -224,16 +232,46 @@ class DeploymentWiringTests(unittest.TestCase):
             "expected exactly five trap lines in this order; observed rows="
             + repr([f"line {line_number}: {text}" for line_number, text in trap_rows]),
         )
+        for line_number, text in trap_rows[2:]:
+            self.assertEqual(
+                text,
+                text.lstrip(),
+                "top-level trap registrations must remain at column 0: "
+                f"line {line_number}: {text!r}",
+            )
 
         def definition_rows(name: str) -> list[tuple[int, str]]:
-            pattern = re.compile(
-                r"^[ \t]*" + re.escape(name) + r"\(\)[ \t]*\{"
+            direct_patterns = (
+                re.compile(
+                    r"^[ \t]*" + re.escape(name) + r"\(\)[ \t]*\{"
+                ),
+                re.compile(
+                    r"^[ \t]*function[ \t]+"
+                    + re.escape(name)
+                    + r"(?:\(\))?[ \t]*\{"
+                ),
             )
-            return [
-                (line_number, line.strip())
-                for line_number, line in enumerate(deploy_lines, 1)
-                if pattern.match(line)
-            ]
+            multiline_name = re.compile(
+                r"^[ \t]*" + re.escape(name) + r"\(\)[ \t]*$"
+            )
+            opening_brace = re.compile(r"^[ \t]*\{")
+            rows: list[tuple[int, str]] = []
+            for index, line in enumerate(deploy_lines):
+                if any(pattern.match(line) for pattern in direct_patterns):
+                    rows.append((index + 1, line.strip()))
+                    continue
+                if (
+                    multiline_name.fullmatch(line)
+                    and index + 1 < len(deploy_lines)
+                    and opening_brace.match(deploy_lines[index + 1])
+                ):
+                    rows.append(
+                        (
+                            index + 1,
+                            f"{line.strip()}\\n{deploy_lines[index + 1].strip()}",
+                        )
+                    )
+            return rows
 
         cleanup_definitions = definition_rows("_cleanup_on_exit")
         signal_definitions = definition_rows("_handle_cleanup_signal")
@@ -250,11 +288,12 @@ class DeploymentWiringTests(unittest.TestCase):
             + repr(signal_definitions),
         )
         cleanup_definition_line = cleanup_definitions[0][0]
+        signal_definition_line = signal_definitions[0][0]
 
         reset_rows = {
             text: line_number
             for line_number, text in trap_rows
-            if text in {"trap - EXIT", "trap '' INT TERM"}
+            if text in {"    trap - EXIT", "    trap '' INT TERM"}
         }
         registration_texts = [
             "trap _cleanup_on_exit EXIT",
@@ -268,7 +307,7 @@ class DeploymentWiringTests(unittest.TestCase):
         ]
         self.assertEqual(
             set(reset_rows),
-            {"trap - EXIT", "trap '' INT TERM"},
+            {"    trap - EXIT", "    trap '' INT TERM"},
             "expected both cleanup reset lines; observed rows=" + repr(trap_rows),
         )
         self.assertEqual(
@@ -277,7 +316,7 @@ class DeploymentWiringTests(unittest.TestCase):
             "expected three cleanup registration rows; observed rows="
             + repr(registration_rows),
         )
-        for reset_text in ("trap - EXIT", "trap '' INT TERM"):
+        for reset_text in ("    trap - EXIT", "    trap '' INT TERM"):
             with self.subTest(reset=reset_text):
                 reset_line = reset_rows[reset_text]
                 self.assertGreater(
@@ -285,6 +324,13 @@ class DeploymentWiringTests(unittest.TestCase):
                     cleanup_definition_line,
                     "cleanup reset must follow the cleanup definition: "
                     f"definition={cleanup_definition_line}, reset={reset_line}",
+                )
+                self.assertLess(
+                    reset_line,
+                    signal_definition_line,
+                    "cleanup reset must stay inside _cleanup_on_exit, before "
+                    "_handle_cleanup_signal: "
+                    f"reset={reset_line}, signal_definition={signal_definition_line}",
                 )
                 self.assertLess(
                     reset_line,
@@ -330,6 +376,22 @@ class DeploymentWiringTests(unittest.TestCase):
             "expected six preflight-shaped call rows; observed rows="
             + repr(candidate_call_rows),
         )
+
+    def test_trap_function_shadowing_is_absent(self):
+        """Reject Bash ``trap`` function declarations, including split braces."""
+        deploy = DEPLOY.read_text(encoding="utf-8")
+        shadow_patterns = (
+            re.compile(r"^[ \t]*trap[ \t]*\(\)", re.MULTILINE),
+            re.compile(r"^[ \t]*function[ \t]+trap\b", re.MULTILINE),
+        )
+        for pattern in shadow_patterns:
+            with self.subTest(pattern=pattern.pattern):
+                self.assertEqual(
+                    pattern.findall(deploy),
+                    [],
+                    "trap function shadowing is outside the supported contract: "
+                    + pattern.pattern,
+                )
 
     def test_wrapper_is_registered_for_portable_path_lint(self):
         checker = (REPO_ROOT / "scripts/check-portable-paths.py").read_text(
@@ -758,12 +820,10 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
     def _run_signal_cleanup(self, signal_name: str) -> tuple[int, str]:
         """Run one real signal path with bounded child and parent lifetimes.
 
-        Code-path budget: readiness waits at most 4 s (``SECONDS + 4``), the
-        preflight reap is 25 x 0.05 s = 1.25 s under the deterministic shim,
-        and the post-signal guard polls at most 60 x 0.05 s = 3 s.  A
-        successful signal path is about 5.3 s; a guarded failure can consume
-        about 8.25 s (4 + 1.25 + 3), leaving about 1.75 s under the 10 s
-        subprocess timeout.
+        Code-path budget from measured runs: a typical successful path is
+        ~0.2–1.3 s; a guarded failure is bounded by
+        ``max(4 + 1.25, 4 + 3) ≈ 7 s`` (the two post-readiness terms are
+        mutually exclusive), and both fit within the 10 s subprocess timeout.
         """
         signal_status = {"INT": 130, "TERM": 143}[signal_name]
         cleanup_sleep = self._cleanup_sleep_literal()
@@ -925,6 +985,75 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
         self.assertEqual(status, 143, events)
         self.assertEqual(events.count("probe-term"), 1, events)
         self.assertEqual(events.count("cleanup=143"), 1, events)
+
+    def test_exit_cleanup_runs_once_and_masks_int_during_cleanup(self):
+        """Exercise the production EXIT registration, including a heredoc backstop.
+
+        Each case executes the production cleanup/registration slice and exits
+        normally.  The second case sends INT from the cleanup body itself; the
+        reset lines must already be owned by ``_cleanup_on_exit`` so the marker
+        is not duplicated by signal-handler re-entry.  This behavioral check is
+        also what catches an EXIT registration that a physical-line scan sees
+        only because it is hidden inside a heredoc.
+        """
+
+        def run_exit_case(inject_int: bool) -> tuple[int, str]:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                event_log = root / "events.log"
+                injected_marker = root / "injected.marker"
+                script = (
+                    "set -euo pipefail\n"
+                    f"EVENT_LOG={shlex.quote(str(event_log))}\n"
+                    f"INJECT_INT={int(inject_int)}\n"
+                    f"INJECTED_MARKER={shlex.quote(str(injected_marker))}\n"
+                    "export EVENT_LOG INJECT_INT INJECTED_MARKER\n"
+                    "PG_TUNNEL_PREFLIGHT_PID=\"\"\n"
+                    "PG_TUNNEL_PREFLIGHT_CONNINFO_DIR=\"\"\n"
+                    "PG_TUNNEL_PREFLIGHT_PASSWORD_FILE=\"\"\n"
+                    "PG_TUNNEL_ROLLBACK_ARMED=0\n"
+                    "PG_TUNNEL_ROLLBACK_DIR=\"\"\n"
+                    "PG_TUNNEL_ROLLBACK_JOB_LOADED=0\n"
+                    "PG_TUNNEL_ROLLBACK_MANUAL_KIND=none\n"
+                    "PG_TUNNEL_ROLLBACK_MANUAL_CONFIG=\"\"\n"
+                    "PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE=\"\"\n"
+                    "ROLLBACK_ARMED=0\n"
+                    "DEPLOY_OK=0\n"
+                    "STAGED_BINARY=\"\"\n"
+                    "POLICIES_STAGED=\"\"\n"
+                    "LAUNCHD_MIGRATED_STAGED=\"\"\n"
+                    "RELEASE_ROOT_SCRIPTS_STAGED=\"\"\n"
+                    "DEPLOY_MKDIR_LOCK_DIR=\"\"\n"
+                    "_rollback_release_binary() { :; }\n"
+                    + self._production_cleanup_handlers()
+                    + "\n_cleanup_owned_pg_tunnel_preflight() {\n"
+                    + "    printf 'cleanup-enter\\n' >> \"$EVENT_LOG\"\n"
+                    + "    if [ \"$INJECT_INT\" = 1 ] && [ ! -e \"$INJECTED_MARKER\" ]; then\n"
+                    + "        : > \"$INJECTED_MARKER\"\n"
+                    + "        kill -INT $$\n"
+                    + "    fi\n"
+                    + "}\n"
+                    + "_finalize_detached_helper() {\n"
+                    + "    printf 'cleanup-marker=%s\\n' \"$1\" >> \"$EVENT_LOG\"\n"
+                    + "}\n"
+                    + "exit 0\n"
+                )
+                process = subprocess.run(
+                    ["bash", "-c", script], capture_output=True, text=True, timeout=10
+                )
+                events = (
+                    event_log.read_text(encoding="utf-8")
+                    if event_log.exists()
+                    else ""
+                )
+                return process.returncode, events
+
+        for inject_int in (False, True):
+            with self.subTest(inject_int=inject_int):
+                status, events = run_exit_case(inject_int)
+                self.assertEqual(status, 0, events)
+                self.assertEqual(events.count("cleanup-enter"), 1, events)
+                self.assertEqual(events.count("cleanup-marker=0"), 1, events)
 
     def test_probe_uses_individual_libpq_environment_without_dsn_argv(self):
         block = self._pg_block()

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -191,22 +191,32 @@ class DeploymentWiringTests(unittest.TestCase):
         self.assertIn("tests.test_pg_tunnel", ci)
 
     def test_signal_traps_match_exact_physical_line_contract(self):
-        """Require the complete physical trap-line contract in deploy-release.sh.
+        """Enforce the deliberately narrow static trap contract.
 
-        This guard intentionally does no bash parsing: every physical line that
-        starts with trap is compared as a full-line ordered multiset.  It also
-        pins unique cleanup definitions, relative reset/registration order, and
-        the preflight-call strip set.  The real-signal INT/TERM and EXIT harnesses
-        behaviorally backstop indirect changes only inside the production slice
-        ending immediately before ``_self_hosted_release_session``.  Past the
-        registrations, a separate conservative lexical guard rejects trap/eval
-        commands through EOF because executing the rest of the deploy is neither
-        hermetic nor safe in a unit test.  Neither this physical-line/definition
-        scan nor ``test_trap_function_shadowing_is_absent`` excludes heredoc
-        bodies, and the tail guard is likewise lexical.  Harmless command-looking
-        heredoc text can therefore be a false positive in all of them; that is an
-        accepted fail-closed tradeoff.  A query such as ``trap -p INT`` is still
-        a trap line and therefore fails the exact contract.
+        The static contract covers literal ``trap`` commands that start a
+        physical line and cleanup-handler definitions that start a physical line
+        or immediately follow ``;``, ``&``, or ``|``.  For those definitions,
+        whitespace, newlines, and comments between ``()`` and ``{`` are covered.
+        This is not a Bash parser.  Trap tokens elsewhere on a line, function
+        indirection such as ``_disarm_exit``, commands assembled in variables,
+        ``builtin``/``command``/``eval`` dispatch, and other multi-segment
+        definition syntax are outside the static contract.
+
+        The dynamic INT/TERM/EXIT backstop executes only the production slice
+        that starts at ``_cleanup_owned_pg_tunnel_preflight`` and ends immediately
+        before ``_self_hosted_release_session``.  Trap-state changes outside that
+        slice are covered only by the static contract and inherit the limitations
+        above.  The post-registration tail guard applies the same physical-line
+        literal-``trap`` boundary and ignores full-line and trailing comments.
+        That tail contains detached-child paths where clearing an inherited trap
+        with ``trap - EXIT`` can be legitimate; if such a use is needed, this
+        contract must be changed explicitly rather than treating it as
+        dynamically covered.
+
+        Inside this boundary, exact ordered trap lines, unique cleanup-handler
+        definitions, reset/registration order, and the preflight-call strip set
+        are pinned.  A line-leading query such as ``trap -p INT`` is therefore
+        also rejected by the exact contract.
         """
         deploy = DEPLOY.read_text(encoding="utf-8")
         deploy_lines = deploy.splitlines()
@@ -236,47 +246,35 @@ class DeploymentWiringTests(unittest.TestCase):
 
         def definition_rows(name: str) -> list[tuple[int, str]]:
             spaced_parens = r"[ \t]*\([ \t]*\)"
-            direct_patterns = (
+            definition_anchor = r"(?:^|[;&|]\s*)[ \t]*"
+            brace_gap = r"(?:[ \t]*(?:#[^\n]*)?\n)*[ \t]*"
+            patterns = (
                 re.compile(
-                    r"^[ \t]*" + re.escape(name) + spaced_parens + r"[ \t]*\{"
+                    definition_anchor
+                    + re.escape(name)
+                    + spaced_parens
+                    + brace_gap
+                    + r"\{",
+                    re.MULTILINE,
                 ),
                 re.compile(
-                    r"^[ \t]*function[ \t]+"
+                    definition_anchor
+                    + r"function[ \t]+"
                     + re.escape(name)
                     + r"(?:"
                     + spaced_parens
-                    + r")?[ \t]*\{"
+                    + r")?"
+                    + brace_gap
+                    + r"\{",
+                    re.MULTILINE,
                 ),
             )
-            multiline_names = (
-                re.compile(
-                    r"^[ \t]*" + re.escape(name) + spaced_parens + r"[ \t]*$"
-                ),
-                re.compile(
-                    r"^[ \t]*function[ \t]+"
-                    + re.escape(name)
-                    + r"(?:"
-                    + spaced_parens
-                    + r")?[ \t]*$"
-                ),
-            )
-            opening_brace = re.compile(r"^[ \t]*\{")
             rows: list[tuple[int, str]] = []
-            for index, line in enumerate(deploy_lines):
-                if any(pattern.match(line) for pattern in direct_patterns):
-                    rows.append((index + 1, line.strip()))
-                    continue
-                if (
-                    any(pattern.fullmatch(line) for pattern in multiline_names)
-                    and index + 1 < len(deploy_lines)
-                    and opening_brace.match(deploy_lines[index + 1])
-                ):
-                    rows.append(
-                        (
-                            index + 1,
-                            f"{line.strip()}\\n{deploy_lines[index + 1].strip()}",
-                        )
-                    )
+            for pattern in patterns:
+                for match in pattern.finditer(deploy):
+                    line_number = deploy.count("\n", 0, match.start()) + 1
+                    rows.append((line_number, match.group(0).strip()))
+            rows.sort(key=lambda row: row[0])
             return rows
 
         cleanup_definitions = definition_rows("_cleanup_on_exit")
@@ -409,32 +407,30 @@ class DeploymentWiringTests(unittest.TestCase):
                     + pattern.pattern,
                 )
 
-    def test_no_trap_or_eval_commands_follow_production_registrations(self):
-        """Fail closed on trap mutation outside the executable harness slice.
+    def test_no_line_leading_trap_follows_production_registrations(self):
+        """Apply the narrow line-leading trap contract after registrations.
 
         The dynamic harness safely executes through the three registrations but
         cannot execute the remaining deploy flow.  From that boundary through
-        EOF, command-looking trap/eval text is forbidden.  This is deliberately
-        lexical and can reject harmless heredoc documentation; accepting that
-        false-positive risk keeps the unexecuted region fail closed.
+        EOF, only a literal ``trap`` command at physical line start is forbidden.
+        Comment text is removed before that lexical check, including trailing
+        comments; indirect, assembled, builtin, command, and eval forms remain
+        outside the declared static contract.
         """
         deploy = DEPLOY.read_text(encoding="utf-8")
         boundary = "trap '_handle_cleanup_signal 143' TERM"
         tail = deploy[deploy.index(boundary) + len(boundary) :]
-        forbidden = re.compile(
-            r"\b(?:(?:builtin|command)[ \t]+)?trap(?:[ \t]|$)"
-            r"|\beval(?:[ \t]|$)"
-        )
+        forbidden = re.compile(r"^[ \t]*trap(?:[ \t]|$)")
         rows = [
             (line_number, line)
             for line_number, line in enumerate(tail.splitlines(), 1)
-            if not line.lstrip().startswith("#") and forbidden.search(line)
+            if forbidden.search(line.partition("#")[0])
         ]
         self.assertEqual(
             rows,
             [],
-            "trap/eval commands after production registration are outside the "
-            "dynamic backstop; tail-relative rows=" + repr(rows),
+            "line-leading trap commands after production registration are "
+            "outside the dynamic backstop; tail-relative rows=" + repr(rows),
         )
 
     def test_wrapper_is_registered_for_portable_path_lint(self):
@@ -865,9 +861,14 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
         """Run one real signal path with bounded child and parent lifetimes.
 
         Code-path budget from measured runs: a typical successful path is
-        ~0.2–1.3 s; a guarded failure is bounded by the serial path
-        ``4 + 3 + 1.25 ≈ 8.25 s`` (readiness guard, signal guard, then EXIT
-        cleanup), leaving about 1.75 s within the 10 s subprocess timeout.
+        ~0.2–1.3 s.  Five isolated runs of the old 60 x 0.05 s signal guard
+        averaged 7.01 s on this host; added to readiness near 4 s, that agrees
+        with the observed ~10.75 s failure and disproves the former 8.25 s bound.
+        The reduced 20-iteration guard averaged 2.37 s, giving a conservative
+        serial estimate of ``4 + 2.37 + 1.25 = 7.62 s`` including maximum EXIT
+        cleanup.  The external 10 s timeout still fails closed and reaps the
+        process group, but scheduler delay can make it fire before the intended
+        internal diagnostic.
         """
         signal_status = {"INT": 130, "TERM": 143}[signal_name]
         cleanup_sleep = self._cleanup_sleep_literal()
@@ -943,7 +944,7 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
                 f"kill -{signal_name} $$\n"
                 "signal_wait_attempts=0\n"
                 "while :; do\n"
-                "    if [ \"$signal_wait_attempts\" -ge 60 ]; then\n"
+                "    if [ \"$signal_wait_attempts\" -ge 20 ]; then\n"
                 "        printf 'signal cleanup timeout after %s attempts\\n' \"$signal_wait_attempts\" >&2\n"
                 "        exit 97\n"
                 "    fi\n"

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import os
 import plistlib
+import re
 import shlex
+import signal
 import subprocess
 import tempfile
 import unittest
@@ -156,12 +159,19 @@ class WrapperSafetyTests(unittest.TestCase):
         self.assertIn('"$PG_TUNNEL_SSH_TARGET"', text)
 
     def test_probe_cleanup_always_waits_after_term_and_kill(self):
+        """Static contract: every owned-probe signal is followed by a reap."""
         deploy = DEPLOY.read_text(encoding="utf-8")
         start = deploy.index("_cleanup_owned_pg_tunnel_preflight() {")
         end = deploy.index("_rollback_pg_tunnel_migration() {", start)
         cleanup = deploy[start:end]
+        preflight_end = deploy.index("_reset_pg_tunnel_rollback_state() {", start)
+        preflight = deploy[start:preflight_end]
         self.assertLess(cleanup.index('kill -TERM "$pid"'), cleanup.index('wait "$pid"'))
         self.assertLess(cleanup.index('kill -KILL "$pid"'), cleanup.index('wait "$pid"'))
+        self.assertIn('while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 25 ]; do', preflight)
+        self.assertEqual(
+            re.findall(r"sleep 0\.2(?![0-9])", preflight), ["sleep 0.2"]
+        )
 
 
 class DeploymentWiringTests(unittest.TestCase):
@@ -179,6 +189,147 @@ class DeploymentWiringTests(unittest.TestCase):
     def test_ci_script_checks_runs_this_suite(self):
         ci = (REPO_ROOT / "scripts/ci-script-checks.sh").read_text(encoding="utf-8")
         self.assertIn("tests.test_pg_tunnel", ci)
+
+    def test_signal_traps_match_exact_physical_line_contract(self):
+        """Require the complete physical trap-line contract in deploy-release.sh.
+
+        This guard intentionally does no bash parsing: every physical line that
+        starts with trap is compared as a full-line ordered multiset.  It also
+        pins unique cleanup definitions, relative reset/registration order, and
+        the preflight-call strip set.  Indirect registrations through the
+        builtin trap command or eval are outside this static guard; the
+        real-signal INT/TERM harness is the behavioral backstop.  A query such
+        as trap -p INT is still a trap line and therefore fails the exact
+        contract.
+        """
+        deploy = DEPLOY.read_text(encoding="utf-8")
+        deploy_lines = deploy.splitlines()
+
+        trap_rows = [
+            (line_number, line.strip())
+            for line_number, line in enumerate(deploy_lines, 1)
+            if re.match(r"^[ \t]*trap[ \t]", line)
+        ]
+        expected_traps = [
+            "trap - EXIT",
+            "trap '' INT TERM",
+            "trap _cleanup_on_exit EXIT",
+            "trap '_handle_cleanup_signal 130' INT",
+            "trap '_handle_cleanup_signal 143' TERM",
+        ]
+        observed_traps = [text for _line_number, text in trap_rows]
+        self.assertEqual(
+            observed_traps,
+            expected_traps,
+            "expected exactly five trap lines in this order; observed rows="
+            + repr([f"line {line_number}: {text}" for line_number, text in trap_rows]),
+        )
+
+        def definition_rows(name: str) -> list[tuple[int, str]]:
+            pattern = re.compile(
+                r"^[ \t]*" + re.escape(name) + r"\(\)[ \t]*\{"
+            )
+            return [
+                (line_number, line.strip())
+                for line_number, line in enumerate(deploy_lines, 1)
+                if pattern.match(line)
+            ]
+
+        cleanup_definitions = definition_rows("_cleanup_on_exit")
+        signal_definitions = definition_rows("_handle_cleanup_signal")
+        self.assertEqual(
+            len(cleanup_definitions),
+            1,
+            "expected one _cleanup_on_exit() definition; observed rows="
+            + repr(cleanup_definitions),
+        )
+        self.assertEqual(
+            len(signal_definitions),
+            1,
+            "expected one _handle_cleanup_signal() definition; observed rows="
+            + repr(signal_definitions),
+        )
+        cleanup_definition_line = cleanup_definitions[0][0]
+
+        reset_rows = {
+            text: line_number
+            for line_number, text in trap_rows
+            if text in {"trap - EXIT", "trap '' INT TERM"}
+        }
+        registration_texts = [
+            "trap _cleanup_on_exit EXIT",
+            "trap '_handle_cleanup_signal 130' INT",
+            "trap '_handle_cleanup_signal 143' TERM",
+        ]
+        registration_rows = [
+            (line_number, text)
+            for line_number, text in trap_rows
+            if text in registration_texts
+        ]
+        self.assertEqual(
+            set(reset_rows),
+            {"trap - EXIT", "trap '' INT TERM"},
+            "expected both cleanup reset lines; observed rows=" + repr(trap_rows),
+        )
+        self.assertEqual(
+            len(registration_rows),
+            3,
+            "expected three cleanup registration rows; observed rows="
+            + repr(registration_rows),
+        )
+        for reset_text in ("trap - EXIT", "trap '' INT TERM"):
+            with self.subTest(reset=reset_text):
+                reset_line = reset_rows[reset_text]
+                self.assertGreater(
+                    reset_line,
+                    cleanup_definition_line,
+                    "cleanup reset must follow the cleanup definition: "
+                    f"definition={cleanup_definition_line}, reset={reset_line}",
+                )
+                self.assertLess(
+                    reset_line,
+                    min(line_number for line_number, _text in registration_rows),
+                    "cleanup reset must precede all signal registrations: "
+                    f"reset={reset_line}, registrations={registration_rows}",
+                )
+
+        expected_call_name = "_cleanup_owned_pg_tunnel_preflight"
+        call_rows = []
+        candidate_call_rows = []
+        call_pattern = re.compile(
+            r"^([A-Za-z_][A-Za-z0-9_]*)(?:[ \t]*(?:;|&&|\|\||\||&))?$"
+        )
+        for line_number, line in enumerate(deploy_lines, 1):
+            stripped = line.strip()
+            match = call_pattern.fullmatch(stripped)
+            if match is None:
+                continue
+            name = match.group(1)
+            if name == expected_call_name:
+                call_rows.append((line_number, stripped))
+            if "cleanup_owned_pg_tunnel_preflight" in name:
+                candidate_call_rows.append((line_number, stripped))
+
+        expected_call_set = {expected_call_name}
+        observed_call_set = {text for _line_number, text in candidate_call_rows}
+        self.assertEqual(
+            observed_call_set,
+            expected_call_set,
+            "preflight call strip set mismatch; observed rows="
+            + repr(candidate_call_rows),
+        )
+        self.assertEqual(
+            len(call_rows),
+            6,
+            "expected six _cleanup_owned_pg_tunnel_preflight calls; observed rows="
+            + repr(call_rows),
+        )
+        self.assertEqual(
+            len(candidate_call_rows),
+            6,
+            "expected six preflight-shaped call rows; observed rows="
+            + repr(candidate_call_rows),
+        )
 
     def test_wrapper_is_registered_for_portable_path_lint(self):
         checker = (REPO_ROOT / "scripts/check-portable-paths.py").read_text(
@@ -367,6 +518,12 @@ def stop(_signum, _frame):
 
 
 signal.signal(signal.SIGTERM, stop)
+def expire(_signum, _frame):
+    raise SystemExit(124)
+
+
+signal.signal(signal.SIGALRM, expire)
+signal.alarm(8)
 open(os.environ["PROBE_READY"], "a", encoding="utf-8").close()
 while True:
     signal.pause()
@@ -582,14 +739,47 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
         end = deploy.index("_cleanup_on_exit() {", start)
         return deploy[start:end]
 
+    @staticmethod
+    def _cleanup_sleep_literal() -> str:
+        deploy = DEPLOY.read_text(encoding="utf-8")
+        start = deploy.index("_cleanup_owned_pg_tunnel_preflight() {")
+        end = deploy.index("_reset_pg_tunnel_rollback_state() {", start)
+        preflight = deploy[start:end]
+        matches = re.findall(
+            r"sleep[ \t]+([0-9]+(?:\.[0-9]+)?)(?![0-9])", preflight
+        )
+        if len(matches) != 1:
+            raise AssertionError(
+                "expected one cleanup sleep literal in deploy preflight: "
+                f"{matches!r}"
+            )
+        return matches[0]
+
     def _run_signal_cleanup(self, signal_name: str) -> tuple[int, str]:
+        """Run one real signal path with bounded child and parent lifetimes.
+
+        Code-path budget: readiness waits at most 4 s (``SECONDS + 4``), the
+        preflight reap is 25 x 0.05 s = 1.25 s under the deterministic shim,
+        and the post-signal guard polls at most 60 x 0.05 s = 3 s.  A
+        successful signal path is about 5.3 s; a guarded failure can consume
+        about 8.25 s (4 + 1.25 + 3), leaving about 1.75 s under the 10 s
+        subprocess timeout.
+        """
+        signal_status = {"INT": 130, "TERM": 143}[signal_name]
+        cleanup_sleep = self._cleanup_sleep_literal()
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             fake_bin = root / "fake-bin"
             fake_bin.mkdir()
             event_log = root / "events.log"
             (fake_bin / "sleep").write_text(
-                "#!/bin/sh\nexec /bin/sleep 0.01\n", encoding="utf-8"
+                "#!/bin/sh\n"
+                f'if [ "${{1:-}}" = {cleanup_sleep} ]; then\n'
+                '  printf "scaled-sleep=%s\\n" "$1" >> "$EVENT_LOG"\n'
+                "  exec /bin/sleep 0.05\n"
+                "fi\n"
+                "exec /bin/sleep 0.01\n",
+                encoding="utf-8",
             )
             (fake_bin / "sleep").chmod(0o755)
             probe = root / "probe.py"
@@ -605,6 +795,11 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
                 "    raise SystemExit(0)\n"
                 "\n"
                 "signal.signal(signal.SIGTERM, stop)\n"
+                "def expire(_signum, _frame):\n"
+                "    raise SystemExit(124)\n"
+                "\n"
+                "signal.signal(signal.SIGALRM, expire)\n"
+                "signal.alarm(8)\n"
                 "with open(os.environ['EVENT_LOG'], 'a', encoding='utf-8') as handle:\n"
                 "    handle.write('probe-ready\\n')\n"
                 "while True:\n"
@@ -628,20 +823,89 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
                 "LAUNCHD_MIGRATED_STAGED=\"\"\n"
                 "RELEASE_ROOT_SCRIPTS_STAGED=\"\"\n"
                 "DEPLOY_MKDIR_LOCK_DIR=\"\"\n"
-                "_rollback_pg_tunnel_migration() { :; }\n"
                 "_rollback_release_binary() { :; }\n"
                 "_finalize_detached_helper() { printf 'cleanup=%s\\n' \"$1\" >> \"$EVENT_LOG\"; }\n"
                 + self._production_cleanup_handlers()
                 + f"\nPARENT_PID=$$ {shlex.quote(str(probe))} &\n"
                 "PG_TUNNEL_PREFLIGHT_PID=$!\n"
-                "while ! grep -q '^probe-ready$' \"$EVENT_LOG\"; do /bin/sleep 0.01; done\n"
+                "probe_ready_deadline=$((SECONDS + 4))\n"
+                "while ! grep -q '^probe-ready$' \"$EVENT_LOG\"; do\n"
+                "    if [ \"$SECONDS\" -ge \"$probe_ready_deadline\" ]; then\n"
+                "        printf 'probe-ready timeout at SECONDS=%s (deadline=%s)\\n' \"$SECONDS\" \"$probe_ready_deadline\" >&2\n"
+                "        exit 98\n"
+                "    fi\n"
+                "    /bin/sleep 0.01\n"
+                "done\n"
                 f"kill -{signal_name} $$\n"
-                "exit 99\n"
+                "signal_wait_attempts=0\n"
+                "while :; do\n"
+                "    if [ \"$signal_wait_attempts\" -ge 60 ]; then\n"
+                "        printf 'signal cleanup timeout after %s attempts\\n' \"$signal_wait_attempts\" >&2\n"
+                "        exit 97\n"
+                "    fi\n"
+                "    /bin/sleep 0.05\n"
+                "    signal_wait_attempts=$((signal_wait_attempts + 1))\n"
+                "done\n"
+            )
+            process = subprocess.Popen(
+                ["bash", "-c", script],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                start_new_session=True,
+            )
+            try:
+                stdout, stderr = process.communicate(timeout=10)
+            except subprocess.TimeoutExpired as exc:
+                # The probe is a child of the harness.  Kill its process group
+                # and synchronously communicate again so no orphan survives a
+                # failed bounded run.
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                stdout, stderr = process.communicate()
+                self.fail(
+                    "signal cleanup harness timed out after 10 s; "
+                    f"stdout={stdout or exc.stdout!r} stderr={stderr or exc.stderr!r}"
+                )
+            p = subprocess.CompletedProcess(
+                process.args, process.returncode, stdout, stderr
+            )
+            events = event_log.read_text(encoding="utf-8") if event_log.exists() else ""
+            self.assertEqual(p.returncode, signal_status, p.stdout + p.stderr + events)
+            return p.returncode, events
+
+    def test_cleanup_sleep_shim_scales_preflight_delay_deterministically(self):
+        """Exercise the fake sleep once without relying on a busy-wait race."""
+        cleanup_sleep = self._cleanup_sleep_literal()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_bin = root / "fake-bin"
+            fake_bin.mkdir()
+            event_log = root / "events.log"
+            (fake_bin / "sleep").write_text(
+                "#!/bin/sh\n"
+                f'if [ "${{1:-}}" = {cleanup_sleep} ]; then\n'
+                '  printf "scaled-sleep=%s\\n" "$1" >> "$EVENT_LOG"\n'
+                "  exec /bin/sleep 0.05\n"
+                "fi\n"
+                "exec /bin/sleep 0.01\n",
+                encoding="utf-8",
+            )
+            (fake_bin / "sleep").chmod(0o755)
+            script = (
+                f"EVENT_LOG={shlex.quote(str(event_log))}\n"
+                f"PATH={shlex.quote(str(fake_bin))}:/usr/bin:/bin\n"
+                "export EVENT_LOG PATH\n"
+                f"sleep {cleanup_sleep}\n"
             )
             p = subprocess.run(
-                ["bash", "-c", script], capture_output=True, text=True, timeout=10
+                ["/bin/sh", "-c", script], capture_output=True, text=True, timeout=5
             )
-            return p.returncode, event_log.read_text(encoding="utf-8")
+            events = event_log.read_text(encoding="utf-8") if event_log.exists() else ""
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr + events)
+            self.assertEqual(events, f"scaled-sleep={cleanup_sleep}\n")
 
     @staticmethod
     def _production_cleanup_handlers() -> str:

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -201,6 +201,10 @@ class DeploymentWiringTests(unittest.TestCase):
         indirection such as ``_disarm_exit``, commands assembled in variables,
         ``builtin``/``command``/``eval`` dispatch, and other multi-segment
         definition syntax are outside the static contract.
+        Neither this physical-line/definition scan nor
+        ``test_trap_function_shadowing_is_absent`` excludes heredoc bodies.
+        Harmless command-looking heredoc text can therefore be reported as a
+        false positive; that is an accepted fail-closed tradeoff.
 
         The dynamic INT/TERM/EXIT backstop executes only the production slice
         that starts at ``_cleanup_owned_pg_tunnel_preflight`` and ends immediately
@@ -394,9 +398,14 @@ class DeploymentWiringTests(unittest.TestCase):
     def test_trap_function_shadowing_is_absent(self):
         """Reject Bash ``trap`` function declarations, including spaced parens."""
         deploy = DEPLOY.read_text(encoding="utf-8")
+        definition_anchor = r"(?:^|[;&|]\s*)[ \t]*"
         shadow_patterns = (
-            re.compile(r"^[ \t]*trap[ \t]*\([ \t]*\)", re.MULTILINE),
-            re.compile(r"^[ \t]*function[ \t]+trap\b", re.MULTILINE),
+            re.compile(
+                definition_anchor + r"trap[ \t]*\([ \t]*\)", re.MULTILINE
+            ),
+            re.compile(
+                definition_anchor + r"function[ \t]+trap\b", re.MULTILINE
+            ),
         )
         for pattern in shadow_patterns:
             with self.subTest(pattern=pattern.pattern):

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -182,7 +182,7 @@ class DeploymentWiringTests(unittest.TestCase):
         """Remove physical-line comments without hiding code after quoted ``#``."""
         token = re.compile(
             r''' '(?:[^'\r\n]*)' | "(?:\\[^\r\n]|[^"\\\r\n])*" |
-                \\[^\r\n] | [ \t]*\#[^\r\n]* ''',
+                \\[^\r\n] | (?m:^\#[^\r\n]*) | (?<=[ \t])\#[^\r\n]* ''',
             re.VERBOSE,
         )
 

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -178,6 +178,21 @@ class DeploymentWiringTests(unittest.TestCase):
     """Pin every load-bearing launchd/deploy invariant individually."""
 
     @staticmethod
+    def _strip_shell_comments(text: str) -> str:
+        """Remove physical-line comments without hiding code after quoted ``#``."""
+        token = re.compile(
+            r''' '(?:[^'\r\n]*)' | "(?:\\[^\r\n]|[^"\\\r\n])*" |
+                \\[^\r\n] | [ \t]*\#[^\r\n]* ''',
+            re.VERBOSE,
+        )
+
+        def replace(match: re.Match[str]) -> str:
+            value = match.group(0)
+            return "" if value.lstrip(" \t").startswith("#") else value
+
+        return token.sub(replace, text)
+
+    @staticmethod
     def _pg_block() -> str:
         deploy = DEPLOY.read_text(encoding="utf-8")
         start = deploy.index("PG_TUNNEL_LABEL=\"com.agentdesk.pg-tunnel\"")
@@ -201,17 +216,22 @@ class DeploymentWiringTests(unittest.TestCase):
         indirection such as ``_disarm_exit``, commands assembled in variables,
         ``builtin``/``command``/``eval`` dispatch, and other multi-segment
         definition syntax are outside the static contract.
-        Neither this physical-line/definition scan nor
-        ``test_trap_function_shadowing_is_absent`` excludes heredoc bodies.
-        Harmless command-looking heredoc text can therefore be reported as a
-        false positive; that is an accepted fail-closed tradeoff.
+        All three static scans (this physical-line/definition scan,
+        ``test_trap_function_shadowing_is_absent``, and the post-registration
+        tail guard) remove text from ``#`` through each physical line end before
+        matching, while preserving simple quoted spans so a real forbidden form
+        after a quoted ``#`` is not hidden.  This is not a shell parser and does
+        not identify heredoc bodies.  A harmless command-looking heredoc line
+        without a comment can therefore still be reported as a false positive;
+        that is an accepted fail-closed tradeoff.
 
         The dynamic INT/TERM/EXIT backstop executes only the production slice
         that starts at ``_cleanup_owned_pg_tunnel_preflight`` and ends immediately
         before ``_self_hosted_release_session``.  Trap-state changes outside that
         slice are covered only by the static contract and inherit the limitations
         above.  The post-registration tail guard applies the same physical-line
-        literal-``trap`` boundary and ignores full-line and trailing comments.
+        literal-``trap`` prefix check (``trap`` followed by whitespace or
+        end-of-line) and ignores full-line and trailing comments.
         That tail contains detached-child paths where clearing an inherited trap
         with ``trap - EXIT`` can be legitimate; if such a use is needed, this
         contract must be changed explicitly rather than treating it as
@@ -222,7 +242,9 @@ class DeploymentWiringTests(unittest.TestCase):
         are pinned.  A line-leading query such as ``trap -p INT`` is therefore
         also rejected by the exact contract.
         """
-        deploy = DEPLOY.read_text(encoding="utf-8")
+        deploy = self._strip_shell_comments(
+            DEPLOY.read_text(encoding="utf-8")
+        )
         deploy_lines = deploy.splitlines()
 
         trap_rows = [
@@ -397,7 +419,9 @@ class DeploymentWiringTests(unittest.TestCase):
 
     def test_trap_function_shadowing_is_absent(self):
         """Reject Bash ``trap`` function declarations, including spaced parens."""
-        deploy = DEPLOY.read_text(encoding="utf-8")
+        deploy = self._strip_shell_comments(
+            DEPLOY.read_text(encoding="utf-8")
+        )
         definition_anchor = r"(?:^|[;&|]\s*)[ \t]*"
         shadow_patterns = (
             re.compile(
@@ -426,14 +450,16 @@ class DeploymentWiringTests(unittest.TestCase):
         comments; indirect, assembled, builtin, command, and eval forms remain
         outside the declared static contract.
         """
-        deploy = DEPLOY.read_text(encoding="utf-8")
+        deploy = self._strip_shell_comments(
+            DEPLOY.read_text(encoding="utf-8")
+        )
         boundary = "trap '_handle_cleanup_signal 143' TERM"
         tail = deploy[deploy.index(boundary) + len(boundary) :]
         forbidden = re.compile(r"^[ \t]*trap(?:[ \t]|$)")
         rows = [
             (line_number, line)
             for line_number, line in enumerate(tail.splitlines(), 1)
-            if forbidden.search(line.partition("#")[0])
+            if forbidden.search(line)
         ]
         self.assertEqual(
             rows,

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -196,16 +196,17 @@ class DeploymentWiringTests(unittest.TestCase):
         This guard intentionally does no bash parsing: every physical line that
         starts with trap is compared as a full-line ordered multiset.  It also
         pins unique cleanup definitions, relative reset/registration order, and
-        the preflight-call strip set.  Trap tokens that are not at line start
-        (for example after ``;`` in a compound command), indirect registrations
-        through the builtin trap command, and registrations assembled by eval
-        are outside this static guard; the real-signal INT/TERM harness is the
-        behavioral backstop.  The EXIT-leg harness executes this production
-        slice on normal exit and injects INT during cleanup, so a registration
-        hidden in a heredoc is caught behaviorally even though this exact-line
-        guard deliberately does not parse shell syntax.  A query such as
-        ``trap -p INT`` is still a trap line and therefore fails the exact
-        contract.
+        the preflight-call strip set.  The real-signal INT/TERM and EXIT harnesses
+        behaviorally backstop indirect changes only inside the production slice
+        ending immediately before ``_self_hosted_release_session``.  Past the
+        registrations, a separate conservative lexical guard rejects trap/eval
+        commands through EOF because executing the rest of the deploy is neither
+        hermetic nor safe in a unit test.  Neither this physical-line/definition
+        scan nor ``test_trap_function_shadowing_is_absent`` excludes heredoc
+        bodies, and the tail guard is likewise lexical.  Harmless command-looking
+        heredoc text can therefore be a false positive in all of them; that is an
+        accepted fail-closed tradeoff.  A query such as ``trap -p INT`` is still
+        a trap line and therefore fails the exact contract.
         """
         deploy = DEPLOY.read_text(encoding="utf-8")
         deploy_lines = deploy.splitlines()
@@ -215,9 +216,9 @@ class DeploymentWiringTests(unittest.TestCase):
             for line_number, line in enumerate(deploy_lines, 1)
             if re.match(r"^[ \t]*trap[ \t]", line)
         ]
-        # The reset commands are deliberately indented as function-body lines;
-        # all five rows remain raw exact matches, while the three top-level
-        # registrations below are required to stay at column 0.
+        # The reset commands are deliberately indented as function-body lines.
+        # The raw expected literals themselves enforce that the three
+        # registrations remain at column 0.
         expected_traps = [
             "    trap - EXIT",
             "    trap '' INT TERM",
@@ -232,27 +233,32 @@ class DeploymentWiringTests(unittest.TestCase):
             "expected exactly five trap lines in this order; observed rows="
             + repr([f"line {line_number}: {text}" for line_number, text in trap_rows]),
         )
-        for line_number, text in trap_rows[2:]:
-            self.assertEqual(
-                text,
-                text.lstrip(),
-                "top-level trap registrations must remain at column 0: "
-                f"line {line_number}: {text!r}",
-            )
 
         def definition_rows(name: str) -> list[tuple[int, str]]:
+            spaced_parens = r"[ \t]*\([ \t]*\)"
             direct_patterns = (
                 re.compile(
-                    r"^[ \t]*" + re.escape(name) + r"\(\)[ \t]*\{"
+                    r"^[ \t]*" + re.escape(name) + spaced_parens + r"[ \t]*\{"
                 ),
                 re.compile(
                     r"^[ \t]*function[ \t]+"
                     + re.escape(name)
-                    + r"(?:\(\))?[ \t]*\{"
+                    + r"(?:"
+                    + spaced_parens
+                    + r")?[ \t]*\{"
                 ),
             )
-            multiline_name = re.compile(
-                r"^[ \t]*" + re.escape(name) + r"\(\)[ \t]*$"
+            multiline_names = (
+                re.compile(
+                    r"^[ \t]*" + re.escape(name) + spaced_parens + r"[ \t]*$"
+                ),
+                re.compile(
+                    r"^[ \t]*function[ \t]+"
+                    + re.escape(name)
+                    + r"(?:"
+                    + spaced_parens
+                    + r")?[ \t]*$"
+                ),
             )
             opening_brace = re.compile(r"^[ \t]*\{")
             rows: list[tuple[int, str]] = []
@@ -261,7 +267,7 @@ class DeploymentWiringTests(unittest.TestCase):
                     rows.append((index + 1, line.strip()))
                     continue
                 if (
-                    multiline_name.fullmatch(line)
+                    any(pattern.fullmatch(line) for pattern in multiline_names)
                     and index + 1 < len(deploy_lines)
                     and opening_brace.match(deploy_lines[index + 1])
                 ):
@@ -316,6 +322,17 @@ class DeploymentWiringTests(unittest.TestCase):
             "expected three cleanup registration rows; observed rows="
             + repr(registration_rows),
         )
+        first_registration_line = min(
+            line_number for line_number, _text in registration_rows
+        )
+        self.assertLess(
+            max(cleanup_definition_line, signal_definition_line),
+            first_registration_line,
+            "the last cleanup-handler definition must be the contract definition "
+            "before registrations: "
+            f"cleanup={cleanup_definition_line}, signal={signal_definition_line}, "
+            f"registrations={registration_rows}",
+        )
         for reset_text in ("    trap - EXIT", "    trap '' INT TERM"):
             with self.subTest(reset=reset_text):
                 reset_line = reset_rows[reset_text]
@@ -328,8 +345,7 @@ class DeploymentWiringTests(unittest.TestCase):
                 self.assertLess(
                     reset_line,
                     signal_definition_line,
-                    "cleanup reset must stay inside _cleanup_on_exit, before "
-                    "_handle_cleanup_signal: "
+                    "cleanup reset must precede the signal-handler definition: "
                     f"reset={reset_line}, signal_definition={signal_definition_line}",
                 )
                 self.assertLess(
@@ -378,10 +394,10 @@ class DeploymentWiringTests(unittest.TestCase):
         )
 
     def test_trap_function_shadowing_is_absent(self):
-        """Reject Bash ``trap`` function declarations, including split braces."""
+        """Reject Bash ``trap`` function declarations, including spaced parens."""
         deploy = DEPLOY.read_text(encoding="utf-8")
         shadow_patterns = (
-            re.compile(r"^[ \t]*trap[ \t]*\(\)", re.MULTILINE),
+            re.compile(r"^[ \t]*trap[ \t]*\([ \t]*\)", re.MULTILINE),
             re.compile(r"^[ \t]*function[ \t]+trap\b", re.MULTILINE),
         )
         for pattern in shadow_patterns:
@@ -392,6 +408,34 @@ class DeploymentWiringTests(unittest.TestCase):
                     "trap function shadowing is outside the supported contract: "
                     + pattern.pattern,
                 )
+
+    def test_no_trap_or_eval_commands_follow_production_registrations(self):
+        """Fail closed on trap mutation outside the executable harness slice.
+
+        The dynamic harness safely executes through the three registrations but
+        cannot execute the remaining deploy flow.  From that boundary through
+        EOF, command-looking trap/eval text is forbidden.  This is deliberately
+        lexical and can reject harmless heredoc documentation; accepting that
+        false-positive risk keeps the unexecuted region fail closed.
+        """
+        deploy = DEPLOY.read_text(encoding="utf-8")
+        boundary = "trap '_handle_cleanup_signal 143' TERM"
+        tail = deploy[deploy.index(boundary) + len(boundary) :]
+        forbidden = re.compile(
+            r"\b(?:(?:builtin|command)[ \t]+)?trap(?:[ \t]|$)"
+            r"|\beval(?:[ \t]|$)"
+        )
+        rows = [
+            (line_number, line)
+            for line_number, line in enumerate(tail.splitlines(), 1)
+            if not line.lstrip().startswith("#") and forbidden.search(line)
+        ]
+        self.assertEqual(
+            rows,
+            [],
+            "trap/eval commands after production registration are outside the "
+            "dynamic backstop; tail-relative rows=" + repr(rows),
+        )
 
     def test_wrapper_is_registered_for_portable_path_lint(self):
         checker = (REPO_ROOT / "scripts/check-portable-paths.py").read_text(
@@ -821,9 +865,9 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
         """Run one real signal path with bounded child and parent lifetimes.
 
         Code-path budget from measured runs: a typical successful path is
-        ~0.2–1.3 s; a guarded failure is bounded by
-        ``max(4 + 1.25, 4 + 3) ≈ 7 s`` (the two post-readiness terms are
-        mutually exclusive), and both fit within the 10 s subprocess timeout.
+        ~0.2–1.3 s; a guarded failure is bounded by the serial path
+        ``4 + 3 + 1.25 ≈ 8.25 s`` (readiness guard, signal guard, then EXIT
+        cleanup), leaving about 1.75 s within the 10 s subprocess timeout.
         """
         signal_status = {"INT": 130, "TERM": 143}[signal_name]
         cleanup_sleep = self._cleanup_sleep_literal()
@@ -985,6 +1029,31 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
         self.assertEqual(status, 143, events)
         self.assertEqual(events.count("probe-term"), 1, events)
         self.assertEqual(events.count("cleanup=143"), 1, events)
+
+    def test_cleanup_traps_register_without_test_environment(self):
+        """Observe production registrations with all harness-only vars unset."""
+        script = (
+            "set -euo pipefail\n"
+            + self._production_cleanup_handlers()
+            + "\nprintf 'EXIT=<%s>\\n' \"$(builtin trap -p EXIT)\"\n"
+            + "printf 'INT=<%s>\\n' \"$(builtin trap -p INT)\"\n"
+            + "printf 'TERM=<%s>\\n' \"$(builtin trap -p TERM)\"\n"
+            + "builtin trap - EXIT INT TERM\n"
+        )
+        process = subprocess.run(
+            ["/bin/bash", "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env={"PATH": "/usr/bin:/bin"},
+        )
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertEqual(
+            process.stdout,
+            "EXIT=<trap -- '_cleanup_on_exit' EXIT>\n"
+            "INT=<trap -- '_handle_cleanup_signal 130' SIGINT>\n"
+            "TERM=<trap -- '_handle_cleanup_signal 143' SIGTERM>\n",
+        )
 
     def test_exit_cleanup_runs_once_and_masks_int_during_cleanup(self):
         """Exercise the production EXIT registration, including a heredoc backstop.


### PR DESCRIPTION
#5071 T0 ④ / #4996. `tests/test_pg_tunnel.py` 단독 변경(+504/−6). `scripts/deploy-release.sh`는 무변경이다.

## 두 가지를 고친다

**1. flaky의 실체.** `test_int_cleanup_reaps_probe_once_and_returns_130`이 CPU 경합 하에서 130 대신 99를 반환했다. 병렬 레인 5개가 도는 상태에서만 재현되고 단독 실행에서는 통과하는 전형적 타이밍 의존이었다. 신호 하네스를 결정적으로 재작성했다.

**2. 정적 trap 계약.** flaky를 파다 보니 더 큰 문제가 있었다 — 배포 셸의 EXIT trap 등록/해제를 지키는 정적 가드가 **평범한 편집으로 우회 가능**했다. 그걸 닫는 과정이 이 PR의 대부분이다.

## 이 PR의 핵심 판단: 커버리지 경쟁을 포기했다

v1~v3는 정적 렉서로 bash 문법 공간을 닫으려 했고, **라운드마다 새 우회가 재생산되며 발산했다**. 리뷰가 반례를 내면 패턴을 넓히고, 넓히면 다음 라운드에 또 다른 반례가 나왔다.

v4에서 방향을 뒤집었다. 스캐너 507줄을 삭제하고 **계약 경계를 행-앵커 형태로 명시 한정한 뒤, 경계 밖은 잡지 않는다고 정직하게 선언**했다. 커버리지를 늘리는 대신 "무엇을 보장하고 무엇을 보장하지 않는가"를 문서화한 것이다.

리뷰어 판정: *"정적 계약은 평범한 편집으로 생기는 회귀(행 선두 `trap - EXIT` 추가/삭제/순서변경, 핸들러 재정의)를 여전히 전부 잡고, 의도적 난독화만 포기했으며 그 포기를 문서화했다. v4의 방향 전환은 타당한 판단이다."*

v4 이후 P0는 계속 0이다. 경계 밖(함수 인다이렉션 `_disarm_exit`, 변수 조립, `eval`, backslash 분할, case-branch 정의)은 docstring에 명시 제외로 남는다.

## v5~v7 — 각 라운드가 직전 라운드의 좁은 회귀를 닫았다

| | 고친 것 | 새로 만든 것 |
|---|---|---|
| v5 | 형제 가드 간 앵커 비일관성(`(?:^\|[;&\|]\s*)`를 shadowing 가드에도 적용) | **주석 위양성** — 금지 형태를 문서화한 주석 한 줄로 CI가 red |
| v6 | 매칭 전 주석 절단, 세 스캔이 공용 헬퍼 사용 | **단어 중간 `#` 위음성** — `review_x=#; trap() { :; }`가 실제로 trap을 재정의하는데 미검출 |
| v7 | 절단 규칙을 Bash 실제 규칙에 맞춤 | 없음 |

v7의 정규식:
```
before: [ \t]*\#[^\r\n]*
after:  (?m:^\#[^\r\n]*) | (?<=[ \t])\#[^\r\n]*
```
Bash에서 `#`는 **단어 시작 위치**에서만 주석을 연다. 이전 패턴은 공백 0개를 허용해 모든 비인용 `#`를 잘랐다. lookbehind라 선행 공백을 소비하지 않아 토큰 경계가 보존된다.

## 검증
55 tests OK. 표준 배터리 전부 green — fmt / check(접촉 `.rs` 0개) / docs 재생성 후 트리 clean / audit / `ci-script-checks.sh` rc=0.

뮤테이션 전건이 실제 실행 로그로 증명된다(리뷰어 독립 재현):
- v6 위음성 반례 4종(단어 중간 `#` 3형 + heredoc delimiter `<<REVIEW#TAG;`) → 각각 `injected rc=1 / restored rc=0`. 그 줄이 **정말 유효한 bash이고 trap을 재정의함**을 `bash -n` + 실제 실행으로 확인(`trap is a function`).
- 진짜 주석 3종(전체행·행말·금지형태 문서화) → `rc=0`. v6의 성과 유지.
- v5까지의 실제 반례 6종 → 전부 `rc=1` 유지.
- 인용 `#` 3종과 heredoc 본문 → `rc=1`(fail-closed 위양성, 방향 불변).

## 리뷰
전용 워크트리로 분리해 진행했다(뮤테이션 주입이 다른 leg의 읽기를 오염시키는 사고가 실제로 있었다).
- v4: sol P0/P1 0 · Opus P0/P1 0 — 축소 재구성 방향 타당 판정.
- v5: sol **CLEAN**(뮤테이션 전건 실행) · Opus P0/P1 0.
- v6: sol P1 1건(위 단어 중간 `#` 위음성) — 실제 bash 실행으로 실증.
- v7: sol **VERDICT: CLEAN**, P0/P1 0.

## 후속 항목 (P2, verdict 미반영)
Bash는 제어 연산자 뒤에서도 `#`가 새 word를 시작하면 주석으로 처리하는데, v7은 행 시작 또는 공백/탭 뒤만 절단한다. `true;# harmless example; trap() { :; }` 같은 형태는 주석 안의 두 번째 `;`를 앵커로 오인한다 — **fail-closed 위양성**이라 안전 미검출은 아니다.

Closes #4996