### PR TITLE
fix(#4880): scope AutoQueue reset to a single run and route it through canonical cleanup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -361,6 +361,7 @@ src/
 │   │   ├── activate_command.rs
 │   │   ├── activate_preflight.rs
 │   │   ├── activate_route.rs
+│   │   ├── auto_queue_reset_pg_tests.rs
 │   │   ├── cancel_run.rs
 │   │   ├── command.rs
 │   │   ├── control_routes.rs

--- a/dashboard/src/api/autoQueue.ts
+++ b/dashboard/src/api/autoQueue.ts
@@ -229,20 +229,20 @@ export async function reorderAutoQueueEntries(
 }
 
 export interface AutoQueueResetScope {
-  runId?: string | null;
+  runId: string;
   repo?: string | null;
-  agentId: string;
+  agentId?: string | null;
 }
 
 export async function resetAutoQueue(
   scope: AutoQueueResetScope,
-): Promise<{ ok: boolean; deleted_entries: number; completed_runs: number }> {
+): Promise<Record<string, unknown>> {
   return request("/api/queue/reset", {
     method: "POST",
     body: JSON.stringify({
-      run_id: scope.runId ?? undefined,
+      run_id: scope.runId,
       repo: scope.repo ?? undefined,
-      agent_id: scope.agentId,
+      agent_id: scope.agentId ?? undefined,
     }),
   });
 }

--- a/dashboard/src/components/agent-manager/AutoQueuePanel.tsx
+++ b/dashboard/src/components/agent-manager/AutoQueuePanel.tsx
@@ -17,7 +17,7 @@ import {
   normalizeAutoQueueStatus,
   shouldClearSuppressedAutoQueueRun,
 } from "./auto-queue-panel-state";
-import { buildRequestGenerateGroups } from "./auto-queue-actions";
+import { buildRequestGenerateGroups, resetAutoQueueForSelection } from "./auto-queue-actions";
 import AutoQueuePanelView from "./AutoQueuePanelView";
 import { useSortableReorder } from "./AutoQueueSortableRows";
 import { formatRequestGroupKey, isCompletedEntry, requestGroupKey, sortEntriesForDisplay, type ViewMode } from "./auto-queue-panel-utils";
@@ -250,24 +250,27 @@ export default function AutoQueuePanel({
   const handleReset = async () => {
     setError(null);
     setNoReadyCards(false);
-    suppressedRunIdRef.current = status?.run?.id ?? null;
+    const activeRunId = status?.run?.id?.trim();
+    if (!activeRunId) {
+      setError(
+        tr(
+          "초기화할 활성 run을 찾지 못했습니다.",
+          "No active run to reset.",
+        ),
+      );
+      return;
+    }
+    suppressedRunIdRef.current = activeRunId;
     try {
-      const targets = resolveResetAgentTargets();
-      if (targets.length === 0) {
-        throw new Error(
-          tr(
-            "초기화할 에이전트를 찾지 못했습니다. 상단 필터에서 에이전트를 선택하세요.",
-            "No agent to reset. Select an agent from the filter above.",
-          ),
-        );
-      }
-      for (const agentId of targets) {
-        await api.resetAutoQueue({
-          runId: status?.run?.id ?? null,
-          repo: selectedRepo || null,
-          agentId,
-        });
-      }
+      // A multi-agent run has no single agent owner. Do not turn the
+      // dashboard's filter into a narrower claim and then reject the whole
+      // run on an ownership mismatch; the run id is the destructive scope.
+      await resetAutoQueueForSelection(
+        api,
+        selectedRepo || null,
+        status?.run?.agent_id ?? null,
+        activeRunId,
+      );
       resetPanelState();
     } catch (e) {
       suppressedRunIdRef.current = null;
@@ -361,16 +364,6 @@ export default function AutoQueuePanel({
   const entries = status?.entries ?? [];
   const phaseGates = status?.phase_gates ?? [];
   const deployPhases = new Set(run?.deploy_phases ?? []);
-  const resetAgentId = selectedAgentId ?? run?.agent_id ?? null;
-  const resolveResetAgentTargets = (): string[] => {
-    if (resetAgentId) return [resetAgentId];
-    const fromEntries = Array.from(
-      new Set(entries.map((e) => e.agent_id).filter((id): id is string => Boolean(id))),
-    );
-    if (fromEntries.length > 0) return fromEntries;
-    const fromStats = Object.keys(status?.agents ?? {});
-    return fromStats;
-  };
   const gatesByPhase = new Map<number, PhaseGateInfo[]>();
   for (const gate of phaseGates) {
     const list = gatesByPhase.get(gate.phase) ?? [];

--- a/dashboard/src/components/agent-manager/AutoQueuePanel.tsx
+++ b/dashboard/src/components/agent-manager/AutoQueuePanel.tsx
@@ -262,12 +262,11 @@ export default function AutoQueuePanel({
     }
     suppressedRunIdRef.current = activeRunId;
     try {
-      // A multi-agent run has no single agent owner. Do not turn the
-      // dashboard's filter into a narrower claim and then reject the whole
-      // run on an ownership mismatch; the run id is the destructive scope.
+      // Dashboard repo/agent filters are selectors, not ownership claims.
+      // The run id is the destructive scope; only the run's actual agent owner
+      // is safe to echo when one exists.
       await resetAutoQueueForSelection(
         api,
-        selectedRepo || null,
         status?.run?.agent_id ?? null,
         activeRunId,
       );

--- a/dashboard/src/components/agent-manager/AutoQueuePanel.tsx
+++ b/dashboard/src/components/agent-manager/AutoQueuePanel.tsx
@@ -262,9 +262,9 @@ export default function AutoQueuePanel({
     }
     suppressedRunIdRef.current = activeRunId;
     try {
-      // Dashboard repo/agent filters are selectors, not ownership claims.
-      // The run id is the destructive scope; only the run's actual agent owner
-      // is safe to echo when one exists.
+      // Dashboard filters select what is shown; they do not authorize reset.
+      // The run id narrows the destructive scope to one run. Echo only the
+      // run's recorded agent as an optional consistency constraint.
       await resetAutoQueueForSelection(
         api,
         status?.run?.agent_id ?? null,

--- a/dashboard/src/components/agent-manager/auto-queue-actions.test.ts
+++ b/dashboard/src/components/agent-manager/auto-queue-actions.test.ts
@@ -7,7 +7,7 @@ import {
 } from "./auto-queue-actions";
 
 describe("auto-queue-actions", () => {
-  it("passes the selected repo and agent to reset and generate", async () => {
+  it("uses the selected repo for generation but not as a reset ownership claim", async () => {
     const resetAutoQueue = vi.fn().mockResolvedValue({ ok: true });
     const generateAutoQueue = vi
       .fn()
@@ -21,27 +21,24 @@ describe("auto-queue-actions", () => {
     );
 
     expect(resetAutoQueue).toHaveBeenCalledWith({
-      repo: "test-repo",
       agentId: "agent-selected",
       runId: "run-123",
     });
     expect(generateAutoQueue).toHaveBeenCalledWith("test-repo", "agent-selected");
   });
 
-  it("passes the selected scope to reset-only actions", async () => {
+  it("omits the dashboard repo filter when resetting a multi-repo run", async () => {
     const resetAutoQueue = vi.fn().mockResolvedValue({ ok: true });
 
     await resetAutoQueueForSelection(
       { resetAutoQueue },
-      "test-repo",
-      "agent-selected",
-      "run-123",
+      "run-agent",
+      "run-multi-repo",
     );
 
     expect(resetAutoQueue).toHaveBeenCalledWith({
-      repo: "test-repo",
-      agentId: "agent-selected",
-      runId: "run-123",
+      agentId: "run-agent",
+      runId: "run-multi-repo",
     });
     expect(resetAutoQueue).toHaveBeenCalledTimes(1);
   });
@@ -52,7 +49,6 @@ describe("auto-queue-actions", () => {
     await expect(
       resetAutoQueueForSelection(
         { resetAutoQueue },
-        "test-repo",
         "agent-selected",
         null,
       ),

--- a/dashboard/src/components/agent-manager/auto-queue-actions.test.ts
+++ b/dashboard/src/components/agent-manager/auto-queue-actions.test.ts
@@ -7,7 +7,7 @@ import {
 } from "./auto-queue-actions";
 
 describe("auto-queue-actions", () => {
-  it("uses the selected repo for generation but not as a reset ownership claim", async () => {
+  it("uses the selected repo for generation but not as a reset scope constraint", async () => {
     const resetAutoQueue = vi.fn().mockResolvedValue({ ok: true });
     const generateAutoQueue = vi
       .fn()

--- a/dashboard/src/components/agent-manager/auto-queue-actions.test.ts
+++ b/dashboard/src/components/agent-manager/auto-queue-actions.test.ts
@@ -17,11 +17,13 @@ describe("auto-queue-actions", () => {
       { resetAutoQueue, generateAutoQueue },
       "test-repo",
       "agent-selected",
+      "run-123",
     );
 
     expect(resetAutoQueue).toHaveBeenCalledWith({
       repo: "test-repo",
       agentId: "agent-selected",
+      runId: "run-123",
     });
     expect(generateAutoQueue).toHaveBeenCalledWith("test-repo", "agent-selected");
   });
@@ -41,6 +43,21 @@ describe("auto-queue-actions", () => {
       agentId: "agent-selected",
       runId: "run-123",
     });
+    expect(resetAutoQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a reset without the active run scope", async () => {
+    const resetAutoQueue = vi.fn().mockResolvedValue({ ok: true });
+
+    await expect(
+      resetAutoQueueForSelection(
+        { resetAutoQueue },
+        "test-repo",
+        "agent-selected",
+        null,
+      ),
+    ).rejects.toThrow("run_id is required for reset");
+    expect(resetAutoQueue).not.toHaveBeenCalled();
   });
 
   it("groups request-generate candidates by repo and agent", () => {

--- a/dashboard/src/components/agent-manager/auto-queue-actions.ts
+++ b/dashboard/src/components/agent-manager/auto-queue-actions.ts
@@ -67,7 +67,6 @@ export async function generateAutoQueueForSelection(
   }
 
   await api.resetAutoQueue({
-    repo,
     agentId: resetAgentId,
     runId: runId.trim(),
   });
@@ -76,7 +75,6 @@ export async function generateAutoQueueForSelection(
 
 export async function resetAutoQueueForSelection(
   api: AutoQueueResetApi,
-  repo: string | null,
   agentId: string | null | undefined,
   runId: string | null | undefined,
 ): Promise<unknown> {
@@ -87,7 +85,6 @@ export async function resetAutoQueueForSelection(
   const resetAgentId = agentId?.trim();
 
   return api.resetAutoQueue({
-    repo,
     agentId: resetAgentId,
     runId: runId.trim(),
   });

--- a/dashboard/src/components/agent-manager/auto-queue-actions.ts
+++ b/dashboard/src/components/agent-manager/auto-queue-actions.ts
@@ -1,7 +1,7 @@
 export interface AutoQueueResetScope {
-  runId?: string | null;
+  runId: string;
   repo?: string | null;
-  agentId: string;
+  agentId?: string | null;
 }
 
 interface AutoQueueGenerateApi {
@@ -55,13 +55,22 @@ export async function generateAutoQueueForSelection(
   api: AutoQueueGenerateApi,
   repo: string | null,
   agentId: string | null | undefined,
+  runId: string | null | undefined = null,
 ): Promise<Record<string, unknown>> {
   const resetAgentId = agentId?.trim();
   if (!resetAgentId) {
     throw new Error("agent_id is required for reset");
   }
 
-  await api.resetAutoQueue({ repo, agentId: resetAgentId });
+  if (!runId?.trim()) {
+    throw new Error("run_id is required for reset");
+  }
+
+  await api.resetAutoQueue({
+    repo,
+    agentId: resetAgentId,
+    runId: runId.trim(),
+  });
   return api.generateAutoQueue(repo, agentId);
 }
 
@@ -69,16 +78,17 @@ export async function resetAutoQueueForSelection(
   api: AutoQueueResetApi,
   repo: string | null,
   agentId: string | null | undefined,
-  runId?: string | null,
+  runId: string | null | undefined,
 ): Promise<unknown> {
-  const resetAgentId = agentId?.trim();
-  if (!resetAgentId) {
-    throw new Error("agent_id is required for reset");
+  if (!runId?.trim()) {
+    throw new Error("run_id is required for reset");
   }
+
+  const resetAgentId = agentId?.trim();
 
   return api.resetAutoQueue({
     repo,
     agentId: resetAgentId,
-    runId: runId ?? null,
+    runId: runId.trim(),
   });
 }

--- a/dashboard/src/components/agent-manager/auto-queue-panel-state.test.ts
+++ b/dashboard/src/components/agent-manager/auto-queue-panel-state.test.ts
@@ -27,7 +27,11 @@ function makeRun(
   };
 }
 
-function makeStatus(run: AutoQueueRun | null, entryCount = 0): AutoQueueStatus {
+function makeStatus(
+  run: AutoQueueRun | null,
+  entryCount = 0,
+  entryStatus: AutoQueueStatus["entries"][number]["status"] = "pending",
+): AutoQueueStatus {
   return {
     run,
     entries: Array.from({ length: entryCount }, (_, index) => ({
@@ -36,7 +40,7 @@ function makeStatus(run: AutoQueueRun | null, entryCount = 0): AutoQueueStatus {
       card_id: `card-${index}`,
       priority_rank: index,
       reason: null,
-      status: "pending",
+      status: entryStatus,
       created_at: 0,
       dispatched_at: null,
       completed_at: null,
@@ -47,10 +51,17 @@ function makeStatus(run: AutoQueueRun | null, entryCount = 0): AutoQueueStatus {
 }
 
 describe("auto-queue-panel-state", () => {
-  it("suppresses a reset-cleared run until a new run appears", () => {
-    const status = makeStatus(makeRun("generated", "run-reset"), 0);
+  it("suppresses a reset-cancelled run with retained skipped entries until a new run appears", () => {
+    const status = makeStatus(makeRun("cancelled", "run-reset"), 2, "skipped");
 
     expect(normalizeAutoQueueStatus(status, "run-reset")).toEqual(createEmptyAutoQueueStatus());
+  });
+
+  it("shows Generate after reset polling returns the cancelled run", () => {
+    const polled = makeStatus(makeRun("cancelled", "run-reset"), 2, "skipped");
+    const normalized = normalizeAutoQueueStatus(polled, "run-reset");
+
+    expect(getAutoQueuePrimaryAction(normalized.run, 0)).toBe("generate");
   });
 
   it("keeps a PM-assisted pending run when it was not suppressed", () => {
@@ -59,8 +70,8 @@ describe("auto-queue-panel-state", () => {
     expect(normalizeAutoQueueStatus(status, null)).toEqual(status);
   });
 
-  it("keeps suppression while the server still returns the reset-cleared run", () => {
-    const status = makeStatus(makeRun("generated", "run-reset"), 0);
+  it("keeps suppression while the server still returns the reset-cancelled run", () => {
+    const status = makeStatus(makeRun("cancelled", "run-reset"), 2, "skipped");
 
     expect(shouldClearSuppressedAutoQueueRun(status, "run-reset")).toBe(false);
   });
@@ -73,6 +84,7 @@ describe("auto-queue-panel-state", () => {
   it("returns the correct primary action per run state", () => {
     expect(getAutoQueuePrimaryAction(null, 0)).toBe("generate");
     expect(getAutoQueuePrimaryAction(makeRun("completed"), 0)).toBe("generate");
+    expect(getAutoQueuePrimaryAction(makeRun("cancelled"), 0)).toBe("generate");
     expect(getAutoQueuePrimaryAction(makeRun("generated"), 2)).toBe("start");
     expect(getAutoQueuePrimaryAction(makeRun("active"), 2)).toBe("dispatch");
     expect(getAutoQueuePrimaryAction(makeRun("generated"), 0)).toBeNull();

--- a/dashboard/src/components/agent-manager/auto-queue-panel-state.ts
+++ b/dashboard/src/components/agent-manager/auto-queue-panel-state.ts
@@ -16,7 +16,7 @@ export function normalizeAutoQueueStatus(
   suppressedRunId: string | null,
 ): AutoQueueStatus {
   if (!status.run) return status;
-  if (suppressedRunId && status.run.id === suppressedRunId && status.entries.length === 0) {
+  if (suppressedRunId && status.run.id === suppressedRunId) {
     return createEmptyAutoQueueStatus();
   }
   return status;
@@ -35,7 +35,7 @@ export function getAutoQueuePrimaryAction(
   run: AutoQueueRun | null,
   pendingCount: number,
 ): AutoQueuePrimaryAction {
-  if (!run || run.status === "completed") return "generate";
+  if (!run || run.status === "completed" || run.status === "cancelled") return "generate";
   if (run.status === "generated" && pendingCount > 0) return "start";
   if (run.status === "active" && pendingCount > 0) return "dispatch";
   return null;

--- a/src/services/auto_queue/auto_queue_reset_pg_tests.rs
+++ b/src/services/auto_queue/auto_queue_reset_pg_tests.rs
@@ -2,11 +2,11 @@ use axum::{
     Router,
     body::{Body, to_bytes},
     http::{Method, Request, StatusCode, header},
-    routing::post,
+    routing::{get, post},
 };
 use serde_json::{Value, json};
 use sqlx::PgPool;
-use std::{path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
 use tower::ServiceExt;
 
 struct ResetFixture {
@@ -69,7 +69,19 @@ async fn seed_reset_run(
     } else {
         ""
     };
-    let slot_index = if with_live_cleanup { 0_i64 } else { -1_i64 };
+    let slot_index = if with_live_cleanup {
+        sqlx::query_scalar::<_, i64>(
+            "SELECT (COALESCE(MAX(slot_index), -1) + 1)::BIGINT
+             FROM auto_queue_slots
+             WHERE agent_id = $1",
+        )
+        .bind(agent_id)
+        .fetch_one(pool)
+        .await
+        .expect("choose reset slot")
+    } else {
+        -1_i64
+    };
     sqlx::query(
         "INSERT INTO auto_queue_entries
             (id, run_id, kanban_card_id, agent_id, status, dispatch_id, slot_index)
@@ -90,9 +102,10 @@ async fn seed_reset_run(
         sqlx::query(
             "INSERT INTO auto_queue_slots
                 (agent_id, slot_index, assigned_run_id, assigned_thread_group)
-             VALUES ($1, 0, $2, 0)",
+             VALUES ($1, $2, $3, 0)",
         )
         .bind(agent_id)
+        .bind(slot_index)
         .bind(&run_id)
         .execute(pool)
         .await
@@ -114,6 +127,61 @@ async fn seed_reset_run(
         entry_id,
         dispatch_id,
     }
+}
+
+async fn seed_additional_entry(
+    pool: &PgPool,
+    run_id: &str,
+    suffix: &str,
+    repo: &str,
+    agent_id: &str,
+    status: &str,
+) -> String {
+    let card_id = format!("card-reset-extra-{suffix}");
+    let entry_id = format!("entry-reset-extra-{suffix}");
+    sqlx::query(
+        "INSERT INTO kanban_cards (id, repo_id, title, status)
+         VALUES ($1, $2, 'Additional reset card', 'ready')",
+    )
+    .bind(&card_id)
+    .bind(repo)
+    .execute(pool)
+    .await
+    .expect("seed additional reset card");
+    sqlx::query(
+        "INSERT INTO auto_queue_entries
+            (id, run_id, kanban_card_id, agent_id, status, priority_rank)
+         VALUES ($1, $2, $3, $4, $5, 1)",
+    )
+    .bind(&entry_id)
+    .bind(run_id)
+    .bind(&card_id)
+    .bind(agent_id)
+    .bind(status)
+    .execute(pool)
+    .await
+    .expect("seed additional reset entry");
+    entry_id
+}
+
+async fn scoped_live_counts(pool: &PgPool, run_id: &str) -> (i64, i64, i64, i64, i64) {
+    sqlx::query_as(
+        "SELECT
+             (SELECT COUNT(*) FROM auto_queue_runs
+              WHERE id = $1 AND status IN ('generated', 'pending', 'active', 'paused', 'restoring')),
+             (SELECT COUNT(*) FROM auto_queue_entries WHERE run_id = $1),
+             (SELECT COUNT(*) FROM task_dispatches d
+              WHERE EXISTS (
+                  SELECT 1 FROM auto_queue_entries e
+                  WHERE e.run_id = $1 AND e.dispatch_id = d.id
+              )),
+             (SELECT COUNT(*) FROM auto_queue_slots WHERE assigned_run_id = $1),
+             (SELECT COUNT(*) FROM auto_queue_phase_gates WHERE run_id = $1)",
+    )
+    .bind(run_id)
+    .fetch_one(pool)
+    .await
+    .expect("count scoped live reset state")
 }
 
 async fn reset_test_db() -> (crate::db::auto_queue::test_support::TestPostgresDb, PgPool) {
@@ -141,6 +209,7 @@ fn reset_test_app(pool: PgPool) -> Router {
     };
     Router::new()
         .route("/queue/reset", post(super::reset))
+        .route("/queue/status", get(super::status))
         .with_state(state)
 }
 
@@ -164,6 +233,69 @@ async fn post_reset(app: &Router, body: Value) -> (StatusCode, Value) {
     (status, body)
 }
 
+async fn get_status(app: &Router, query: &str) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/queue/status{query}"))
+        .body(Body::empty())
+        .expect("build status request");
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("send status request");
+    let status = response.status();
+    let body = to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .expect("read status response");
+    let body = serde_json::from_slice(&body).expect("decode status response");
+    (status, body)
+}
+
+async fn wait_for_reset_entry_scan_lock(pool: &PgPool) {
+    for _ in 0..200 {
+        let waiting = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*)::BIGINT
+             FROM pg_stat_activity
+             WHERE datname = current_database()
+               AND wait_event_type = 'Lock'
+               AND query LIKE '%FROM auto_queue_entries%'
+               AND query LIKE '%FOR UPDATE%'",
+        )
+        .fetch_one(pool)
+        .await
+        .expect("inspect reset lock wait");
+        if waiting > 0 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("reset never reached the locked entry scan");
+}
+
+async fn wait_for_concurrent_enqueue_lock(pool: &PgPool) {
+    for _ in 0..200 {
+        let waiting = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*)::BIGINT
+             FROM pg_stat_activity
+             WHERE datname = current_database()
+               AND wait_event_type = 'Lock'
+               AND (
+                   query LIKE '%pg_advisory_xact_lock%'
+                   OR query LIKE '%thread_group_count%'
+               )",
+        )
+        .fetch_one(pool)
+        .await
+        .expect("inspect enqueue lock wait");
+        if waiting > 0 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("enqueue never overlapped the blocked reset");
+}
+
 #[tokio::test]
 async fn reset_run_scope_preserves_same_agent_other_repo_run_pg() {
     let (pg_db, pool) = reset_test_db().await;
@@ -174,19 +306,33 @@ async fn reset_run_scope_preserves_same_agent_other_repo_run_pg() {
         "agent-reset",
         "active",
         "pending",
-        false,
+        true,
     )
     .await;
-    let untouched = seed_reset_run(
+    let same_repo_untouched = seed_reset_run(
         &pool,
         "scope-b",
+        "repo-reset-a",
+        "agent-reset",
+        "active",
+        "pending",
+        true,
+    )
+    .await;
+    let other_repo_untouched = seed_reset_run(
+        &pool,
+        "scope-c",
         "repo-reset-b",
         "agent-reset",
         "active",
         "pending",
-        false,
+        true,
     )
     .await;
+    let same_repo_before = scoped_live_counts(&pool, &same_repo_untouched.run_id).await;
+    let other_repo_before = scoped_live_counts(&pool, &other_repo_untouched.run_id).await;
+    assert_eq!(same_repo_before, (1, 1, 1, 1, 1));
+    assert_eq!(other_repo_before, (1, 1, 1, 1, 1));
     let app = reset_test_app(pool.clone());
 
     let (status, body) = post_reset(
@@ -201,20 +347,15 @@ async fn reset_run_scope_preserves_same_agent_other_repo_run_pg() {
     assert_eq!(status, StatusCode::OK, "reset response: {body}");
     assert_eq!(body["cancelled_runs"], 1);
 
-    let untouched_state = sqlx::query_as::<_, (String, String)>(
-        "SELECT r.status, e.status
-         FROM auto_queue_runs r
-         JOIN auto_queue_entries e ON e.run_id = r.id
-         WHERE r.id = $1",
-    )
-    .bind(&untouched.run_id)
-    .fetch_one(&pool)
-    .await
-    .expect("load untouched run");
+    let same_repo_after = scoped_live_counts(&pool, &same_repo_untouched.run_id).await;
+    let other_repo_after = scoped_live_counts(&pool, &other_repo_untouched.run_id).await;
     assert_eq!(
-        untouched_state,
-        ("active".to_string(), "pending".to_string()),
-        "same-agent run in another repo must be untouched"
+        same_repo_after, same_repo_before,
+        "same-repo sibling run and all live cleanup records must be untouched"
+    );
+    assert_eq!(
+        other_repo_after, other_repo_before,
+        "same-agent run in another repo and all live cleanup records must be untouched"
     );
     let target_status: String =
         sqlx::query_scalar("SELECT status FROM auto_queue_runs WHERE id = $1")
@@ -223,6 +364,95 @@ async fn reset_run_scope_preserves_same_agent_other_repo_run_pg() {
             .await
             .expect("load target status");
     assert_eq!(target_status, "cancelled");
+
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn reset_multi_repo_run_without_dashboard_repo_claim_pg() {
+    let (pg_db, pool) = reset_test_db().await;
+    let target = seed_reset_run(
+        &pool,
+        "multi-repo",
+        "repo-reset-a",
+        "agent-reset",
+        "active",
+        "pending",
+        false,
+    )
+    .await;
+    seed_additional_entry(
+        &pool,
+        &target.run_id,
+        "multi-repo-b",
+        "repo-reset-b",
+        "agent-reset",
+        "pending",
+    )
+    .await;
+    let app = reset_test_app(pool.clone());
+
+    let (status, body) = post_reset(
+        &app,
+        json!({
+            "run_id": target.run_id.as_str(),
+            "agent_id": "agent-reset"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "multi-repo reset: {body}");
+    assert_eq!(body["cancelled_runs"], 1);
+    assert_eq!(body["cancelled_entries"], 2);
+
+    let states = sqlx::query_as::<_, (String, String)>(
+        "SELECT r.status, e.status
+         FROM auto_queue_runs r
+         JOIN auto_queue_entries e ON e.run_id = r.id
+         WHERE r.id = $1
+         ORDER BY e.id",
+    )
+    .bind(&target.run_id)
+    .fetch_all(&pool)
+    .await
+    .expect("load multi-repo reset state");
+    assert_eq!(
+        states,
+        vec![
+            ("cancelled".to_string(), "skipped".to_string()),
+            ("cancelled".to_string(), "skipped".to_string()),
+        ]
+    );
+
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn reset_then_status_returns_cancelled_run_with_skipped_entries_pg() {
+    let (pg_db, pool) = reset_test_db().await;
+    let target = seed_reset_run(
+        &pool,
+        "status-poll",
+        "repo-reset",
+        "agent-reset",
+        "active",
+        "pending",
+        false,
+    )
+    .await;
+    let app = reset_test_app(pool.clone());
+
+    let (reset_status, reset_body) =
+        post_reset(&app, json!({ "run_id": target.run_id.as_str() })).await;
+    assert_eq!(reset_status, StatusCode::OK, "reset response: {reset_body}");
+
+    let (status, body) = get_status(&app, "").await;
+    assert_eq!(status, StatusCode::OK, "status response: {body}");
+    assert_eq!(body["run"]["id"], target.run_id);
+    assert_eq!(body["run"]["status"], "cancelled");
+    assert_eq!(body["entries"].as_array().map(Vec::len), Some(1));
+    assert_eq!(body["entries"][0]["status"], "skipped");
 
     pool.close().await;
     pg_db.drop().await;
@@ -434,6 +664,112 @@ async fn reset_canonical_cleanup_summarizes_dispatch_gate_slot_and_entry_transit
             "skipped".to_string(),
             "run_cancel".to_string()
         )
+    );
+
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn reset_serializes_concurrent_entry_enqueue_and_rejects_terminal_run_pg() {
+    let (pg_db, pool) = reset_test_db().await;
+    let target = seed_reset_run(
+        &pool,
+        "enqueue-race",
+        "repo-reset",
+        "agent-reset",
+        "active",
+        "pending",
+        false,
+    )
+    .await;
+    let late_card_id = "card-reset-late-enqueue".to_string();
+    sqlx::query(
+        "INSERT INTO kanban_cards (id, repo_id, title, status)
+         VALUES ($1, 'repo-reset', 'Late reset card', 'ready')",
+    )
+    .bind(&late_card_id)
+    .execute(&pool)
+    .await
+    .expect("seed late enqueue card");
+
+    let mut blocker = pool.begin().await.expect("begin entry blocker");
+    sqlx::query("SELECT id FROM auto_queue_entries WHERE id = $1 FOR UPDATE")
+        .bind(&target.entry_id)
+        .fetch_one(&mut *blocker)
+        .await
+        .expect("lock existing reset entry");
+
+    let cancel_pool = pool.clone();
+    let cancel_run_id = target.run_id.clone();
+    let cancel_task = tokio::spawn(async move {
+        crate::services::auto_queue::cancel_run::cancel_selected_runs_with_pg(
+            None,
+            &cancel_pool,
+            &[cancel_run_id],
+            "reset_enqueue_race_test",
+        )
+        .await
+    });
+    wait_for_reset_entry_scan_lock(&pool).await;
+
+    let enqueue_pool = pool.clone();
+    let enqueue_run_id = target.run_id.clone();
+    let enqueue_task = tokio::spawn(async move {
+        let issue_number = 4880_i64;
+        let mut cards_by_issue = HashMap::new();
+        cards_by_issue.insert(
+            issue_number,
+            super::ResolvedDispatchCard {
+                issue_number,
+                card_id: late_card_id,
+                repo_id: Some("repo-reset".to_string()),
+                status: "ready".to_string(),
+                assigned_agent_id: Some("agent-reset".to_string()),
+            },
+        );
+        super::dispatch_command::enqueue_entries_into_existing_run_with_pg(
+            &enqueue_pool,
+            &enqueue_run_id,
+            &[super::GenerateEntryBody {
+                issue_number,
+                batch_phase: Some(0),
+                thread_group: Some(0),
+                phase_gate_kind: None,
+            }],
+            &cards_by_issue,
+        )
+        .await
+    });
+    wait_for_concurrent_enqueue_lock(&pool).await;
+    blocker.commit().await.expect("release existing entry");
+
+    let summary = cancel_task
+        .await
+        .expect("join reset task")
+        .expect("reset target run");
+    let enqueue_result = enqueue_task.await.expect("join enqueue task");
+    assert!(
+        enqueue_result.is_err(),
+        "entry enqueue must reject the terminal run: {enqueue_result:?}"
+    );
+    assert_eq!(summary["cancelled_entries"], 1);
+
+    let states = sqlx::query_as::<_, (String, String)>(
+        "SELECT r.status, e.status
+         FROM auto_queue_runs r
+         JOIN auto_queue_entries e ON e.run_id = r.id
+         WHERE r.id = $1
+         ORDER BY e.id",
+    )
+    .bind(&target.run_id)
+    .fetch_all(&pool)
+    .await
+    .expect("load reset/enqueue race state");
+    assert_eq!(
+        states,
+        vec![("cancelled".to_string(), "skipped".to_string())],
+        "reset must not leave a pending entry orphan"
     );
 
     pool.close().await;

--- a/src/services/auto_queue/auto_queue_reset_pg_tests.rs
+++ b/src/services/auto_queue/auto_queue_reset_pg_tests.rs
@@ -459,11 +459,11 @@ async fn reset_then_status_returns_cancelled_run_with_skipped_entries_pg() {
 }
 
 #[tokio::test]
-async fn reset_repo_and_agent_ownership_mismatch_returns_conflict_pg() {
+async fn reset_repo_and_agent_scope_mismatch_returns_conflict_pg() {
     let (pg_db, pool) = reset_test_db().await;
     let target = seed_reset_run(
         &pool,
-        "ownership",
+        "scope-mismatch",
         "repo-reset-a",
         "agent-reset",
         "active",
@@ -507,8 +507,8 @@ async fn reset_repo_and_agent_ownership_mismatch_returns_conflict_pg() {
         .bind(&target.run_id)
         .fetch_one(&pool)
         .await
-        .expect("load ownership target status");
-    assert_eq!(run_status, "active", "ownership rejection must not mutate");
+        .expect("load scope-mismatch target status");
+    assert_eq!(run_status, "active", "scope rejection must not mutate");
 
     pool.close().await;
     pg_db.drop().await;

--- a/src/services/auto_queue/auto_queue_reset_pg_tests.rs
+++ b/src/services/auto_queue/auto_queue_reset_pg_tests.rs
@@ -1,0 +1,441 @@
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Method, Request, StatusCode, header},
+    routing::post,
+};
+use serde_json::{Value, json};
+use sqlx::PgPool;
+use std::{path::PathBuf, sync::Arc};
+use tower::ServiceExt;
+
+struct ResetFixture {
+    run_id: String,
+    entry_id: String,
+    dispatch_id: String,
+}
+
+async fn seed_reset_run(
+    pool: &PgPool,
+    suffix: &str,
+    repo: &str,
+    agent_id: &str,
+    run_status: &str,
+    entry_status: &str,
+    with_live_cleanup: bool,
+) -> ResetFixture {
+    let run_id = format!("run-reset-{suffix}");
+    let entry_id = format!("entry-reset-{suffix}");
+    let dispatch_id = format!("dispatch-reset-{suffix}");
+    let card_id = format!("card-reset-{suffix}");
+
+    sqlx::query(
+        "INSERT INTO auto_queue_runs (id, repo, agent_id, status)
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind(&run_id)
+    .bind(repo)
+    .bind(agent_id)
+    .bind(run_status)
+    .execute(pool)
+    .await
+    .expect("seed reset run");
+    sqlx::query(
+        "INSERT INTO kanban_cards (id, repo_id, title, status)
+         VALUES ($1, $2, 'Reset card', 'in_progress')",
+    )
+    .bind(&card_id)
+    .bind(repo)
+    .execute(pool)
+    .await
+    .expect("seed reset card");
+
+    if with_live_cleanup {
+        sqlx::query(
+            "INSERT INTO task_dispatches
+                (id, kanban_card_id, to_agent_id, dispatch_type, status, title)
+             VALUES ($1, $2, $3, 'implementation', 'dispatched', 'Reset dispatch')",
+        )
+        .bind(&dispatch_id)
+        .bind(&card_id)
+        .bind(agent_id)
+        .execute(pool)
+        .await
+        .expect("seed reset dispatch");
+    }
+
+    let dispatch = if with_live_cleanup {
+        dispatch_id.as_str()
+    } else {
+        ""
+    };
+    let slot_index = if with_live_cleanup { 0_i64 } else { -1_i64 };
+    sqlx::query(
+        "INSERT INTO auto_queue_entries
+            (id, run_id, kanban_card_id, agent_id, status, dispatch_id, slot_index)
+         VALUES ($1, $2, $3, $4, $5, NULLIF($6, ''), NULLIF($7, -1))",
+    )
+    .bind(&entry_id)
+    .bind(&run_id)
+    .bind(&card_id)
+    .bind(agent_id)
+    .bind(entry_status)
+    .bind(dispatch)
+    .bind(slot_index)
+    .execute(pool)
+    .await
+    .expect("seed reset entry");
+
+    if with_live_cleanup {
+        sqlx::query(
+            "INSERT INTO auto_queue_slots
+                (agent_id, slot_index, assigned_run_id, assigned_thread_group)
+             VALUES ($1, 0, $2, 0)",
+        )
+        .bind(agent_id)
+        .bind(&run_id)
+        .execute(pool)
+        .await
+        .expect("seed reset slot");
+        sqlx::query(
+            "INSERT INTO auto_queue_phase_gates
+                (run_id, phase, status, dispatch_id)
+             VALUES ($1, 0, 'pending', NULLIF($2, ''))",
+        )
+        .bind(&run_id)
+        .bind(dispatch)
+        .execute(pool)
+        .await
+        .expect("seed reset phase gate");
+    }
+
+    ResetFixture {
+        run_id,
+        entry_id,
+        dispatch_id,
+    }
+}
+
+async fn reset_test_db() -> (crate::db::auto_queue::test_support::TestPostgresDb, PgPool) {
+    let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+    let pool = pg_db.connect_and_migrate().await;
+    (pg_db, pool)
+}
+
+fn reset_test_app(pool: PgPool) -> Router {
+    let mut config = crate::config::Config::default();
+    config.server.host = "127.0.0.1".to_string();
+    config.policies.dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");
+    let engine = crate::engine::PolicyEngine::new_with_pg(&config, Some(pool.clone()))
+        .expect("create reset test policy engine");
+    let broadcast_tx = crate::server::ws::new_broadcast();
+    let batch_buffer = crate::server::ws::spawn_batch_flusher(broadcast_tx.clone());
+    let state = crate::app_state::AppState {
+        pg_pool: Some(pool),
+        engine,
+        config: Arc::new(config),
+        broadcast_tx,
+        batch_buffer,
+        health_registry: None,
+        cluster_instance_id: None,
+    };
+    Router::new()
+        .route("/queue/reset", post(super::reset))
+        .with_state(state)
+}
+
+async fn post_reset(app: &Router, body: Value) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/queue/reset")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("build reset request");
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("send reset request");
+    let status = response.status();
+    let body = to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .expect("read reset response");
+    let body = serde_json::from_slice(&body).expect("decode reset response");
+    (status, body)
+}
+
+#[tokio::test]
+async fn reset_run_scope_preserves_same_agent_other_repo_run_pg() {
+    let (pg_db, pool) = reset_test_db().await;
+    let target = seed_reset_run(
+        &pool,
+        "scope-a",
+        "repo-reset-a",
+        "agent-reset",
+        "active",
+        "pending",
+        false,
+    )
+    .await;
+    let untouched = seed_reset_run(
+        &pool,
+        "scope-b",
+        "repo-reset-b",
+        "agent-reset",
+        "active",
+        "pending",
+        false,
+    )
+    .await;
+    let app = reset_test_app(pool.clone());
+
+    let (status, body) = post_reset(
+        &app,
+        json!({
+            "run_id": target.run_id.as_str(),
+            "repo": "repo-reset-a",
+            "agent_id": "agent-reset"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "reset response: {body}");
+    assert_eq!(body["cancelled_runs"], 1);
+
+    let untouched_state = sqlx::query_as::<_, (String, String)>(
+        "SELECT r.status, e.status
+         FROM auto_queue_runs r
+         JOIN auto_queue_entries e ON e.run_id = r.id
+         WHERE r.id = $1",
+    )
+    .bind(&untouched.run_id)
+    .fetch_one(&pool)
+    .await
+    .expect("load untouched run");
+    assert_eq!(
+        untouched_state,
+        ("active".to_string(), "pending".to_string()),
+        "same-agent run in another repo must be untouched"
+    );
+    let target_status: String =
+        sqlx::query_scalar("SELECT status FROM auto_queue_runs WHERE id = $1")
+            .bind(&target.run_id)
+            .fetch_one(&pool)
+            .await
+            .expect("load target status");
+    assert_eq!(target_status, "cancelled");
+
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn reset_repo_and_agent_ownership_mismatch_returns_conflict_pg() {
+    let (pg_db, pool) = reset_test_db().await;
+    let target = seed_reset_run(
+        &pool,
+        "ownership",
+        "repo-reset-a",
+        "agent-reset",
+        "active",
+        "pending",
+        false,
+    )
+    .await;
+    let app = reset_test_app(pool.clone());
+
+    let (repo_status, repo_body) = post_reset(
+        &app,
+        json!({
+            "run_id": target.run_id.as_str(),
+            "repo": "repo-reset-other",
+            "agent_id": "agent-reset"
+        }),
+    )
+    .await;
+    assert_eq!(
+        repo_status,
+        StatusCode::CONFLICT,
+        "repo mismatch: {repo_body}"
+    );
+
+    let (agent_status, agent_body) = post_reset(
+        &app,
+        json!({
+            "run_id": target.run_id.as_str(),
+            "repo": "repo-reset-a",
+            "agent_id": "agent-reset-other"
+        }),
+    )
+    .await;
+    assert_eq!(
+        agent_status,
+        StatusCode::CONFLICT,
+        "agent mismatch: {agent_body}"
+    );
+
+    let run_status: String = sqlx::query_scalar("SELECT status FROM auto_queue_runs WHERE id = $1")
+        .bind(&target.run_id)
+        .fetch_one(&pool)
+        .await
+        .expect("load ownership target status");
+    assert_eq!(run_status, "active", "ownership rejection must not mutate");
+
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn reset_unknown_missing_and_terminal_run_contracts_are_pg() {
+    let (pg_db, pool) = reset_test_db().await;
+    let terminal = seed_reset_run(
+        &pool,
+        "terminal",
+        "repo-reset",
+        "agent-reset",
+        "completed",
+        "skipped",
+        false,
+    )
+    .await;
+    let app = reset_test_app(pool.clone());
+
+    let (unknown_status, unknown_body) = post_reset(
+        &app,
+        json!({
+            "run_id": "run-unknown-field",
+            "unexpected": true
+        }),
+    )
+    .await;
+    assert_eq!(
+        unknown_status,
+        StatusCode::BAD_REQUEST,
+        "unknown field: {unknown_body}"
+    );
+
+    let (missing_status, missing_body) =
+        post_reset(&app, json!({ "run_id": "run-does-not-exist" })).await;
+    assert_eq!(
+        missing_status,
+        StatusCode::NOT_FOUND,
+        "missing run: {missing_body}"
+    );
+
+    let (terminal_status, terminal_body) = post_reset(
+        &app,
+        json!({
+            "run_id": terminal.run_id.as_str(),
+            "repo": "repo-reset",
+            "agent_id": "agent-reset"
+        }),
+    )
+    .await;
+    assert_eq!(
+        terminal_status,
+        StatusCode::CONFLICT,
+        "terminal run: {terminal_body}"
+    );
+
+    for (suffix, status) in [("generated", "generated"), ("pending", "pending")] {
+        let run = seed_reset_run(
+            &pool,
+            suffix,
+            &format!("repo-reset-{suffix}"),
+            &format!("agent-reset-{suffix}"),
+            status,
+            "pending",
+            false,
+        )
+        .await;
+        let (status, body) = post_reset(&app, json!({ "run_id": run.run_id.as_str() })).await;
+        assert_eq!(status, StatusCode::OK, "cancel {suffix}: {body}");
+        assert_eq!(body["cancelled_runs"], 1);
+        assert_eq!(body["cancelled_entries"], 1);
+        let state = sqlx::query_as::<_, (String, String)>(
+            "SELECT r.status, e.status
+             FROM auto_queue_runs r JOIN auto_queue_entries e ON e.run_id = r.id
+             WHERE r.id = $1",
+        )
+        .bind(&run.run_id)
+        .fetch_one(&pool)
+        .await
+        .expect("load generated/pending reset state");
+        assert_eq!(state, ("cancelled".to_string(), "skipped".to_string()));
+    }
+
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn reset_canonical_cleanup_summarizes_dispatch_gate_slot_and_entry_transition_pg() {
+    let (pg_db, pool) = reset_test_db().await;
+    let target = seed_reset_run(
+        &pool,
+        "cleanup",
+        "repo-reset",
+        "agent-reset",
+        "active",
+        "dispatched",
+        true,
+    )
+    .await;
+    let app = reset_test_app(pool.clone());
+
+    let (status, body) = post_reset(&app, json!({ "run_id": target.run_id.as_str() })).await;
+    assert_eq!(status, StatusCode::OK, "cleanup response: {body}");
+    assert_eq!(body["cancelled_dispatches"], 1);
+    assert_eq!(body["deleted_phase_gates"], 1);
+    assert_eq!(body["released_slots"], 1);
+    assert_eq!(body["cancelled_entries"], 1);
+    assert_eq!(body["entry_transition_summary"]["pending_to_skipped"], 1);
+
+    let state = sqlx::query_as::<_, (String, String, String, Option<String>, Option<String>, i64)>(
+        "SELECT r.status, e.status, d.status, e.dispatch_id, s.assigned_run_id,
+                (SELECT COUNT(*) FROM auto_queue_phase_gates WHERE run_id = $1)
+         FROM auto_queue_runs r
+         JOIN auto_queue_entries e ON e.id = $2
+         JOIN task_dispatches d ON d.id = $3
+         JOIN auto_queue_slots s ON s.agent_id = 'agent-reset' AND s.slot_index = 0
+         WHERE r.id = $1",
+    )
+    .bind(&target.run_id)
+    .bind(&target.entry_id)
+    .bind(&target.dispatch_id)
+    .fetch_one(&pool)
+    .await
+    .expect("load canonical reset state");
+    assert_eq!(
+        state,
+        (
+            "cancelled".to_string(),
+            "skipped".to_string(),
+            "cancelled".to_string(),
+            None,
+            None,
+            0,
+        )
+    );
+    let transition = sqlx::query_as::<_, (String, String, String)>(
+        "SELECT from_status, to_status, trigger_source
+         FROM auto_queue_entry_transitions
+         WHERE entry_id = $1
+         ORDER BY id DESC
+         LIMIT 1",
+    )
+    .bind(&target.entry_id)
+    .fetch_one(&pool)
+    .await
+    .expect("load reset entry transition");
+    assert_eq!(
+        transition,
+        (
+            "pending".to_string(),
+            "skipped".to_string(),
+            "run_cancel".to_string()
+        )
+    );
+
+    pool.close().await;
+    pg_db.drop().await;
+}

--- a/src/services/auto_queue/cancel_run.rs
+++ b/src/services/auto_queue/cancel_run.rs
@@ -883,6 +883,9 @@ pub(crate) async fn cancel_selected_runs_with_pg(
         .await
         .map_err(|error| format!("begin postgres run cancel transaction: {error}"))?;
 
+    // hashtext is a 32-bit key: unrelated run ids can collide and wait on one
+    // another, but that only over-serializes cancellation/enqueue operations;
+    // it does not weaken the per-run exclusion guarantee.
     let locked_run_ids = sqlx::query_scalar::<_, String>(
         "WITH target_runs AS (
              SELECT id

--- a/src/services/auto_queue/cancel_run.rs
+++ b/src/services/auto_queue/cancel_run.rs
@@ -888,9 +888,14 @@ pub(crate) async fn cancel_selected_runs_with_pg(
     // removes them. But it is not free: this statement locks several runs, and
     // `ORDER BY id ASC` orders by run id, not by lock key. Two cancellations
     // over different run sets can therefore acquire the *same* two hash keys in
-    // opposite order and deadlock; PostgreSQL aborts one of them. Reproduced on
-    // PG17 with the colliding pairs 248961/52834 and 32829/293472. Callers must
-    // treat a cancellation abort as retryable rather than as a lost run.
+    // opposite order and deadlock; PostgreSQL aborts one of them with 40P01.
+    // Reproduced on PG17.9 by interleaving the colliding pairs 202051/509634
+    // and 111418/403214 (values verified against this expression, not against
+    // hashtext of the bare id).
+    //
+    // No caller retries: every path converts the error and returns it, up to
+    // the HTTP handler, so an aborted cancellation surfaces as a failed request
+    // and the run stays live until someone re-issues it.
     let locked_run_ids = sqlx::query_scalar::<_, String>(
         "WITH target_runs AS (
              SELECT id

--- a/src/services/auto_queue/cancel_run.rs
+++ b/src/services/auto_queue/cancel_run.rs
@@ -883,9 +883,14 @@ pub(crate) async fn cancel_selected_runs_with_pg(
         .await
         .map_err(|error| format!("begin postgres run cancel transaction: {error}"))?;
 
-    // hashtext is a 32-bit key: unrelated run ids can collide and wait on one
-    // another, but that only over-serializes cancellation/enqueue operations;
-    // it does not weaken the per-run exclusion guarantee.
+    // hashtext is a 32-bit key, so unrelated run ids can collide onto one lock.
+    // Per-run exclusion still holds — a collision only ever adds waiters, never
+    // removes them. But it is not free: this statement locks several runs, and
+    // `ORDER BY id ASC` orders by run id, not by lock key. Two cancellations
+    // over different run sets can therefore acquire the *same* two hash keys in
+    // opposite order and deadlock; PostgreSQL aborts one of them. Reproduced on
+    // PG17 with the colliding pairs 248961/52834 and 32829/293472. Callers must
+    // treat a cancellation abort as retryable rather than as a lost run.
     let locked_run_ids = sqlx::query_scalar::<_, String>(
         "WITH target_runs AS (
              SELECT id

--- a/src/services/auto_queue/cancel_run.rs
+++ b/src/services/auto_queue/cancel_run.rs
@@ -30,7 +30,7 @@ impl AutoQueueService {
         })?;
 
         match run_status.flatten() {
-            Some(status) if is_live_run_status(&status) => cancel_selected_runs_with_pg(
+            Some(status) if is_resettable_run_status(&status) => cancel_selected_runs_with_pg(
                 health_registry,
                 pool,
                 &[run_id.to_string()],
@@ -43,7 +43,7 @@ impl AutoQueueService {
                     .with_context("run_id", run_id)
                     .with_operation("auto_queue.cancel_run_with_pg.cancel_selected_runs_with_pg")
             }),
-            Some(status) => Err(ServiceError::bad_request(format!(
+            Some(status) => Err(ServiceError::conflict(format!(
                 "auto-queue run '{run_id}' is not cancelable (status={status})"
             ))
             .with_code(ErrorCode::AutoQueue)
@@ -70,6 +70,13 @@ impl AutoQueueService {
                     .with_operation("auto_queue.cancel_runs_with_pg.cancel_with_pg")
             })
     }
+}
+
+/// Reset and explicit single-run cancellation share the same cleanup contract.
+/// Generated and pending runs can still own entries, gates, dispatches, or
+/// slots, so they must not fall through to a no-op terminal path.
+fn is_resettable_run_status(status: &str) -> bool {
+    is_live_run_status(status) || matches!(status.trim(), "generated" | "pending")
 }
 
 #[derive(Debug, Default)]
@@ -956,7 +963,7 @@ pub(crate) async fn cancel_selected_runs_with_pg(
          SET status = 'cancelled',
              completed_at = NOW()
          WHERE id = ANY($1)
-           AND status IN ('active', 'paused', 'restoring')",
+           AND status IN ('generated', 'pending', 'active', 'paused', 'restoring')",
     )
     .bind(&locked_run_ids)
     .execute(&mut *tx)
@@ -978,6 +985,9 @@ pub(crate) async fn cancel_selected_runs_with_pg(
     .map_err(|error| format!("load postgres cancel entries: {error}"))?;
 
     let mut cancelled_entries = 0usize;
+    let mut pending_to_skipped = 0usize;
+    let mut dispatched_to_skipped = 0usize;
+    let mut user_cancelled_to_skipped = 0usize;
     let mut cancel_metas = Vec::new();
     let mut seen_dispatch_ids = HashSet::new();
     for (entry_id, _entry_status, dispatch_id) in entry_rows {
@@ -999,20 +1009,32 @@ pub(crate) async fn cancel_selected_runs_with_pg(
                 .fetch_one(&mut *tx)
                 .await
                 .map_err(|error| format!("reload postgres cancel entry {entry_id}: {error}"))?;
-        if matches!(
+        let transition = if matches!(
             current_status.as_str(),
             "pending" | "dispatched" | "user_cancelled"
         ) {
-            crate::db::auto_queue::update_entry_status_on_pg_tx(
-                &mut tx,
-                &entry_id,
-                crate::db::auto_queue::ENTRY_STATUS_SKIPPED,
-                "run_cancel",
-                &crate::db::auto_queue::EntryStatusUpdateOptions::default(),
+            Some(
+                crate::db::auto_queue::update_entry_status_on_pg_tx(
+                    &mut tx,
+                    &entry_id,
+                    crate::db::auto_queue::ENTRY_STATUS_SKIPPED,
+                    "run_cancel",
+                    &crate::db::auto_queue::EntryStatusUpdateOptions::default(),
+                )
+                .await?,
             )
-            .await?;
+        } else {
+            None
+        };
+        if let Some(transition) = transition.filter(|transition| transition.changed) {
+            cancelled_entries += 1;
+            match transition.from_status.as_str() {
+                "pending" => pending_to_skipped += 1,
+                "dispatched" => dispatched_to_skipped += 1,
+                "user_cancelled" => user_cancelled_to_skipped += 1,
+                _ => {}
+            }
         }
-        cancelled_entries += 1;
     }
 
     for dispatch_id in &live_dispatch_ids {
@@ -1122,6 +1144,13 @@ pub(crate) async fn cancel_selected_runs_with_pg(
         "remaining_live_dispatches": remaining_live_dispatches,
         "released_slots": cleanup.slot_cleanup.released_slots,
         "cleared_slot_sessions": cleanup.slot_cleanup.cleared_slot_sessions,
+        "entry_transition_summary": {
+            "total": cancelled_entries,
+            "skipped": cancelled_entries,
+            "pending_to_skipped": pending_to_skipped,
+            "dispatched_to_skipped": dispatched_to_skipped,
+            "user_cancelled_to_skipped": user_cancelled_to_skipped,
+        },
     });
     if let Some(warning) = slot_cleanup_warning(&cleanup.slot_cleanup.warnings) {
         response["warning"] = json!(warning);

--- a/src/services/auto_queue/command.rs
+++ b/src/services/auto_queue/command.rs
@@ -98,9 +98,9 @@ pub(super) async fn reset_scoped_with_pg(
                 .map(str::trim)
                 .is_some_and(|run_repo| !run_repo.is_empty())
             {
-                return Err(reset_ownership_conflict(
+                return Err(reset_scope_conflict(
                     run_id,
-                    "repo does not own the requested run",
+                    "repo constraint does not match the requested run",
                 ));
             }
             let mismatched_entries = sqlx::query_scalar::<_, i64>(
@@ -116,16 +116,16 @@ pub(super) async fn reset_scoped_with_pg(
             .await
             .map_err(|error| {
                 AppError::internal(format!(
-                    "check auto-queue run '{run_id}' repo ownership: {error}"
+                    "check auto-queue run '{run_id}' repo constraint: {error}"
                 ))
                 .with_code(ErrorCode::Database)
                 .with_context("run_id", run_id)
-                .with_operation("auto_queue.reset.check_repo_ownership")
+                .with_operation("auto_queue.reset.check_repo_constraint")
             })?;
             if mismatched_entries == 0 {
-                return Err(reset_ownership_conflict(
+                return Err(reset_scope_conflict(
                     run_id,
-                    "repo does not own the requested run",
+                    "repo constraint does not match the requested run",
                 ));
             }
         }
@@ -144,16 +144,16 @@ pub(super) async fn reset_scoped_with_pg(
         .await
         .map_err(|error| {
             AppError::internal(format!(
-                "check auto-queue entry repo ownership for '{run_id}': {error}"
+                "check auto-queue entry repo constraint for '{run_id}': {error}"
             ))
             .with_code(ErrorCode::Database)
             .with_context("run_id", run_id)
-            .with_operation("auto_queue.reset.check_entry_repo_ownership")
+            .with_operation("auto_queue.reset.check_entry_repo_constraint")
         })?;
         if foreign_repo_entries > 0 {
-            return Err(reset_ownership_conflict(
+            return Err(reset_scope_conflict(
                 run_id,
-                "repo does not own every entry in the requested run",
+                "repo constraint does not match every entry in the requested run",
             ));
         }
     }
@@ -165,9 +165,9 @@ pub(super) async fn reset_scoped_with_pg(
                 .map(str::trim)
                 .is_some_and(|run_agent| !run_agent.is_empty())
             {
-                return Err(reset_ownership_conflict(
+                return Err(reset_scope_conflict(
                     run_id,
-                    "agent_id does not own the requested run",
+                    "agent_id constraint does not match the requested run",
                 ));
             }
             let matching_entries = sqlx::query_scalar::<_, i64>(
@@ -182,16 +182,16 @@ pub(super) async fn reset_scoped_with_pg(
             .await
             .map_err(|error| {
                 AppError::internal(format!(
-                    "check auto-queue run '{run_id}' agent ownership: {error}"
+                    "check auto-queue run '{run_id}' agent constraint: {error}"
                 ))
                 .with_code(ErrorCode::Database)
                 .with_context("run_id", run_id)
-                .with_operation("auto_queue.reset.check_agent_ownership")
+                .with_operation("auto_queue.reset.check_agent_constraint")
             })?;
             if matching_entries == 0 {
-                return Err(reset_ownership_conflict(
+                return Err(reset_scope_conflict(
                     run_id,
-                    "agent_id does not own the requested run",
+                    "agent_id constraint does not match the requested run",
                 ));
             }
         }
@@ -209,16 +209,16 @@ pub(super) async fn reset_scoped_with_pg(
         .await
         .map_err(|error| {
             AppError::internal(format!(
-                "check auto-queue entry agent ownership for '{run_id}': {error}"
+                "check auto-queue entry agent constraint for '{run_id}': {error}"
             ))
             .with_code(ErrorCode::Database)
             .with_context("run_id", run_id)
-            .with_operation("auto_queue.reset.check_entry_agent_ownership")
+            .with_operation("auto_queue.reset.check_entry_agent_constraint")
         })?;
         if foreign_agent_entries > 0 {
-            return Err(reset_ownership_conflict(
+            return Err(reset_scope_conflict(
                 run_id,
-                "agent_id does not own every entry in the requested run",
+                "agent_id constraint does not match every entry in the requested run",
             ));
         }
     }
@@ -238,9 +238,9 @@ pub(super) async fn reset_scoped_with_pg(
     })
 }
 
-fn reset_ownership_conflict(run_id: &str, reason: &str) -> AppError {
+fn reset_scope_conflict(run_id: &str, reason: &str) -> AppError {
     AppError::conflict(format!(
-        "auto-queue reset ownership mismatch for run '{run_id}': {reason}"
+        "auto-queue reset scope constraint mismatch for run '{run_id}': {reason}"
     ))
     .with_code(ErrorCode::AutoQueue)
     .with_context("run_id", run_id)

--- a/src/services/auto_queue/command.rs
+++ b/src/services/auto_queue/command.rs
@@ -16,33 +16,234 @@ pub(super) async fn cancel_selected_runs_with_pg(
 }
 
 pub(super) async fn reset_scoped_with_pg(
-    agent_id: &str,
+    health_registry: Option<Arc<crate::services::discord::health::HealthRegistry>>,
+    body: &ResetBody,
     pool: &sqlx::PgPool,
-) -> Result<serde_json::Value, String> {
-    let deleted_entries = sqlx::query("DELETE FROM auto_queue_entries WHERE agent_id = $1")
-        .bind(agent_id)
-        .execute(pool)
-        .await
-        .map_err(|error| format!("delete auto_queue_entries for agent {agent_id}: {error}"))?
-        .rows_affected() as usize;
-    let completed_runs = sqlx::query(
-        "UPDATE auto_queue_runs
-             SET status = 'completed',
-                 completed_at = NOW()
-             WHERE status IN ('generated', 'pending', 'active', 'paused')
-               AND agent_id = $1",
+) -> Result<serde_json::Value, AppError> {
+    let run_id = body.run_id.trim();
+    if run_id.is_empty() {
+        return Err(
+            AppError::bad_request("run_id is required for reset").with_code(ErrorCode::AutoQueue)
+        );
+    }
+
+    let run = sqlx::query(
+        "SELECT repo, agent_id, status
+         FROM auto_queue_runs
+         WHERE id = $1",
     )
-    .bind(agent_id)
-    .execute(pool)
+    .bind(run_id)
+    .fetch_optional(pool)
     .await
-    .map_err(|error| format!("complete auto_queue_runs for agent {agent_id}: {error}"))?
-    .rows_affected() as usize;
-    Ok(json!({
-        "ok": true,
-        "deleted_entries": deleted_entries,
-        "completed_runs": completed_runs,
-        "protected_active_runs": 0usize,
-    }))
+    .map_err(|error| {
+        AppError::internal(format!("load auto-queue run '{run_id}': {error}"))
+            .with_code(ErrorCode::Database)
+            .with_context("run_id", run_id)
+            .with_operation("auto_queue.reset.load_run")
+    })?
+    .ok_or_else(|| {
+        AppError::not_found(format!("auto-queue run '{run_id}' not found"))
+            .with_code(ErrorCode::AutoQueue)
+            .with_context("run_id", run_id)
+    })?;
+
+    let run_repo: Option<String> = run.try_get("repo").map_err(|error| {
+        AppError::internal(format!("decode auto-queue run '{run_id}' repo: {error}"))
+            .with_code(ErrorCode::Database)
+            .with_context("run_id", run_id)
+            .with_operation("auto_queue.reset.decode_run_repo")
+    })?;
+    let run_agent_id: Option<String> = run.try_get("agent_id").map_err(|error| {
+        AppError::internal(format!(
+            "decode auto-queue run '{run_id}' agent_id: {error}"
+        ))
+        .with_code(ErrorCode::Database)
+        .with_context("run_id", run_id)
+        .with_operation("auto_queue.reset.decode_run_agent")
+    })?;
+    let run_status: String = run.try_get("status").map_err(|error| {
+        AppError::internal(format!("decode auto-queue run '{run_id}' status: {error}"))
+            .with_code(ErrorCode::Database)
+            .with_context("run_id", run_id)
+            .with_operation("auto_queue.reset.decode_run_status")
+    })?;
+
+    if !matches!(
+        run_status.as_str(),
+        "generated" | "pending" | "active" | "paused" | "restoring"
+    ) {
+        return Err(AppError::conflict(format!(
+            "auto-queue run '{run_id}' is not resettable (status={run_status})"
+        ))
+        .with_code(ErrorCode::AutoQueue)
+        .with_context("run_id", run_id)
+        .with_context("status", run_status));
+    }
+
+    let requested_repo = body
+        .repo
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let requested_agent = body
+        .agent_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    if let Some(requested_repo) = requested_repo {
+        if run_repo.as_deref().map(str::trim) != Some(requested_repo) {
+            if run_repo
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|run_repo| !run_repo.is_empty())
+            {
+                return Err(reset_ownership_conflict(
+                    run_id,
+                    "repo does not own the requested run",
+                ));
+            }
+            let mismatched_entries = sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*)
+                 FROM auto_queue_entries e
+                 JOIN kanban_cards c ON c.id = e.kanban_card_id
+                 WHERE e.run_id = $1
+                   AND c.repo_id = $2",
+            )
+            .bind(run_id)
+            .bind(requested_repo)
+            .fetch_one(pool)
+            .await
+            .map_err(|error| {
+                AppError::internal(format!(
+                    "check auto-queue run '{run_id}' repo ownership: {error}"
+                ))
+                .with_code(ErrorCode::Database)
+                .with_context("run_id", run_id)
+                .with_operation("auto_queue.reset.check_repo_ownership")
+            })?;
+            if mismatched_entries == 0 {
+                return Err(reset_ownership_conflict(
+                    run_id,
+                    "repo does not own the requested run",
+                ));
+            }
+        }
+
+        let foreign_repo_entries = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*)
+             FROM auto_queue_entries e
+             JOIN kanban_cards c ON c.id = e.kanban_card_id
+             WHERE e.run_id = $1
+               AND c.repo_id IS NOT NULL
+               AND c.repo_id <> $2",
+        )
+        .bind(run_id)
+        .bind(requested_repo)
+        .fetch_one(pool)
+        .await
+        .map_err(|error| {
+            AppError::internal(format!(
+                "check auto-queue entry repo ownership for '{run_id}': {error}"
+            ))
+            .with_code(ErrorCode::Database)
+            .with_context("run_id", run_id)
+            .with_operation("auto_queue.reset.check_entry_repo_ownership")
+        })?;
+        if foreign_repo_entries > 0 {
+            return Err(reset_ownership_conflict(
+                run_id,
+                "repo does not own every entry in the requested run",
+            ));
+        }
+    }
+
+    if let Some(requested_agent) = requested_agent {
+        if run_agent_id.as_deref().map(str::trim) != Some(requested_agent) {
+            if run_agent_id
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|run_agent| !run_agent.is_empty())
+            {
+                return Err(reset_ownership_conflict(
+                    run_id,
+                    "agent_id does not own the requested run",
+                ));
+            }
+            let matching_entries = sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*)
+                 FROM auto_queue_entries
+                 WHERE run_id = $1
+                   AND BTRIM(COALESCE(agent_id, '')) = $2",
+            )
+            .bind(run_id)
+            .bind(requested_agent)
+            .fetch_one(pool)
+            .await
+            .map_err(|error| {
+                AppError::internal(format!(
+                    "check auto-queue run '{run_id}' agent ownership: {error}"
+                ))
+                .with_code(ErrorCode::Database)
+                .with_context("run_id", run_id)
+                .with_operation("auto_queue.reset.check_agent_ownership")
+            })?;
+            if matching_entries == 0 {
+                return Err(reset_ownership_conflict(
+                    run_id,
+                    "agent_id does not own the requested run",
+                ));
+            }
+        }
+
+        let foreign_agent_entries = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*)
+             FROM auto_queue_entries
+             WHERE run_id = $1
+               AND BTRIM(COALESCE(agent_id, '')) <> ''
+               AND BTRIM(agent_id) <> $2",
+        )
+        .bind(run_id)
+        .bind(requested_agent)
+        .fetch_one(pool)
+        .await
+        .map_err(|error| {
+            AppError::internal(format!(
+                "check auto-queue entry agent ownership for '{run_id}': {error}"
+            ))
+            .with_code(ErrorCode::Database)
+            .with_context("run_id", run_id)
+            .with_operation("auto_queue.reset.check_entry_agent_ownership")
+        })?;
+        if foreign_agent_entries > 0 {
+            return Err(reset_ownership_conflict(
+                run_id,
+                "agent_id does not own every entry in the requested run",
+            ));
+        }
+    }
+
+    crate::services::auto_queue::cancel_run::cancel_selected_runs_with_pg(
+        health_registry,
+        pool,
+        &[run_id.to_string()],
+        "auto_queue_reset",
+    )
+    .await
+    .map_err(|error| {
+        AppError::internal(format!("reset auto-queue run '{run_id}': {error}"))
+            .with_code(ErrorCode::Database)
+            .with_context("run_id", run_id)
+            .with_operation("auto_queue.reset.cancel_selected_runs_with_pg")
+    })
+}
+
+fn reset_ownership_conflict(run_id: &str, reason: &str) -> AppError {
+    AppError::conflict(format!(
+        "auto-queue reset ownership mismatch for run '{run_id}': {reason}"
+    ))
+    .with_code(ErrorCode::AutoQueue)
+    .with_context("run_id", run_id)
 }
 
 pub(super) async fn reset_global_with_pg(pool: &sqlx::PgPool) -> Result<serde_json::Value, String> {

--- a/src/services/auto_queue/control_routes.rs
+++ b/src/services/auto_queue/control_routes.rs
@@ -101,8 +101,13 @@ pub async fn reset_slot_thread(
 
 /// POST /api/queue/reset
 /// Reset exactly one run selected by `run_id`. Optional repo/agent values are
-/// defensive consistency constraints, not authorization: when supplied they
-/// must match the run and every entry to reduce operator targeting mistakes.
+/// defensive consistency constraints, not authorization — the handler takes no
+/// `RequestPrincipal`, and the only access check is the global one in
+/// `server/routes/auth.rs`. They narrow operator targeting mistakes, and the
+/// narrowing is partial: the repo check joins through cards and compares only
+/// non-null `repo_id`, and the agent check skips empty or null `agent_id`, so
+/// entries missing a card, repo, or agent satisfy either constraint whatever
+/// the caller supplies. `run_id` is what actually bounds the blast radius.
 pub async fn reset(
     State(state): State<AppState>,
     body: Bytes,

--- a/src/services/auto_queue/control_routes.rs
+++ b/src/services/auto_queue/control_routes.rs
@@ -100,7 +100,8 @@ pub async fn reset_slot_thread(
 }
 
 /// POST /api/queue/reset
-/// Reset a single agent queue. Requires `agent_id`.
+/// Reset exactly one run. The optional repo/agent fields are ownership claims,
+/// not selectors: when supplied they must match the run and its entries.
 pub async fn reset(
     State(state): State<AppState>,
     body: Bytes,
@@ -115,30 +116,12 @@ pub async fn reset(
         }
     };
 
-    let agent_id = match body
-        .agent_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        Some(agent_id) => agent_id,
-        None => {
-            return Err(auto_queue_json_error(
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "agent_id is required for reset"})),
-            ));
-        }
-    };
-
     let Some(pool) = state.pg_pool_ref() else {
         return Err(auto_queue_tuple_error(pg_unavailable_response()));
     };
-    match reset_scoped_with_pg(agent_id, pool).await {
+    match reset_scoped_with_pg(state.health_registry.clone(), &body, pool).await {
         Ok(response) => Ok((StatusCode::OK, Json(response))),
-        Err(error) => Err(auto_queue_json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": error})),
-        )),
+        Err(error) => Err(error),
     }
 }
 

--- a/src/services/auto_queue/control_routes.rs
+++ b/src/services/auto_queue/control_routes.rs
@@ -100,8 +100,9 @@ pub async fn reset_slot_thread(
 }
 
 /// POST /api/queue/reset
-/// Reset exactly one run. The optional repo/agent fields are ownership claims,
-/// not selectors: when supplied they must match the run and its entries.
+/// Reset exactly one run selected by `run_id`. Optional repo/agent values are
+/// defensive consistency constraints, not authorization: when supplied they
+/// must match the run and every entry to reduce operator targeting mistakes.
 pub async fn reset(
     State(state): State<AppState>,
     body: Bytes,

--- a/src/services/auto_queue/dispatch_command.rs
+++ b/src/services/auto_queue/dispatch_command.rs
@@ -49,9 +49,19 @@ pub(super) async fn enqueue_entries_into_existing_run_with_pg(
         .await
         .map_err(|err| format!("begin enqueue transaction: {err}"))?;
 
-    // Serialize entry creation with reset/cancel. The status reload must be a
-    // separate statement after the advisory lock so READ COMMITTED observes a
-    // terminal transition that won the lock first.
+    // The post-lock status reload depends on a fresh statement snapshot. Pin
+    // this transaction instead of trusting a database/role default that an
+    // operator could change to REPEATABLE READ.
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+        .execute(&mut *tx)
+        .await
+        .map_err(|err| format!("set enqueue isolation for run {run_id}: {err}"))?;
+
+    // Serialize entry creation with reset/cancel. PostgreSQL hashtext returns
+    // 32 bits, so distinct run ids can collide. Such a collision only causes
+    // conservative cross-run serialization; it cannot bypass this safety lock.
+    // The separate SELECT after the lock then observes a terminal transition
+    // that acquired the same key first.
     sqlx::query("SELECT pg_advisory_xact_lock(hashtext('aq_run:' || $1))")
         .bind(run_id)
         .execute(&mut *tx)

--- a/src/services/auto_queue/dispatch_command.rs
+++ b/src/services/auto_queue/dispatch_command.rs
@@ -49,6 +49,31 @@ pub(super) async fn enqueue_entries_into_existing_run_with_pg(
         .await
         .map_err(|err| format!("begin enqueue transaction: {err}"))?;
 
+    // Serialize entry creation with reset/cancel. The status reload must be a
+    // separate statement after the advisory lock so READ COMMITTED observes a
+    // terminal transition that won the lock first.
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtext('aq_run:' || $1))")
+        .bind(run_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|err| format!("lock auto-queue run {run_id} for enqueue: {err}"))?;
+    let run_status = sqlx::query_scalar::<_, String>(
+        "SELECT status
+         FROM auto_queue_runs
+         WHERE id = $1",
+    )
+    .bind(run_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|err| format!("reload auto-queue run {run_id} for enqueue: {err}"))?
+    .ok_or_else(|| format!("auto-queue run {run_id} not found"))?;
+    if run_status != "active" {
+        tx.rollback().await.ok();
+        return Err(format!(
+            "auto-queue run {run_id} is not active (status={run_status})"
+        ));
+    }
+
     let existing_live_cards: HashSet<String> = sqlx::query_scalar::<_, String>(
         "SELECT kanban_card_id
          FROM auto_queue_entries

--- a/src/services/auto_queue/route.rs
+++ b/src/services/auto_queue/route.rs
@@ -91,6 +91,10 @@ pub use view_admin_routes::{add_run_entry, history, restore_run, status, update_
 pub(crate) use activate_command::activate_with_deps_pg;
 pub(crate) use fsm::{AutoQueueActivateDeps, activate_with_bridge_pg};
 
+#[cfg(test)]
+#[path = "auto_queue_reset_pg_tests.rs"]
+mod auto_queue_reset_pg_tests;
+
 use activate_preflight::*;
 use command::*;
 use dispatch_assignment_command::*;

--- a/src/services/auto_queue/route_types.rs
+++ b/src/services/auto_queue/route_types.rs
@@ -103,12 +103,16 @@ pub struct AddRunEntryBody {
     pub batch_phase: Option<i64>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ResetBody {
+    pub run_id: String,
+    pub repo: Option<String>,
     pub agent_id: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ResetGlobalBody {
     pub confirmation_token: Option<String>,
 }


### PR DESCRIPTION
## 무엇을

`#4880` — AutoQueue **Reset 이 agent 전체를 지우던 것을 run 스코프로 좁히고**, raw DELETE 대신 canonical cancel transaction 을 쓴다.

**11파일 +781/−98.**

## 무엇이 문제였나

Dashboard 는 `run_id`·`repo`·`agent_id` 를 보내는데(`autoQueue.ts:231`) 서버 `ResetBody` 에는 `agent_id` 만 있고 `deny_unknown_fields` 도 없어서 **`run_id`/`repo` 가 조용히 무시**됐다(`route_types.rs:106`). 그 결과 reset 이 그 agent 의 **모든** entry 를 DELETE 하고 **모든** live/promotable run 을 completed 로 바꿨다(`command.rs:18`). 이 경로에는 dispatch cancel·gate cleanup·entry transition audit·slot release 가 전부 없었다.

## 계약

- `ResetBody` 에 **`run_id` 필수** + 선택적 ownership claim + `#[serde(deny_unknown_fields)]`
- ownership mismatch → **409**, unknown field → **400**, missing run → **404**
- 선택된 **단일 run 만** canonical cancel transaction 으로 전달 — gate 삭제·dispatch cancel·audited entry transition·slot release 가 한 transaction
- `generated`/`pending` run 도 cancelable 하게 만들어 상태별로 버튼이 깨지지 않게 함
- Dashboard 는 active panel 의 run 에 대해 **한 번만** 요청

## 스코프 축소로 남는 것이 없나

같은 agent 의 다른 run·다른 repo 가 `active`/`pending` 상태 그대로 보존되는 것을 PG 테스트로 고정했다(`auto_queue_reset_pg_tests.rs:170`). 명시적 확인이 필요한 `reset-global` 은 별도 global 계약으로 유지된다.

## 뮤테이션 증명

가드를 제거하면 **자기 assert 로** 실패한다 (컴파일 에러 아님):

| 뮤테이션 | 결과 |
|---|---|
| unknown-field guard 제거 | `404 != 400`, rc=101 |
| run scope 를 다른 run 까지 확장 | untouched assert `2 != 1`, rc=101 |

복원 후 PG 4/4 통과.

## 테스트가 실제로 도는가

새 테스트 4건 전부 PG 레인 필터(`_pg pg_ postgres`)에 선택되는 것을 `cargo test --lib -- _pg pg_ postgres --list` 로 확인했다:

```
services::auto_queue::route::auto_queue_reset_pg_tests::reset_canonical_cleanup_summarizes_dispatch_gate_slot_and_entry_transition_pg
services::auto_queue::route::auto_queue_reset_pg_tests::reset_repo_and_agent_ownership_mismatch_returns_conflict_pg
services::auto_queue::route::auto_queue_reset_pg_tests::reset_run_scope_preserves_same_agent_other_repo_run_pg
services::auto_queue::route::auto_queue_reset_pg_tests::reset_unknown_missing_and_terminal_run_contracts_are_pg
```

3,161줄짜리 기존 preflight harness 대신 **전용 파일**로 격리했다.

## 게이트

리베이스(`c88c808c8`) 후 재실행: `cargo fmt --check` / `cargo check --lib` / coverage(`--baseline-ref origin/main`) / PG membership / `audit_maintainability --check` / docs freshness **전부 rc=0**. Dashboard Vitest 48 files 305 tests rc=0. baseline·cap 인상 없음.

---

# r2 (`9e19d49c9`) — 리뷰 반려 3건 반영

## 수정

- **P0-2** `auto-queue-panel-state.ts:14` — reset 한 동일 run 은 retained skipped entry 수와 무관하게 폴링 응답에서 억제. 새로고침처럼 suppression ref 가 없어도 `cancelled` 를 Generate 상태로 처리. 프런트 테스트 + `cancelled run + skipped entry` 를 반환하는 PG 테스트 추가(`auto_queue_reset_pg_tests.rs:432`).
- **P1-1** `AutoQueuePanel.tsx:250` — dashboard repo 필터를 reset ownership claim 으로 보내지 않는다. run id 와 실제 run agent 만 사용. multi-repo PG reset 테스트 추가(`:373`).
- **P1-2** `dispatch_command.rs:52` — enqueue 가 cancel 과 동일한 `aq_run:<id>` advisory transaction lock 을 잡고, 획득 후 새 READ COMMITTED snapshot 으로 run 이 여전히 `active` 인지 재검증. blocked reset 중 late enqueue 반례 테스트 추가(`:674`).

## 뮤테이션

| 뮤테이션 | 결과 |
|---|---|
| terminal 상태 재검증 제거 | late enqueue `Ok(...)` 를 자기 assert 가 검출, rc=101 |
| advisory lock 제거 | 동일 orphan 반례를 자기 assert 가 검출, rc=101 |
| 양쪽 복원 후 race 테스트 | rc=0, 1 passed |

## ⚠️ PR 크기 상한 초과 — 불가분 사유

**14파일 `+1165/−117`.** 파일 수는 상한(20) 이내이나 줄수가 상한(±800)을 넘는다. **분할하지 않는다.**

| 구분 | 파일 | 줄수 |
|---|---:|---:|
| prod | 11 | **450** |
| test | 3 | **832** |

초과분의 대부분이 `auto_queue_reset_pg_tests.rs` **단일 신규 파일 +777** 이다. 이 테스트는 **직전 리뷰 라운드가 명시적으로 요구한 것**(프런트·상태 응답·멀티-repo·동시성·5요소 범위)이고, **신규 prod API 를 참조하므로 prod 변경과 분리하면 독립 검증이 불가능**하다. 리뷰 대상 로직 표면은 prod 11파일 450줄이다.

## 게이트

12개 전부 rc=0 — `cargo fmt --all --check` / `cargo check --lib` / PG reset 7 passed / Dashboard Vitest 48 files 306 tests / inventory 생성 / docs freshness / coverage(`--baseline-ref origin/main`) / PG lane membership / maintainability audit / `ci-script-checks.sh` / `git diff --check` / clean tree.

접촉 파일 신규 경고 0. `cancel_run.rs` 의 unused-function 경고 1건은 `origin/main` 에도 존재하는 기존 경고다. baseline·cap 인상 없음. **테스트 삭제 없음** — 선언 수 PG `4→7`, panel-state `5→6`, actions `5→5`.

## RISKS

- enqueue 와 reset 이 같은 run 에서 직렬화되므로 동시 reset 시 enqueue 가 잠시 대기한다. orphan 방지를 위한 의도된 비용이다.