### PR TITLE
refactor(#4979): S7 — run the observability PG tests in the postgres lane

### DIFF
--- a/justfile
+++ b/justfile
@@ -96,6 +96,8 @@ test-non-pg:
     cargo test --lib canonical_identity::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib session_canonical_identity::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib services::observability::metrics::tests -- --skip _pg --skip pg_ --skip postgres
+    cargo test --lib services::observability::turn_lifecycle::tests -- --skip _pg --skip pg_ --skip postgres
+    cargo test --lib services::observability::recovery_audit::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib cli::args::tests::legacy_queue_help_directs_users_to_query_without_changing_compatibility_contract
     cargo test --all-targets transition -- --skip _pg --skip pg_ --skip postgres --test-threads=1
     cargo test --all-targets auto_queue -- --skip _pg --skip pg_ --skip postgres

--- a/scripts/pg_test_lane_baseline.txt
+++ b/scripts/pg_test_lane_baseline.txt
@@ -37,9 +37,6 @@ services::maintenance::jobs::db_retention::tests::db_retention_keeps_skill_usage
 services::maintenance::jobs::db_retention::tests::db_retention_preserves_permanent_outbox_dedupe_sentinels
 services::maintenance::jobs::db_retention::tests::db_retention_prunes_old_rows_archives_turns_and_is_idempotent
 services::maintenance::jobs::db_retention::tests::db_retention_turns_window_is_strict_with_no_archive_less_delete
-services::observability::recovery_audit::tests::recovery_audit_round_trips_and_fetches_by_turn
-services::observability::turn_lifecycle::tests::emit_turn_lifecycle_enqueues_expected_notifications_and_dedupes
-services::observability::turn_lifecycle::tests::emit_turn_lifecycle_persists_round_trip
 services::session_resume::tests::production_resume_lock_blocks_effective_intake_snapshot_until_rebind_finishes
 services::session_resume::tests::resume_production_path_clears_stale_binding_and_rebinds_runtime
 services::session_resume::tests::resume_production_path_retains_live_owner_after_teardown
@@ -218,9 +215,6 @@ services::maintenance::jobs::db_retention::tests::db_retention_preserves_permane
 services::maintenance::jobs::db_retention::tests::db_retention_prunes_old_rows_archives_turns_and_is_idempotent
 services::maintenance::jobs::db_retention::tests::db_retention_turns_window_is_strict_with_no_archive_less_delete
 services::observability::queries::alert_authority_tests::rollup_is_aggregation_only_and_rule_engine_is_sole_alerter_pg
-services::observability::recovery_audit::tests::recovery_audit_round_trips_and_fetches_by_turn
-services::observability::turn_lifecycle::tests::emit_turn_lifecycle_enqueues_expected_notifications_and_dedupes
-services::observability::turn_lifecycle::tests::emit_turn_lifecycle_persists_round_trip
 services::pipeline_routes::tests::replace_stages_persists_backoff_round_trip_pg
 services::session_forwarding::tests::cancel_owner_does_not_fall_back_to_agent_binding_pg
 services::session_forwarding::tests::cancel_owner_ignores_disconnected_sessions_pg

--- a/scripts/pg_test_lane_manifest.txt
+++ b/scripts/pg_test_lane_manifest.txt
@@ -138,8 +138,8 @@ services::maintenance::jobs::worktree_orphan_sweep::resumable_keep_set_query_pg_
 services::message_outbox::postgres_held_gc_tests
 services::message_outbox::postgres_source_contract_tests
 services::observability::queries::alert_authority_tests
-services::observability::recovery_audit::tests
-services::observability::turn_lifecycle::tests
+services::observability::recovery_audit::tests::recovery_audit_pg_tests
+services::observability::turn_lifecycle::tests::turn_lifecycle_pg_tests
 services::pipeline_override::pipeline_override_pg_tests
 services::pipeline_routes::tests
 services::scheduled_messages::context_snapshot::postgres_tests
@@ -515,9 +515,9 @@ services::message_outbox::postgres_source_contract_tests::every_enqueue_variant_
 services::message_outbox::postgres_source_contract_tests::fixed_lifecycle_enqueue_uses_registered_source_pg
 services::message_outbox::postgres_source_contract_tests::persistent_dedupe_returns_old_row_and_distinct_slot_inserts_pg
 services::observability::queries::alert_authority_tests::rollup_is_aggregation_only_and_rule_engine_is_sole_alerter_pg
-services::observability::recovery_audit::tests::recovery_audit_round_trips_and_fetches_by_turn
-services::observability::turn_lifecycle::tests::emit_turn_lifecycle_enqueues_expected_notifications_and_dedupes
-services::observability::turn_lifecycle::tests::emit_turn_lifecycle_persists_round_trip
+services::observability::recovery_audit::tests::recovery_audit_pg_tests::recovery_audit_round_trips_and_fetches_by_turn
+services::observability::turn_lifecycle::tests::turn_lifecycle_pg_tests::emit_turn_lifecycle_enqueues_expected_notifications_and_dedupes
+services::observability::turn_lifecycle::tests::turn_lifecycle_pg_tests::emit_turn_lifecycle_persists_round_trip
 services::pipeline_override::pipeline_override_pg_tests::agent_write_rejects_dangling_repo_assigned_card_context_when_repo_pair_valid
 services::pipeline_override::pipeline_override_pg_tests::agent_write_rejects_malformed_existing_repo_override
 services::pipeline_override::pipeline_override_pg_tests::agent_write_rejects_standalone_assigned_card_context_when_repo_pair_valid

--- a/scripts/test_lane_coverage_baseline.txt
+++ b/scripts/test_lane_coverage_baseline.txt
@@ -568,9 +568,7 @@ services::message_outbox_recovery_tests
 services::observability::cancellation_observability_tests
 services::observability::emit::tests
 services::observability::queries::alert_authority_tests
-services::observability::recovery_audit::tests
 services::observability::relay_signal_alert::tests
-services::observability::turn_lifecycle::tests
 services::onboarding::canonical_status_tests
 services::onboarding::credential_token_permission_tests
 services::opencode::tests

--- a/src/services/observability/recovery_audit.rs
+++ b/src/services/observability/recovery_audit.rs
@@ -482,56 +482,81 @@ mod tests {
         assert!(!record.redacted_preview.contains("live-token"));
     }
 
-    #[tokio::test]
-    async fn recovery_audit_round_trips_and_fetches_by_turn() -> Result<()> {
-        let Some(pg_db) = TestPostgresDb::try_create().await else {
-            return Ok(());
-        };
-        let pool = pg_db.connect_and_migrate().await?;
+    // #4979 S7: PG tests live below a marked module so `just test-postgres`
+    // selects them by the whole-path `_pg` substring. The pure sibling stays
+    // in this parent and is selected by the curated non-PG invocation. The
+    // enforced marker contract is only `_pg`, `pg_`, or `postgres` as a
+    // normalized-path substring; this module suffix is a human convention.
+    //
+    // Batch mutation measurements at this declaration and the sibling in
+    // turn_lifecycle.rs (rc values are measured, not inferred):
+    //
+    //   1. Rename both modules away from the marker, retaining `#[cfg(test)]`:
+    //        membership rc=1 (manifest drift; after snapshot regeneration,
+    //        membership rc=1 again on rule1/rule2 baseline growth)
+    //        coverage rc=0; after snapshot regeneration coverage rc=0
+    //      The curated parent invocations cover the renamed modules, so the
+    //      membership manifest/baseline ratchet, not coverage, guards markers.
+    //
+    //   2. Remove only both nested `#[cfg(test)]` attributes:
+    //        membership rc=0, coverage rc=1 (two newly uncovered parents)
+    //      The parent coverage debts were removed in S7 after adding the pure
+    //      invocations. Thus this attribute IS load-bearing in this slice.
+    #[cfg(test)]
+    mod recovery_audit_pg_tests {
+        use super::*;
 
-        let full_context = "Alice: alice@example.com\nBob: Bearer token-value";
-        let inserted = insert_recovery_audit_record(
-            &pool,
-            RecoveryAuditDraft::discord_recent(
-                "42",
-                Some("agentdesk-session".to_string()),
-                full_context,
-                300,
-            ),
-        )
-        .await?;
+        #[tokio::test]
+        async fn recovery_audit_round_trips_and_fetches_by_turn() -> Result<()> {
+            let Some(pg_db) = TestPostgresDb::try_create().await else {
+                return Ok(());
+            };
+            let pool = pg_db.connect_and_migrate().await?;
 
-        assert_eq!(inserted.message_count, 2);
-        assert_eq!(inserted.authors, vec!["Alice", "Bob"]);
-        assert_eq!(
-            inserted.content_sha256,
-            recovery_context_sha256(full_context)
-        );
-        assert!(inserted.redacted_preview.contains("***@***"));
-        assert!(inserted.redacted_preview.contains("Bearer ***"));
-        assert!(!inserted.redacted_preview.contains("alice@example.com"));
-        assert!(!inserted.redacted_preview.contains("token-value"));
+            let full_context = "Alice: alice@example.com\nBob: Bearer token-value";
+            let inserted = insert_recovery_audit_record(
+                &pool,
+                RecoveryAuditDraft::discord_recent(
+                    "42",
+                    Some("agentdesk-session".to_string()),
+                    full_context,
+                    300,
+                ),
+            )
+            .await?;
 
-        let stamped = mark_recovery_audit_consumed(&pool, "42", "discord:42:420")
-            .await?
-            .expect("unconsumed record should be stamped");
-        assert_eq!(
-            stamped.consumed_by_turn_id.as_deref(),
-            Some("discord:42:420")
-        );
+            assert_eq!(inserted.message_count, 2);
+            assert_eq!(inserted.authors, vec!["Alice", "Bob"]);
+            assert_eq!(
+                inserted.content_sha256,
+                recovery_context_sha256(full_context)
+            );
+            assert!(inserted.redacted_preview.contains("***@***"));
+            assert!(inserted.redacted_preview.contains("Bearer ***"));
+            assert!(!inserted.redacted_preview.contains("alice@example.com"));
+            assert!(!inserted.redacted_preview.contains("token-value"));
 
-        let by_turn = fetch_recovery_audit_for_turn(&pool, "discord:42:420")
-            .await?
-            .expect("record should be fetchable by turn");
-        assert_eq!(by_turn.id, inserted.id);
-        assert_eq!(by_turn.channel_id, "42");
+            let stamped = mark_recovery_audit_consumed(&pool, "42", "discord:42:420")
+                .await?
+                .expect("unconsumed record should be stamped");
+            assert_eq!(
+                stamped.consumed_by_turn_id.as_deref(),
+                Some("discord:42:420")
+            );
 
-        let by_channel = fetch_recovery_audit(&pool, "42", 10).await?;
-        assert_eq!(by_channel.len(), 1);
-        assert_eq!(by_channel[0].id, inserted.id);
+            let by_turn = fetch_recovery_audit_for_turn(&pool, "discord:42:420")
+                .await?
+                .expect("record should be fetchable by turn");
+            assert_eq!(by_turn.id, inserted.id);
+            assert_eq!(by_turn.channel_id, "42");
 
-        pool.close().await;
-        pg_db.drop().await;
-        Ok(())
+            let by_channel = fetch_recovery_audit(&pool, "42", 10).await?;
+            assert_eq!(by_channel.len(), 1);
+            assert_eq!(by_channel[0].id, inserted.id);
+
+            pool.close().await;
+            pg_db.drop().await;
+            Ok(())
+        }
     }
 }

--- a/src/services/observability/recovery_audit.rs
+++ b/src/services/observability/recovery_audit.rs
@@ -484,9 +484,20 @@ mod tests {
 
     // #4979 S7: PG tests live below a marked module so `just test-postgres`
     // selects them by the whole-path `_pg` substring. The pure sibling stays
-    // in this parent and is selected by the curated non-PG invocation. The
-    // enforced marker contract is only `_pg`, `pg_`, or `postgres` as a
-    // normalized-path substring; this module suffix is a human convention.
+    // in this parent and is selected by the curated non-PG invocation.
+    //
+    // The `*_pg_tests` suffix is a human convention, but the marker contract
+    // it satisfies is enforced, and it is two-sided — a name that clears one
+    // side can still fail the other:
+    //   rule1 (`justfile` test-postgres) selects on `_pg`, `pg_`, or
+    //     `postgres` as a normalized-path substring;
+    //   rule2 (nightly pgless sweep, ci-nightly.yml:121 and :163) excludes on
+    //     `_pg_` or `postgres_` — note the trailing underscore.
+    // So `pg_foo_tests` clears rule1 yet is still swept by the pgless lane and
+    // lands as rule2 debt; a live example sits at
+    // scripts/pg_test_lane_baseline.txt:81
+    // (`dispatch::dispatch_cancel::pg_observability_tests::…`). The `_pg_tests`
+    // suffix used here contains `_pg_` and so clears both sides.
     //
     // Batch mutation measurements at this declaration and the sibling in
     // turn_lifecycle.rs (rc values are measured, not inferred):

--- a/src/services/observability/turn_lifecycle.rs
+++ b/src/services/observability/turn_lifecycle.rs
@@ -729,43 +729,67 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn emit_turn_lifecycle_persists_round_trip() -> Result<()> {
-        let Some(pg_db) = TestPostgresDb::try_create().await else {
-            return Ok(());
-        };
-        let pool = pg_db.connect_and_migrate().await?;
+    // #4979 S7: PG tests live below a marked module so `just test-postgres`
+    // selects them by the whole-path `_pg` substring. The three pure siblings
+    // stay in this parent and are selected by the curated non-PG invocation.
+    // The enforced marker contract is only `_pg`, `pg_`, or `postgres` as a
+    // normalized-path substring; this module suffix is a human convention.
+    //
+    // Batch mutation measurements at this declaration and the sibling in
+    // recovery_audit.rs (rc values are measured, not inferred):
+    //
+    //   1. Rename both modules away from the marker, retaining `#[cfg(test)]`:
+    //        membership rc=1 (manifest drift; after snapshot regeneration,
+    //        membership rc=1 again on rule1/rule2 baseline growth)
+    //        coverage rc=0; after snapshot regeneration coverage rc=0
+    //      The curated parent invocations cover the renamed modules, so the
+    //      membership manifest/baseline ratchet, not coverage, guards markers.
+    //
+    //   2. Remove only both nested `#[cfg(test)]` attributes:
+    //        membership rc=0, coverage rc=1 (two newly uncovered parents)
+    //      The parent coverage debts were removed in S7 after adding the pure
+    //      invocations. Thus this attribute IS load-bearing in this slice.
+    #[cfg(test)]
+    mod turn_lifecycle_pg_tests {
+        use super::*;
 
-        let persisted = emit_turn_lifecycle(
-            &pool,
-            TurnLifecycleEmit::new(
-                "discord:42:420",
-                "42",
-                TurnEvent::SessionResumeFailedWithRecovery(RecoveryDetails {
-                    reason: "session transcript missing".to_string(),
-                    recovery_action: "start fresh session".to_string(),
-                    previous_session_key: Some("agentdesk-old".to_string()),
-                    recovered_session_key: Some("agentdesk-new".to_string()),
-                    recovery: Some(RecoveryContextDetails {
-                        source: "discord_recent_messages".to_string(),
-                        message_count: 7,
-                        max_chars: 300,
+        #[tokio::test]
+        async fn emit_turn_lifecycle_persists_round_trip() -> Result<()> {
+            let Some(pg_db) = TestPostgresDb::try_create().await else {
+                return Ok(());
+            };
+            let pool = pg_db.connect_and_migrate().await?;
+
+            let persisted = emit_turn_lifecycle(
+                &pool,
+                TurnLifecycleEmit::new(
+                    "discord:42:420",
+                    "42",
+                    TurnEvent::SessionResumeFailedWithRecovery(RecoveryDetails {
+                        reason: "session transcript missing".to_string(),
+                        recovery_action: "start fresh session".to_string(),
+                        previous_session_key: Some("agentdesk-old".to_string()),
+                        recovered_session_key: Some("agentdesk-new".to_string()),
+                        recovery: Some(RecoveryContextDetails {
+                            source: "discord_recent_messages".to_string(),
+                            message_count: 7,
+                            max_chars: 300,
+                        }),
                     }),
-                }),
-                "resume failed; started fresh session",
+                    "resume failed; started fresh session",
+                )
+                .session_key("agentdesk-new")
+                .dispatch_id("dispatch-123"),
             )
-            .session_key("agentdesk-new")
-            .dispatch_id("dispatch-123"),
-        )
-        .await?
-        .expect("event should persist");
+            .await?
+            .expect("event should persist");
 
-        assert_eq!(persisted.kind, "session_resume_failed_with_recovery");
-        assert_eq!(persisted.severity, "warn");
-        assert!(persisted.notify_user);
-        assert_eq!(persisted.notification_enqueued, Some(true));
+            assert_eq!(persisted.kind, "session_resume_failed_with_recovery");
+            assert_eq!(persisted.severity, "warn");
+            assert!(persisted.notify_user);
+            assert_eq!(persisted.notification_enqueued, Some(true));
 
-        let row = sqlx::query(
+            let row = sqlx::query(
             "SELECT turn_id, channel_id, session_key, dispatch_id, kind, severity, summary, details_json
              FROM turn_lifecycle_events
              WHERE id = $1",
@@ -774,178 +798,179 @@ mod tests {
         .fetch_one(&pool)
         .await?;
 
-        assert_eq!(row.try_get::<String, _>("turn_id")?, "discord:42:420");
-        assert_eq!(row.try_get::<String, _>("channel_id")?, "42");
-        assert_eq!(
-            row.try_get::<Option<String>, _>("session_key")?,
-            Some("agentdesk-new".to_string())
-        );
-        assert_eq!(
-            row.try_get::<Option<String>, _>("dispatch_id")?,
-            Some("dispatch-123".to_string())
-        );
-        assert_eq!(
-            row.try_get::<String, _>("kind")?,
-            "session_resume_failed_with_recovery"
-        );
-        assert_eq!(row.try_get::<String, _>("severity")?, "warn");
-        assert_eq!(
-            row.try_get::<String, _>("summary")?,
-            "resume failed; started fresh session"
-        );
-        let details = row.try_get::<Value, _>("details_json")?;
-        assert_eq!(details["reason"], "session transcript missing");
-        assert_eq!(details["recoveryAction"], "start fresh session");
-        assert_eq!(details["previousSessionKey"], "agentdesk-old");
-        assert_eq!(details["recoveredSessionKey"], "agentdesk-new");
-        assert_eq!(details["recovery"]["source"], "discord_recent_messages");
-        assert_eq!(details["recovery"]["messageCount"], 7);
-        assert_eq!(details["recovery"]["maxChars"], 300);
+            assert_eq!(row.try_get::<String, _>("turn_id")?, "discord:42:420");
+            assert_eq!(row.try_get::<String, _>("channel_id")?, "42");
+            assert_eq!(
+                row.try_get::<Option<String>, _>("session_key")?,
+                Some("agentdesk-new".to_string())
+            );
+            assert_eq!(
+                row.try_get::<Option<String>, _>("dispatch_id")?,
+                Some("dispatch-123".to_string())
+            );
+            assert_eq!(
+                row.try_get::<String, _>("kind")?,
+                "session_resume_failed_with_recovery"
+            );
+            assert_eq!(row.try_get::<String, _>("severity")?, "warn");
+            assert_eq!(
+                row.try_get::<String, _>("summary")?,
+                "resume failed; started fresh session"
+            );
+            let details = row.try_get::<Value, _>("details_json")?;
+            assert_eq!(details["reason"], "session transcript missing");
+            assert_eq!(details["recoveryAction"], "start fresh session");
+            assert_eq!(details["previousSessionKey"], "agentdesk-old");
+            assert_eq!(details["recoveredSessionKey"], "agentdesk-new");
+            assert_eq!(details["recovery"]["source"], "discord_recent_messages");
+            assert_eq!(details["recovery"]["messageCount"], 7);
+            assert_eq!(details["recovery"]["maxChars"], 300);
 
-        let outbox = sqlx::query(
-            "SELECT target, content, bot, source, reason_code, session_key
+            let outbox = sqlx::query(
+                "SELECT target, content, bot, source, reason_code, session_key
              FROM message_outbox
              ORDER BY id ASC",
-        )
-        .fetch_one(&pool)
-        .await?;
-        assert_eq!(outbox.try_get::<String, _>("target")?, "channel:42");
-        assert_eq!(outbox.try_get::<String, _>("bot")?, "notify");
-        assert_eq!(
-            outbox.try_get::<String, _>("source")?,
-            crate::services::message_outbox::LIFECYCLE_NOTIFIER_SOURCE
-        );
-        assert_eq!(
-            outbox.try_get::<Option<String>, _>("reason_code")?,
-            Some("lifecycle.session_resume_failed".to_string())
-        );
-        assert_eq!(
-            outbox.try_get::<Option<String>, _>("session_key")?,
-            Some("channel:42".to_string())
-        );
-        let content = outbox.try_get::<String, _>("content")?;
-        assert!(content.contains("♻️ 이전 대화 이어가기 실패"));
-        assert!(content.contains("사유: session transcript missing"));
-        assert!(content.contains("복구: start fresh session"));
-
-        pool.close().await;
-        pg_db.drop().await;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn emit_turn_lifecycle_enqueues_expected_notifications_and_dedupes() -> Result<()> {
-        let Some(pg_db) = TestPostgresDb::try_create().await else {
-            return Ok(());
-        };
-        let pool = pg_db.connect_and_migrate().await?;
-
-        let fresh_first = emit_turn_lifecycle(
-            &pool,
-            TurnLifecycleEmit::new(
-                "discord:77:1",
-                "77",
-                TurnEvent::SessionFresh(SessionStrategyDetails::fresh("first_turn")),
-                "fresh session",
             )
-            .session_key("session-a"),
-        )
-        .await?
-        .expect("fresh event persists");
-        assert!(!fresh_first.notify_user);
-        assert_eq!(fresh_first.notification_enqueued, None);
+            .fetch_one(&pool)
+            .await?;
+            assert_eq!(outbox.try_get::<String, _>("target")?, "channel:42");
+            assert_eq!(outbox.try_get::<String, _>("bot")?, "notify");
+            assert_eq!(
+                outbox.try_get::<String, _>("source")?,
+                crate::services::message_outbox::LIFECYCLE_NOTIFIER_SOURCE
+            );
+            assert_eq!(
+                outbox.try_get::<Option<String>, _>("reason_code")?,
+                Some("lifecycle.session_resume_failed".to_string())
+            );
+            assert_eq!(
+                outbox.try_get::<Option<String>, _>("session_key")?,
+                Some("channel:42".to_string())
+            );
+            let content = outbox.try_get::<String, _>("content")?;
+            assert!(content.contains("♻️ 이전 대화 이어가기 실패"));
+            assert!(content.contains("사유: session transcript missing"));
+            assert!(content.contains("복구: start fresh session"));
 
-        let fresh_duplicate = emit_turn_lifecycle(
-            &pool,
-            TurnLifecycleEmit::new(
-                "discord:77:2",
-                "77",
-                TurnEvent::SessionFresh(SessionStrategyDetails::fresh(
-                    "no_cached_provider_session",
-                )),
-                "fresh session again",
+            pool.close().await;
+            pg_db.drop().await;
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn emit_turn_lifecycle_enqueues_expected_notifications_and_dedupes() -> Result<()> {
+            let Some(pg_db) = TestPostgresDb::try_create().await else {
+                return Ok(());
+            };
+            let pool = pg_db.connect_and_migrate().await?;
+
+            let fresh_first = emit_turn_lifecycle(
+                &pool,
+                TurnLifecycleEmit::new(
+                    "discord:77:1",
+                    "77",
+                    TurnEvent::SessionFresh(SessionStrategyDetails::fresh("first_turn")),
+                    "fresh session",
+                )
+                .session_key("session-a"),
             )
-            .session_key("session-b"),
-        )
-        .await?
-        .expect("duplicate fresh event still persists");
-        assert_eq!(fresh_duplicate.notification_enqueued, None);
+            .await?
+            .expect("fresh event persists");
+            assert!(!fresh_first.notify_user);
+            assert_eq!(fresh_first.notification_enqueued, None);
 
-        let resumed = emit_turn_lifecycle(
-            &pool,
-            TurnLifecycleEmit::new(
-                "discord:77:3",
-                "77",
-                TurnEvent::SessionResumed(SessionStrategyDetails::resumed(
-                    "runtime_cached_provider_session",
-                    "provider-session-123",
-                )),
-                "session resumed",
+            let fresh_duplicate = emit_turn_lifecycle(
+                &pool,
+                TurnLifecycleEmit::new(
+                    "discord:77:2",
+                    "77",
+                    TurnEvent::SessionFresh(SessionStrategyDetails::fresh(
+                        "no_cached_provider_session",
+                    )),
+                    "fresh session again",
+                )
+                .session_key("session-b"),
             )
-            .session_key("session-b"),
-        )
-        .await?
-        .expect("resumed event persists");
-        assert!(!resumed.notify_user);
-        assert_eq!(resumed.notification_enqueued, None);
+            .await?
+            .expect("duplicate fresh event still persists");
+            assert_eq!(fresh_duplicate.notification_enqueued, None);
 
-        let compacted = emit_turn_lifecycle(
-            &pool,
-            TurnLifecycleEmit::new(
-                "discord:77:4",
-                "77",
-                TurnEvent::ContextCompacted(ContextCompactionDetails {
-                    before_pct: 88,
-                    after_pct: Some(41),
-                    preserved_sections: vec![
-                        "Goal".to_string(),
-                        "Progress".to_string(),
-                        "Decisions".to_string(),
-                        "Files".to_string(),
-                        "Next".to_string(),
-                    ],
-                }),
-                "context compacted",
+            let resumed = emit_turn_lifecycle(
+                &pool,
+                TurnLifecycleEmit::new(
+                    "discord:77:3",
+                    "77",
+                    TurnEvent::SessionResumed(SessionStrategyDetails::resumed(
+                        "runtime_cached_provider_session",
+                        "provider-session-123",
+                    )),
+                    "session resumed",
+                )
+                .session_key("session-b"),
             )
-            .session_key("session-b"),
-        )
-        .await?
-        .expect("compacted event persists");
-        assert_eq!(compacted.notification_enqueued, Some(true));
+            .await?
+            .expect("resumed event persists");
+            assert!(!resumed.notify_user);
+            assert_eq!(resumed.notification_enqueued, None);
 
-        let rows = sqlx::query(
-            "SELECT reason_code, content, source
+            let compacted = emit_turn_lifecycle(
+                &pool,
+                TurnLifecycleEmit::new(
+                    "discord:77:4",
+                    "77",
+                    TurnEvent::ContextCompacted(ContextCompactionDetails {
+                        before_pct: 88,
+                        after_pct: Some(41),
+                        preserved_sections: vec![
+                            "Goal".to_string(),
+                            "Progress".to_string(),
+                            "Decisions".to_string(),
+                            "Files".to_string(),
+                            "Next".to_string(),
+                        ],
+                    }),
+                    "context compacted",
+                )
+                .session_key("session-b"),
+            )
+            .await?
+            .expect("compacted event persists");
+            assert_eq!(compacted.notification_enqueued, Some(true));
+
+            let rows = sqlx::query(
+                "SELECT reason_code, content, source
              FROM message_outbox
              WHERE target = 'channel:77'
              ORDER BY id ASC",
-        )
-        .fetch_all(&pool)
-        .await?;
+            )
+            .fetch_all(&pool)
+            .await?;
 
-        assert_eq!(rows.len(), 1);
-        assert_eq!(
-            rows[0].try_get::<Option<String>, _>("reason_code")?,
-            Some("lifecycle.context_compacted".to_string())
-        );
-        assert!(
-            rows[0]
-                .try_get::<String, _>("content")?
-                .contains("이전 88% → 이후 41%")
-        );
-        for row in rows {
+            assert_eq!(rows.len(), 1);
             assert_eq!(
-                row.try_get::<String, _>("source")?,
-                crate::services::message_outbox::LIFECYCLE_NOTIFIER_SOURCE
+                rows[0].try_get::<Option<String>, _>("reason_code")?,
+                Some("lifecycle.context_compacted".to_string())
             );
+            assert!(
+                rows[0]
+                    .try_get::<String, _>("content")?
+                    .contains("이전 88% → 이후 41%")
+            );
+            for row in rows {
+                assert_eq!(
+                    row.try_get::<String, _>("source")?,
+                    crate::services::message_outbox::LIFECYCLE_NOTIFIER_SOURCE
+                );
+            }
+
+            assert_eq!(
+                crate::services::message_outbox::LIFECYCLE_NOTIFY_DEDUPE_TTL_SECS,
+                5 * 60
+            );
+
+            pool.close().await;
+            pg_db.drop().await;
+            Ok(())
         }
-
-        assert_eq!(
-            crate::services::message_outbox::LIFECYCLE_NOTIFY_DEDUPE_TTL_SECS,
-            5 * 60
-        );
-
-        pool.close().await;
-        pg_db.drop().await;
-        Ok(())
     }
 }

--- a/src/services/observability/turn_lifecycle.rs
+++ b/src/services/observability/turn_lifecycle.rs
@@ -732,8 +732,19 @@ mod tests {
     // #4979 S7: PG tests live below a marked module so `just test-postgres`
     // selects them by the whole-path `_pg` substring. The three pure siblings
     // stay in this parent and are selected by the curated non-PG invocation.
-    // The enforced marker contract is only `_pg`, `pg_`, or `postgres` as a
-    // normalized-path substring; this module suffix is a human convention.
+    //
+    // The `*_pg_tests` suffix is a human convention, but the marker contract
+    // it satisfies is enforced, and it is two-sided — a name that clears one
+    // side can still fail the other:
+    //   rule1 (`justfile` test-postgres) selects on `_pg`, `pg_`, or
+    //     `postgres` as a normalized-path substring;
+    //   rule2 (nightly pgless sweep, ci-nightly.yml:121 and :163) excludes on
+    //     `_pg_` or `postgres_` — note the trailing underscore.
+    // So `pg_foo_tests` clears rule1 yet is still swept by the pgless lane and
+    // lands as rule2 debt; a live example sits at
+    // scripts/pg_test_lane_baseline.txt:81
+    // (`dispatch::dispatch_cancel::pg_observability_tests::…`). The `_pg_tests`
+    // suffix used here contains `_pg_` and so clears both sides.
     //
     // Batch mutation measurements at this declaration and the sibling in
     // recovery_audit.rs (rc values are measured, not inferred):

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -83,6 +83,8 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --lib canonical_identity::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib session_canonical_identity::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib services::observability::metrics::tests -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib services::observability::turn_lifecycle::tests -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib services::observability::recovery_audit::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib cli::args::tests::legacy_queue_help_directs_users_to_query_without_changing_compatibility_contract",
     "cargo test --all-targets transition -- --skip _pg --skip pg_ --skip postgres --test-threads=1",
     "cargo test --all-targets auto_queue -- --skip _pg --skip pg_ --skip postgres",


### PR DESCRIPTION
## 무엇을

`#4979` **S7** — `services::observability`의 PG 의존 테스트 3건을 `just test-postgres` 레인에 태운다. T1 폭발 반경 이관의 마지막 배치다.

| 모듈 | PG 이관 | 부모 잔여(순수) |
|---|---:|---:|
| `turn_lifecycle::tests` → `::turn_lifecycle_pg_tests` | 2 | 3 |
| `recovery_audit::tests` → `::recovery_audit_pg_tests` | 1 | 1 |

프로덕션 로직 무변경 — 전부 `#[cfg(test)]` 내부 이동 + 레인 배선이다.

## 왜 nest인가

두 모듈 모두 PG/비-PG가 섞여 있어 모듈째 rename하면 순수 테스트 4건이 PG 레인으로 딸려가 비-PG 커버리지를 잃는다. 중첩 `*_pg_tests` 자식으로 옮기고, 부모에 남는 순수 4건은 `justfile`의 curated 비-PG 호출 2줄로 등재해 커버리지 부채에서 뺐다.

## 검증

- **본문 무변경**: 정규화 라인 다중집합 before/after — 두 파일 모두 **removed 0 / added 24**, added 전부 모듈 선언·`cfg`·`use super::*`·닫는 괄호·주석. 신규 `#[rustfmt::skip]` 0개.
- **전체 목록 불변**: `cargo test --lib -- --list` = **7,402 → 7,402**. 옛 경로 3건 소멸, 새 경로 3건 생성.
- **레인 배선 5단계**: 두 파일 모두 `pg_db`의 `src/services/observability/**`에 매칭 → `test_fast`의 `pg_db == true` → `just test-postgres` → libtest positives `('_pg','pg_','postgres')`가 새 경로 3건 선택.
- **양방향 분리**: 순수 4건은 curated 부모 호출에 선택되고 PG 필터엔 미선택. 실제 실행 `turn_lifecycle` 3/3, `recovery_audit` 1/1 통과.
- **실제 PG 실행**: `AGENTDESK_REQUIRE_PG=1`로 soft-skip을 막고 이관 3건 전부 통과.
- **뮤테이션(실측 rc, 주석에 기록)**: ① 마커 제거 → membership rc=1(스냅샷 재생성 후에도 baseline growth로 rc=1), coverage rc=0 ② 중첩 `cfg(test)` 제거 → membership rc=0, **coverage rc=1**(새 uncovered 부모 2개).

## 부채

`rule1 59→56`, `rule2 210→207`, `rule3 25→25`, coverage debt `669→667`.

## 게이트

`cargo fmt --check` / membership / coverage(`--baseline-ref origin/main`) / fast-check wiring 24 tests / `ci-script-checks.sh` 전부 rc=0. inventory 재생성 diff 없음, 신규 Python import 0.
