### PR TITLE
refactor(#4881): unify auto-queue run completion behind a single typed readiness writer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,6 +68,7 @@ src/
 │   │   ├── phase_gate_verdict.rs
 │   │   ├── phase_gates.rs
 │   │   ├── queries.rs
+│   │   ├── readiness_pg_tests.rs
 │   │   ├── run_status.rs
 │   │   ├── runs.rs
 │   │   ├── slot_predicate.rs
@@ -374,6 +375,7 @@ src/
 │   │   ├── phase_gate_violations.rs
 │   │   ├── planning.rs
 │   │   ├── query.rs
+│   │   ├── readiness_pg_tests.rs
 │   │   ├── route.rs
 │   │   ├── route_generate.rs
 │   │   ├── route_request_generate.rs

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,6 +61,8 @@ src/
 │   ├── auto_queue/
 │   │   ├── entries/
 │   │   │   └── dispatch_failure.rs
+│   │   ├── phase_gates/
+│   │   │   └── orphan_repair.rs
 │   │   ├── claim.rs
 │   │   ├── consultation.rs
 │   │   ├── entries.rs

--- a/README.md
+++ b/README.md
@@ -556,7 +556,8 @@ agentdesk.autoQueue.activate("run-123")                   // or activate({ run_i
 agentdesk.autoQueue.updateEntryStatus(entryId, "active", "policy")
 agentdesk.autoQueue.pauseRun(runId, "manual-hold")
 agentdesk.autoQueue.resumeRun(runId, "policy-resume")
-agentdesk.autoQueue.completeRun(runId, "policy", { reason: "all entries done" })
+agentdesk.autoQueue.finalizeRunIfReady(runId)             // derived completion; returns typed outcome
+agentdesk.autoQueue.forceCompleteRun(runId, { operator: "admin", source: "manual-recovery" })
 agentdesk.autoQueue.savePhaseGateState(runId, phase, state)
 agentdesk.queue.status()                                  // run/slot snapshot used by dashboards
 

--- a/docs/auto-queue-turn-finalization.md
+++ b/docs/auto-queue-turn-finalization.md
@@ -60,6 +60,23 @@ identity. Required gates should fail when a scenario declares `controlled` or
 | Discord mailbox cleanup | mailbox finish/stop helpers | Cleans runtime state after canonical completion/cancel has recorded durable state. |
 | Watchdog | detector/reconciler | Emits suspicion/timeout and invokes cancel/recovery; never marks work complete directly. |
 
+## Completion Block Ownership
+
+`RunCompletionBlockedReason` is a refusal to write `completed`, not a generic
+retry promise. The enum beside the writer is the authoritative maintenance
+contract: every new reason must name its resolver, failure signal, and slot
+effect. This table mirrors that contract for operators.
+
+| Reason | Resolution owner | Resolution-failure signal | Slot effect |
+| --- | --- | --- | --- |
+| `blocking_phase_gate` | Valid gate: terminal-dispatch reconcile, automatic. Orphan gate: operator HTTP repair, manual; no tick calls repair. | Typed readiness result; failed-gate alert and repair audit/summary where applicable. | Readiness does not release a slot. Normal gate creation pauses before creating gate dispatches, and pause releases the slot; an independently injected gate has no such guarantee. |
+| `phase_gate_grace_window` | DB deadline expiry plus the bounded completion tick, automatic. App `Date.now()` writes the deadline while DB `NOW()` compares it, so finite clock skew can extend the wait. | Typed readiness result on each attempted finalization. | Readiness preserves current ownership. During the pre-gate continuation race the slot remains held until continuation clears the deadline or pauses; gate pause releases it. |
+| `user_cancelled_entry` | Bounded tick changes otherwise drained, gate-free, grace-expired cancellations to `skipped`, automatic. | Typed readiness result; policy error logging if the tick transition fails. | An assigned slot remains held until the transition allows canonical completion to release it. |
+| `runnable_entry` | Active-run dispatch tick, automatic. A final-phase block first resumes a paused run. `generated`/`pending` are outside that tick but are pre-activation. | Typed readiness result; warning if final-phase resume fails. | Readiness preserves current ownership. Pre-activation `generated`/`pending` runs have no assigned slot. |
+| `run_status_not_completable` | No automatic resolver. A crash between `apply_restore_state_changes_pg` committing `restoring` (`fsm.rs:292-313`) and `finalize_restore_run_pg` (`fsm.rs:398-437`) requires an operator restore retry. This is pre-existing debt, not introduced by #4881. | Typed result only when readiness is explicitly called; a crash-stuck `restoring` run has no periodic sweep or alert. | The slot is deliberately retained across restore. |
+| `policy_continuation_pending` | `onCardTerminal` policy continuation, automatic. | Typed terminal-entry result while continuation is pending. | Readiness retains it; continuation keeps it while dispatching more work, or releases it by completion/gate pause. |
+| `run_not_found` | No resolver applies; the identifier is stale or invalid. | Typed readiness result to the caller. | No run-row slot transition is performed. |
+
 ## Migration Checklist
 
 ### #1638 - Canonical Streaming-Final Hook

--- a/docs/auto-queue-turn-finalization.md
+++ b/docs/auto-queue-turn-finalization.md
@@ -56,7 +56,7 @@ identity. Required gates should fail when a scenario declares `controlled` or
 | Dispatch completion | dispatch status transition helper | Called by the streaming-final hook and explicit fallback helpers only. |
 | Auto-queue entry terminal state | `update_entry_status_on_pg` / terminal-entry helper | Entry status drives run readiness; no policy hook is required to close the run. |
 | Auto-queue run completion | `maybe_finalize_run_if_ready_pg` | Transactional derivation from run status, blocking gates, grace, `user_cancelled`, and runnable entries; returns `Completed`, `Blocked(reason)`, or `AlreadyTerminal`. |
-| Operator force completion | `force_complete_run_on_pg` | Separate command requiring operator and source; the only completion path allowed to delete gates, with an `audit_logs` record in the same transaction. |
+| Operator force completion | `force_complete_run_on_pg` | Separate command requiring operator and source; the only completion path allowed to bulk-delete valid gates, with an `audit_logs` record in the same transaction. Non-force repair may delete only orphan gates that have no matching dispatch. |
 | Discord mailbox cleanup | mailbox finish/stop helpers | Cleans runtime state after canonical completion/cancel has recorded durable state. |
 | Watchdog | detector/reconciler | Emits suspicion/timeout and invokes cancel/recovery; never marks work complete directly. |
 
@@ -78,7 +78,7 @@ identity. Required gates should fail when a scenario declares `controlled` or
 
 - After dispatch completion, update the matching auto-queue entry through the
   terminal-entry helper instead of relying on policy/card terminal side effects.
-- Preserve `user_cancelled` as resumable and non-run-finalizing.
+- Preserve `user_cancelled` as non-dispatchable and operator-resumable while runnable work remains; once a run is otherwise drained, the bounded tick normalizes it to `skipped` so the run and slot cannot remain pinned forever.
 - Keep `maybe_finalize_run_if_ready_pg` as the only run completion writer.
 - Rollback point: disable the new entry update and leave existing policy/GitHub
   cleanup fallbacks in place.
@@ -97,7 +97,8 @@ identity. Required gates should fail when a scenario declares `controlled` or
 - Unit tests for the canonical finalizer input contract and idempotent repeated
   completion.
 - Postgres tests covering dispatch completed, entry terminal, phase-gated run
-  completion, and `user_cancelled` non-finalization.
+  completion, immediate `user_cancelled` non-finalization, and bounded tick
+  terminalization after the run drains.
 - Route or integration tests for watcher completion, bridge fallback completion,
   watchdog timeout cancellation, and GitHub/card terminal cleanup fallback.
 - Observability assertions that completion events are emitted once per terminal

--- a/docs/auto-queue-turn-finalization.md
+++ b/docs/auto-queue-turn-finalization.md
@@ -55,7 +55,8 @@ identity. Required gates should fail when a scenario declares `controlled` or
 | Streaming turn completion | canonical streaming-final hook | One hook receives full response, dispatch id, provider/channel, token usage, and completion source. |
 | Dispatch completion | dispatch status transition helper | Called by the streaming-final hook and explicit fallback helpers only. |
 | Auto-queue entry terminal state | `update_entry_status_on_pg` / terminal-entry helper | Entry status drives run readiness; no policy hook is required to close the run. |
-| Auto-queue run completion | `maybe_finalize_run_if_ready_pg` | Pure derivation from entries and phase gates. |
+| Auto-queue run completion | `maybe_finalize_run_if_ready_pg` | Transactional derivation from run status, blocking gates, grace, `user_cancelled`, and runnable entries; returns `Completed`, `Blocked(reason)`, or `AlreadyTerminal`. |
+| Operator force completion | `force_complete_run_on_pg` | Separate command requiring operator and source; the only completion path allowed to delete gates, with an `audit_logs` record in the same transaction. |
 | Discord mailbox cleanup | mailbox finish/stop helpers | Cleans runtime state after canonical completion/cancel has recorded durable state. |
 | Watchdog | detector/reconciler | Emits suspicion/timeout and invokes cancel/recovery; never marks work complete directly. |
 

--- a/policies/__tests__/auto-queue.test.js
+++ b/policies/__tests__/auto-queue.test.js
@@ -561,6 +561,13 @@ test("auto-queue onTick1min honors stale dispatched runtime config", () => {
         result: []
       },
       {
+        match(sql) {
+          return sql.includes("SELECT e.id, e.run_id") &&
+            sql.includes("WHERE e.status = 'user_cancelled'");
+        },
+        result: []
+      },
+      {
         match: "FROM auto_queue_runs r WHERE r.status IN ('active', 'paused')",
         result: []
       },
@@ -664,6 +671,13 @@ test("auto-queue terminal cleanup uses pipeline terminal states", () => {
       },
       {
         match(sql) {
+          return sql.includes("SELECT e.id, e.run_id") &&
+            sql.includes("WHERE e.status = 'user_cancelled'");
+        },
+        result: []
+      },
+      {
+        match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
             sql.includes("WHERE r.status IN ('active', 'paused')");
         },
@@ -699,7 +713,7 @@ test("auto-queue terminal cleanup uses pipeline terminal states", () => {
   ]);
 });
 
-test("auto-queue finalization sweep delegates readiness to the canonical writer", () => {
+test("auto-queue terminalizes drained user-cancelled entries before readiness", () => {
   const { policy, state } = loadPolicy("policies/auto-queue.js", {
     dbQuery: createSqlRouter([
       {
@@ -708,11 +722,83 @@ test("auto-queue finalization sweep delegates readiness to the canonical writer"
       },
       {
         match(sql) {
-          return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("WHERE r.status IN ('active', 'paused')") &&
-            sql.includes("ORDER BY r.id ASC");
+          return sql.includes("SELECT e.id, e.run_id") &&
+            sql.includes("WHERE e.status = 'user_cancelled'") &&
+            sql.includes("remaining.status IN ('pending', 'dispatched')") &&
+            sql.includes("auto_queue_phase_gates") &&
+            sql.includes("phase_gate_grace_until") &&
+            sql.includes("LIMIT 50");
         },
-        result: [{ id: "run-eligible" }]
+        result: [{ id: "entry-user-cancelled", run_id: "run-drained" }]
+      },
+      {
+        match: "SELECT run_id, id as entry_id, kanban_card_id as card_id",
+        result: [{
+          run_id: "run-drained",
+          entry_id: "entry-user-cancelled",
+          card_id: null,
+          dispatch_id: null,
+          agent_id: "agent-drained",
+          thread_group: 0,
+          batch_phase: 0,
+          slot_index: null
+        }]
+      },
+      {
+        match(sql) {
+          return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
+            sql.includes("auto_queue_phase_gates");
+        },
+        result: []
+      },
+      {
+        match(sql) {
+          return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
+            sql.includes("JOIN LATERAL (");
+        },
+        result: []
+      },
+      { match: "e.status = 'dispatched'", result: [] }
+    ])
+  });
+
+  policy.onTick1min();
+
+  assert.deepEqual(state.autoQueueStatusUpdates, [{
+    entryId: "entry-user-cancelled",
+    status: "skipped",
+    reason: "tick_user_cancelled_terminalization",
+    extra: null
+  }]);
+});
+
+test("auto-queue finalization sweep prefilters blocked runs and caps writer calls", () => {
+  const candidateRuns = Array.from({ length: 200 }, (_, index) => ({ id: `run-${index}` }));
+  const { policy, state } = loadPolicy("policies/auto-queue.js", {
+    dbQuery: createSqlRouter([
+      {
+        match: "JOIN kanban_cards kc ON kc.id = e.kanban_card_id",
+        result: []
+      },
+      {
+        match(sql) {
+          return sql.includes("SELECT e.id, e.run_id") &&
+            sql.includes("WHERE e.status = 'user_cancelled'");
+        },
+        result: []
+      },
+      {
+        match(sql) {
+          return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
+            sql.includes("auto_queue_phase_gates");
+        },
+        result(sql) {
+          assert.match(sql, /status IN \('pending', 'dispatched', 'user_cancelled'\)/);
+          assert.match(sql, /pg\.status IN \('pending', 'failed'\)/);
+          assert.match(sql, /phase_gate_grace_until/);
+          assert.match(sql, /ORDER BY r\.id ASC LIMIT 50/);
+          return candidateRuns.slice(0, 50);
+        }
       },
       {
         match(sql) {
@@ -735,12 +821,30 @@ test("auto-queue finalization sweep delegates readiness to the canonical writer"
 
   const finishedRunQuery = state.queries.find((query) =>
     query.sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-    query.sql.includes("WHERE r.status IN ('active', 'paused')")
+    query.sql.includes("auto_queue_phase_gates")
   );
-  assert.doesNotMatch(finishedRunQuery.sql, /auto_queue_phase_gates|phase_gate_grace_until|auto_queue_entries/);
-  assert.deepEqual(state.autoQueueCompletes, [
-    { runId: "run-eligible" }
-  ]);
+  assert.ok(finishedRunQuery);
+  assert.equal(candidateRuns.length, 200);
+  assert.equal(state.autoQueueCompletes.length, 50);
+  assert.deepEqual(state.autoQueueCompletes.at(0), { runId: "run-0" });
+  assert.deepEqual(state.autoQueueCompletes.at(-1), { runId: "run-49" });
+});
+
+test("final-phase readiness block resumes paused run for bounded tick recovery", () => {
+  const { module, state } = loadPolicy("policies/lib/auto-queue-lifecycle.js", {
+    autoQueueFinalizeRunIfReady() {
+      return { outcome: "blocked", reason: "runnable_entry" };
+    }
+  });
+
+  module.completeRunAndNotify("run-final-phase-blocked");
+
+  assert.deepEqual(state.autoQueueCompletes, [{ runId: "run-final-phase-blocked" }]);
+  assert.deepEqual(state.autoQueueResumes, [{
+    runId: "run-final-phase-blocked",
+    source: "phase_gate_completion_deferred"
+  }]);
+  assert.deepEqual(state.autoQueueActivations, []);
 });
 
 test("auto-queue rotates saturated active runs in bounded tick sweep", () => {
@@ -748,6 +852,13 @@ test("auto-queue rotates saturated active runs in bounded tick sweep", () => {
     dbQuery: createSqlRouter([
       {
         match: "JOIN kanban_cards kc ON kc.id = e.kanban_card_id",
+        result: []
+      },
+      {
+        match(sql) {
+          return sql.includes("SELECT e.id, e.run_id") &&
+            sql.includes("WHERE e.status = 'user_cancelled'");
+        },
         result: []
       },
       {
@@ -791,6 +902,13 @@ test("auto-queue does not rotate deferred active run activations", () => {
     dbQuery: createSqlRouter([
       {
         match: "JOIN kanban_cards kc ON kc.id = e.kanban_card_id",
+        result: []
+      },
+      {
+        match(sql) {
+          return sql.includes("SELECT e.id, e.run_id") &&
+            sql.includes("WHERE e.status = 'user_cancelled'");
+        },
         result: []
       },
       {

--- a/policies/__tests__/auto-queue.test.js
+++ b/policies/__tests__/auto-queue.test.js
@@ -699,7 +699,7 @@ test("auto-queue terminal cleanup uses pipeline terminal states", () => {
   ]);
 });
 
-test("auto-queue finalization sweep filters blocked runs before LIMIT", () => {
+test("auto-queue finalization sweep delegates readiness to the canonical writer", () => {
   const { policy, state } = loadPolicy("policies/auto-queue.js", {
     dbQuery: createSqlRouter([
       {
@@ -709,27 +709,10 @@ test("auto-queue finalization sweep filters blocked runs before LIMIT", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("auto_queue_phase_gates") &&
-            sql.includes("phase_gate_grace_until") &&
-            sql.includes("ORDER BY r.id ASC LIMIT 50");
+            sql.includes("WHERE r.status IN ('active', 'paused')") &&
+            sql.includes("ORDER BY r.id ASC");
         },
         result: [{ id: "run-eligible" }]
-      },
-      {
-        match: "SELECT COUNT(*) as cnt FROM auto_queue_phase_gates",
-        result: [{ cnt: 0 }]
-      },
-      {
-        match: "SELECT COUNT(*) as cnt FROM auto_queue_entries WHERE run_id = ? AND status IN ('pending', 'dispatched')",
-        result: [{ cnt: 0 }]
-      },
-      {
-        match: "SELECT COUNT(*) as cnt FROM auto_queue_entries WHERE run_id = ? AND status = 'user_cancelled'",
-        result: [{ cnt: 0 }]
-      },
-      {
-        match: "SELECT phase_gate_grace_until FROM auto_queue_runs WHERE id = ?",
-        result: [{ phase_gate_grace_until: null }]
       },
       {
         match(sql) {
@@ -752,12 +735,11 @@ test("auto-queue finalization sweep filters blocked runs before LIMIT", () => {
 
   const finishedRunQuery = state.queries.find((query) =>
     query.sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-    query.sql.includes("auto_queue_phase_gates")
+    query.sql.includes("WHERE r.status IN ('active', 'paused')")
   );
-  assert.match(finishedRunQuery.sql, /NOT EXISTS \(  SELECT 1 FROM auto_queue_phase_gates pg/);
-  assert.match(finishedRunQuery.sql, /datetime\(r\.phase_gate_grace_until\) <= datetime\('now'\)/);
+  assert.doesNotMatch(finishedRunQuery.sql, /auto_queue_phase_gates|phase_gate_grace_until|auto_queue_entries/);
   assert.deepEqual(state.autoQueueCompletes, [
-    { runId: "run-eligible", reason: "finalize_without_phase_gate", options: { releaseSlots: true } }
+    { runId: "run-eligible" }
   ]);
 });
 

--- a/policies/__tests__/auto-queue.test.js
+++ b/policies/__tests__/auto-queue.test.js
@@ -847,6 +847,23 @@ test("final-phase readiness block resumes paused run for bounded tick recovery",
   assert.deepEqual(state.autoQueueActivations, []);
 });
 
+test("final-phase completion exception resumes paused run without inline activation", () => {
+  const { module, state } = loadPolicy("policies/lib/auto-queue-lifecycle.js", {
+    autoQueueFinalizeRunIfReady() {
+      throw new Error("notification enqueue failed");
+    }
+  });
+
+  module.completeRunAndNotify("run-final-phase-error");
+
+  assert.deepEqual(state.autoQueueCompletes, [{ runId: "run-final-phase-error" }]);
+  assert.deepEqual(state.autoQueueResumes, [{
+    runId: "run-final-phase-error",
+    source: "phase_gate_completion_deferred"
+  }]);
+  assert.deepEqual(state.autoQueueActivations, []);
+});
+
 test("auto-queue rotates saturated active runs in bounded tick sweep", () => {
   const { policy, state } = loadPolicy("policies/auto-queue.js", {
     dbQuery: createSqlRouter([

--- a/policies/__tests__/auto-queue.test.js
+++ b/policies/__tests__/auto-queue.test.js
@@ -665,7 +665,7 @@ test("auto-queue terminal cleanup uses pipeline terminal states", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("user_cancelled");
+            sql.includes("WHERE r.status IN ('active', 'paused')");
         },
         result: []
       },
@@ -753,7 +753,7 @@ test("auto-queue rotates saturated active runs in bounded tick sweep", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("user_cancelled");
+            sql.includes("WHERE r.status IN ('active', 'paused')");
         },
         result: []
       },
@@ -796,7 +796,7 @@ test("auto-queue does not rotate deferred active run activations", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("user_cancelled");
+            sql.includes("WHERE r.status IN ('active', 'paused')");
         },
         result: []
       },

--- a/policies/__tests__/support/harness.js
+++ b/policies/__tests__/support/harness.js
@@ -443,9 +443,12 @@ function createAgentdeskMock(options) {
         }
         return { activated: true };
       },
-      completeRun(runId, reason, optionsArg) {
-        state.autoQueueCompletes.push({ runId, reason, options: clone(optionsArg || {}) });
-        return { changed: true };
+      finalizeRunIfReady(runId) {
+        state.autoQueueCompletes.push({ runId });
+        if (typeof settings.autoQueueFinalizeRunIfReady === "function") {
+          return clone(settings.autoQueueFinalizeRunIfReady(runId, state));
+        }
+        return { changed: true, outcome: "completed", reason: null };
       },
       pauseRun(runId, source) {
         state.autoQueuePauses.push({ runId, source });

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -506,11 +506,64 @@ var autoQueue = {
       );
     }
 
+    // #815 + #4881 r2: an explicit user cancellation remains non-dispatchable,
+    // but it must not pin an otherwise drained run (and its slot) forever.
+    // Preserve the operator recovery window while runnable work exists; once
+    // none remains, normalize the cancelled entries to `skipped`. The shared
+    // entry writer then invokes canonical readiness and completes the run when
+    // the last such entry transitions. Keep this recovery bounded separately
+    // from the ordinary readiness sweep.
+    var drainedUserCancelled = agentdesk.db.query(
+      "SELECT e.id, e.run_id " +
+      "FROM auto_queue_entries e " +
+      "JOIN auto_queue_runs r ON r.id = e.run_id " +
+      "WHERE e.status = 'user_cancelled' " +
+      "AND r.status IN ('active', 'paused') " +
+      "AND NOT EXISTS (" +
+      "  SELECT 1 FROM auto_queue_entries remaining " +
+      "  WHERE remaining.run_id = e.run_id " +
+      "    AND remaining.status IN ('pending', 'dispatched')" +
+      ") " +
+      "AND NOT EXISTS (" +
+      "  SELECT 1 FROM auto_queue_phase_gates pg " +
+      "  WHERE pg.run_id = e.run_id AND pg.status IN ('pending', 'failed')" +
+      ") " +
+      "AND (" +
+      "  r.phase_gate_grace_until IS NULL " +
+      "  OR datetime(r.phase_gate_grace_until) <= datetime('now')" +
+      ") " +
+      "ORDER BY e.updated_at ASC LIMIT 50",
+      []
+    );
+    for (var uc = 0; uc < drainedUserCancelled.length; uc++) {
+      var cancelled = drainedUserCancelled[uc];
+      autoQueueLog("info", "onTick1min: terminalizing drained user-cancelled entry " + cancelled.id, {
+        run_id: cancelled.run_id,
+        entry_id: cancelled.id
+      });
+      agentdesk.autoQueue.updateEntryStatus(
+        cancelled.id,
+        "skipped",
+        "tick_user_cancelled_terminalization"
+      );
+    }
+
     var finishedRuns = agentdesk.db.query(
       "SELECT r.id " +
       "FROM auto_queue_runs r " +
       "WHERE r.status IN ('active', 'paused') " +
-      "ORDER BY r.id ASC",
+      "AND NOT EXISTS (" +
+      "  SELECT 1 FROM auto_queue_entries e " +
+      "  WHERE e.run_id = r.id AND e.status IN ('pending', 'dispatched', 'user_cancelled')" +
+      ") " +
+      "AND NOT EXISTS (" +
+      "  SELECT 1 FROM auto_queue_phase_gates pg " +
+      "  WHERE pg.run_id = r.id AND pg.status IN ('pending', 'failed')" +
+      ") " +
+      "AND (" +
+      "  r.phase_gate_grace_until IS NULL " +
+      "  OR datetime(r.phase_gate_grace_until) <= datetime('now')" +
+      ") ORDER BY r.id ASC LIMIT 50",
       []
     );
     for (var fr = 0; fr < finishedRuns.length; fr++) {

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -79,7 +79,6 @@ var clearPhaseGateState = _autoQueuePhaseGateLib.clearPhaseGateState;
 var runHasBlockingPhaseGate = _autoQueuePhaseGateLib.runHasBlockingPhaseGate;
 var beginPhaseGateGraceWindow = _autoQueuePhaseGateLib.beginPhaseGateGraceWindow;
 var clearPhaseGateGraceWindow = _autoQueuePhaseGateLib.clearPhaseGateGraceWindow;
-var runWithinPhaseGateGrace = _autoQueuePhaseGateLib.runWithinPhaseGateGrace;
 var pauseRun = _autoQueuePhaseGateLib.pauseRun;
 var loadPhaseGateDispatches = _autoQueuePhaseGateLib.loadPhaseGateDispatches;
 var _phaseGateRequired = _autoQueuePhaseGateLib.phaseGateRequired;
@@ -90,7 +89,6 @@ var _createPhaseGateDispatches = _autoQueuePhaseGateLib.createPhaseGateDispatche
 // ── lifecycle helpers ───────────────────────────────────────────────
 var loadRunInfo = _autoQueueLifecycleLib.loadRunInfo;
 var remainingRunnableEntryCount = _autoQueueLifecycleLib.remainingRunnableEntryCount;
-var runHasUserCancelledEntry = _autoQueueLifecycleLib.runHasUserCancelledEntry;
 var finalizeRunWithoutPhaseGate = _autoQueueLifecycleLib.finalizeRunWithoutPhaseGate;
 var completeRunAndNotify = _autoQueueLifecycleLib.completeRunAndNotify;
 var continueRunAfterEntry = _autoQueueLifecycleLib.continueRunAfterEntry;
@@ -512,18 +510,7 @@ var autoQueue = {
       "SELECT r.id " +
       "FROM auto_queue_runs r " +
       "WHERE r.status IN ('active', 'paused') " +
-      "AND NOT EXISTS (" +
-      "  SELECT 1 FROM auto_queue_entries e " +
-      "  WHERE e.run_id = r.id AND e.status IN ('pending', 'dispatched', 'user_cancelled')" +
-      ") " +
-      "AND NOT EXISTS (" +
-      "  SELECT 1 FROM auto_queue_phase_gates pg " +
-      "  WHERE pg.run_id = r.id AND pg.status IN ('pending', 'failed')" +
-      ") " +
-      "AND (" +
-      "  r.phase_gate_grace_until IS NULL " +
-      "  OR datetime(r.phase_gate_grace_until) <= datetime('now')" +
-      ") ORDER BY r.id ASC LIMIT 50",
+      "ORDER BY r.id ASC",
       []
     );
     for (var fr = 0; fr < finishedRuns.length; fr++) {

--- a/policies/lib/auto-queue-lifecycle.js
+++ b/policies/lib/auto-queue-lifecycle.js
@@ -23,10 +23,8 @@ var _autoQueuePhaseGateLib = require("./auto-queue-phase-gate");
 
 var autoQueueLog = _autoQueueLogLib.autoQueueLog;
 var activateRun = _autoQueueDispatchLib.activateRun;
-var runHasBlockingPhaseGate = _autoQueuePhaseGateLib.runHasBlockingPhaseGate;
 var beginPhaseGateGraceWindow = _autoQueuePhaseGateLib.beginPhaseGateGraceWindow;
 var clearPhaseGateGraceWindow = _autoQueuePhaseGateLib.clearPhaseGateGraceWindow;
-var runWithinPhaseGateGrace = _autoQueuePhaseGateLib.runWithinPhaseGateGrace;
 var _createPhaseGateDispatches = _autoQueuePhaseGateLib.createPhaseGateDispatches;
 var _phaseGateRequired = _autoQueuePhaseGateLib.phaseGateRequired;
 
@@ -52,48 +50,19 @@ function remainingRunnableEntryCount(runId, phase) {
   return (rows.length > 0) ? rows[0].cnt : 0;
 }
 
-function runHasUserCancelledEntry(runId) {
-  var rows = agentdesk.db.query(
-    "SELECT COUNT(*) as cnt FROM auto_queue_entries " +
-    "WHERE run_id = ? AND status = 'user_cancelled'",
-    [runId]
-  );
-  return (rows.length > 0) && rows[0].cnt > 0;
-}
-
 function finalizeRunWithoutPhaseGate(runId) {
   if (!runId) return false;
 
-  if (runHasBlockingPhaseGate(runId)) return false;
-  if (remainingRunnableEntryCount(runId) > 0) return false;
-  // #815 P1: `user_cancelled` entries are operator-held terminal state.
-  // They are intentionally non-runnable, but they must still block the
-  // tick-side backstop from auto-completing the run; otherwise the next
-  // minute tick would strand a user-stopped run in `completed`.
-  if (runHasUserCancelledEntry(runId)) {
-    autoQueueLog("info", "Deferring finalize for run " + runId + " — user_cancelled entry still present", {
-      run_id: runId
-    });
-    return false;
-  }
-  // Phase-gate race guard: the main engine's `onCardTerminal` may still be
-  // in the middle of creating gate dispatches. Respect the grace window so
-  // we never mark a run completed before phase gates get registered.
-  if (runWithinPhaseGateGrace(runId)) {
-    autoQueueLog("info", "Deferring finalize for run " + runId + " — phase-gate grace window active", {
-      run_id: runId
-    });
-    return false;
-  }
-
   var completed = false;
   try {
-    var result = agentdesk.autoQueue.completeRun(
-      runId,
-      "finalize_without_phase_gate",
-      { releaseSlots: true }
-    );
-    completed = !!(result && result.changed);
+    var result = agentdesk.autoQueue.finalizeRunIfReady(runId);
+    completed = !!(result && result.outcome === "completed");
+    if (!completed && result && result.outcome === "blocked") {
+      autoQueueLog("info", "Deferring finalize for run " + runId + " — " + result.reason, {
+        run_id: runId,
+        reason: result.reason
+      });
+    }
   } catch (e) {
     autoQueueLog("warn", "Failed to finalize run " + runId + ": " + e, {
       run_id: runId
@@ -111,28 +80,17 @@ function finalizeRunWithoutPhaseGate(runId) {
 function completeRunAndNotify(runId) {
   if (!runId) return;
   try {
-    var completed = agentdesk.autoQueue.completeRun(
-      runId,
-      "phase_gate_complete",
-      { releaseSlots: true }
-    );
-    if (completed && completed.changed) return;
-    autoQueueLog("warn", "Phase-gate completion did not mark run " + runId + " completed; falling back to resume", {
-      run_id: runId
+    var completed = agentdesk.autoQueue.finalizeRunIfReady(runId);
+    if (completed && (completed.outcome === "completed" || completed.outcome === "already_terminal")) return;
+    autoQueueLog("info", "Phase-gate completion deferred for run " + runId, {
+      run_id: runId,
+      reason: completed ? completed.reason : null
     });
   } catch (e) {
     autoQueueLog("warn", "Failed to complete final phase-gate run " + runId + ": " + e, {
       run_id: runId
     });
   }
-  try {
-    agentdesk.autoQueue.resumeRun(runId, "phase_gate_complete_resume_fallback");
-  } catch (e) {
-    autoQueueLog("warn", "Failed to resume final phase-gate run " + runId + ": " + e, {
-      run_id: runId
-    });
-  }
-  activateRun(runId, null);
 }
 
 function continueRunAfterEntry(runId, agentId, doneGroup, donePhase, anchorCardId) {
@@ -184,9 +142,7 @@ function continueRunAfterEntry(runId, agentId, doneGroup, donePhase, anchorCardI
     // No more work AND no phase gate required → grace window no longer
     // needed. Clear it so finalization can proceed immediately.
     clearPhaseGateGraceWindow(runId);
-    if (!finalizeRunWithoutPhaseGate(runId)) {
-      completeRunAndNotify(runId);
-    }
+    finalizeRunWithoutPhaseGate(runId);
     return;
   }
 
@@ -250,7 +206,6 @@ function resumeRunAndActivate(runId, nextPhase) {
 module.exports = {
   loadRunInfo: loadRunInfo,
   remainingRunnableEntryCount: remainingRunnableEntryCount,
-  runHasUserCancelledEntry: runHasUserCancelledEntry,
   finalizeRunWithoutPhaseGate: finalizeRunWithoutPhaseGate,
   completeRunAndNotify: completeRunAndNotify,
   continueRunAfterEntry: continueRunAfterEntry,

--- a/policies/lib/auto-queue-lifecycle.js
+++ b/policies/lib/auto-queue-lifecycle.js
@@ -82,10 +82,24 @@ function completeRunAndNotify(runId) {
   try {
     var completed = agentdesk.autoQueue.finalizeRunIfReady(runId);
     if (completed && (completed.outcome === "completed" || completed.outcome === "already_terminal")) return;
-    autoQueueLog("info", "Phase-gate completion deferred for run " + runId, {
+    autoQueueLog("info", "Phase-gate completion deferred for run " + runId + "; resuming for tick recovery", {
       run_id: runId,
       reason: completed ? completed.reason : null
     });
+    // A final-phase gate pauses the run before dispatching its checks. Once
+    // the gate row is cleared, any readiness block (for example a pending
+    // entry restored by an operator) must not leave the run paused with no
+    // gate. Return it to `active`; the bounded tick owns both dispatch and
+    // completion retries from here. Do not activate inline because the writer
+    // reason may be grace rather than runnable work.
+    try {
+      agentdesk.autoQueue.resumeRun(runId, "phase_gate_completion_deferred");
+    } catch (resumeError) {
+      autoQueueLog("warn", "Failed to resume deferred final phase-gate run " + runId + ": " + resumeError, {
+        run_id: runId,
+        reason: completed ? completed.reason : null
+      });
+    }
   } catch (e) {
     autoQueueLog("warn", "Failed to complete final phase-gate run " + runId + ": " + e, {
       run_id: runId

--- a/policies/lib/auto-queue-lifecycle.js
+++ b/policies/lib/auto-queue-lifecycle.js
@@ -92,17 +92,27 @@ function completeRunAndNotify(runId) {
     // gate. Return it to `active`; the bounded tick owns both dispatch and
     // completion retries from here. Do not activate inline because the writer
     // reason may be grace rather than runnable work.
-    try {
-      agentdesk.autoQueue.resumeRun(runId, "phase_gate_completion_deferred");
-    } catch (resumeError) {
-      autoQueueLog("warn", "Failed to resume deferred final phase-gate run " + runId + ": " + resumeError, {
-        run_id: runId,
-        reason: completed ? completed.reason : null
-      });
-    }
+    resumeFinalPhaseRunForTickRecovery(runId, completed ? completed.reason : null);
   } catch (e) {
     autoQueueLog("warn", "Failed to complete final phase-gate run " + runId + ": " + e, {
       run_id: runId
+    });
+    // Completion can fail before returning a typed readiness outcome (for
+    // example, notification enqueue can roll the transaction back). The gate
+    // row has already been cleared, so leaving the run paused would remove it
+    // from dispatch recovery. Resume only; the bounded tick remains the sole
+    // activation/completion retry owner.
+    resumeFinalPhaseRunForTickRecovery(runId, "completion_error");
+  }
+}
+
+function resumeFinalPhaseRunForTickRecovery(runId, reason) {
+  try {
+    agentdesk.autoQueue.resumeRun(runId, "phase_gate_completion_deferred");
+  } catch (resumeError) {
+    autoQueueLog("warn", "Failed to resume deferred final phase-gate run " + runId + ": " + resumeError, {
+      run_id: runId,
+      reason: reason
     });
   }
 }

--- a/scripts/pg_test_lane_manifest.txt
+++ b/scripts/pg_test_lane_manifest.txt
@@ -2,6 +2,7 @@
 [files]
 src/db/auto_queue/entries/dispatch_failure.rs
 src/db/auto_queue/phase_gates.rs
+src/db/auto_queue/readiness_pg_tests.rs
 src/db/auto_queue/tests.rs
 src/db/dispatched_sessions.rs
 src/db/dispatched_sessions/rebind_override.rs
@@ -37,6 +38,7 @@ src/services/auto_queue/activate_command.rs
 src/services/auto_queue/cancel_run.rs
 src/services/auto_queue/phase_gate.rs
 src/services/auto_queue/planning.rs
+src/services/auto_queue/readiness_pg_tests.rs
 src/services/auto_queue/route_generate.rs
 src/services/cluster/intake_preflight.rs
 src/services/cluster/intake_router_hook.rs
@@ -75,6 +77,7 @@ src/voice/turn_link.rs
 db::auto_queue::entries::dispatch_failure::tests
 db::auto_queue::phase_gates::current_batch_phase_pg_tests
 db::auto_queue::phase_gates::reconcile_phase_gate_pg_tests
+db::auto_queue::readiness_pg_tests::cases_pg_tests
 db::auto_queue::tests::dispatch_terminal_sync_pg_tests
 db::dispatched_session_rebind_override::tests
 db::dispatched_sessions::selector_cleanup_tests::session_authority_pg_tests
@@ -111,6 +114,7 @@ services::auto_queue::route::activate_command::tests::depth_gate_activate_pg_tes
 services::auto_queue::route::activate_command::tests::side_path_hijack_pg_tests
 services::auto_queue::route::phase_gate::pg_tests
 services::auto_queue::route::planning::failed_entry_alert_tests
+services::auto_queue::route::readiness_pg_tests::cases_pg_tests
 services::auto_queue::route::route_generate::deploy_gate_request_rejection_tests::postgres_tests
 services::auto_queue::tests
 services::cluster::intake_preflight::tests
@@ -189,6 +193,13 @@ db::auto_queue::phase_gates::reconcile_phase_gate_pg_tests::repair_reports_orpha
 db::auto_queue::phase_gates::reconcile_phase_gate_pg_tests::repair_serializes_with_concurrent_dispatch_update_without_deadlock
 db::auto_queue::phase_gates::reconcile_phase_gate_pg_tests::status_only_completion_uses_persisted_result_for_pass
 db::auto_queue::phase_gates::reconcile_phase_gate_pg_tests::verdict_mismatch_marks_gate_failed_and_pauses_run
+db::auto_queue::readiness_pg_tests::cases_pg_tests::completion_notification_failure_rolls_back_status_and_slot_pg
+db::auto_queue::readiness_pg_tests::cases_pg_tests::completion_updates_status_slot_and_outbox_once_pg
+db::auto_queue::readiness_pg_tests::cases_pg_tests::force_completion_deletes_gate_and_audits_operator_source_pg
+db::auto_queue::readiness_pg_tests::cases_pg_tests::pending_and_failed_phase_gates_block_readiness_pg
+db::auto_queue::readiness_pg_tests::cases_pg_tests::phase_gate_grace_blocks_readiness_pg
+db::auto_queue::readiness_pg_tests::cases_pg_tests::runnable_entry_blocks_readiness_pg
+db::auto_queue::readiness_pg_tests::cases_pg_tests::user_cancelled_with_other_terminal_entry_blocks_readiness_pg
 db::auto_queue::tests::dispatch_terminal_sync_pg_tests::allocate_slot_for_group_agent_pg_does_not_reuse_busy_existing_group_slot
 db::auto_queue::tests::dispatch_terminal_sync_pg_tests::allocate_slot_for_group_agent_pg_rejects_pending_review_slot_blocker
 db::auto_queue::tests::dispatch_terminal_sync_pg_tests::allocate_slot_for_group_agent_pg_releases_claim_when_dispatch_appears_after_update
@@ -381,6 +392,7 @@ services::auto_queue::route::activate_command::tests::side_path_hijack_pg_tests:
 services::auto_queue::route::phase_gate::pg_tests::cancelled_run_rejects_dispatch_attach
 services::auto_queue::route::planning::failed_entry_alert_tests::failed_entry_transition_and_alert_share_commit_with_explicit_ttl_pg
 services::auto_queue::route::planning::failed_entry_alert_tests::production_failure_wrapper_preserves_restoring_slot_binding_pg
+services::auto_queue::route::readiness_pg_tests::cases_pg_tests::activate_empty_drain_and_submit_order_zero_share_readiness_outcome_pg
 services::auto_queue::route::route_generate::deploy_gate_request_rejection_tests::postgres_tests::unavailable_deploy_gate_creates_no_database_rows
 services::auto_queue::tests::auto_queue_status_query_uses_latest_review_clock_pg
 services::cluster::intake_preflight::tests::evaluation_does_not_mutate_production_handoff_state_pg

--- a/src/db/auto_queue/entries.rs
+++ b/src/db/auto_queue/entries.rs
@@ -1033,10 +1033,11 @@ pub async fn finalize_completed_dispatch_terminal_entry_on_pg_tx(
     .await?;
 
     for run_id in &result.affected_run_ids {
-        if auto_queue_run_review_disabled_on_pg_tx(tx, &run_id).await?
-            && maybe_finalize_run_if_ready_pg(tx, &run_id).await?
-        {
-            result.finalized_run_ids.push(run_id.clone());
+        if auto_queue_run_review_disabled_on_pg_tx(tx, &run_id).await? {
+            let outcome = maybe_finalize_run_if_ready_pg(tx, &run_id).await?;
+            if outcome.is_completed() {
+                result.finalized_run_ids.push(run_id.clone());
+            }
         }
     }
 

--- a/src/db/auto_queue/entries.rs
+++ b/src/db/auto_queue/entries.rs
@@ -20,8 +20,9 @@ pub const ENTRY_STATUS_SKIPPED: &str = "skipped";
 pub const ENTRY_STATUS_FAILED: &str = "failed";
 /// Non-dispatchable terminal state used when the operator explicitly stopped
 /// the linked dispatch (#815). The auto-queue tick must NOT resurrect these
-/// entries back to `pending`; only a deliberate operator action (re-activate,
-/// pmd_reopen, etc.) should move them out of this state.
+/// entries back to `pending`. An operator may re-activate them while work
+/// remains; once the run is otherwise drained, the bounded tick may normalize
+/// them to `skipped` so the run and slot do not remain pinned forever.
 pub const ENTRY_STATUS_USER_CANCELLED: &str = "user_cancelled";
 
 /// Returns true when an entry in `status` is eligible for the auto-queue
@@ -584,13 +585,10 @@ pub async fn update_entry_status_on_pg(
         )
         .await?;
 
-        // #815 P1: `user_cancelled` is a NON-run-finalizing terminal status.
-        // The run must stay in its prior state (`active` / `paused`) so the
-        // operator can flip the entry back to `pending` (e.g. via the API) and
-        // a later tick can re-pick it up. Auto-completing the run would
-        // strand the entry — `restore` only accepts cancelled/restoring,
-        // `resume` only reopens paused, and `activate()` only promotes
-        // generated/pending, so no path could re-open the entry.
+        // #815 + #4881 r2: `user_cancelled` never directly finalizes or
+        // re-dispatches the run. This preserves an operator recovery window;
+        // the bounded tick owns the later `user_cancelled -> skipped`
+        // terminalization once no runnable work or gate/grace blocker remains.
         if matches!(
             normalized,
             ENTRY_STATUS_DONE | ENTRY_STATUS_SKIPPED | ENTRY_STATUS_FAILED
@@ -825,9 +823,9 @@ pub async fn update_entry_status_on_pg_tx(
     record_entry_transition_on_pg(tx, entry_id, &current.status, normalized, trigger_source)
         .await?;
 
-    // #815 P1: `user_cancelled` is intentionally NOT in this list — the run
-    // must stay in its prior state so the operator can flip the entry back to
-    // `pending` and a later tick can re-pick it up.
+    // #815 + #4881 r2: `user_cancelled` is intentionally NOT in this list. It
+    // stays recoverable while work remains; the bounded tick separately moves
+    // drained cancellations to `skipped`, which invokes this writer.
     if matches!(
         normalized,
         ENTRY_STATUS_DONE | ENTRY_STATUS_SKIPPED | ENTRY_STATUS_FAILED

--- a/src/db/auto_queue/mod.rs
+++ b/src/db/auto_queue/mod.rs
@@ -10,6 +10,8 @@ pub mod slot_predicate;
 pub mod slots;
 
 #[cfg(test)]
+mod readiness_pg_tests;
+#[cfg(test)]
 pub(crate) mod test_support;
 #[cfg(test)]
 mod tests;

--- a/src/db/auto_queue/phase_gates.rs
+++ b/src/db/auto_queue/phase_gates.rs
@@ -694,7 +694,9 @@ async fn reconcile_phase_gate_for_terminal_dispatch_on_pg_tx_inner(
         })?;
 
     let run_resumed = resume_run_if_paused_on_pg_tx(tx, &gate.run_id).await?;
-    let run_finalized = super::runs::maybe_finalize_run_if_ready_pg(tx, &gate.run_id).await?;
+    let run_finalized = super::runs::maybe_finalize_run_if_ready_pg(tx, &gate.run_id)
+        .await?
+        .is_completed();
 
     Ok(PhaseGateReconciliation::Cleared {
         run_id: gate.run_id,

--- a/src/db/auto_queue/phase_gates.rs
+++ b/src/db/auto_queue/phase_gates.rs
@@ -2,6 +2,8 @@ use serde_json::Value;
 use sqlx::{PgPool, Row as SqlxRow};
 use thiserror::Error;
 
+mod orphan_repair;
+
 // #4884: verdict inference lives in exactly one place. The aliases keep this
 // module's long-standing local names while the bodies moved to the canonical
 // reducer shared with the dispatch finalize path.
@@ -781,10 +783,7 @@ pub struct PhaseGateRepairSummary {
     pub awaiting_siblings: usize,
     pub stale_dispatches: usize,
     pub no_context_dispatches: usize,
-    /// #2257: gates that match the filter but have `dispatch_id IS NULL`.
-    /// The repair candidate query skips them (it requires a JOIN onto
-    /// `task_dispatches`), but operators need to see they exist so they
-    /// can decide whether to delete or hand-patch them separately.
+    /// Compatibility field; successful repair no longer skips matching orphans.
     pub orphan_gates_skipped: usize,
     pub blocking_gates_remaining: i64,
     pub run_status: Option<String>,
@@ -814,11 +813,10 @@ struct PhaseGateRepairCandidate {
 const PHASE_GATE_REPAIR_CANDIDATE_PHASES_SQL: &str = "\
 SELECT DISTINCT pg.phase
 FROM auto_queue_phase_gates pg
-JOIN task_dispatches td ON td.id = pg.dispatch_id
+LEFT JOIN task_dispatches td ON td.id = pg.dispatch_id
 WHERE pg.run_id = $1
   AND pg.status IN ('pending', 'failed')
-  AND pg.dispatch_id IS NOT NULL
-  AND td.status NOT IN ('pending', 'dispatched')
+  AND (td.id IS NULL OR td.status NOT IN ('pending', 'dispatched'))
   AND ($2::BIGINT IS NULL OR pg.phase = $2)
   AND ($3::TEXT IS NULL OR pg.dispatch_id = $3)
 ORDER BY pg.phase";
@@ -1075,6 +1073,15 @@ pub async fn repair_phase_gates_for_run_on_pg(
         outcomes.push(repair_outcome);
     }
 
+    let orphan_gates_cleared = orphan_repair::clear_orphan_gates_on_pg_tx(
+        &mut tx,
+        run_id,
+        options.phase,
+        dispatch_id.as_deref(),
+    )
+    .await?;
+    cleared_gates += orphan_gates_cleared;
+
     let blocking_gates_remaining = sqlx::query_scalar::<_, i64>(
         "SELECT COUNT(*)::BIGINT
          FROM auto_queue_phase_gates
@@ -1094,28 +1101,18 @@ pub async fn repair_phase_gates_for_run_on_pg(
         ))
     })?;
 
-    // #2257: surface the count of orphan gates (no dispatch row) so operators
-    // know the candidate query intentionally skipped them. Orphans cannot
-    // match a concrete dispatch-id filter, so a filtered repair reports 0.
-    let orphan_gates_skipped = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*)::BIGINT
-         FROM auto_queue_phase_gates
-         WHERE run_id = $1
-           AND status IN ('pending', 'failed')
-           AND dispatch_id IS NULL
-           AND ($2::BIGINT IS NULL OR phase = $2)
-           AND $3::TEXT IS NULL",
-    )
-    .bind(run_id)
-    .bind(options.phase)
-    .bind(dispatch_id.as_deref())
-    .fetch_one(&mut *tx)
-    .await
-    .map_err(|error| {
-        PhaseGateRepairError::database(format!(
-            "count orphan phase gates for run {run_id}: {error}"
-        ))
-    })? as usize;
+    // Response compatibility: successful repair never skips a matching
+    // orphan. A concrete filter cannot match a NULL dispatch id.
+    let orphan_gates_skipped = 0;
+
+    if orphan_gates_cleared > 0 && blocking_gates_remaining == 0 {
+        resume_run_if_paused_on_pg_tx(&mut tx, run_id)
+            .await
+            .map_err(PhaseGateRepairError::reconcile)?;
+        super::runs::maybe_finalize_run_if_ready_pg(&mut tx, run_id)
+            .await
+            .map_err(PhaseGateRepairError::reconcile)?;
+    }
 
     let run_status =
         sqlx::query_scalar::<_, Option<String>>("SELECT status FROM auto_queue_runs WHERE id = $1")
@@ -2926,58 +2923,7 @@ mod reconcile_phase_gate_pg_tests {
     async fn repair_reports_orphan_null_dispatch_gates_without_clearing_them() {
         let pg_db = TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
-        fixture(&pool).await;
-        save_phase_gate_state_on_pg(
-            &pool,
-            "run-pg-test",
-            0,
-            &PhaseGateStateWrite {
-                status: "failed".into(),
-                pass_verdict: "phase_gate_passed".into(),
-                dispatch_ids: vec![],
-                next_phase: Some(1),
-                final_phase: false,
-                failure_reason: Some("orphaned phase gate".into()),
-                ..Default::default()
-            },
-        )
-        .await
-        .expect("seed orphan gate state");
-        sqlx::query("UPDATE auto_queue_runs SET status='paused' WHERE id='run-pg-test'")
-            .execute(&pool)
-            .await
-            .unwrap();
-
-        let summary = repair_phase_gates_for_run_on_pg(
-            &pool,
-            "run-pg-test",
-            PhaseGateRepairOptions::default(),
-        )
-        .await
-        .expect("repair reports orphan gates");
-
-        assert_eq!(summary.candidate_dispatches, 0);
-        assert_eq!(summary.cleared_gates, 0);
-        assert_eq!(summary.orphan_gates_skipped, 1);
-        assert_eq!(summary.blocking_gates_remaining, 1);
-        assert_eq!(summary.run_status.as_deref(), Some("paused"));
-        assert_eq!(gate_count(&pool, "run-pg-test", 0).await, 1);
-
-        let dispatch_filtered = repair_phase_gates_for_run_on_pg(
-            &pool,
-            "run-pg-test",
-            PhaseGateRepairOptions {
-                dispatch_id: Some("dispatch-that-cannot-match-null".to_string()),
-                ..Default::default()
-            },
-        )
-        .await
-        .expect("dispatch-filtered repair ignores null-dispatch orphans");
-        assert_eq!(dispatch_filtered.candidate_dispatches, 0);
-        assert_eq!(dispatch_filtered.cleared_gates, 0);
-        assert_eq!(dispatch_filtered.orphan_gates_skipped, 0);
-        assert_eq!(dispatch_filtered.blocking_gates_remaining, 0);
-
+        super::orphan_repair::assert_filtered_then_unfiltered_repair_contract(&pool).await;
         pool.close().await;
         pg_db.drop().await;
     }

--- a/src/db/auto_queue/phase_gates/orphan_repair.rs
+++ b/src/db/auto_queue/phase_gates/orphan_repair.rs
@@ -1,0 +1,129 @@
+//! Narrow non-force cleanup for phase gates that cannot reconcile.
+
+use super::PhaseGateRepairError;
+
+/// Delete only blocking gate rows whose dispatch is absent. Valid gates remain
+/// owned by normal dispatch reconciliation (or explicit force completion).
+/// The caller has already acquired the candidate phase advisory locks, so two
+/// repairs converge on the same deletion without widening force authority.
+pub(super) async fn clear_orphan_gates_on_pg_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    run_id: &str,
+    phase_filter: Option<i64>,
+    dispatch_id_filter: Option<&str>,
+) -> Result<usize, PhaseGateRepairError> {
+    let cleared = sqlx::query(
+        "DELETE FROM auto_queue_phase_gates pg
+         WHERE pg.run_id = $1
+           AND pg.status IN ('pending', 'failed')
+           AND ($2::BIGINT IS NULL OR pg.phase = $2)
+           AND ($3::TEXT IS NULL OR pg.dispatch_id = $3)
+           AND NOT EXISTS (
+               SELECT 1 FROM task_dispatches td WHERE td.id = pg.dispatch_id
+           )",
+    )
+    .bind(run_id)
+    .bind(phase_filter)
+    .bind(dispatch_id_filter)
+    .execute(&mut **tx)
+    .await
+    .map_err(|error| {
+        PhaseGateRepairError::database(format!(
+            "clear orphan phase gates for run {run_id}: {error}"
+        ))
+    })?
+    .rows_affected();
+    Ok(cleared as usize)
+}
+
+#[cfg(test)]
+pub(super) async fn assert_filtered_then_unfiltered_repair_contract(pool: &sqlx::PgPool) {
+    sqlx::query(
+        "INSERT INTO agents (id, name, provider, discord_channel_id)
+         VALUES ('agent-pg-test', 'Agent', 'claude', '999')",
+    )
+    .execute(pool)
+    .await
+    .expect("seed agent"); // agentdesk-audit: allow-unwrap — test-only PG assertion helper
+    sqlx::query(
+        "INSERT INTO auto_queue_runs (id, repo, agent_id, status)
+         VALUES ('run-pg-test', 'repo', 'agent-pg-test', 'paused')",
+    )
+    .execute(pool)
+    .await
+    .expect("seed paused run"); // agentdesk-audit: allow-unwrap — test-only PG assertion helper
+    super::save_phase_gate_state_on_pg(
+        pool,
+        "run-pg-test",
+        0,
+        &super::PhaseGateStateWrite {
+            status: "failed".into(),
+            pass_verdict: "phase_gate_passed".into(),
+            dispatch_ids: vec![],
+            next_phase: Some(1),
+            failure_reason: Some("orphaned phase gate".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("seed orphan gate state"); // agentdesk-audit: allow-unwrap — test-only PG assertion helper
+
+    // A concrete dispatch filter cannot match this NULL orphan.
+    let filtered = super::repair_phase_gates_for_run_on_pg(
+        pool,
+        "run-pg-test",
+        super::PhaseGateRepairOptions {
+            dispatch_id: Some("dispatch-that-cannot-match-null".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("filtered repair leaves NULL orphan untouched"); // agentdesk-audit: allow-unwrap — test-only PG assertion helper
+    assert_eq!(filtered.cleared_gates, 0);
+    assert_eq!(filtered.blocking_gates_remaining, 0);
+    assert_eq!(gate_count(pool).await, 1);
+    assert_eq!(run_status(pool).await, "paused");
+
+    let summary = super::repair_phase_gates_for_run_on_pg(
+        pool,
+        "run-pg-test",
+        super::PhaseGateRepairOptions::default(),
+    )
+    .await
+    .expect("unfiltered repair clears orphan gate"); // agentdesk-audit: allow-unwrap — test-only PG assertion helper
+    assert_eq!(summary.candidate_dispatches, 0);
+    assert_eq!(summary.cleared_gates, 1);
+    assert_eq!(summary.orphan_gates_skipped, 0);
+    assert_eq!(summary.blocking_gates_remaining, 0);
+    assert_eq!(summary.run_status.as_deref(), Some("completed"));
+    assert_eq!(gate_count(pool).await, 0);
+
+    let repeated = super::repair_phase_gates_for_run_on_pg(
+        pool,
+        "run-pg-test",
+        super::PhaseGateRepairOptions::default(),
+    )
+    .await
+    .expect("repeat repair is idempotent"); // agentdesk-audit: allow-unwrap — test-only PG assertion helper
+    assert_eq!(repeated.cleared_gates, 0);
+    assert_eq!(repeated.blocking_gates_remaining, 0);
+}
+
+#[cfg(test)]
+async fn gate_count(pool: &sqlx::PgPool) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*)::BIGINT FROM auto_queue_phase_gates
+         WHERE run_id = 'run-pg-test' AND phase = 0",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("count orphan gates") // agentdesk-audit: allow-unwrap — test-only PG assertion helper
+}
+
+#[cfg(test)]
+async fn run_status(pool: &sqlx::PgPool) -> String {
+    sqlx::query_scalar("SELECT status FROM auto_queue_runs WHERE id = 'run-pg-test'")
+        .fetch_one(pool)
+        .await
+        .expect("load repaired run status") // agentdesk-audit: allow-unwrap — test-only PG assertion helper
+}

--- a/src/db/auto_queue/readiness_pg_tests.rs
+++ b/src/db/auto_queue/readiness_pg_tests.rs
@@ -1,292 +1,297 @@
-use super::{
-    ForceRunCompletionCommand, RunCompletionBlockedReason as Blocked,
-    RunReadinessOutcome as Outcome, finalize_run_if_ready_on_pg, force_complete_run_on_pg,
-};
-use crate::db::auto_queue::test_support::TestPostgresDb;
-use sqlx::{PgPool, Row};
+#![cfg(test)]
 
-async fn setup_pool() -> (TestPostgresDb, PgPool) {
-    let pg_db = TestPostgresDb::create().await;
-    let pool = pg_db.connect_and_migrate().await;
-    sqlx::query(
-        "INSERT INTO agents (id, name, provider, discord_channel_id)
+#[cfg(test)]
+mod cases_pg_tests {
+    use super::super::{
+        ForceRunCompletionCommand, RunCompletionBlockedReason as Blocked,
+        RunReadinessOutcome as Outcome, finalize_run_if_ready_on_pg, force_complete_run_on_pg,
+    };
+    use crate::db::auto_queue::test_support::TestPostgresDb;
+    use sqlx::{PgPool, Row};
+
+    async fn setup_pool() -> (TestPostgresDb, PgPool) {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        sqlx::query(
+            "INSERT INTO agents (id, name, provider, discord_channel_id)
          VALUES ('readiness-agent', 'Readiness Agent', 'claude', '123456789')",
-    )
-    .execute(&pool)
-    .await
-    .expect("seed readiness agent");
-    (pg_db, pool)
-}
+        )
+        .execute(&pool)
+        .await
+        .expect("seed readiness agent");
+        (pg_db, pool)
+    }
 
-async fn seed_run_with_slot(pool: &PgPool, run_id: &str) {
-    sqlx::query(
-        "INSERT INTO auto_queue_runs (id, repo, agent_id, status)
+    async fn seed_run_with_slot(pool: &PgPool, run_id: &str) {
+        sqlx::query(
+            "INSERT INTO auto_queue_runs (id, repo, agent_id, status)
          VALUES ($1, 'repo/readiness', 'readiness-agent', 'active')",
-    )
-    .bind(run_id)
-    .execute(pool)
-    .await
-    .expect("seed readiness run");
-    sqlx::query(
-        "INSERT INTO auto_queue_slots
+        )
+        .bind(run_id)
+        .execute(pool)
+        .await
+        .expect("seed readiness run");
+        sqlx::query(
+            "INSERT INTO auto_queue_slots
             (agent_id, slot_index, assigned_run_id, assigned_thread_group, thread_id_map)
          VALUES ('readiness-agent', 0, $1, 0, '{}'::jsonb)
          ON CONFLICT (agent_id, slot_index) DO UPDATE
          SET assigned_run_id = EXCLUDED.assigned_run_id,
              assigned_thread_group = EXCLUDED.assigned_thread_group",
-    )
-    .bind(run_id)
-    .execute(pool)
-    .await
-    .expect("seed readiness slot");
-}
-
-async fn run_status(pool: &PgPool, run_id: &str) -> String {
-    sqlx::query_scalar("SELECT status FROM auto_queue_runs WHERE id = $1")
+        )
         .bind(run_id)
-        .fetch_one(pool)
+        .execute(pool)
         .await
-        .expect("load run status")
-}
+        .expect("seed readiness slot");
+    }
 
-async fn assigned_run(pool: &PgPool) -> Option<String> {
-    sqlx::query_scalar(
-        "SELECT assigned_run_id FROM auto_queue_slots
+    async fn run_status(pool: &PgPool, run_id: &str) -> String {
+        sqlx::query_scalar("SELECT status FROM auto_queue_runs WHERE id = $1")
+            .bind(run_id)
+            .fetch_one(pool)
+            .await
+            .expect("load run status")
+    }
+
+    async fn assigned_run(pool: &PgPool) -> Option<String> {
+        sqlx::query_scalar(
+            "SELECT assigned_run_id FROM auto_queue_slots
          WHERE agent_id = 'readiness-agent' AND slot_index = 0",
-    )
-    .fetch_one(pool)
-    .await
-    .expect("load assigned run")
-}
-
-async fn outbox_count(pool: &PgPool) -> i64 {
-    sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM message_outbox")
+        )
         .fetch_one(pool)
         .await
-        .expect("count completion outbox")
-}
+        .expect("load assigned run")
+    }
 
-#[tokio::test]
-async fn user_cancelled_with_other_terminal_entry_blocks_readiness_pg() {
-    let (pg_db, pool) = setup_pool().await;
-    seed_run_with_slot(&pool, "run-user-cancelled").await;
-    sqlx::query(
-        "INSERT INTO auto_queue_entries (id, run_id, agent_id, status)
+    async fn outbox_count(pool: &PgPool) -> i64 {
+        sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM message_outbox")
+            .fetch_one(pool)
+            .await
+            .expect("count completion outbox")
+    }
+
+    #[tokio::test]
+    async fn user_cancelled_with_other_terminal_entry_blocks_readiness_pg() {
+        let (pg_db, pool) = setup_pool().await;
+        seed_run_with_slot(&pool, "run-user-cancelled").await;
+        sqlx::query(
+            "INSERT INTO auto_queue_entries (id, run_id, agent_id, status)
          VALUES ('entry-user-cancelled', 'run-user-cancelled', 'readiness-agent', 'user_cancelled'),
                 ('entry-terminal', 'run-user-cancelled', 'readiness-agent', 'failed')",
-    )
-    .execute(&pool)
-    .await
-    .expect("seed user-cancelled and terminal entries");
-
-    let outcome = finalize_run_if_ready_on_pg(&pool, "run-user-cancelled")
+        )
+        .execute(&pool)
         .await
-        .expect("evaluate user-cancelled run");
+        .expect("seed user-cancelled and terminal entries");
 
-    assert_eq!(outcome, Outcome::Blocked(Blocked::UserCancelledEntry));
-    assert_eq!(run_status(&pool, "run-user-cancelled").await, "active");
-    assert_eq!(
-        assigned_run(&pool).await.as_deref(),
-        Some("run-user-cancelled")
-    );
-    assert_eq!(outbox_count(&pool).await, 0);
-    pool.close().await;
-    pg_db.drop().await;
-}
+        let outcome = finalize_run_if_ready_on_pg(&pool, "run-user-cancelled")
+            .await
+            .expect("evaluate user-cancelled run");
 
-#[tokio::test]
-async fn phase_gate_grace_blocks_readiness_pg() {
-    let (pg_db, pool) = setup_pool().await;
-    seed_run_with_slot(&pool, "run-grace").await;
-    sqlx::query(
-        "UPDATE auto_queue_runs
+        assert_eq!(outcome, Outcome::Blocked(Blocked::UserCancelledEntry));
+        assert_eq!(run_status(&pool, "run-user-cancelled").await, "active");
+        assert_eq!(
+            assigned_run(&pool).await.as_deref(),
+            Some("run-user-cancelled")
+        );
+        assert_eq!(outbox_count(&pool).await, 0);
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn phase_gate_grace_blocks_readiness_pg() {
+        let (pg_db, pool) = setup_pool().await;
+        seed_run_with_slot(&pool, "run-grace").await;
+        sqlx::query(
+            "UPDATE auto_queue_runs
          SET phase_gate_grace_until = NOW() + INTERVAL '5 minutes'
          WHERE id = 'run-grace'",
-    )
-    .execute(&pool)
-    .await
-    .expect("seed phase-gate grace");
-
-    let outcome = finalize_run_if_ready_on_pg(&pool, "run-grace")
-        .await
-        .expect("evaluate grace-held run");
-
-    assert_eq!(outcome, Outcome::Blocked(Blocked::PhaseGateGraceWindow));
-    assert_eq!(run_status(&pool, "run-grace").await, "active");
-    assert_eq!(assigned_run(&pool).await.as_deref(), Some("run-grace"));
-    pool.close().await;
-    pg_db.drop().await;
-}
-
-#[tokio::test]
-async fn pending_and_failed_phase_gates_block_readiness_pg() {
-    let (pg_db, pool) = setup_pool().await;
-    for (phase, gate_status) in [(1_i32, "pending"), (2_i32, "failed")] {
-        let run_id = format!("run-gate-{gate_status}");
-        sqlx::query(
-            "INSERT INTO auto_queue_runs (id, status)
-             VALUES ($1, 'active')",
         )
-        .bind(&run_id)
         .execute(&pool)
         .await
-        .expect("seed gate-held run");
-        sqlx::query(
-            "INSERT INTO auto_queue_phase_gates (run_id, phase, status)
-             VALUES ($1, $2, $3)",
-        )
-        .bind(&run_id)
-        .bind(phase)
-        .bind(gate_status)
-        .execute(&pool)
-        .await
-        .expect("seed blocking phase gate");
+        .expect("seed phase-gate grace");
 
-        let outcome = finalize_run_if_ready_on_pg(&pool, &run_id)
+        let outcome = finalize_run_if_ready_on_pg(&pool, "run-grace")
             .await
-            .expect("evaluate gate-held run");
-        assert_eq!(
-            outcome,
-            Outcome::Blocked(Blocked::BlockingPhaseGate),
-            "{gate_status} gate must block completion"
-        );
-        assert_eq!(run_status(&pool, &run_id).await, "active");
+            .expect("evaluate grace-held run");
+
+        assert_eq!(outcome, Outcome::Blocked(Blocked::PhaseGateGraceWindow));
+        assert_eq!(run_status(&pool, "run-grace").await, "active");
+        assert_eq!(assigned_run(&pool).await.as_deref(), Some("run-grace"));
+        pool.close().await;
+        pg_db.drop().await;
     }
-    pool.close().await;
-    pg_db.drop().await;
-}
 
-#[tokio::test]
-async fn runnable_entry_blocks_readiness_pg() {
-    let (pg_db, pool) = setup_pool().await;
-    seed_run_with_slot(&pool, "run-runnable").await;
-    sqlx::query(
-        "INSERT INTO auto_queue_entries (id, run_id, agent_id, status)
+    #[tokio::test]
+    async fn pending_and_failed_phase_gates_block_readiness_pg() {
+        let (pg_db, pool) = setup_pool().await;
+        for (phase, gate_status) in [(1_i32, "pending"), (2_i32, "failed")] {
+            let run_id = format!("run-gate-{gate_status}");
+            sqlx::query(
+                "INSERT INTO auto_queue_runs (id, status)
+             VALUES ($1, 'active')",
+            )
+            .bind(&run_id)
+            .execute(&pool)
+            .await
+            .expect("seed gate-held run");
+            sqlx::query(
+                "INSERT INTO auto_queue_phase_gates (run_id, phase, status)
+             VALUES ($1, $2, $3)",
+            )
+            .bind(&run_id)
+            .bind(phase)
+            .bind(gate_status)
+            .execute(&pool)
+            .await
+            .expect("seed blocking phase gate");
+
+            let outcome = finalize_run_if_ready_on_pg(&pool, &run_id)
+                .await
+                .expect("evaluate gate-held run");
+            assert_eq!(
+                outcome,
+                Outcome::Blocked(Blocked::BlockingPhaseGate),
+                "{gate_status} gate must block completion"
+            );
+            assert_eq!(run_status(&pool, &run_id).await, "active");
+        }
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn runnable_entry_blocks_readiness_pg() {
+        let (pg_db, pool) = setup_pool().await;
+        seed_run_with_slot(&pool, "run-runnable").await;
+        sqlx::query(
+            "INSERT INTO auto_queue_entries (id, run_id, agent_id, status)
          VALUES ('entry-runnable', 'run-runnable', 'readiness-agent', 'pending')",
-    )
-    .execute(&pool)
-    .await
-    .expect("seed runnable entry");
-
-    let outcome = finalize_run_if_ready_on_pg(&pool, "run-runnable")
+        )
+        .execute(&pool)
         .await
-        .expect("evaluate runnable run");
-    assert_eq!(outcome, Outcome::Blocked(Blocked::RunnableEntry));
-    assert_eq!(run_status(&pool, "run-runnable").await, "active");
-    assert_eq!(assigned_run(&pool).await.as_deref(), Some("run-runnable"));
-    pool.close().await;
-    pg_db.drop().await;
-}
+        .expect("seed runnable entry");
 
-#[tokio::test]
-async fn completion_updates_status_slot_and_outbox_once_pg() {
-    let (pg_db, pool) = setup_pool().await;
-    seed_run_with_slot(&pool, "run-complete").await;
-    sqlx::query(
-        "INSERT INTO auto_queue_entries (id, run_id, agent_id, status)
+        let outcome = finalize_run_if_ready_on_pg(&pool, "run-runnable")
+            .await
+            .expect("evaluate runnable run");
+        assert_eq!(outcome, Outcome::Blocked(Blocked::RunnableEntry));
+        assert_eq!(run_status(&pool, "run-runnable").await, "active");
+        assert_eq!(assigned_run(&pool).await.as_deref(), Some("run-runnable"));
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn completion_updates_status_slot_and_outbox_once_pg() {
+        let (pg_db, pool) = setup_pool().await;
+        seed_run_with_slot(&pool, "run-complete").await;
+        sqlx::query(
+            "INSERT INTO auto_queue_entries (id, run_id, agent_id, status)
          VALUES ('entry-complete', 'run-complete', 'readiness-agent', 'skipped')",
-    )
-    .execute(&pool)
-    .await
-    .expect("seed terminal entry");
-
-    let first = finalize_run_if_ready_on_pg(&pool, "run-complete")
+        )
+        .execute(&pool)
         .await
-        .expect("complete ready run");
-    assert_eq!(first, Outcome::Completed);
-    assert_eq!(run_status(&pool, "run-complete").await, "completed");
-    assert_eq!(assigned_run(&pool).await, None);
-    assert_eq!(outbox_count(&pool).await, 1);
+        .expect("seed terminal entry");
 
-    let second = finalize_run_if_ready_on_pg(&pool, "run-complete")
-        .await
-        .expect("repeat completion");
-    assert_eq!(second, Outcome::AlreadyTerminal);
-    assert_eq!(outbox_count(&pool).await, 1);
-    pool.close().await;
-    pg_db.drop().await;
-}
+        let first = finalize_run_if_ready_on_pg(&pool, "run-complete")
+            .await
+            .expect("complete ready run");
+        assert_eq!(first, Outcome::Completed);
+        assert_eq!(run_status(&pool, "run-complete").await, "completed");
+        assert_eq!(assigned_run(&pool).await, None);
+        assert_eq!(outbox_count(&pool).await, 1);
 
-#[tokio::test]
-async fn completion_notification_failure_rolls_back_status_and_slot_pg() {
-    let (pg_db, pool) = setup_pool().await;
-    seed_run_with_slot(&pool, "run-rollback").await;
-    sqlx::query(
-        "CREATE FUNCTION reject_completion_outbox() RETURNS TRIGGER AS $$
+        let second = finalize_run_if_ready_on_pg(&pool, "run-complete")
+            .await
+            .expect("repeat completion");
+        assert_eq!(second, Outcome::AlreadyTerminal);
+        assert_eq!(outbox_count(&pool).await, 1);
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn completion_notification_failure_rolls_back_status_and_slot_pg() {
+        let (pg_db, pool) = setup_pool().await;
+        seed_run_with_slot(&pool, "run-rollback").await;
+        sqlx::query(
+            "CREATE FUNCTION reject_completion_outbox() RETURNS TRIGGER AS $$
          BEGIN RAISE EXCEPTION 'forced completion outbox failure'; END;
          $$ LANGUAGE plpgsql",
-    )
-    .execute(&pool)
-    .await
-    .expect("create outbox rejection function");
-    sqlx::query(
-        "CREATE TRIGGER reject_completion_outbox
+        )
+        .execute(&pool)
+        .await
+        .expect("create outbox rejection function");
+        sqlx::query(
+            "CREATE TRIGGER reject_completion_outbox
          BEFORE INSERT ON message_outbox
          FOR EACH ROW EXECUTE FUNCTION reject_completion_outbox()",
-    )
-    .execute(&pool)
-    .await
-    .expect("create outbox rejection trigger");
-
-    let error = finalize_run_if_ready_on_pg(&pool, "run-rollback")
+        )
+        .execute(&pool)
         .await
-        .expect_err("outbox failure must abort completion");
-    assert!(
-        error.contains("forced completion outbox failure"),
-        "{error}"
-    );
-    assert_eq!(run_status(&pool, "run-rollback").await, "active");
-    assert_eq!(assigned_run(&pool).await.as_deref(), Some("run-rollback"));
-    assert_eq!(outbox_count(&pool).await, 0);
-    pool.close().await;
-    pg_db.drop().await;
-}
+        .expect("create outbox rejection trigger");
 
-#[tokio::test]
-async fn force_completion_deletes_gate_and_audits_operator_source_pg() {
-    let (pg_db, pool) = setup_pool().await;
-    seed_run_with_slot(&pool, "run-force").await;
-    sqlx::query(
-        "INSERT INTO auto_queue_phase_gates (run_id, phase, status)
+        let error = finalize_run_if_ready_on_pg(&pool, "run-rollback")
+            .await
+            .expect_err("outbox failure must abort completion");
+        assert!(
+            error.contains("forced completion outbox failure"),
+            "{error}"
+        );
+        assert_eq!(run_status(&pool, "run-rollback").await, "active");
+        assert_eq!(assigned_run(&pool).await.as_deref(), Some("run-rollback"));
+        assert_eq!(outbox_count(&pool).await, 0);
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn force_completion_deletes_gate_and_audits_operator_source_pg() {
+        let (pg_db, pool) = setup_pool().await;
+        seed_run_with_slot(&pool, "run-force").await;
+        sqlx::query(
+            "INSERT INTO auto_queue_phase_gates (run_id, phase, status)
          VALUES ('run-force', 1, 'failed')",
-    )
-    .execute(&pool)
-    .await
-    .expect("seed force-deleted gate");
+        )
+        .execute(&pool)
+        .await
+        .expect("seed force-deleted gate");
 
-    let outcome = force_complete_run_on_pg(
-        &pool,
-        &ForceRunCompletionCommand {
-            run_id: "run-force",
-            operator: "operator@example.com",
-            source: "queue_admin",
-        },
-    )
-    .await
-    .expect("force complete run");
-    assert_eq!(outcome, Outcome::Completed);
-    assert_eq!(run_status(&pool, "run-force").await, "completed");
-    assert_eq!(assigned_run(&pool).await, None);
-    let gate_count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*)::BIGINT FROM auto_queue_phase_gates WHERE run_id = 'run-force'",
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("count remaining gates");
-    assert_eq!(gate_count, 0);
-    let audit = sqlx::query(
-        "SELECT action, actor FROM audit_logs
+        let outcome = force_complete_run_on_pg(
+            &pool,
+            &ForceRunCompletionCommand {
+                run_id: "run-force",
+                operator: "operator@example.com",
+                source: "queue_admin",
+            },
+        )
+        .await
+        .expect("force complete run");
+        assert_eq!(outcome, Outcome::Completed);
+        assert_eq!(run_status(&pool, "run-force").await, "completed");
+        assert_eq!(assigned_run(&pool).await, None);
+        let gate_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*)::BIGINT FROM auto_queue_phase_gates WHERE run_id = 'run-force'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("count remaining gates");
+        assert_eq!(gate_count, 0);
+        let audit = sqlx::query(
+            "SELECT action, actor FROM audit_logs
          WHERE entity_type = 'auto_queue_run' AND entity_id = 'run-force'",
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("load force audit");
-    assert_eq!(
-        audit.get::<String, _>("action"),
-        "force_complete:queue_admin"
-    );
-    assert_eq!(audit.get::<String, _>("actor"), "operator@example.com");
-    assert_eq!(outbox_count(&pool).await, 1);
-    pool.close().await;
-    pg_db.drop().await;
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("load force audit");
+        assert_eq!(
+            audit.get::<String, _>("action"),
+            "force_complete:queue_admin"
+        );
+        assert_eq!(audit.get::<String, _>("actor"), "operator@example.com");
+        assert_eq!(outbox_count(&pool).await, 1);
+        pool.close().await;
+        pg_db.drop().await;
+    }
 }

--- a/src/db/auto_queue/readiness_pg_tests.rs
+++ b/src/db/auto_queue/readiness_pg_tests.rs
@@ -1,0 +1,266 @@
+use super::{
+    ForceRunCompletionCommand, RunCompletionBlockedReason, RunReadinessOutcome,
+    finalize_run_if_ready_on_pg, force_complete_run_on_pg,
+};
+use crate::db::auto_queue::test_support::TestPostgresDb;
+use sqlx::{PgPool, Row};
+
+async fn setup_pool() -> (TestPostgresDb, PgPool) {
+    let pg_db = TestPostgresDb::create().await;
+    let pool = pg_db.connect_and_migrate().await;
+    sqlx::query(
+        "INSERT INTO agents (id, name, provider, discord_channel_id)
+         VALUES ('readiness-agent', 'Readiness Agent', 'claude', '123456789')",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed readiness agent");
+    (pg_db, pool)
+}
+
+async fn seed_run_with_slot(pool: &PgPool, run_id: &str) {
+    sqlx::query(
+        "INSERT INTO auto_queue_runs (id, repo, agent_id, status)
+         VALUES ($1, 'repo/readiness', 'readiness-agent', 'active')",
+    )
+    .bind(run_id)
+    .execute(pool)
+    .await
+    .expect("seed readiness run");
+    sqlx::query(
+        "INSERT INTO auto_queue_slots
+            (agent_id, slot_index, assigned_run_id, assigned_thread_group, thread_id_map)
+         VALUES ('readiness-agent', 0, $1, 0, '{}'::jsonb)
+         ON CONFLICT (agent_id, slot_index) DO UPDATE
+         SET assigned_run_id = EXCLUDED.assigned_run_id,
+             assigned_thread_group = EXCLUDED.assigned_thread_group",
+    )
+    .bind(run_id)
+    .execute(pool)
+    .await
+    .expect("seed readiness slot");
+}
+
+async fn run_status(pool: &PgPool, run_id: &str) -> String {
+    sqlx::query_scalar("SELECT status FROM auto_queue_runs WHERE id = $1")
+        .bind(run_id)
+        .fetch_one(pool)
+        .await
+        .expect("load run status")
+}
+
+async fn assigned_run(pool: &PgPool) -> Option<String> {
+    sqlx::query_scalar(
+        "SELECT assigned_run_id FROM auto_queue_slots
+         WHERE agent_id = 'readiness-agent' AND slot_index = 0",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("load assigned run")
+}
+
+async fn outbox_count(pool: &PgPool) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM message_outbox")
+        .fetch_one(pool)
+        .await
+        .expect("count completion outbox")
+}
+
+#[tokio::test]
+async fn user_cancelled_with_other_terminal_entry_blocks_readiness_pg() {
+    let (pg_db, pool) = setup_pool().await;
+    seed_run_with_slot(&pool, "run-user-cancelled").await;
+    sqlx::query(
+        "INSERT INTO auto_queue_entries (id, run_id, agent_id, status)
+         VALUES ('entry-user-cancelled', 'run-user-cancelled', 'readiness-agent', 'user_cancelled'),
+                ('entry-terminal', 'run-user-cancelled', 'readiness-agent', 'failed')",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed user-cancelled and terminal entries");
+
+    let outcome = finalize_run_if_ready_on_pg(&pool, "run-user-cancelled")
+        .await
+        .expect("evaluate user-cancelled run");
+
+    assert_eq!(
+        outcome,
+        RunReadinessOutcome::Blocked(RunCompletionBlockedReason::UserCancelledEntry)
+    );
+    assert_eq!(run_status(&pool, "run-user-cancelled").await, "active");
+    assert_eq!(
+        assigned_run(&pool).await.as_deref(),
+        Some("run-user-cancelled")
+    );
+    assert_eq!(outbox_count(&pool).await, 0);
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn phase_gate_grace_blocks_readiness_pg() {
+    let (pg_db, pool) = setup_pool().await;
+    seed_run_with_slot(&pool, "run-grace").await;
+    sqlx::query(
+        "UPDATE auto_queue_runs
+         SET phase_gate_grace_until = NOW() + INTERVAL '5 minutes'
+         WHERE id = 'run-grace'",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed phase-gate grace");
+
+    let outcome = finalize_run_if_ready_on_pg(&pool, "run-grace")
+        .await
+        .expect("evaluate grace-held run");
+
+    assert_eq!(
+        outcome,
+        RunReadinessOutcome::Blocked(RunCompletionBlockedReason::PhaseGateGraceWindow)
+    );
+    assert_eq!(run_status(&pool, "run-grace").await, "active");
+    assert_eq!(assigned_run(&pool).await.as_deref(), Some("run-grace"));
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn pending_and_failed_phase_gates_block_readiness_pg() {
+    let (pg_db, pool) = setup_pool().await;
+    for (phase, gate_status) in [(1_i32, "pending"), (2_i32, "failed")] {
+        let run_id = format!("run-gate-{gate_status}");
+        sqlx::query(
+            "INSERT INTO auto_queue_runs (id, status)
+             VALUES ($1, 'active')",
+        )
+        .bind(&run_id)
+        .execute(&pool)
+        .await
+        .expect("seed gate-held run");
+        sqlx::query(
+            "INSERT INTO auto_queue_phase_gates (run_id, phase, status)
+             VALUES ($1, $2, $3)",
+        )
+        .bind(&run_id)
+        .bind(phase)
+        .bind(gate_status)
+        .execute(&pool)
+        .await
+        .expect("seed blocking phase gate");
+
+        let outcome = finalize_run_if_ready_on_pg(&pool, &run_id)
+            .await
+            .expect("evaluate gate-held run");
+        assert_eq!(
+            outcome,
+            RunReadinessOutcome::Blocked(RunCompletionBlockedReason::BlockingPhaseGate),
+            "{gate_status} gate must block completion"
+        );
+        assert_eq!(run_status(&pool, &run_id).await, "active");
+    }
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn runnable_entry_blocks_readiness_pg() {
+    let (pg_db, pool) = setup_pool().await;
+    seed_run_with_slot(&pool, "run-runnable").await;
+    sqlx::query(
+        "INSERT INTO auto_queue_entries (id, run_id, agent_id, status)
+         VALUES ('entry-runnable', 'run-runnable', 'readiness-agent', 'pending')",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed runnable entry");
+
+    let outcome = finalize_run_if_ready_on_pg(&pool, "run-runnable")
+        .await
+        .expect("evaluate runnable run");
+    assert_eq!(
+        outcome,
+        RunReadinessOutcome::Blocked(RunCompletionBlockedReason::RunnableEntry)
+    );
+    assert_eq!(run_status(&pool, "run-runnable").await, "active");
+    assert_eq!(assigned_run(&pool).await.as_deref(), Some("run-runnable"));
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn completion_updates_status_slot_and_outbox_once_pg() {
+    let (pg_db, pool) = setup_pool().await;
+    seed_run_with_slot(&pool, "run-complete").await;
+    sqlx::query(
+        "INSERT INTO auto_queue_entries (id, run_id, agent_id, status)
+         VALUES ('entry-complete', 'run-complete', 'readiness-agent', 'skipped')",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed terminal entry");
+
+    let first = finalize_run_if_ready_on_pg(&pool, "run-complete")
+        .await
+        .expect("complete ready run");
+    assert_eq!(first, RunReadinessOutcome::Completed);
+    assert_eq!(run_status(&pool, "run-complete").await, "completed");
+    assert_eq!(assigned_run(&pool).await, None);
+    assert_eq!(outbox_count(&pool).await, 1);
+
+    let second = finalize_run_if_ready_on_pg(&pool, "run-complete")
+        .await
+        .expect("repeat completion");
+    assert_eq!(second, RunReadinessOutcome::AlreadyTerminal);
+    assert_eq!(outbox_count(&pool).await, 1);
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn force_completion_deletes_gate_and_audits_operator_source_pg() {
+    let (pg_db, pool) = setup_pool().await;
+    seed_run_with_slot(&pool, "run-force").await;
+    sqlx::query(
+        "INSERT INTO auto_queue_phase_gates (run_id, phase, status)
+         VALUES ('run-force', 1, 'failed')",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed force-deleted gate");
+
+    let outcome = force_complete_run_on_pg(
+        &pool,
+        &ForceRunCompletionCommand {
+            run_id: "run-force",
+            operator: "operator@example.com",
+            source: "queue_admin",
+        },
+    )
+    .await
+    .expect("force complete run");
+    assert_eq!(outcome, RunReadinessOutcome::Completed);
+    assert_eq!(run_status(&pool, "run-force").await, "completed");
+    assert_eq!(assigned_run(&pool).await, None);
+    let gate_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::BIGINT FROM auto_queue_phase_gates WHERE run_id = 'run-force'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count remaining gates");
+    assert_eq!(gate_count, 0);
+    let audit = sqlx::query(
+        "SELECT action, actor FROM audit_logs
+         WHERE entity_type = 'auto_queue_run' AND entity_id = 'run-force'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("load force audit");
+    assert_eq!(
+        audit.get::<String, _>("action"),
+        "force_complete:queue_admin"
+    );
+    assert_eq!(audit.get::<String, _>("actor"), "operator@example.com");
+    assert_eq!(outbox_count(&pool).await, 1);
+    pool.close().await;
+    pg_db.drop().await;
+}

--- a/src/db/auto_queue/readiness_pg_tests.rs
+++ b/src/db/auto_queue/readiness_pg_tests.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod cases_pg_tests {
     use super::super::{
-        ForceRunCompletionCommand, RunCompletionBlockedReason as Blocked,
+        EntryStatusUpdateOptions, ForceRunCompletionCommand, RunCompletionBlockedReason as Blocked,
         RunReadinessOutcome as Outcome, finalize_run_if_ready_on_pg, force_complete_run_on_pg,
+        update_entry_status_on_pg,
     };
     use crate::db::auto_queue::test_support::TestPostgresDb;
     use sqlx::{PgPool, Row};
@@ -68,17 +69,47 @@ mod cases_pg_tests {
         .await
         .expect("seed user-cancelled and terminal entries");
 
-        let outcome = finalize_run_if_ready_on_pg(&pool, "run-user-cancelled")
-            .await
-            .expect("evaluate user-cancelled run");
-
-        assert_eq!(outcome, Outcome::Blocked(Blocked::UserCancelledEntry));
+        for _ in 0..3 {
+            let outcome = finalize_run_if_ready_on_pg(&pool, "run-user-cancelled")
+                .await
+                .expect("evaluate user-cancelled run");
+            assert_eq!(outcome, Outcome::Blocked(Blocked::UserCancelledEntry));
+        }
         assert_eq!(run_status(&pool, "run-user-cancelled").await, "active");
         assert_eq!(
             assigned_run(&pool).await.as_deref(),
             Some("run-user-cancelled")
         );
         assert_eq!(outbox_count(&pool).await, 0);
+
+        update_entry_status_on_pg(
+            &pool,
+            "entry-user-cancelled",
+            "skipped",
+            "tick_user_cancelled_terminalization",
+            &EntryStatusUpdateOptions::default(),
+        )
+        .await
+        .expect("tick terminalizes drained user-cancelled entry");
+
+        let trigger_source: String = sqlx::query_scalar(
+            "SELECT trigger_source FROM auto_queue_entry_transitions
+             WHERE entry_id = 'entry-user-cancelled'
+             ORDER BY id DESC LIMIT 1",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("load tick terminalization transition");
+        assert_eq!(trigger_source, "tick_user_cancelled_terminalization");
+        assert_eq!(run_status(&pool, "run-user-cancelled").await, "completed");
+        assert_eq!(assigned_run(&pool).await, None);
+        assert_eq!(outbox_count(&pool).await, 1);
+        assert_eq!(
+            finalize_run_if_ready_on_pg(&pool, "run-user-cancelled")
+                .await
+                .expect("repeat completed readiness"),
+            Outcome::AlreadyTerminal
+        );
         pool.close().await;
         pg_db.drop().await;
     }

--- a/src/db/auto_queue/readiness_pg_tests.rs
+++ b/src/db/auto_queue/readiness_pg_tests.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 #[cfg(test)]
 mod cases_pg_tests {
     use super::super::{
@@ -12,10 +10,7 @@ mod cases_pg_tests {
     async fn setup_pool() -> (TestPostgresDb, PgPool) {
         let pg_db = TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
-        sqlx::query(
-            "INSERT INTO agents (id, name, provider, discord_channel_id)
-         VALUES ('readiness-agent', 'Readiness Agent', 'claude', '123456789')",
-        )
+        sqlx::query("INSERT INTO agents (id, name, provider, discord_channel_id) VALUES ('readiness-agent', 'Readiness Agent', 'claude', '123456789')")
         .execute(&pool)
         .await
         .expect("seed readiness agent");
@@ -23,22 +18,12 @@ mod cases_pg_tests {
     }
 
     async fn seed_run_with_slot(pool: &PgPool, run_id: &str) {
-        sqlx::query(
-            "INSERT INTO auto_queue_runs (id, repo, agent_id, status)
-         VALUES ($1, 'repo/readiness', 'readiness-agent', 'active')",
-        )
+        sqlx::query("INSERT INTO auto_queue_runs (id, repo, agent_id, status) VALUES ($1, 'repo/readiness', 'readiness-agent', 'active')")
         .bind(run_id)
         .execute(pool)
         .await
         .expect("seed readiness run");
-        sqlx::query(
-            "INSERT INTO auto_queue_slots
-            (agent_id, slot_index, assigned_run_id, assigned_thread_group, thread_id_map)
-         VALUES ('readiness-agent', 0, $1, 0, '{}'::jsonb)
-         ON CONFLICT (agent_id, slot_index) DO UPDATE
-         SET assigned_run_id = EXCLUDED.assigned_run_id,
-             assigned_thread_group = EXCLUDED.assigned_thread_group",
-        )
+        sqlx::query("INSERT INTO auto_queue_slots (agent_id, slot_index, assigned_run_id, assigned_thread_group, thread_id_map) VALUES ('readiness-agent', 0, $1, 0, '{}'::jsonb) ON CONFLICT (agent_id, slot_index) DO UPDATE SET assigned_run_id = EXCLUDED.assigned_run_id, assigned_thread_group = EXCLUDED.assigned_thread_group")
         .bind(run_id)
         .execute(pool)
         .await

--- a/src/db/auto_queue/readiness_pg_tests.rs
+++ b/src/db/auto_queue/readiness_pg_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    ForceRunCompletionCommand, RunCompletionBlockedReason, RunReadinessOutcome,
-    finalize_run_if_ready_on_pg, force_complete_run_on_pg,
+    ForceRunCompletionCommand, RunCompletionBlockedReason as Blocked,
+    RunReadinessOutcome as Outcome, finalize_run_if_ready_on_pg, force_complete_run_on_pg,
 };
 use crate::db::auto_queue::test_support::TestPostgresDb;
 use sqlx::{PgPool, Row};
@@ -83,10 +83,7 @@ async fn user_cancelled_with_other_terminal_entry_blocks_readiness_pg() {
         .await
         .expect("evaluate user-cancelled run");
 
-    assert_eq!(
-        outcome,
-        RunReadinessOutcome::Blocked(RunCompletionBlockedReason::UserCancelledEntry)
-    );
+    assert_eq!(outcome, Outcome::Blocked(Blocked::UserCancelledEntry));
     assert_eq!(run_status(&pool, "run-user-cancelled").await, "active");
     assert_eq!(
         assigned_run(&pool).await.as_deref(),
@@ -114,10 +111,7 @@ async fn phase_gate_grace_blocks_readiness_pg() {
         .await
         .expect("evaluate grace-held run");
 
-    assert_eq!(
-        outcome,
-        RunReadinessOutcome::Blocked(RunCompletionBlockedReason::PhaseGateGraceWindow)
-    );
+    assert_eq!(outcome, Outcome::Blocked(Blocked::PhaseGateGraceWindow));
     assert_eq!(run_status(&pool, "run-grace").await, "active");
     assert_eq!(assigned_run(&pool).await.as_deref(), Some("run-grace"));
     pool.close().await;
@@ -153,7 +147,7 @@ async fn pending_and_failed_phase_gates_block_readiness_pg() {
             .expect("evaluate gate-held run");
         assert_eq!(
             outcome,
-            RunReadinessOutcome::Blocked(RunCompletionBlockedReason::BlockingPhaseGate),
+            Outcome::Blocked(Blocked::BlockingPhaseGate),
             "{gate_status} gate must block completion"
         );
         assert_eq!(run_status(&pool, &run_id).await, "active");
@@ -177,10 +171,7 @@ async fn runnable_entry_blocks_readiness_pg() {
     let outcome = finalize_run_if_ready_on_pg(&pool, "run-runnable")
         .await
         .expect("evaluate runnable run");
-    assert_eq!(
-        outcome,
-        RunReadinessOutcome::Blocked(RunCompletionBlockedReason::RunnableEntry)
-    );
+    assert_eq!(outcome, Outcome::Blocked(Blocked::RunnableEntry));
     assert_eq!(run_status(&pool, "run-runnable").await, "active");
     assert_eq!(assigned_run(&pool).await.as_deref(), Some("run-runnable"));
     pool.close().await;
@@ -202,7 +193,7 @@ async fn completion_updates_status_slot_and_outbox_once_pg() {
     let first = finalize_run_if_ready_on_pg(&pool, "run-complete")
         .await
         .expect("complete ready run");
-    assert_eq!(first, RunReadinessOutcome::Completed);
+    assert_eq!(first, Outcome::Completed);
     assert_eq!(run_status(&pool, "run-complete").await, "completed");
     assert_eq!(assigned_run(&pool).await, None);
     assert_eq!(outbox_count(&pool).await, 1);
@@ -210,8 +201,43 @@ async fn completion_updates_status_slot_and_outbox_once_pg() {
     let second = finalize_run_if_ready_on_pg(&pool, "run-complete")
         .await
         .expect("repeat completion");
-    assert_eq!(second, RunReadinessOutcome::AlreadyTerminal);
+    assert_eq!(second, Outcome::AlreadyTerminal);
     assert_eq!(outbox_count(&pool).await, 1);
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn completion_notification_failure_rolls_back_status_and_slot_pg() {
+    let (pg_db, pool) = setup_pool().await;
+    seed_run_with_slot(&pool, "run-rollback").await;
+    sqlx::query(
+        "CREATE FUNCTION reject_completion_outbox() RETURNS TRIGGER AS $$
+         BEGIN RAISE EXCEPTION 'forced completion outbox failure'; END;
+         $$ LANGUAGE plpgsql",
+    )
+    .execute(&pool)
+    .await
+    .expect("create outbox rejection function");
+    sqlx::query(
+        "CREATE TRIGGER reject_completion_outbox
+         BEFORE INSERT ON message_outbox
+         FOR EACH ROW EXECUTE FUNCTION reject_completion_outbox()",
+    )
+    .execute(&pool)
+    .await
+    .expect("create outbox rejection trigger");
+
+    let error = finalize_run_if_ready_on_pg(&pool, "run-rollback")
+        .await
+        .expect_err("outbox failure must abort completion");
+    assert!(
+        error.contains("forced completion outbox failure"),
+        "{error}"
+    );
+    assert_eq!(run_status(&pool, "run-rollback").await, "active");
+    assert_eq!(assigned_run(&pool).await.as_deref(), Some("run-rollback"));
+    assert_eq!(outbox_count(&pool).await, 0);
     pool.close().await;
     pg_db.drop().await;
 }
@@ -238,7 +264,7 @@ async fn force_completion_deletes_gate_and_audits_operator_source_pg() {
     )
     .await
     .expect("force complete run");
-    assert_eq!(outcome, RunReadinessOutcome::Completed);
+    assert_eq!(outcome, Outcome::Completed);
     assert_eq!(run_status(&pool, "run-force").await, "completed");
     assert_eq!(assigned_run(&pool).await, None);
     let gate_count: i64 = sqlx::query_scalar(

--- a/src/db/auto_queue/runs.rs
+++ b/src/db/auto_queue/runs.rs
@@ -4,13 +4,62 @@ use super::entries::{ENTRY_STATUS_DONE, ENTRY_STATUS_USER_CANCELLED};
 use super::slots::release_run_slots_on_pg_tx;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Why canonical run completion declined to write `completed`.
+///
+/// Every new variant must document all three parts of its ownership contract:
+/// the resolver (and whether it is automatic or manual), the signal emitted
+/// when resolution does not happen, and whether the run's slot is retained or
+/// has already been released by the surrounding lifecycle.
 pub enum RunCompletionBlockedReason {
+    /// Resolution: a valid gate is cleared automatically by terminal-dispatch
+    /// reconciliation; an orphan gate has no automatic resolver and requires
+    /// the operator HTTP repair route. Signal: readiness returns this typed
+    /// reason, while failed-gate handling and operator repair emit their
+    /// existing alerts/audit summary; no tick invokes orphan repair. Slot:
+    /// readiness itself changes nothing, but normal gate creation pauses the
+    /// run before gate dispatch creation, and that pause releases its slot.
     BlockingPhaseGate,
+    /// Resolution: the bounded completion tick retries after the DB comparison
+    /// says the grace deadline has passed. Signal: readiness returns this typed
+    /// reason until then. Slot: readiness preserves current ownership. A tick
+    /// racing the pre-gate continuation leaves the slot held until that
+    /// continuation clears the deadline or pauses; gate creation then releases
+    /// the slot through pause.
+    /// The deadline is written from application `Date.now()` but compared with
+    /// DB `NOW()`, so finite clock skew can extend the otherwise bounded wait.
     PhaseGateGraceWindow,
+    /// Resolution: the bounded tick automatically changes drained, gate-free,
+    /// grace-expired `user_cancelled` entries to `skipped`, then re-enters the
+    /// canonical writer. Signal: readiness returns this typed reason and tick
+    /// transition failures reach policy error logging. Slot: any assigned slot
+    /// remains held until the automatic transition lets completion release it.
     UserCancelledEntry,
+    /// Resolution: the bounded dispatch tick automatically advances pending
+    /// work on `active` runs; a final-phase block first resumes a paused run.
+    /// Signal: readiness returns this typed reason and a failed final-phase
+    /// resume emits a warning. Slot: readiness preserves current ownership.
+    /// `generated`/`pending` runs are not scanned by that tick, but are still
+    /// pre-activation and therefore do not own an assigned slot.
     RunnableEntry,
+    /// Resolution: none is automatic. In particular, if the process crashes
+    /// after `apply_restore_state_changes_pg` commits `restoring`
+    /// (`fsm.rs:292-313`) but before `finalize_restore_run_pg`
+    /// (`fsm.rs:398-437`), only an operator restore retry exits the state.
+    /// Signal: an explicit readiness call returns this typed reason, but the
+    /// stuck `restoring` state has no periodic sweep or alert. Slot: retained
+    /// deliberately across restore. This crash window is pre-existing debt,
+    /// not introduced by #4881.
     RunStatusNotCompletable,
+    /// Resolution: the `onCardTerminal` policy hook automatically performs the
+    /// continuation that may create a phase gate or re-enter finalization.
+    /// Signal: the terminal-entry writer returns this typed reason while that
+    /// continuation is pending. Slot: readiness retains it; continuation keeps
+    /// it while dispatching more work, or releases it by completion/gate pause.
     PolicyContinuationPending,
+    /// Resolution: none applies because no run row exists. Signal: the caller
+    /// receives this typed reason and must treat the identifier as stale or
+    /// invalid. Slot: readiness neither acquires nor releases a slot for the
+    /// missing run.
     RunNotFound,
 }
 

--- a/src/db/auto_queue/runs.rs
+++ b/src/db/auto_queue/runs.rs
@@ -193,8 +193,9 @@ pub(super) async fn maybe_finalize_run_after_terminal_entry_pg(
             RunCompletionBlockedReason::PolicyContinuationPending,
         ));
     }
-    // #815 P1: never finalize on `user_cancelled` — it must leave the run in a
-    // resumable state so the operator can flip the entry back to `pending`.
+    // #815 + #4881 r2: never finalize directly on `user_cancelled`. Preserve
+    // the operator recovery window; the bounded tick later normalizes a
+    // drained cancellation to `skipped` and re-enters readiness.
     if new_status == ENTRY_STATUS_USER_CANCELLED {
         return Ok(RunReadinessOutcome::Blocked(
             RunCompletionBlockedReason::UserCancelledEntry,
@@ -253,7 +254,6 @@ pub(crate) async fn maybe_finalize_run_if_ready_pg(
             RunCompletionBlockedReason::PhaseGateGraceWindow,
         ));
     }
-
     let has_user_cancelled = sqlx::query_scalar::<_, bool>(
         "SELECT EXISTS(
              SELECT 1 FROM auto_queue_entries
@@ -285,7 +285,6 @@ pub(crate) async fn maybe_finalize_run_if_ready_pg(
             RunCompletionBlockedReason::RunnableEntry,
         ));
     }
-
     // The status transition is the release authority. In particular, a run in
     // the restore hand-off window must retain its slot until restore finalizes;
     // releasing first and then discovering the status is ineligible creates a
@@ -437,13 +436,11 @@ pub async fn force_complete_run_on_pg(
             RunCompletionBlockedReason::RunStatusNotCompletable,
         ));
     }
-    // #2048 F17: only this explicit force command may drop any
-    // pending/failed phase-gate rows AND release the run's slot bindings.
-    // Otherwise a completed run leaves stale phase_gate rows that next
-    // restore/audit treats as still-pending, plus zombie slot assignments
-    // that block other runs from picking up the slot. We perform the
-    // delete + release inside the same transaction so the operation is
-    // atomic with the status flip.
+    // #2048 F17 + #4881 r2: only this explicit force command may bulk-drop
+    // valid pending/failed phase gates. The non-force repair path may delete
+    // only orphan rows that have no corresponding dispatch and therefore can
+    // never reconcile. Force keeps the broad delete + slot release atomic
+    // with the status flip.
     sqlx::query("DELETE FROM auto_queue_phase_gates WHERE run_id = $1")
         .bind(run_id)
         .execute(&mut *tx)

--- a/src/db/auto_queue/runs.rs
+++ b/src/db/auto_queue/runs.rs
@@ -3,6 +3,66 @@ use sqlx::{PgPool, Row as SqlxRow};
 use super::entries::{ENTRY_STATUS_DONE, ENTRY_STATUS_USER_CANCELLED};
 use super::slots::release_run_slots_on_pg_tx;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunCompletionBlockedReason {
+    BlockingPhaseGate,
+    PhaseGateGraceWindow,
+    UserCancelledEntry,
+    RunnableEntry,
+    RunStatusNotCompletable,
+    PolicyContinuationPending,
+    RunNotFound,
+}
+
+impl RunCompletionBlockedReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::BlockingPhaseGate => "blocking_phase_gate",
+            Self::PhaseGateGraceWindow => "phase_gate_grace_window",
+            Self::UserCancelledEntry => "user_cancelled_entry",
+            Self::RunnableEntry => "runnable_entry",
+            Self::RunStatusNotCompletable => "run_status_not_completable",
+            Self::PolicyContinuationPending => "policy_continuation_pending",
+            Self::RunNotFound => "run_not_found",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunReadinessOutcome {
+    Completed,
+    Blocked(RunCompletionBlockedReason),
+    AlreadyTerminal,
+}
+
+impl RunReadinessOutcome {
+    pub fn is_completed(&self) -> bool {
+        matches!(self, Self::Completed)
+    }
+
+    pub fn outcome_name(&self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Blocked(_) => "blocked",
+            Self::AlreadyTerminal => "already_terminal",
+        }
+    }
+
+    pub fn blocked_reason(&self) -> Option<&'static str> {
+        match self {
+            Self::Blocked(reason) => Some(reason.as_str()),
+            Self::Completed | Self::AlreadyTerminal => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForceRunCompletionCommand<'a> {
+    pub run_id: &'a str,
+    pub operator: &'a str,
+    pub source: &'a str,
+}
+
 async fn queue_run_completion_notify_on_pg(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     run_id: &str,
@@ -127,14 +187,18 @@ pub(super) async fn maybe_finalize_run_after_terminal_entry_pg(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     run_id: &str,
     new_status: &str,
-) -> Result<bool, String> {
+) -> Result<RunReadinessOutcome, String> {
     if new_status == ENTRY_STATUS_DONE {
-        return Ok(false);
+        return Ok(RunReadinessOutcome::Blocked(
+            RunCompletionBlockedReason::PolicyContinuationPending,
+        ));
     }
     // #815 P1: never finalize on `user_cancelled` — it must leave the run in a
     // resumable state so the operator can flip the entry back to `pending`.
     if new_status == ENTRY_STATUS_USER_CANCELLED {
-        return Ok(false);
+        return Ok(RunReadinessOutcome::Blocked(
+            RunCompletionBlockedReason::UserCancelledEntry,
+        ));
     }
 
     maybe_finalize_run_if_ready_pg(tx, run_id).await
@@ -143,9 +207,67 @@ pub(super) async fn maybe_finalize_run_after_terminal_entry_pg(
 pub(crate) async fn maybe_finalize_run_if_ready_pg(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     run_id: &str,
-) -> Result<bool, String> {
+) -> Result<RunReadinessOutcome, String> {
+    let run = sqlx::query(
+        "SELECT status,
+                phase_gate_grace_until IS NOT NULL
+                    AND phase_gate_grace_until > NOW() AS within_phase_gate_grace
+         FROM auto_queue_runs
+         WHERE id = $1
+         FOR UPDATE",
+    )
+    .bind(run_id)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(|error| format!("lock auto-queue run {run_id} for readiness: {error}"))?;
+    let Some(run) = run else {
+        return Ok(RunReadinessOutcome::Blocked(
+            RunCompletionBlockedReason::RunNotFound,
+        ));
+    };
+    let status: String = run
+        .try_get("status")
+        .map_err(|error| format!("decode readiness status for run {run_id}: {error}"))?;
+    if matches!(status.as_str(), "completed" | "cancelled" | "failed") {
+        return Ok(RunReadinessOutcome::AlreadyTerminal);
+    }
+    if !matches!(
+        status.as_str(),
+        "active" | "paused" | "generated" | "pending"
+    ) {
+        return Ok(RunReadinessOutcome::Blocked(
+            RunCompletionBlockedReason::RunStatusNotCompletable,
+        ));
+    }
+
     if super::phase_gates::run_has_blocking_phase_gate_on_pg_tx(tx, run_id).await? {
-        return Ok(false);
+        return Ok(RunReadinessOutcome::Blocked(
+            RunCompletionBlockedReason::BlockingPhaseGate,
+        ));
+    }
+    let within_phase_gate_grace: bool = run
+        .try_get("within_phase_gate_grace")
+        .map_err(|error| format!("decode phase-gate grace readiness for run {run_id}: {error}"))?;
+    if within_phase_gate_grace {
+        return Ok(RunReadinessOutcome::Blocked(
+            RunCompletionBlockedReason::PhaseGateGraceWindow,
+        ));
+    }
+
+    let has_user_cancelled = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(
+             SELECT 1 FROM auto_queue_entries
+             WHERE run_id = $1 AND status = 'user_cancelled'
+         )",
+    )
+    .bind(run_id)
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(|error| format!("check user-cancelled entries for run {run_id}: {error}"))?;
+    if has_user_cancelled {
+        return Ok(RunReadinessOutcome::Blocked(
+            RunCompletionBlockedReason::UserCancelledEntry,
+        ));
     }
 
     let remaining = sqlx::query_scalar::<_, i64>(
@@ -159,7 +281,9 @@ pub(crate) async fn maybe_finalize_run_if_ready_pg(
     .await
     .map_err(|error| format!("count remaining auto-queue entries for run {run_id}: {error}"))?;
     if remaining > 0 {
-        return Ok(false);
+        return Ok(RunReadinessOutcome::Blocked(
+            RunCompletionBlockedReason::RunnableEntry,
+        ));
     }
 
     // The status transition is the release authority. In particular, a run in
@@ -171,22 +295,38 @@ pub(crate) async fn maybe_finalize_run_if_ready_pg(
          SET status = 'completed',
              completed_at = NOW()
          WHERE id = $1
-           AND status IN ('active', 'paused', 'generated', 'pending')",
+           AND status = $2",
     )
     .bind(run_id)
+    .bind(&status)
     .execute(&mut **tx)
     .await
     .map_err(|error| format!("complete auto-queue run {run_id}: {error}"))?
     .rows_affected();
     if updated == 0 {
-        return Ok(false);
+        return Ok(RunReadinessOutcome::AlreadyTerminal);
     }
 
     release_run_slots_on_pg_tx(tx, run_id)
         .await
         .map_err(|error| format!("release auto-queue slots for run {run_id}: {error}"))?;
     queue_run_completion_notify_on_pg(tx, run_id).await?;
-    Ok(true)
+    Ok(RunReadinessOutcome::Completed)
+}
+
+pub async fn finalize_run_if_ready_on_pg(
+    pool: &PgPool,
+    run_id: &str,
+) -> Result<RunReadinessOutcome, String> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|error| format!("begin postgres readiness for run {run_id}: {error}"))?;
+    let outcome = maybe_finalize_run_if_ready_pg(&mut tx, run_id).await?;
+    tx.commit()
+        .await
+        .map_err(|error| format!("commit postgres readiness for run {run_id}: {error}"))?;
+    Ok(outcome)
 }
 
 pub(super) async fn auto_queue_run_review_disabled_on_pg_tx(
@@ -251,12 +391,53 @@ pub async fn resume_run_on_pg(pool: &PgPool, run_id: &str) -> Result<bool, Strin
     Ok(updated > 0)
 }
 
-pub async fn complete_run_on_pg(pool: &PgPool, run_id: &str) -> Result<bool, String> {
+pub async fn force_complete_run_on_pg(
+    pool: &PgPool,
+    command: &ForceRunCompletionCommand<'_>,
+) -> Result<RunReadinessOutcome, String> {
+    let run_id = command.run_id.trim();
+    let operator = command.operator.trim();
+    let source = command.source.trim();
+    if run_id.is_empty() || operator.is_empty() || source.is_empty() {
+        return Err("force completion requires run_id, operator, and source".to_string());
+    }
     let mut tx = pool
         .begin()
         .await
         .map_err(|error| format!("begin postgres complete auto-queue run {run_id}: {error}"))?;
-    // #2048 F17: even an explicit "manual complete" call must drop any
+    let status = sqlx::query_scalar::<_, String>(
+        "SELECT status FROM auto_queue_runs WHERE id = $1 FOR UPDATE",
+    )
+    .bind(run_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|error| format!("lock force-completed run {run_id}: {error}"))?;
+    let Some(status) = status else {
+        tx.rollback()
+            .await
+            .map_err(|error| format!("rollback missing force-completed run {run_id}: {error}"))?;
+        return Ok(RunReadinessOutcome::Blocked(
+            RunCompletionBlockedReason::RunNotFound,
+        ));
+    };
+    if matches!(status.as_str(), "completed" | "cancelled" | "failed") {
+        tx.rollback()
+            .await
+            .map_err(|error| format!("rollback terminal force-completed run {run_id}: {error}"))?;
+        return Ok(RunReadinessOutcome::AlreadyTerminal);
+    }
+    if !matches!(
+        status.as_str(),
+        "active" | "paused" | "generated" | "pending"
+    ) {
+        tx.rollback().await.map_err(|error| {
+            format!("rollback ineligible force-completed run {run_id}: {error}")
+        })?;
+        return Ok(RunReadinessOutcome::Blocked(
+            RunCompletionBlockedReason::RunStatusNotCompletable,
+        ));
+    }
+    // #2048 F17: only this explicit force command may drop any
     // pending/failed phase-gate rows AND release the run's slot bindings.
     // Otherwise a completed run leaves stale phase_gate rows that next
     // restore/audit treats as still-pending, plus zombie slot assignments
@@ -284,7 +465,7 @@ pub async fn complete_run_on_pg(pool: &PgPool, run_id: &str) -> Result<bool, Str
         tx.rollback().await.map_err(|error| {
             format!("rollback stale postgres complete auto-queue run {run_id}: {error}")
         })?;
-        return Ok(false);
+        return Ok(RunReadinessOutcome::AlreadyTerminal);
     }
 
     release_run_slots_on_pg_tx(&mut tx, run_id)
@@ -292,8 +473,18 @@ pub async fn complete_run_on_pg(pool: &PgPool, run_id: &str) -> Result<bool, Str
         .map_err(|error| format!("release slots for completed run {run_id}: {error}"))?;
 
     queue_run_completion_notify_on_pg(&mut tx, run_id).await?;
+    sqlx::query(
+        "INSERT INTO audit_logs (entity_type, entity_id, action, actor)
+         VALUES ('auto_queue_run', $1, $2, $3)",
+    )
+    .bind(run_id)
+    .bind(format!("force_complete:{source}"))
+    .bind(operator)
+    .execute(&mut *tx)
+    .await
+    .map_err(|error| format!("audit force completion for run {run_id}: {error}"))?;
     tx.commit()
         .await
         .map_err(|error| format!("commit postgres complete auto-queue run {run_id}: {error}"))?;
-    Ok(true)
+    Ok(RunReadinessOutcome::Completed)
 }

--- a/src/db/auto_queue/runs.rs
+++ b/src/db/auto_queue/runs.rs
@@ -254,6 +254,12 @@ pub(super) async fn maybe_finalize_run_after_terminal_entry_pg(
     maybe_finalize_run_if_ready_pg(tx, run_id).await
 }
 
+/// The policy sweep's `LIMIT 50` caps writer invocations, not SQL statements.
+/// `pg_stat_statements` measurements excluding transaction control recorded
+/// 801 statements for the old unfiltered 200-writer scenario and at least 401
+/// for one prefilter plus 50 ready writers. There is no fixed SQL upper bound:
+/// notification routing varies with agent/fallback channel lookup, entry-count
+/// lookup, and one outbox insert per resolved target.
 pub(crate) async fn maybe_finalize_run_if_ready_pg(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     run_id: &str,

--- a/src/db/auto_queue/slots.rs
+++ b/src/db/auto_queue/slots.rs
@@ -65,6 +65,7 @@ pub async fn clear_inactive_slot_assignments_pg(pool: &PgPool) -> Result<u64, sq
     Ok(result.rows_affected())
 }
 
+#[cfg(test)]
 pub async fn release_run_slots_pg(pool: &PgPool, run_id: &str) -> Result<u64, sqlx::Error> {
     let result = sqlx::query(
         "UPDATE auto_queue_slots

--- a/src/engine/ops/auto_queue_ops.rs
+++ b/src/engine/ops/auto_queue_ops.rs
@@ -50,13 +50,20 @@ pub(super) fn register_auto_queue_ops<'js>(
             },
         )?,
     )?;
-    let pg_complete_run = pg_pool.clone();
+    let pg_finalize_run = pg_pool.clone();
     auto_queue_obj.set(
-        "__completeRunRaw",
+        "__finalizeRunIfReadyRaw",
+        Function::new(ctx.clone(), move |run_id: String| -> String {
+            finalize_run_if_ready_raw(pg_finalize_run.as_ref(), &run_id)
+        })?,
+    )?;
+    let pg_force_complete_run = pg_pool.clone();
+    auto_queue_obj.set(
+        "__forceCompleteRunRaw",
         Function::new(
             ctx.clone(),
-            move |run_id: String, source: String, opts_json: String| -> String {
-                complete_run_raw(pg_complete_run.as_ref(), &run_id, &source, &opts_json)
+            move |run_id: String, command_json: String| -> String {
+                force_complete_run_raw(pg_force_complete_run.as_ref(), &run_id, &command_json)
             },
         )?,
     )?;
@@ -185,12 +192,18 @@ pub(super) fn register_auto_queue_ops<'js>(
                 if (result.error) throw new Error(result.error);
                 return result;
             };
-            agentdesk.autoQueue.completeRun = function(runId, source, opts) {
+            agentdesk.autoQueue.finalizeRunIfReady = function(runId) {
                 var result = JSON.parse(
-                    agentdesk.autoQueue.__completeRunRaw(
+                    agentdesk.autoQueue.__finalizeRunIfReadyRaw(runId)
+                );
+                if (result.error) throw new Error(result.error);
+                return result;
+            };
+            agentdesk.autoQueue.forceCompleteRun = function(runId, command) {
+                var result = JSON.parse(
+                    agentdesk.autoQueue.__forceCompleteRunRaw(
                         runId,
-                        source || "",
-                        JSON.stringify(opts || {})
+                        JSON.stringify(command || {})
                     )
                 );
                 if (result.error) throw new Error(result.error);
@@ -352,47 +365,70 @@ fn resume_run_raw(pg_pool: Option<&PgPool>, run_id: &str, source: &str) -> Strin
     }
 }
 
-fn complete_run_raw(
-    pg_pool: Option<&PgPool>,
-    run_id: &str,
-    source: &str,
-    opts_json: &str,
-) -> String {
-    if source.trim().is_empty() {
-        return r#"{"error":"source is required"}"#.to_string();
-    }
+fn finalize_run_if_ready_raw(pg_pool: Option<&PgPool>, run_id: &str) -> String {
+    let Some(pool) = pg_pool else {
+        return r#"{"error":"postgres backend is required for autoQueue.finalizeRunIfReady"}"#
+            .to_string();
+    };
+    let run_id_owned = run_id.to_string();
+    let result = run_async_bridge_pg(pool, move |pool| async move {
+        crate::db::auto_queue::finalize_run_if_ready_on_pg(&pool, &run_id_owned).await
+    });
 
-    let opts_value: serde_json::Value = match serde_json::from_str(opts_json) {
-        Ok(value) => value,
+    match result {
+        Ok(outcome) => serde_json::json!({
+            "ok": true,
+            "changed": outcome.is_completed(),
+            "outcome": outcome.outcome_name(),
+            "reason": outcome.blocked_reason(),
+        })
+        .to_string(),
+        Err(error) => serde_json::json!({
+            "error": error.to_string()
+        })
+        .to_string(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ForceRunCompletionPayload {
+    operator: String,
+    source: String,
+}
+
+fn force_complete_run_raw(pg_pool: Option<&PgPool>, run_id: &str, command_json: &str) -> String {
+    let command: ForceRunCompletionPayload = match serde_json::from_str(command_json) {
+        Ok(command) => command,
         Err(error) => {
             return serde_json::json!({
-                "error": format!("invalid opts JSON: {error}")
+                "error": format!("invalid force completion command JSON: {error}")
             })
             .to_string();
         }
     };
-    let release_slots = opts_value
-        .get("releaseSlots")
-        .and_then(|value| value.as_bool())
-        .unwrap_or(false);
-
     let Some(pool) = pg_pool else {
-        return r#"{"error":"postgres backend is required for autoQueue.completeRun"}"#.to_string();
+        return r#"{"error":"postgres backend is required for autoQueue.forceCompleteRun"}"#
+            .to_string();
     };
     let run_id_owned = run_id.to_string();
     let result = run_async_bridge_pg(pool, move |pool| async move {
-        if release_slots {
-            crate::db::auto_queue::release_run_slots_pg(&pool, &run_id_owned)
-                .await
-                .map_err(|error| format!("release postgres auto-queue slots: {error}"))?;
-        }
-        crate::db::auto_queue::complete_run_on_pg(&pool, &run_id_owned).await
+        crate::db::auto_queue::force_complete_run_on_pg(
+            &pool,
+            &crate::db::auto_queue::ForceRunCompletionCommand {
+                run_id: &run_id_owned,
+                operator: &command.operator,
+                source: &command.source,
+            },
+        )
+        .await
     });
 
     match result {
-        Ok(changed) => serde_json::json!({
+        Ok(outcome) => serde_json::json!({
             "ok": true,
-            "changed": changed,
+            "changed": outcome.is_completed(),
+            "outcome": outcome.outcome_name(),
+            "reason": outcome.blocked_reason(),
         })
         .to_string(),
         Err(error) => serde_json::json!({

--- a/src/services/auto_queue/activate_command.rs
+++ b/src/services/auto_queue/activate_command.rs
@@ -841,11 +841,11 @@ async fn promote_run_and_clear_inactive_slots(
     Ok(())
 }
 
-/// Counts the run's entries; when zero, best-effort completes the stale run
+/// Counts the run's entries; when zero, delegates completion to the readiness writer
 /// and short-circuits the activate request. Both the "stale empty run
 /// completed" OK response and any DB failure are returned as
 /// `Err(ActivateResponse)`; `Ok(())` means the run has entries to dispatch.
-async fn complete_run_if_empty(
+pub(super) async fn complete_run_if_empty(
     pool: &sqlx::PgPool,
     run_id: &str,
     run_log_ctx: &AutoQueueLogContext<'_>,
@@ -870,39 +870,33 @@ async fn complete_run_if_empty(
         }
     };
     if entry_count == 0 {
-        if let Err(error) = sqlx::query(
-            // #2048 F18: only auto-complete runs that are still active /
-            // promotable. A caller passing a cancelled/completed run_id
-            // should not flip its status — only the explicit cancel/complete
-            // paths may finalize. The activate path is best-effort.
-            "UPDATE auto_queue_runs
-             SET status = 'completed',
-                 completed_at = NOW()
-             WHERE id = $1
-               AND status IN ('active', 'paused', 'generated', 'pending')",
-        )
-        .bind(run_id)
-        .execute(pool)
-        .await
-        {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(
-                    json!({"error": format!("complete stale postgres auto-queue run {run_id}: {error}")}),
-                ),
-            ));
-        }
+        let outcome = match crate::db::auto_queue::finalize_run_if_ready_on_pg(pool, run_id).await {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(
+                        json!({"error": format!("finalize stale postgres auto-queue run {run_id}: {error}")}),
+                    ),
+                ));
+            }
+        };
         crate::auto_queue_log!(
             info,
-            "activate_stale_empty_run_completed_pg",
+            "activate_stale_empty_run_readiness_pg",
             run_log_ctx.clone(),
-            "[auto-queue] Completed stale empty PG run {run_id} — no entries, skipping fallback populate (#85)"
+            "[auto-queue] Empty PG run {run_id} readiness outcome: {}",
+            outcome.outcome_name()
         );
         return Err((
             StatusCode::OK,
-            Json(
-                json!({ "dispatched": [], "count": 0, "message": "Stale empty run completed — no entries to dispatch" }),
-            ),
+            Json(json!({
+                "dispatched": [],
+                "count": 0,
+                "message": "Stale empty run evaluated — no entries to dispatch",
+                "completion_outcome": outcome.outcome_name(),
+                "completion_blocked_reason": outcome.blocked_reason(),
+            })),
         ));
     }
     Ok(())
@@ -1267,12 +1261,12 @@ async fn compute_activate_groups_to_dispatch(
     })
 }
 
-/// Final activate phase: drains the run if no entries remain (releasing slots
-/// and best-effort completing the run), recomputes the active/pending group
+/// Final activate phase: asks the readiness writer to drain the run if no entries remain,
+/// recomputes the active/pending group
 /// counts and post-activate turn count, and builds the success payload. Count
 /// failures short-circuit with a 500 returned as `Err(ActivateResponse)`; the
 /// success payload is returned as `Ok(ActivateResponse)`.
-async fn finalize_activate_run_and_build_response(
+pub(super) async fn finalize_activate_run_and_build_response(
     pool: &sqlx::PgPool,
     run_id: &str,
     run_log_ctx: &AutoQueueLogContext<'_>,
@@ -1299,59 +1293,21 @@ async fn finalize_activate_run_and_build_response(
             ));
         }
     };
-    if remaining == 0 {
-        if let Err(error) = crate::db::auto_queue::release_run_slots_pg(pool, run_id).await {
-            crate::auto_queue_log!(
-                warn,
-                "activate_release_run_slots_failed_pg",
-                run_log_ctx.clone(),
-                "[auto-queue] failed to release PG slots for drained run {}: {}",
-                run_id,
-                error
-            );
-        }
-        let still_dispatched = match sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*)::BIGINT
-             FROM auto_queue_entries
-             WHERE run_id = $1
-               AND status = 'dispatched'",
-        )
-        .bind(run_id)
-        .fetch_one(pool)
-        .await
-        {
-            Ok(value) => value,
+    let completion_outcome = if remaining == 0 {
+        match crate::db::auto_queue::finalize_run_if_ready_on_pg(pool, run_id).await {
+            Ok(outcome) => Some(outcome),
             Err(error) => {
                 return Err((
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(
-                        json!({"error": format!("count postgres dispatched entries for {run_id}: {error}")}),
+                        json!({"error": format!("finalize drained postgres auto-queue run {run_id}: {error}")}),
                     ),
                 ));
             }
-        };
-        if still_dispatched == 0
-            && let Err(error) = sqlx::query(
-                "UPDATE auto_queue_runs
-                 SET status = 'completed',
-                     completed_at = NOW()
-                 WHERE id = $1
-                   AND status IN ('active', 'paused', 'generated', 'pending')",
-            )
-            .bind(run_id)
-            .execute(pool)
-            .await
-        {
-            crate::auto_queue_log!(
-                warn,
-                "activate_finalize_run_failed_pg",
-                run_log_ctx.clone(),
-                "[auto-queue] failed to finalize PG run {} after dispatch drain: {}",
-                run_id,
-                error
-            );
         }
-    }
+    } else {
+        None
+    };
 
     let active_group_count = match sqlx::query_scalar::<_, i64>(
         "SELECT COUNT(DISTINCT COALESCE(thread_group, 0))::BIGINT
@@ -1428,6 +1384,25 @@ async fn finalize_activate_run_and_build_response(
         "active_turn_count": active_turn_count_after,
         "pending_groups": pending_group_count,
     });
+    if let Some(outcome) = completion_outcome
+        && let Some(map) = body.as_object_mut()
+    {
+        map.insert(
+            "completion_outcome".to_string(),
+            json!(outcome.outcome_name()),
+        );
+        map.insert(
+            "completion_blocked_reason".to_string(),
+            json!(outcome.blocked_reason()),
+        );
+        crate::auto_queue_log!(
+            info,
+            "activate_drained_run_readiness_pg",
+            run_log_ctx.clone(),
+            "[auto-queue] Drained PG run {run_id} readiness outcome: {}",
+            outcome.outcome_name()
+        );
+    }
     if !deferred_entries.is_empty() {
         if let Some(map) = body.as_object_mut() {
             map.insert("deferred_count".to_string(), json!(deferred_entries.len()));

--- a/src/services/auto_queue/order_routes.rs
+++ b/src/services/auto_queue/order_routes.rs
@@ -84,7 +84,6 @@ pub(super) async fn resolve_submit_order_card_with_pg(
 }
 
 pub(super) async fn submit_order_with_pg(
-    state: &AppState,
     run_id: &str,
     headers: &HeaderMap,
     principal: Option<&RequestPrincipal>,
@@ -213,7 +212,7 @@ pub(super) async fn submit_order_with_pg(
                 .map(|agent_id| format!("{agent_id} order submitted"))
                 .unwrap_or_else(|| "API order submitted".to_string())
         });
-    if created > 0 {
+    let completion_outcome = if created > 0 {
         if let Err(error) = sqlx::query(
             "UPDATE auto_queue_runs
              SET status = 'active',
@@ -230,32 +229,42 @@ pub(super) async fn submit_order_with_pg(
                 Json(json!({"error": format!("activate auto-queue run '{run_id}': {error}")})),
             ));
         }
+        None
     } else {
         crate::auto_queue_log!(
             warn,
             "submit_order_no_ready_cards",
             run_log_ctx.clone(),
-            "[auto-queue] submit_order: no ready cards enqueued, run {run_id} stays pending"
+            "[auto-queue] submit_order: no ready cards enqueued, evaluating run {run_id} readiness"
         );
         if let Err(error) = sqlx::query(
             "UPDATE auto_queue_runs
-             SET status = 'completed',
-                 ai_rationale = $1
-             WHERE id = $2",
+             SET ai_rationale = $1
+             WHERE id = $2 AND status = 'pending'",
         )
-        .bind(format!("{rationale} (no ready cards — auto-completed)"))
+        .bind(format!("{rationale} (no ready cards)"))
         .bind(run_id)
         .execute(pool)
         .await
         {
             return Err(auto_queue_json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("complete auto-queue run '{run_id}': {error}")})),
+                Json(
+                    json!({"error": format!("record empty order rationale for run '{run_id}': {error}")}),
+                ),
             ));
         }
-    }
-
-    let _ = state;
+        Some(
+            crate::db::auto_queue::finalize_run_if_ready_on_pg(pool, run_id)
+                .await
+                .map_err(|error| {
+                    auto_queue_json_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": format!("finalize empty ordered run '{run_id}': {error}")})),
+                    )
+                })?,
+        )
+    };
 
     Ok((
         StatusCode::OK,
@@ -264,6 +273,8 @@ pub(super) async fn submit_order_with_pg(
             "created": created,
             "run_id": run_id,
             "message": "Queue active. Call POST /api/queue/dispatch-next to start dispatching.",
+            "completion_outcome": completion_outcome.as_ref().map(|outcome| outcome.outcome_name()),
+            "completion_blocked_reason": completion_outcome.as_ref().and_then(|outcome| outcome.blocked_reason()),
         })),
     ))
 }
@@ -284,7 +295,6 @@ pub async fn submit_order(
         return Err(auto_queue_tuple_error(pg_unavailable_response()));
     };
     submit_order_with_pg(
-        &state,
         &run_id,
         &headers,
         principal.as_ref().map(|Extension(principal)| principal),

--- a/src/services/auto_queue/readiness_pg_tests.rs
+++ b/src/services/auto_queue/readiness_pg_tests.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 #[cfg(test)]
 mod cases_pg_tests {
     use super::super::activate_command::{

--- a/src/services/auto_queue/readiness_pg_tests.rs
+++ b/src/services/auto_queue/readiness_pg_tests.rs
@@ -86,4 +86,12 @@ fn derived_completion_entry_points_have_one_writer_contract_pg() {
     assert!(ops.contains("finalizeRunIfReady"));
     assert!(ops.contains("forceCompleteRun"));
     assert!(!ops.contains("release_run_slots_pg"));
+
+    let runs = include_str!("../../db/auto_queue/runs.rs");
+    assert_eq!(
+        runs.matches("DELETE FROM auto_queue_phase_gates WHERE run_id = $1")
+            .count(),
+        1,
+        "only force completion may delete gates"
+    );
 }

--- a/src/services/auto_queue/readiness_pg_tests.rs
+++ b/src/services/auto_queue/readiness_pg_tests.rs
@@ -1,97 +1,104 @@
-use super::activate_command::{complete_run_if_empty, finalize_activate_run_and_build_response};
-use super::order_routes::{OrderBody, submit_order_with_pg};
-use crate::db::auto_queue::test_support::TestPostgresDb;
-use crate::services::auto_queue::AutoQueueLogContext;
-use axum::http::{HeaderMap, StatusCode};
-use sqlx::PgPool;
+#![cfg(test)]
 
-async fn seed_run(pool: &PgPool, run_id: &str, status: &str) {
-    sqlx::query("INSERT INTO auto_queue_runs (id, status) VALUES ($1, $2)")
-        .bind(run_id)
-        .bind(status)
-        .execute(pool)
+#[cfg(test)]
+mod cases_pg_tests {
+    use super::super::activate_command::{
+        complete_run_if_empty, finalize_activate_run_and_build_response,
+    };
+    use super::super::order_routes::{OrderBody, submit_order_with_pg};
+    use crate::db::auto_queue::test_support::TestPostgresDb;
+    use crate::services::auto_queue::AutoQueueLogContext;
+    use axum::http::{HeaderMap, StatusCode};
+    use sqlx::PgPool;
+
+    async fn seed_run(pool: &PgPool, run_id: &str, status: &str) {
+        sqlx::query("INSERT INTO auto_queue_runs (id, status) VALUES ($1, $2)")
+            .bind(run_id)
+            .bind(status)
+            .execute(pool)
+            .await
+            .expect("seed entry-point run");
+    }
+
+    #[tokio::test]
+    async fn activate_empty_drain_and_submit_order_zero_share_readiness_outcome_pg() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+
+        seed_run(&pool, "run-activate-empty", "active").await;
+        let empty_log = AutoQueueLogContext::new().run("run-activate-empty");
+        let empty_response = complete_run_if_empty(&pool, "run-activate-empty", &empty_log)
+            .await
+            .expect_err("empty activate must short-circuit");
+        assert_eq!(empty_response.0, StatusCode::OK);
+        assert_eq!(empty_response.1.0["completion_outcome"], "completed");
+
+        seed_run(&pool, "run-activate-drain", "active").await;
+        let drain_log = AutoQueueLogContext::new().run("run-activate-drain");
+        let drain_response = finalize_activate_run_and_build_response(
+            &pool,
+            "run-activate-drain",
+            &drain_log,
+            Vec::new(),
+            Vec::new(),
+        )
         .await
-        .expect("seed entry-point run");
-}
+        .expect("build drained activate response");
+        assert_eq!(drain_response.0, StatusCode::OK);
+        assert_eq!(drain_response.1.0["completion_outcome"], "completed");
 
-#[tokio::test]
-async fn activate_empty_drain_and_submit_order_zero_share_readiness_outcome_pg() {
-    let pg_db = TestPostgresDb::create().await;
-    let pool = pg_db.connect_and_migrate().await;
-
-    seed_run(&pool, "run-activate-empty", "active").await;
-    let empty_log = AutoQueueLogContext::new().run("run-activate-empty");
-    let empty_response = complete_run_if_empty(&pool, "run-activate-empty", &empty_log)
+        seed_run(&pool, "run-submit-zero", "pending").await;
+        let (_, order_body) = submit_order_with_pg(
+            "run-submit-zero",
+            &HeaderMap::new(),
+            None,
+            &OrderBody {
+                order: Vec::new(),
+                rationale: Some("no dispatchable cards".to_string()),
+                reasoning: None,
+            },
+            &pool,
+        )
         .await
-        .expect_err("empty activate must short-circuit");
-    assert_eq!(empty_response.0, StatusCode::OK);
-    assert_eq!(empty_response.1.0["completion_outcome"], "completed");
+        .expect("submit zero-card order");
+        assert_eq!(order_body.0["completion_outcome"], "completed");
 
-    seed_run(&pool, "run-activate-drain", "active").await;
-    let drain_log = AutoQueueLogContext::new().run("run-activate-drain");
-    let drain_response = finalize_activate_run_and_build_response(
-        &pool,
-        "run-activate-drain",
-        &drain_log,
-        Vec::new(),
-        Vec::new(),
-    )
-    .await
-    .expect("build drained activate response");
-    assert_eq!(drain_response.0, StatusCode::OK);
-    assert_eq!(drain_response.1.0["completion_outcome"], "completed");
+        pool.close().await;
+        pg_db.drop().await;
+    }
 
-    seed_run(&pool, "run-submit-zero", "pending").await;
-    let (_, order_body) = submit_order_with_pg(
-        "run-submit-zero",
-        &HeaderMap::new(),
-        None,
-        &OrderBody {
-            order: Vec::new(),
-            rationale: Some("no dispatchable cards".to_string()),
-            reasoning: None,
-        },
-        &pool,
-    )
-    .await
-    .expect("submit zero-card order");
-    assert_eq!(order_body.0["completion_outcome"], "completed");
+    #[test]
+    fn derived_completion_entry_points_have_one_writer_contract_pg() {
+        let activate = include_str!("activate_command.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("activate production source");
+        assert_eq!(activate.matches("finalize_run_if_ready_on_pg").count(), 2);
+        assert!(!activate.contains("SET status = 'completed'"));
+        assert!(!activate.contains("release_run_slots_pg"));
 
-    pool.close().await;
-    pg_db.drop().await;
-}
+        let order = include_str!("order_routes.rs");
+        assert_eq!(order.matches("finalize_run_if_ready_on_pg").count(), 1);
+        assert!(!order.contains("SET status = 'completed'"));
 
-#[test]
-fn derived_completion_entry_points_have_one_writer_contract_pg() {
-    let activate = include_str!("activate_command.rs")
-        .split("#[cfg(test)]")
-        .next()
-        .expect("activate production source");
-    assert_eq!(activate.matches("finalize_run_if_ready_on_pg").count(), 2);
-    assert!(!activate.contains("SET status = 'completed'"));
-    assert!(!activate.contains("release_run_slots_pg"));
+        let lifecycle = include_str!("../../../policies/lib/auto-queue-lifecycle.js");
+        assert_eq!(lifecycle.matches("finalizeRunIfReady(").count(), 2);
+        assert!(!lifecycle.contains(".completeRun("));
+        assert!(!lifecycle.contains("releaseSlots"));
+        assert!(!lifecycle.contains("runHasUserCancelledEntry"));
+        assert!(!lifecycle.contains("runWithinPhaseGateGrace"));
 
-    let order = include_str!("order_routes.rs");
-    assert_eq!(order.matches("finalize_run_if_ready_on_pg").count(), 1);
-    assert!(!order.contains("SET status = 'completed'"));
+        let ops = include_str!("../../engine/ops/auto_queue_ops.rs");
+        assert!(ops.contains("finalizeRunIfReady"));
+        assert!(ops.contains("forceCompleteRun"));
+        assert!(!ops.contains("release_run_slots_pg"));
 
-    let lifecycle = include_str!("../../../policies/lib/auto-queue-lifecycle.js");
-    assert_eq!(lifecycle.matches("finalizeRunIfReady(").count(), 2);
-    assert!(!lifecycle.contains(".completeRun("));
-    assert!(!lifecycle.contains("releaseSlots"));
-    assert!(!lifecycle.contains("runHasUserCancelledEntry"));
-    assert!(!lifecycle.contains("runWithinPhaseGateGrace"));
-
-    let ops = include_str!("../../engine/ops/auto_queue_ops.rs");
-    assert!(ops.contains("finalizeRunIfReady"));
-    assert!(ops.contains("forceCompleteRun"));
-    assert!(!ops.contains("release_run_slots_pg"));
-
-    let runs = include_str!("../../db/auto_queue/runs.rs");
-    assert_eq!(
-        runs.matches("DELETE FROM auto_queue_phase_gates WHERE run_id = $1")
-            .count(),
-        1,
-        "only force completion may delete gates"
-    );
+        let runs = include_str!("../../db/auto_queue/runs.rs");
+        assert_eq!(
+            runs.matches("DELETE FROM auto_queue_phase_gates WHERE run_id = $1")
+                .count(),
+            1,
+            "only force completion may delete gates"
+        );
+    }
 }

--- a/src/services/auto_queue/readiness_pg_tests.rs
+++ b/src/services/auto_queue/readiness_pg_tests.rs
@@ -98,5 +98,12 @@ mod cases_pg_tests {
             1,
             "only force completion may delete gates"
         );
+        let phase_gates = include_str!("../../db/auto_queue/phase_gates.rs");
+        assert!(phase_gates.contains("orphan_repair::clear_orphan_gates_on_pg_tx"));
+        let orphan_repair = include_str!("../../db/auto_queue/phase_gates/orphan_repair.rs");
+        assert!(orphan_repair.contains("clear orphan phase gates for run"));
+        assert!(
+            orphan_repair.contains("NOT EXISTS (\n               SELECT 1 FROM task_dispatches")
+        );
     }
 }

--- a/src/services/auto_queue/readiness_pg_tests.rs
+++ b/src/services/auto_queue/readiness_pg_tests.rs
@@ -1,0 +1,89 @@
+use super::activate_command::{complete_run_if_empty, finalize_activate_run_and_build_response};
+use super::order_routes::{OrderBody, submit_order_with_pg};
+use crate::db::auto_queue::test_support::TestPostgresDb;
+use crate::services::auto_queue::AutoQueueLogContext;
+use axum::http::{HeaderMap, StatusCode};
+use sqlx::PgPool;
+
+async fn seed_run(pool: &PgPool, run_id: &str, status: &str) {
+    sqlx::query("INSERT INTO auto_queue_runs (id, status) VALUES ($1, $2)")
+        .bind(run_id)
+        .bind(status)
+        .execute(pool)
+        .await
+        .expect("seed entry-point run");
+}
+
+#[tokio::test]
+async fn activate_empty_drain_and_submit_order_zero_share_readiness_outcome_pg() {
+    let pg_db = TestPostgresDb::create().await;
+    let pool = pg_db.connect_and_migrate().await;
+
+    seed_run(&pool, "run-activate-empty", "active").await;
+    let empty_log = AutoQueueLogContext::new().run("run-activate-empty");
+    let empty_response = complete_run_if_empty(&pool, "run-activate-empty", &empty_log)
+        .await
+        .expect_err("empty activate must short-circuit");
+    assert_eq!(empty_response.0, StatusCode::OK);
+    assert_eq!(empty_response.1.0["completion_outcome"], "completed");
+
+    seed_run(&pool, "run-activate-drain", "active").await;
+    let drain_log = AutoQueueLogContext::new().run("run-activate-drain");
+    let drain_response = finalize_activate_run_and_build_response(
+        &pool,
+        "run-activate-drain",
+        &drain_log,
+        Vec::new(),
+        Vec::new(),
+    )
+    .await
+    .expect("build drained activate response");
+    assert_eq!(drain_response.0, StatusCode::OK);
+    assert_eq!(drain_response.1.0["completion_outcome"], "completed");
+
+    seed_run(&pool, "run-submit-zero", "pending").await;
+    let (_, order_body) = submit_order_with_pg(
+        "run-submit-zero",
+        &HeaderMap::new(),
+        None,
+        &OrderBody {
+            order: Vec::new(),
+            rationale: Some("no dispatchable cards".to_string()),
+            reasoning: None,
+        },
+        &pool,
+    )
+    .await
+    .expect("submit zero-card order");
+    assert_eq!(order_body.0["completion_outcome"], "completed");
+
+    pool.close().await;
+    pg_db.drop().await;
+}
+
+#[test]
+fn derived_completion_entry_points_have_one_writer_contract_pg() {
+    let activate = include_str!("activate_command.rs")
+        .split("#[cfg(test)]")
+        .next()
+        .expect("activate production source");
+    assert_eq!(activate.matches("finalize_run_if_ready_on_pg").count(), 2);
+    assert!(!activate.contains("SET status = 'completed'"));
+    assert!(!activate.contains("release_run_slots_pg"));
+
+    let order = include_str!("order_routes.rs");
+    assert_eq!(order.matches("finalize_run_if_ready_on_pg").count(), 1);
+    assert!(!order.contains("SET status = 'completed'"));
+
+    let lifecycle = include_str!("../../../policies/lib/auto-queue-lifecycle.js");
+    assert_eq!(lifecycle.matches("finalizeRunIfReady(").count(), 2);
+    assert!(!lifecycle.contains(".completeRun("));
+    assert!(!lifecycle.contains("releaseSlots"));
+    assert!(!lifecycle.contains("runHasUserCancelledEntry"));
+    assert!(!lifecycle.contains("runWithinPhaseGateGrace"));
+
+    let ops = include_str!("../../engine/ops/auto_queue_ops.rs");
+    assert!(ops.contains("finalizeRunIfReady"));
+    assert!(ops.contains("forceCompleteRun"));
+    assert!(!ops.contains("release_run_slots_pg"));
+}

--- a/src/services/auto_queue/route.rs
+++ b/src/services/auto_queue/route.rs
@@ -57,6 +57,9 @@ pub mod phase_gate_violations;
 mod planning;
 #[path = "query.rs"]
 mod query;
+#[cfg(test)]
+#[path = "readiness_pg_tests.rs"]
+mod readiness_pg_tests;
 #[path = "route_generate.rs"]
 mod route_generate;
 #[path = "route_request_generate.rs"]


### PR DESCRIPTION
## 무엇을

`#4881` — auto-queue run completion 을 **단일 readiness writer** 로 통합한다. bool 반환을 typed outcome 으로 바꾸고, 흩어진 직접 completion SQL 을 전부 그 writer 로 모은다.

**19파일 +793/−245.**

## 무엇이 split-brain 이었나

canonical writer 는 이미 있었지만(`runs.rs:143`) 그 바깥에 판정과 쓰기가 흩어져 있었다:

- readiness query 가 `pending|dispatched` 만 세서 다른 entry 가 terminal 이 된 뒤 남은 **`user_cancelled` 를 못 봤다** (`runs.rs:151`)
- `phase_gate_grace_until` 을 writer 가 검사하지 않았다
- 정책 JS 가 user-cancel/grace 를 **따로** 판정한 뒤 force 성 `completeRun` 을 호출했다 (`auto-queue-lifecycle.js:64`)
- `completeRun({releaseSlots:true})` 가 별도 transaction 으로 slot 을 먼저 해제하고 다시 slot-release 포함 writer 를 호출했다 — **이중 해제** (`auto_queue_ops.rs:374`)
- activate 에 직접 completion writer 2곳 (`activate_command.rs:848`, `:1302`), order 제출 zero-ready 경로에 1곳 (`order_routes.rs:233`)
- `complete_run_on_pg` 가 gate 삭제 가능한 강제 완료인데 이름·권한·audit 계약이 분리돼 있지 않았다 (`runs.rs:254`)

## 계약

- typed outcome `Completed | Blocked(reason) | AlreadyTerminal` (`runs.rs:32`)
- **같은 transaction 에서** run status·blocking gate·grace·`user_cancelled`·runnable entry 를 검사 (`runs.rs:205`), status 변경·slot release·notification 도 같은 transaction (`runs.rs:295`)
- activate empty/drain 과 submit-order zero 가 **같은 writer** 사용 (`activate_command.rs:873`, `:1297`, `order_routes.rs:258`)
- JS 의 선행 readiness 판정과 선행 slot 해제 제거 (`auto-queue-lifecycle.js:58`)
- `forceCompleteRun` 을 별도 command 로 분리하고 operator/source 입력을 갈랐다 (`auto_queue_ops.rs:195`). **force 만 gate 삭제 허용**하며 `audit_logs` 에 operator/source 기록 (`runs.rs:394`, `:447`)

## 의도된 동작 변화 (검토 요망)

| 케이스 | 이전 | 이후 |
|---|---|---|
| `user_cancelled` + 다른 terminal entry | 완료될 수 있었음 | **`Blocked(user_cancelled_entry)`** |
| grace 활성 중 completion | force 성 JS/direct 경로가 즉시 완료 가능 | grace 종료/해제까지 차단 |
| pending/failed gate | 직접 SQL 경로는 우회 가능 | 전부 차단 |

guard 없는 empty/terminal-only run 은 기존처럼 완료된다. 반복 완료는 `AlreadyTerminal` 이며 notification 을 추가하지 않는다. `restoring` 및 terminal status 경계는 보존했다.

## 뮤테이션 증명

guard 4종을 각각 무력화했을 때 **자기 assert 로** 실패한다 (rc=101):

```
user-cancel : Completed != Blocked(UserCancelledEntry)
grace       : Completed != Blocked(PhaseGateGraceWindow)
gate        : Completed != Blocked(BlockingPhaseGate)
runnable    : Completed != Blocked(RunnableEntry)
```

복원 후 PG 9/9 통과. notification insert 를 강제 실패시켰을 때 status 와 slot 도 함께 rollback 되는 원자성 테스트를 포함한다.

## 테스트가 실제로 도는가

`cargo test --lib -- --list` 에서 fully-qualified `_pg` 이름 9개 확인. PG membership 443 tests / 73 files.

## 게이트

`cargo fmt --check` / `cargo check --lib`(접촉 파일 신규 경고 0) / PG 테스트 9 passed / policy tests 217 passed / inventory freshness / coverage / PG membership / `audit_maintainability --check`(baseline 인상 없음) / `ci-script-checks.sh`(실제 `^FAIL` 0) / `git diff --check` — **전부 rc=0**.

## RISKS

JS tick 이 정확성을 위해 모든 active/paused 후보를 writer 에 위임하므로, 활성 run 이 비정상적으로 많으면 기존 filtered LIMIT 방식보다 DB 호출량이 늘 수 있다.
