### PR TITLE
test(#5077): replace tracing-string oracles with typed assertions

### DIFF
--- a/src/api_caller_observability.rs
+++ b/src/api_caller_observability.rs
@@ -36,6 +36,38 @@ impl RequestPrincipal {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IdentityConsumptionFields {
+    endpoint: &'static str,
+    auth_strength: &'static str,
+    claimed_agent_id: String,
+    claimed_channel_id: String,
+    consumed_agent_id: String,
+    manager_channel_check_relied_on_claimed_header: bool,
+}
+
+impl IdentityConsumptionFields {
+    /// Return the projected fields in the same name/value form used by the
+    /// identity-consumption event.  Keeping this view next to the typed
+    /// projection gives tests a complete, tracing-independent redaction
+    /// oracle for every emitted field.
+    #[cfg(test)]
+    fn named_values(&self) -> Vec<(&'static str, String)> {
+        vec![
+            ("endpoint", self.endpoint.to_string()),
+            ("auth_strength", self.auth_strength.to_string()),
+            ("claimed_agent_id", self.claimed_agent_id.clone()),
+            ("claimed_channel_id", self.claimed_channel_id.clone()),
+            ("consumed_agent_id", self.consumed_agent_id.clone()),
+            (
+                "manager_channel_check_relied_on_claimed_header",
+                self.manager_channel_check_relied_on_claimed_header
+                    .to_string(),
+            ),
+        ]
+    }
+}
+
 pub fn manager_channel_check_relied_on_claimed_header(
     headers: &HeaderMap,
     expected_channel_id: Option<&str>,
@@ -49,32 +81,52 @@ pub fn manager_channel_check_relied_on_claimed_header(
     trimmed_header_value(headers, "x-channel-id").as_deref() == Some(expected_channel_id)
 }
 
+pub(crate) fn identity_consumption_fields(
+    endpoint: &'static str,
+    principal: Option<&RequestPrincipal>,
+    consumed_agent_id: Option<&str>,
+    manager_channel_check_relied_on_claimed_header: bool,
+) -> IdentityConsumptionFields {
+    IdentityConsumptionFields {
+        endpoint,
+        auth_strength: principal
+            .map(|principal| principal.auth_strength.as_str())
+            .unwrap_or(AuthStrength::None.as_str()),
+        claimed_agent_id: principal
+            .and_then(|principal| principal.claimed_agent_id.as_deref())
+            .unwrap_or("")
+            .to_string(),
+        claimed_channel_id: principal
+            .and_then(|principal| principal.claimed_channel_id.as_deref())
+            .unwrap_or("")
+            .to_string(),
+        consumed_agent_id: consumed_agent_id.unwrap_or("").to_string(),
+        manager_channel_check_relied_on_claimed_header,
+    }
+}
+
 pub fn log_identity_consumption(
     endpoint: &'static str,
     principal: Option<&RequestPrincipal>,
     consumed_agent_id: Option<&str>,
     manager_channel_check_relied_on_claimed_header: bool,
 ) {
-    let auth_strength = principal
-        .map(|principal| principal.auth_strength.as_str())
-        .unwrap_or(AuthStrength::None.as_str());
-    let claimed_agent_id = principal
-        .and_then(|principal| principal.claimed_agent_id.as_deref())
-        .unwrap_or("");
-    let claimed_channel_id = principal
-        .and_then(|principal| principal.claimed_channel_id.as_deref())
-        .unwrap_or("");
-    let consumed_agent_id = consumed_agent_id.unwrap_or("");
+    let fields = identity_consumption_fields(
+        endpoint,
+        principal,
+        consumed_agent_id,
+        manager_channel_check_relied_on_claimed_header,
+    );
 
     tracing::info!(
         target: LOG_TARGET,
-        endpoint = endpoint,
-        auth_strength = auth_strength,
-        claimed_agent_id = claimed_agent_id,
-        claimed_channel_id = claimed_channel_id,
-        consumed_agent_id = consumed_agent_id,
-        manager_channel_check_relied_on_claimed_header =
-            manager_channel_check_relied_on_claimed_header,
+        endpoint = fields.endpoint,
+        auth_strength = fields.auth_strength,
+        claimed_agent_id = fields.claimed_agent_id.as_str(),
+        claimed_channel_id = fields.claimed_channel_id.as_str(),
+        consumed_agent_id = fields.consumed_agent_id.as_str(),
+        manager_channel_check_relied_on_claimed_header = fields
+            .manager_channel_check_relied_on_claimed_header,
         "api caller identity consumed"
     );
 }
@@ -136,9 +188,57 @@ mod tests {
         ));
     }
 
-    // `log_identity_consumption` has no typed return/projection: it only emits
-    // a process-global tracing event. The removed formatted-output test had
-    // the same thread-local capture versus callsite-interest race as the
-    // routines test, so field-level assertions must wait for a typed event
-    // surface rather than reintroducing a flaky formatted-output oracle.
+    #[test]
+    fn log_identity_consumption_emits_expected_fields_without_authorization() {
+        let principal = RequestPrincipal {
+            auth_strength: AuthStrength::ServerAdmin,
+            claimed_agent_id: Some("codex".to_string()),
+            claimed_channel_id: Some("manager-channel".to_string()),
+        };
+        let fields = identity_consumption_fields(
+            "POST /api/test",
+            Some(&principal),
+            Some("resolved-codex"),
+            true,
+        );
+
+        for (name, value) in fields.named_values() {
+            let field = format!("{name}={value}");
+            assert!(
+                !field.to_ascii_lowercase().contains("authorization"),
+                "field={field}"
+            );
+        }
+        assert_eq!(
+            fields,
+            IdentityConsumptionFields {
+                endpoint: "POST /api/test",
+                auth_strength: "ServerAdmin",
+                claimed_agent_id: "codex".to_string(),
+                claimed_channel_id: "manager-channel".to_string(),
+                consumed_agent_id: "resolved-codex".to_string(),
+                manager_channel_check_relied_on_claimed_header: true,
+            }
+        );
+
+        let no_principal_fields = identity_consumption_fields("GET /api/test", None, None, false);
+        for (name, value) in no_principal_fields.named_values() {
+            let field = format!("{name}={value}");
+            assert!(
+                !field.to_ascii_lowercase().contains("authorization"),
+                "field={field}"
+            );
+        }
+        assert_eq!(
+            no_principal_fields,
+            IdentityConsumptionFields {
+                endpoint: "GET /api/test",
+                auth_strength: "None",
+                claimed_agent_id: String::new(),
+                claimed_channel_id: String::new(),
+                consumed_agent_id: String::new(),
+                manager_channel_check_relied_on_claimed_header: false,
+            }
+        );
+    }
 }

--- a/src/api_caller_observability.rs
+++ b/src/api_caller_observability.rs
@@ -92,33 +92,6 @@ fn trimmed_header_value(headers: &HeaderMap, name: &str) -> Option<String> {
 mod tests {
     use super::*;
     use axum::http::{HeaderMap, HeaderValue};
-    use std::io::{self, Write};
-    use std::sync::{Arc, Mutex};
-    use tracing_subscriber::fmt::writer::MakeWriter;
-
-    #[derive(Clone)]
-    struct CapturingWriter {
-        buffer: Arc<Mutex<Vec<u8>>>,
-    }
-
-    impl Write for CapturingWriter {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.buffer.lock().unwrap().extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    impl<'a> MakeWriter<'a> for CapturingWriter {
-        type Writer = CapturingWriter;
-
-        fn make_writer(&'a self) -> Self::Writer {
-            self.clone()
-        }
-    }
 
     #[test]
     fn request_principal_classifies_loopback_bearer_and_none() {
@@ -163,57 +136,9 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn log_identity_consumption_emits_expected_fields_without_authorization() {
-        let buffer = Arc::new(Mutex::new(Vec::new()));
-        let writer = CapturingWriter {
-            buffer: buffer.clone(),
-        };
-        let subscriber = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::INFO)
-            .with_ansi(false)
-            .without_time()
-            .with_target(true)
-            .with_writer(writer)
-            .finish();
-        let _guard = tracing::subscriber::set_default(subscriber);
-
-        let principal = RequestPrincipal {
-            auth_strength: AuthStrength::ServerAdmin,
-            claimed_agent_id: Some("codex".to_string()),
-            claimed_channel_id: Some("manager-channel".to_string()),
-        };
-        log_identity_consumption(
-            "POST /api/test",
-            Some(&principal),
-            Some("resolved-codex"),
-            true,
-        );
-        drop(_guard);
-
-        let logs = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
-        assert!(logs.contains(LOG_TARGET), "logs={logs}");
-        assert!(logs.contains("endpoint=\"POST /api/test\""), "logs={logs}");
-        assert!(
-            logs.contains("auth_strength=\"ServerAdmin\""),
-            "logs={logs}"
-        );
-        assert!(logs.contains("claimed_agent_id=\"codex\""), "logs={logs}");
-        assert!(
-            logs.contains("claimed_channel_id=\"manager-channel\""),
-            "logs={logs}"
-        );
-        assert!(
-            logs.contains("consumed_agent_id=\"resolved-codex\""),
-            "logs={logs}"
-        );
-        assert!(
-            logs.contains("manager_channel_check_relied_on_claimed_header=true"),
-            "logs={logs}"
-        );
-        assert!(
-            !logs.to_ascii_lowercase().contains("authorization"),
-            "logs={logs}"
-        );
-    }
+    // `log_identity_consumption` has no typed return/projection: it only emits
+    // a process-global tracing event. The removed formatted-output test had
+    // the same thread-local capture versus callsite-interest race as the
+    // routines test, so field-level assertions must wait for a typed event
+    // surface rather than reintroducing a flaky formatted-output oracle.
 }

--- a/src/api_caller_observability.rs
+++ b/src/api_caller_observability.rs
@@ -49,11 +49,14 @@ pub(crate) struct IdentityConsumptionFields {
 impl IdentityConsumptionFields {
     /// Return only the fields built by `identity_consumption_fields`.
     ///
-    /// This projection lets tests inspect the values supplied to the event
-    /// without formatted tracing capture. It does not observe the emitted
-    /// event, so a field added directly to `tracing::info!` is outside this
-    /// guard. Closing that gap requires generating emission and projection
-    /// from one declarative field list.
+    /// This projection lets tests inspect a field set they construct, without
+    /// formatted tracing capture. Two things sit outside the guard: it does not
+    /// observe the emitted event, so a field added directly to `tracing::info!`
+    /// is invisible here; and a caller that builds its own arguments is not
+    /// checking what any production call site passed. Closing the first gap
+    /// needs emission and projection generated from one declarative field list;
+    /// the second needs a seam reporting emitted values back from production.
+    /// Both are tracked as sites on umbrella #5003.
     #[cfg(test)]
     pub(crate) fn named_values(&self) -> Vec<(&'static str, String)> {
         vec![

--- a/src/api_caller_observability.rs
+++ b/src/api_caller_observability.rs
@@ -47,12 +47,15 @@ pub(crate) struct IdentityConsumptionFields {
 }
 
 impl IdentityConsumptionFields {
-    /// Return the projected fields in the same name/value form used by the
-    /// identity-consumption event.  Keeping this view next to the typed
-    /// projection gives tests a complete, tracing-independent redaction
-    /// oracle for every emitted field.
+    /// Return only the fields built by `identity_consumption_fields`.
+    ///
+    /// This projection lets tests inspect the values supplied to the event
+    /// without formatted tracing capture. It does not observe the emitted
+    /// event, so a field added directly to `tracing::info!` is outside this
+    /// guard. Closing that gap requires generating emission and projection
+    /// from one declarative field list.
     #[cfg(test)]
-    fn named_values(&self) -> Vec<(&'static str, String)> {
+    pub(crate) fn named_values(&self) -> Vec<(&'static str, String)> {
         vec![
             ("endpoint", self.endpoint.to_string()),
             ("auth_strength", self.auth_strength.to_string()),
@@ -111,13 +114,15 @@ pub fn log_identity_consumption(
     consumed_agent_id: Option<&str>,
     manager_channel_check_relied_on_claimed_header: bool,
 ) {
-    let fields = identity_consumption_fields(
+    emit_identity_consumption(identity_consumption_fields(
         endpoint,
         principal,
         consumed_agent_id,
         manager_channel_check_relied_on_claimed_header,
-    );
+    ));
+}
 
+pub(crate) fn emit_identity_consumption(fields: IdentityConsumptionFields) {
     tracing::info!(
         target: LOG_TARGET,
         endpoint = fields.endpoint,
@@ -189,7 +194,7 @@ mod tests {
     }
 
     #[test]
-    fn log_identity_consumption_emits_expected_fields_without_authorization() {
+    fn identity_consumption_fields_projection_excludes_authorization() {
         let principal = RequestPrincipal {
             auth_strength: AuthStrength::ServerAdmin,
             claimed_agent_id: Some("codex".to_string()),

--- a/src/services/routines/store.rs
+++ b/src/services/routines/store.rs
@@ -6,7 +6,10 @@ use sqlx::{PgPool, Postgres, Row, Transaction};
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::api_caller_observability::{RequestPrincipal, log_identity_consumption};
+use crate::api_caller_observability::{
+    IdentityConsumptionFields, RequestPrincipal, emit_identity_consumption,
+    identity_consumption_fields,
+};
 use crate::services::automation_candidate_contract::{
     PIPELINE_STAGE_ID, has_complete_loop_contract,
 };
@@ -500,12 +503,10 @@ fn routine_delete_scope_gate(
     caller_agent_id: Option<&str>,
     principal: Option<&RequestPrincipal>,
 ) -> RoutineDeleteScopeGate {
-    log_identity_consumption(
-        "DELETE /api/routines/{id}",
+    emit_identity_consumption(routine_delete_identity_consumption_fields(
         principal,
         caller_agent_id,
-        false,
-    );
+    ));
 
     let Some(owner) = routine_agent_id
         .map(str::trim)
@@ -529,6 +530,18 @@ fn routine_delete_scope_gate(
             caller: caller.to_string(),
         }
     }
+}
+
+fn routine_delete_identity_consumption_fields(
+    principal: Option<&RequestPrincipal>,
+    caller_agent_id: Option<&str>,
+) -> IdentityConsumptionFields {
+    identity_consumption_fields(
+        "DELETE /api/routines/{id}",
+        principal,
+        caller_agent_id,
+        false,
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
@@ -3565,7 +3578,7 @@ mod tests {
         include_automation_candidate_card_observations, precomputed_observation_from_kv,
         preserve_fresh_context_evidence, resume_without_next_due_is_invalid, truncate_chars,
     };
-    use crate::api_caller_observability::{AuthStrength, RequestPrincipal};
+    use crate::api_caller_observability::{AuthStrength, LOG_TARGET, RequestPrincipal};
     use chrono::{TimeZone, Utc};
     use serde_json::Value;
 
@@ -4023,7 +4036,7 @@ mod tests {
     }
 
     #[test]
-    fn routine_delete_scope_gate_returns_other_agent_for_resolved_caller() {
+    fn routine_delete_scope_gate_preserves_typed_audit_projection() {
         let principal = RequestPrincipal {
             auth_strength: AuthStrength::ServerAdmin,
             claimed_agent_id: Some("codex".to_string()),
@@ -4040,6 +4053,31 @@ mod tests {
                 owner: "codex".to_string(),
                 caller: "resolved-codex".to_string()
             }
+        );
+
+        // This preserves the DELETE site's target and the exact typed fields
+        // passed to emission without the flaky formatted tracing capture. It
+        // does not inspect subscriber output or detect fields added directly
+        // inside `tracing::info!`; a single-source generated field list would
+        // be required to cover that broader contract.
+        assert_eq!(LOG_TARGET, "agentdesk::api_caller_observability");
+        assert_eq!(
+            super::routine_delete_identity_consumption_fields(
+                Some(&principal),
+                Some("resolved-codex")
+            )
+            .named_values(),
+            vec![
+                ("endpoint", "DELETE /api/routines/{id}".to_string()),
+                ("auth_strength", "ServerAdmin".to_string()),
+                ("claimed_agent_id", "codex".to_string()),
+                ("claimed_channel_id", "manager-channel".to_string()),
+                ("consumed_agent_id", "resolved-codex".to_string()),
+                (
+                    "manager_channel_check_relied_on_claimed_header",
+                    "false".to_string(),
+                ),
+            ]
         );
     }
 

--- a/src/services/routines/store.rs
+++ b/src/services/routines/store.rs
@@ -3565,42 +3565,15 @@ mod tests {
         include_automation_candidate_card_observations, precomputed_observation_from_kv,
         preserve_fresh_context_evidence, resume_without_next_due_is_invalid, truncate_chars,
     };
-    use crate::api_caller_observability::{AuthStrength, LOG_TARGET, RequestPrincipal};
+    use crate::api_caller_observability::{AuthStrength, RequestPrincipal};
     use chrono::{TimeZone, Utc};
     use serde_json::Value;
-    use std::io::{self, Write};
-    use std::sync::{Arc, Mutex};
-    use tracing_subscriber::fmt::writer::MakeWriter;
 
     // Integration tests that require a live PG connection live in
     // src/integration_tests.rs and are gated on the `integration` feature.
     // The store SQL is compiled by `cargo check`; concurrent claim/recovery
     // behavior should be covered by PG integration tests once the runtime
     // harness starts executing routines.
-
-    #[derive(Clone)]
-    struct CapturingWriter {
-        buffer: Arc<Mutex<Vec<u8>>>,
-    }
-
-    impl Write for CapturingWriter {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.buffer.lock().unwrap().extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    impl<'a> MakeWriter<'a> for CapturingWriter {
-        type Writer = CapturingWriter;
-
-        fn make_writer(&'a self) -> Self::Writer {
-            self.clone()
-        }
-    }
 
     #[test]
     fn resume_omitted_next_due_rejects_legacy_schedule_less_rows() {
@@ -4050,19 +4023,7 @@ mod tests {
     }
 
     #[test]
-    fn routine_delete_scope_gate_logs_delete_path_identity_consumption() {
-        let buffer = Arc::new(Mutex::new(Vec::new()));
-        let writer = CapturingWriter {
-            buffer: buffer.clone(),
-        };
-        let subscriber = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::INFO)
-            .with_ansi(false)
-            .without_time()
-            .with_target(true)
-            .with_writer(writer)
-            .finish();
-        let _guard = tracing::subscriber::set_default(subscriber);
+    fn routine_delete_scope_gate_returns_other_agent_for_resolved_caller() {
         let principal = RequestPrincipal {
             auth_strength: AuthStrength::ServerAdmin,
             claimed_agent_id: Some("codex".to_string()),
@@ -4079,31 +4040,6 @@ mod tests {
                 owner: "codex".to_string(),
                 caller: "resolved-codex".to_string()
             }
-        );
-        drop(_guard);
-
-        let logs = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
-        assert!(logs.contains(LOG_TARGET), "logs={logs}");
-        assert!(
-            logs.contains("endpoint=\"DELETE /api/routines/{id}\""),
-            "logs={logs}"
-        );
-        assert!(
-            logs.contains("auth_strength=\"ServerAdmin\""),
-            "logs={logs}"
-        );
-        assert!(logs.contains("claimed_agent_id=\"codex\""), "logs={logs}");
-        assert!(
-            logs.contains("claimed_channel_id=\"manager-channel\""),
-            "logs={logs}"
-        );
-        assert!(
-            logs.contains("consumed_agent_id=\"resolved-codex\""),
-            "logs={logs}"
-        );
-        assert!(
-            logs.contains("manager_channel_check_relied_on_claimed_header=false"),
-            "logs={logs}"
         );
     }
 

--- a/src/services/routines/store.rs
+++ b/src/services/routines/store.rs
@@ -4055,11 +4055,15 @@ mod tests {
             }
         );
 
-        // This preserves the DELETE site's target and the exact typed fields
-        // passed to emission without the flaky formatted tracing capture. It
-        // does not inspect subscriber output or detect fields added directly
-        // inside `tracing::info!`; a single-source generated field list would
-        // be required to cover that broader contract.
+        // This asserts the projection helper's own output for the DELETE
+        // argument shape, without the flaky formatted tracing capture. It does
+        // NOT observe the production call site: the helper is invoked here with
+        // arguments this test supplies, so changing what the DELETE handler
+        // actually passes — say, its `caller_agent_id` — leaves this test green.
+        // Nor does it inspect subscriber output or see fields added directly
+        // inside `tracing::info!`. Closing either gap needs a seam that reports
+        // the emitted values back from the production path; tracked as a site on
+        // umbrella #5003.
         assert_eq!(LOG_TARGET, "agentdesk::api_caller_observability");
         assert_eq!(
             super::routine_delete_identity_consumption_fields(


### PR DESCRIPTION
## 무엇을

`#5077` — routines delete-scope-gate 테스트가 **tracing 문자열을 correctness oracle 로** 쓰던 것을 제거하고, 같은 계열의 두 번째 사례를 typed projection 으로 전환한다.

**2파일 +109/−148.**

## 이 테스트는 실제로 main 을 깨뜨리고 있었다

| 실행 | 결과 |
|---|---|
| 정확한 단일 테스트 20회 | 20 pass / 0 fail |
| CI 와 동일한 `cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres` 20회 | **16 pass / 4 fail** |

실패는 전부 `store.rs:4086` 의 `logs=`(빈 문자열)였다. 프로세스 전역 tracing callsite/dispatcher interest 상태와 thread-local capture 가 경쟁해서, 단일 실행에서는 안 나고 병렬 suite 에서만 난다.

이 테스트는 `justfile:105` → main `just check` / Trusted macOS(hosted·self-hosted, `ci-macos-trusted.yml:147,269`) / nightly 에서 돈다. **PR 레인이 아니라 머지 후 레인이라 간헐적으로 main 을 red 로 만들고 있었다.**

## store.rs — 문자열 oracle 제거

이 테스트는 **이미 반환값을 올바르게 검증하고 있었다**(`store.rs:4072-4081`, `RoutineDeleteScopeGate::OtherAgent`). 뒤에 붙은 formatted log assert 가 군더더기였다. `CapturingWriter` 와 함께 제거했다. 다른 사용처는 없다.

수정 후 같은 명령 **20/20 pass**, 각 실행 `185 passed; 0 failed`.

## api_caller_observability.rs — 삭제가 아니라 전환

같은 anti-pattern 이 여기에도 있었는데(`log_identity_consumption_emits_expected_fields_without_authorization`), 이 테스트에는 **보안 회귀 가드**가 들어 있었다:

```rust
assert!(!logs.to_ascii_lowercase().contains("authorization"), "logs={logs}");
```

r1 에서 이걸 대체 없이 삭제했다가 반려됐다. r2 에서 `IdentityConsumptionFields` 구조체로 **필드 계산을 순수 함수로 추출**하고, tracing capture 없이 반환값만 검사하도록 복원했다.

**로깅 동작은 한 글자도 바뀌지 않았다** — target·level·필드 이름·필드 값 전부 보존(`endpoint = fields.endpoint` 등).

복원된 가드는 원본보다 넓다:
- `Some` / `None` principal **두 경우 모두** 검사 (원본은 `Some` 만)
- `name=value` 쌍을 검사하므로 **필드명이 authorization 이든 값에 들어가든** 잡는다

## 뮤테이션 증명

```text
injected: ("authorization", "Bearer secret")
AUTHORIZATION_INJECTION_RC=101
field=authorization=Bearer secret
test ... FAILED

restored:
test result: ok. 1 passed
```

자기 assert 로 실패한다 — 컴파일 에러 사망이 아니다.

## 게이트

`cargo fmt --check` / `cargo check --lib`(접촉 파일 신규 경고 0) / inventory·maintenance freshness / coverage(`--baseline-ref origin/main`) / PG membership / `audit_maintainability --check` / `ci-script-checks.sh` / `git diff --check` — **전부 rc=0**. `api_caller_observability` 3/3 pass.

---

# r4 (`5f210c8a7`) — 주석을 실제 계약으로 정정

## 배경

r3 에서 **두 리뷰 leg 가 독립적으로 같은 문장을 지목**했다(Fable P2 / sol P1). 주석이 이렇게 주장하고 있었다:

> the exact typed fields **passed to emission**

**거짓이다.** 테스트는 `routine_delete_identity_consumption_fields` 를 **자기 인자로 재호출**해 그 반환값을 assert 한다. 프로덕션 DELETE 호출부가 실제로 무엇을 넘겼는지는 어디서도 관측되지 않는다.

sol 실측 — 프로덕션 emit 의 `caller_agent_id` 를 `Some("mutated-emitted-caller")` 로 변조:

| 뮤테이션 | 결과 |
|---|---|
| projection 에 `authorization` 추가 | `rc=101` ✅ 정상 검출 |
| DELETE flag `false→true` | `rc=101` ✅ 정상 검출 |
| **프로덕션 emit 인자 변조** | **`rc=0`** ❌ 미검출 |

## 이번 변경

**주석만 바꿨다.** 실행 코드·테스트·assert·시그니처 전부 불변(`store.rs:4058`, `api_caller_observability.rs:52`).

가드를 실제로 닫으려면 프로덕션 경로가 emit 한 값을 되돌려주는 seam 이 필요한데, 그건 **test-only PR 을 프로덕션 구조 변경으로 넓힌다.** 대신 주석을 실제 계약으로 좁히고 남은 갭은 umbrella **#5003 에 사이트로 등재**했다(issuecomment-5153808389).

## r4 리뷰 (sol, fresh session) — `VERDICT: CLEAN`

| 뮤테이션 | 결과 | 새 주석의 주장 |
|---|---|---|
| 프로덕션 `caller_agent_id` 변조 | 통과 `rc=0` | "관측하지 않는다" ✓ |
| `tracing::info!` 직접 필드 추가 | 통과 `rc=0` | "보이지 않는다" ✓ |
| projection 에 `authorization` | `rc=101` | 실제 보장 ✓ |
| DELETE flag `false→true` | `rc=101` | 실제 보장 ✓ |

리뷰어 판정: **"새 주석은 관측 공백과 실제 projection 보장을 정확히 구분하며 과소주장하지 않습니다."** 과대주장을 고치다 실제 있는 보장까지 부정하지 않았다는 뜻이다.

게이트 전부 rc=0, 테스트 3 / 185 통과, 워크트리 clean.

## ⚠️ 리뷰 라운드 하드캡 예외 (사용자 승인)

r3 에서 필수 leg 전부 CLEAN 을 못 받아 규칙상 **자동 최소집합 재구성** 대상이었다. 예외를 승인받은 근거:

- 브랜치 **2파일 `+155/−151`, 순증 +4줄** — 3라운드 내내 축소
- 잔여 지적이 로직 결함이 아니라 **주석의 과대주장** 1건
- 재구성해도 거의 같은 diff 가 나오면서 3라운드치 검증만 버려짐

캡의 대상은 결함 크기가 아니라 **표면 증가**이고, 이 브랜치에는 증가가 없다.

## 리뷰 leg 축소 근거

r4 는 test-only PR 의 **주석 전용** 변경이다. 핫파일·relay-state-contract·migration·배달 권위·live-turn 전부 비접촉이라 스킬의 간단 수정 예외(카운터리뷰 1 leg)에 해당한다. 구현자가 Claude(오케스트레이터)였으므로 sol 이 **카운터모델 + fresh 세션**이다.