### PR TITLE
fix(#5024): fail closed when a top-level jobs map is present but unparsed

### DIFF
--- a/scripts/check_pg_test_lane_membership.py
+++ b/scripts/check_pg_test_lane_membership.py
@@ -129,6 +129,10 @@ _TEST_ATTR = re.compile(
 _STRUCT = re.compile(r"\bstruct\s+([A-Za-z_][A-Za-z0-9_]*)\b")
 _IMPL = re.compile(r"\bimpl(?:\s*<[^>{}]*>)?\s+(?:[^{}]*?\s+for\s+)?([A-Za-z_][A-Za-z0-9_]*)\b[^{};]*\{")
 _JOBS_KEY = re.compile(
+    r"^(?:jobs|'jobs'|\"jobs\")[^\S\n]*:(?=[^\S\n]|$)",
+    re.MULTILINE,
+)
+_JOBS_BLOCK_KEY = re.compile(
     r"^(?:jobs|'jobs'|\"jobs\"):[^\S\n]*(?:#.*)?$",
     re.MULTILINE,
 )
@@ -604,27 +608,37 @@ def parse_jobs(
     This intentionally stays dependency-free instead of relying on PyYAML, which
     is not declared by AgentDesk's script-check environment. It supports the
     repository's block-style workflows and tracks scalar bodies while locating
-    the next column-zero mapping key. An empty top-level job map is reported as a
-    configuration error; an absent top-level ``jobs:`` key is ignored.
+    the next column-zero mapping key. Top-level ``jobs`` presence is detected
+    more broadly than the supported block syntax so unsupported forms fail as a
+    configuration error instead of looking absent. A genuinely absent key is
+    ignored.
     """
     text = path.read_text("utf-8")
-    jobs_key = _JOBS_KEY.search(text)
-    if jobs_key is None:
+    # Normalize only the presence probe. Enumeration stays strict against the
+    # original text so BOM, flow maps, and pre-colon spacing fail closed rather
+    # than being partially supported by the lightweight block parser.
+    has_bom = text.startswith("\ufeff")
+    present_jobs_key = _JOBS_KEY.search(text.removeprefix("\ufeff"))
+    if present_jobs_key is None:
         return []
-    jobs_indent = 0
-    section_end = _jobs_section_end(text, jobs_key.end())
-    in_section = [
-        match for match in _JOB.finditer(text, jobs_key.end(), section_end)
-        if _indent_width(match.group("indent")) > jobs_indent
-    ]
-    job_indent = min(
-        (_indent_width(match.group("indent")) for match in in_section),
-        default=None,
-    )
-    candidates = [
-        match for match in in_section
-        if _indent_width(match.group("indent")) == job_indent
-    ]
+    jobs_key = None if has_bom else _JOBS_BLOCK_KEY.match(text, present_jobs_key.start())
+    section_end = len(text)
+    candidates: list[re.Match[str]] = []
+    if jobs_key is not None:
+        jobs_indent = 0
+        section_end = _jobs_section_end(text, jobs_key.end())
+        in_section = [
+            match for match in _JOB.finditer(text, jobs_key.end(), section_end)
+            if _indent_width(match.group("indent")) > jobs_indent
+        ]
+        job_indent = min(
+            (_indent_width(match.group("indent")) for match in in_section),
+            default=None,
+        )
+        candidates = [
+            match for match in in_section
+            if _indent_width(match.group("indent")) == job_indent
+        ]
     rel = str(path.relative_to(repo_root))
     if not candidates and findings is not None:
         findings.append(Finding("jobs-empty", rel, "jobs: is present but no job keys were parsed"))

--- a/scripts/check_pg_test_lane_membership.py
+++ b/scripts/check_pg_test_lane_membership.py
@@ -661,7 +661,16 @@ def parse_jobs(
         ]
     rel = str(path.relative_to(repo_root))
     if not candidates and findings is not None:
-        findings.append(Finding("jobs-empty", rel, "jobs: is present but no job keys were parsed"))
+        findings.append(
+            Finding(
+                "jobs-empty",
+                rel,
+                "top-level jobs: found but no job keys parsed; this gate reads a "
+                "plain block header (optionally one anchor) with block-style job "
+                "keys under it, so flow mappings, tags, and a space before the "
+                "colon are not read — rewrite the jobs block in that form",
+            )
+        )
     return [
         Job(
             rel,

--- a/scripts/check_pg_test_lane_membership.py
+++ b/scripts/check_pg_test_lane_membership.py
@@ -47,7 +47,7 @@ def _seed_pattern(seed: str) -> re.Pattern[str]:
 SEED_PATTERNS = tuple(_seed_pattern(seed) for seed in SEEDS)
 CONNECT_SEED_PATTERNS = tuple(_seed_pattern(seed) for seed in CONNECT_SEEDS)
 SECTIONS = ("rule1", "rule2", "rule3", "rule4")
-CONFIGURATION_ERROR_FINDINGS = frozenset({"jobs-empty", "jobs-key-mismatch"})
+CONFIGURATION_ERROR_FINDINGS = frozenset({"jobs-empty"})
 
 
 def _load_coverage_module(repo_root: Path):
@@ -134,12 +134,6 @@ _JOBS_KEY = re.compile(
 )
 _JOBS_BLOCK_KEY = re.compile(
     r"^(?:jobs|'jobs'|\"jobs\"):[^\S\n]*(?:#.*)?$",
-    re.MULTILINE,
-)
-_JOB_KEY = re.compile(
-    r"^(?P<indent>[^\S\r\n]+)"
-    r"(?P<name>[A-Za-z0-9_-]+|'[^']+'|\"[^\"]+\")"
-    r"(?P<pre_colon>[^\S\r\n]*):(?=[^\S\r\n]|$)[^\r\n]*$",
     re.MULTILINE,
 )
 _JOB = re.compile(
@@ -617,10 +611,10 @@ def parse_jobs(
     This intentionally stays dependency-free instead of relying on PyYAML, which
     is not declared by AgentDesk's script-check environment. It supports the
     repository's block-style workflows and tracks scalar bodies while locating
-    the next column-zero mapping key. Top-level and job-key candidates are
-    detected separately from enumeration; an unsupported or mixed job header
-    set is reported as a configuration error. A genuinely absent top-level key
-    is ignored.
+    the next column-zero mapping key. Top-level ``jobs`` presence is detected
+    more broadly than the supported block syntax so a present but unparsed map
+    is a configuration error. Individual jobs are limited to supported block
+    headers; other individual job forms can still be omitted.
     """
     text = path.read_text("utf-8")
     # Normalize only the top-level key probe. The supported ``jobs:`` block
@@ -632,56 +626,35 @@ def parse_jobs(
         return []
     jobs_key = None if has_bom else _JOBS_BLOCK_KEY.match(text, present_jobs_key.start())
     section_end = len(text)
-    job_keys: list[re.Match[str]] = []
-    candidate_indexes: list[int] = []
+    candidates: list[re.Match[str]] = []
     if jobs_key is not None:
         jobs_indent = 0
         section_end = _jobs_section_end(text, jobs_key.end())
         in_section = [
-            match for match in _JOB_KEY.finditer(text, jobs_key.end(), section_end)
+            match for match in _JOB.finditer(text, jobs_key.end(), section_end)
             if _indent_width(match.group("indent")) > jobs_indent
         ]
         job_indent = min(
             (_indent_width(match.group("indent")) for match in in_section),
             default=None,
         )
-        job_keys = [
+        candidates = [
             match for match in in_section
             if _indent_width(match.group("indent")) == job_indent
         ]
-        header_family: str | None = None
-        for index, job_key in enumerate(job_keys):
-            parsed = _JOB.fullmatch(job_key.group(0))
-            if parsed is None:
-                continue
-            family = (
-                "extended"
-                if parsed.group("pre_colon") or parsed.group("decorator")
-                else "plain"
-            )
-            if header_family is None:
-                header_family = family
-            if family == header_family:
-                candidate_indexes.append(index)
     rel = str(path.relative_to(repo_root))
-    if not job_keys and findings is not None:
+    if not candidates and findings is not None:
         findings.append(Finding("jobs-empty", rel, "jobs: is present but no job keys were parsed"))
-    elif len(candidate_indexes) != len(job_keys) and findings is not None:
-        findings.append(Finding(
-            "jobs-key-mismatch",
-            rel,
-            f"jobs: contains {len(job_keys)} job keys but {len(candidate_indexes)} were parsed",
-        ))
     return [
         Job(
             rel,
-            job_keys[index].group("name").strip("'\""),
+            match.group("name").strip("'\""),
             text[
-                job_keys[index].end():
-                job_keys[index + 1].start() if index + 1 < len(job_keys) else section_end
+                match.end():
+                candidates[index + 1].start() if index + 1 < len(candidates) else section_end
             ],
         )
-        for index in candidate_indexes
+        for index, match in enumerate(candidates)
     ]
 
 

--- a/scripts/check_pg_test_lane_membership.py
+++ b/scripts/check_pg_test_lane_membership.py
@@ -668,7 +668,9 @@ def parse_jobs(
                 "top-level jobs: found but no job keys parsed; this gate reads a "
                 "plain block header (optionally one anchor) with block-style job "
                 "keys under it, so flow mappings, tags, and a space before the "
-                "colon are not read — rewrite the jobs block in that form",
+                "colon are not read — rewrite the jobs block in that form. A "
+                "leading UTF-8 BOM also lands here even when the block itself is "
+                "already plain; strip the BOM in that case",
             )
         )
     return [

--- a/scripts/check_pg_test_lane_membership.py
+++ b/scripts/check_pg_test_lane_membership.py
@@ -47,7 +47,7 @@ def _seed_pattern(seed: str) -> re.Pattern[str]:
 SEED_PATTERNS = tuple(_seed_pattern(seed) for seed in SEEDS)
 CONNECT_SEED_PATTERNS = tuple(_seed_pattern(seed) for seed in CONNECT_SEEDS)
 SECTIONS = ("rule1", "rule2", "rule3", "rule4")
-CONFIGURATION_ERROR_FINDINGS = frozenset({"jobs-empty"})
+CONFIGURATION_ERROR_FINDINGS = frozenset({"jobs-empty", "jobs-key-mismatch"})
 
 
 def _load_coverage_module(repo_root: Path):
@@ -136,8 +136,17 @@ _JOBS_BLOCK_KEY = re.compile(
     r"^(?:jobs|'jobs'|\"jobs\"):[^\S\n]*(?:#.*)?$",
     re.MULTILINE,
 )
+_JOB_KEY = re.compile(
+    r"^(?P<indent>[^\S\r\n]+)"
+    r"(?P<name>[A-Za-z0-9_-]+|'[^']+'|\"[^\"]+\")"
+    r"(?P<pre_colon>[^\S\r\n]*):(?=[^\S\r\n]|$)[^\r\n]*$",
+    re.MULTILINE,
+)
 _JOB = re.compile(
-    r"^(?P<indent>[^\S\n]+)(?P<name>[A-Za-z0-9_-]+|'[^']+'|\"[^\"]+\"):[^\S\n]*(?:#.*)?$",
+    r"^(?P<indent>[^\S\r\n]+)"
+    r"(?P<name>[A-Za-z0-9_-]+|'[^']+'|\"[^\"]+\")"
+    r"(?P<pre_colon>[^\S\r\n]*):[^\S\r\n]*"
+    r"(?P<decorator>[&*][^\s\[\]{},]+)?[^\S\r\n]*(?:#.*)?$",
     re.MULTILINE,
 )
 _FN = re.compile(r"\b(?:async\s+)?(?:unsafe\s+)?fn\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)")
@@ -608,50 +617,71 @@ def parse_jobs(
     This intentionally stays dependency-free instead of relying on PyYAML, which
     is not declared by AgentDesk's script-check environment. It supports the
     repository's block-style workflows and tracks scalar bodies while locating
-    the next column-zero mapping key. Top-level ``jobs`` presence is detected
-    more broadly than the supported block syntax so unsupported forms fail as a
-    configuration error instead of looking absent. A genuinely absent key is
-    ignored.
+    the next column-zero mapping key. Top-level and job-key candidates are
+    detected separately from enumeration; an unsupported or mixed job header
+    set is reported as a configuration error. A genuinely absent top-level key
+    is ignored.
     """
     text = path.read_text("utf-8")
-    # Normalize only the presence probe. Enumeration stays strict against the
-    # original text so BOM, flow maps, and pre-colon spacing fail closed rather
-    # than being partially supported by the lightweight block parser.
+    # Normalize only the top-level key probe. The supported ``jobs:`` block
+    # header still matches the original text, so other top-level forms are
+    # reported as configuration errors.
     has_bom = text.startswith("\ufeff")
     present_jobs_key = _JOBS_KEY.search(text.removeprefix("\ufeff"))
     if present_jobs_key is None:
         return []
     jobs_key = None if has_bom else _JOBS_BLOCK_KEY.match(text, present_jobs_key.start())
     section_end = len(text)
-    candidates: list[re.Match[str]] = []
+    job_keys: list[re.Match[str]] = []
+    candidate_indexes: list[int] = []
     if jobs_key is not None:
         jobs_indent = 0
         section_end = _jobs_section_end(text, jobs_key.end())
         in_section = [
-            match for match in _JOB.finditer(text, jobs_key.end(), section_end)
+            match for match in _JOB_KEY.finditer(text, jobs_key.end(), section_end)
             if _indent_width(match.group("indent")) > jobs_indent
         ]
         job_indent = min(
             (_indent_width(match.group("indent")) for match in in_section),
             default=None,
         )
-        candidates = [
+        job_keys = [
             match for match in in_section
             if _indent_width(match.group("indent")) == job_indent
         ]
+        header_family: str | None = None
+        for index, job_key in enumerate(job_keys):
+            parsed = _JOB.fullmatch(job_key.group(0))
+            if parsed is None:
+                continue
+            family = (
+                "extended"
+                if parsed.group("pre_colon") or parsed.group("decorator")
+                else "plain"
+            )
+            if header_family is None:
+                header_family = family
+            if family == header_family:
+                candidate_indexes.append(index)
     rel = str(path.relative_to(repo_root))
-    if not candidates and findings is not None:
+    if not job_keys and findings is not None:
         findings.append(Finding("jobs-empty", rel, "jobs: is present but no job keys were parsed"))
+    elif len(candidate_indexes) != len(job_keys) and findings is not None:
+        findings.append(Finding(
+            "jobs-key-mismatch",
+            rel,
+            f"jobs: contains {len(job_keys)} job keys but {len(candidate_indexes)} were parsed",
+        ))
     return [
         Job(
             rel,
-            match.group("name").strip("'\""),
+            job_keys[index].group("name").strip("'\""),
             text[
-                match.end():
-                candidates[index + 1].start() if index + 1 < len(candidates) else section_end
+                job_keys[index].end():
+                job_keys[index + 1].start() if index + 1 < len(job_keys) else section_end
             ],
         )
-        for index, match in enumerate(candidates)
+        for index in candidate_indexes
     ]
 
 

--- a/scripts/check_pg_test_lane_membership.py
+++ b/scripts/check_pg_test_lane_membership.py
@@ -133,7 +133,7 @@ _JOBS_KEY = re.compile(
     re.MULTILINE,
 )
 _JOBS_BLOCK_KEY = re.compile(
-    r"^(?:jobs|'jobs'|\"jobs\"):[^\S\n]*(?:#.*)?$",
+    r"^(?:jobs|'jobs'|\"jobs\"):[^\S\n]*(?:&[^\s\[\]{},]+[^\S\n]*)?(?:#.*)?$",
     re.MULTILINE,
 )
 _JOB = re.compile(
@@ -611,7 +611,9 @@ def parse_jobs(
     This intentionally stays dependency-free instead of relying on PyYAML, which
     is not declared by AgentDesk's script-check environment. It supports the
     repository's block-style workflows and tracks scalar bodies while locating
-    the next column-zero mapping key.
+    the next column-zero mapping key. A literal top-level ``jobs:`` may carry
+    one anchor after the colon; a tag in that slot (``jobs: !!map &a``) remains
+    unsupported and is reported as ``jobs-empty``.
 
     Two distinct gaps follow from parsing YAML with regexes, and neither is
     closed here. First, top-level ``jobs`` presence is detected by *spelling*:
@@ -620,8 +622,10 @@ def parse_jobs(
     ``!!str jobs`` — is not seen at all. Such a file returns no jobs and no
     finding, so the whole membership check silently passes it. Second, once a
     literal ``jobs:`` block is found, individual jobs are limited to supported
-    block headers; other individual job forms are omitted from the returned
-    list while their siblings are still reported.
+    block headers; other individual job forms can still be returned under
+    their uninterpreted names rather than omitted. That can put a name YAML
+    did not resolve into the list and silently skew name-based comparisons,
+    while their siblings are still reported.
 
     So the ``jobs-empty`` finding means "spelled ``jobs`` was found but nothing
     under it parsed", not "this file has no unparsed job map". Do not read a
@@ -630,9 +634,9 @@ def parse_jobs(
     the script-check environment does not guarantee.
     """
     text = path.read_text("utf-8")
-    # Normalize only the top-level key probe. The supported ``jobs:`` block
-    # header still matches the original text, so other top-level forms are
-    # reported as configuration errors.
+    # Normalize only the top-level key probe. Escaped, explicit, and tagged
+    # top-level key forms do not match the literal probe, so they return no
+    # jobs and no finding rather than a configuration error.
     has_bom = text.startswith("\ufeff")
     present_jobs_key = _JOBS_KEY.search(text.removeprefix("\ufeff"))
     if present_jobs_key is None:

--- a/scripts/check_pg_test_lane_membership.py
+++ b/scripts/check_pg_test_lane_membership.py
@@ -47,6 +47,7 @@ def _seed_pattern(seed: str) -> re.Pattern[str]:
 SEED_PATTERNS = tuple(_seed_pattern(seed) for seed in SEEDS)
 CONNECT_SEED_PATTERNS = tuple(_seed_pattern(seed) for seed in CONNECT_SEEDS)
 SECTIONS = ("rule1", "rule2", "rule3", "rule4")
+CONFIGURATION_ERROR_FINDINGS = frozenset({"jobs-empty"})
 
 
 def _load_coverage_module(repo_root: Path):
@@ -604,7 +605,7 @@ def parse_jobs(
     is not declared by AgentDesk's script-check environment. It supports the
     repository's block-style workflows and tracks scalar bodies while locating
     the next column-zero mapping key. An empty top-level job map is reported as a
-    warn-only finding by ``analyze``; an absent top-level ``jobs:`` key is ignored.
+    configuration error; an absent top-level ``jobs:`` key is ignored.
     """
     text = path.read_text("utf-8")
     jobs_key = _JOBS_KEY.search(text)
@@ -842,6 +843,13 @@ def reference_baseline(repo_root: Path, ref: str) -> tuple[str, dict[str, set[st
     return sha, parse_baseline(blob.stdout, f"{sha}:{BASELINE_REL}")
 
 
+def _configuration_errors(findings: Iterable[Finding]) -> tuple[Finding, ...]:
+    return tuple(
+        finding for finding in findings
+        if finding.kind in CONFIGURATION_ERROR_FINDINGS
+    )
+
+
 def check_analysis(
     analysis: Analysis,
     baseline: dict[str, set[str]],
@@ -852,9 +860,15 @@ def check_analysis(
     allowlist_label: str,
 ) -> int:
     """Apply manifest and one-way baseline contracts to a supplied analysis."""
+    configuration_errors = _configuration_errors(analysis.findings)
     failed = False
     for finding in analysis.findings:
-        print(f"WARN: [{finding.kind}] {finding.source}: {finding.detail}", file=sys.stderr)
+        if finding.kind in CONFIGURATION_ERROR_FINDINGS:
+            print(f"FAIL: [{finding.kind}] {finding.source}: {finding.detail}", file=sys.stderr)
+        else:
+            print(f"WARN: [{finding.kind}] {finding.source}: {finding.detail}", file=sys.stderr)
+    if configuration_errors:
+        return 2
     expected_manifest = render_manifest(analysis.inventory)
     if actual_manifest != expected_manifest:
         print("FAIL: PG test-lane manifest drift.", file=sys.stderr)
@@ -958,6 +972,11 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.write_snapshots:
             analysis = analyze(root, allowlist)
+            configuration_errors = _configuration_errors(analysis.findings)
+            for finding in configuration_errors:
+                print(f"FAIL: [{finding.kind}] {finding.source}: {finding.detail}", file=sys.stderr)
+            if configuration_errors:
+                return 2
             manifest.write_text(render_manifest(analysis.inventory), "utf-8")
             baseline.write_text(render_baseline(analysis.debts), "utf-8")
             print(f"wrote {manifest} and {baseline}")

--- a/scripts/check_pg_test_lane_membership.py
+++ b/scripts/check_pg_test_lane_membership.py
@@ -611,10 +611,23 @@ def parse_jobs(
     This intentionally stays dependency-free instead of relying on PyYAML, which
     is not declared by AgentDesk's script-check environment. It supports the
     repository's block-style workflows and tracks scalar bodies while locating
-    the next column-zero mapping key. Top-level ``jobs`` presence is detected
-    more broadly than the supported block syntax so a present but unparsed map
-    is a configuration error. Individual jobs are limited to supported block
-    headers; other individual job forms can still be omitted.
+    the next column-zero mapping key.
+
+    Two distinct gaps follow from parsing YAML with regexes, and neither is
+    closed here. First, top-level ``jobs`` presence is detected by *spelling*:
+    the probe matches the literal characters, so a key that YAML resolves to
+    ``jobs`` without spelling it that way — ``"jo\\u0062s"``, ``? jobs``,
+    ``!!str jobs`` — is not seen at all. Such a file returns no jobs and no
+    finding, so the whole membership check silently passes it. Second, once a
+    literal ``jobs:`` block is found, individual jobs are limited to supported
+    block headers; other individual job forms are omitted from the returned
+    list while their siblings are still reported.
+
+    So the ``jobs-empty`` finding means "spelled ``jobs`` was found but nothing
+    under it parsed", not "this file has no unparsed job map". Do not read a
+    clean result as proof that the file was understood. Both gaps are tracked
+    as sites on umbrella #5071; closing either needs a real YAML parser, which
+    the script-check environment does not guarantee.
     """
     text = path.read_text("utf-8")
     # Normalize only the top-level key probe. The supported ``jobs:`` block

--- a/tests/test_check_pg_test_lane_membership.py
+++ b/tests/test_check_pg_test_lane_membership.py
@@ -402,11 +402,41 @@ class ParserMutations(FixtureCase):
                     ["pg_lane"],
                 )
 
-    def test_empty_jobs_map_is_warn_only(self) -> None:
+    def test_empty_jobs_shapes_are_configuration_errors(self) -> None:
+        cases = {
+            "comment": "jobs: # parsed, but empty\n",
+            "quoted": "\"jobs\": # quoted and empty\n",
+            "four-space": "jobs:\n    # indented comment, but no job key\n",
+            "tab": "jobs:\n\t# tab-indented comment, but no job key\n",
+        }
         workflow = self.root / ".github/workflows/empty.yml"
-        workflow.write_text("jobs: # parsed, but empty\n", "utf-8")
+        empty = {section: set() for section in membership.SECTIONS}
+        for shape, text in cases.items():
+            with self.subTest(shape=shape):
+                workflow.write_text(text, "utf-8")
+                analysis = self.fx.analysis()
+                findings = [
+                    finding for finding in analysis.findings if finding.kind == "jobs-empty"
+                ]
+                self.assertEqual(len(findings), 1)
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    rc = membership.check_analysis(
+                        analysis,
+                        empty,
+                        empty,
+                        membership.render_manifest(analysis.inventory),
+                        reference_label="fixture base",
+                        allowlist_label="fixture allowlist",
+                    )
+                self.assertEqual(rc, 2)
+                self.assertIn("FAIL: [jobs-empty]", stderr.getvalue())
+
+    def test_workflow_without_jobs_key_is_not_configuration_error(self) -> None:
+        workflow = self.root / ".github/workflows/no-jobs.yml"
+        workflow.write_text("on:\n  push:\n", "utf-8")
         analysis = self.fx.analysis()
-        self.assertTrue(any(finding.kind == "jobs-empty" for finding in analysis.findings))
+        self.assertFalse(any(finding.kind == "jobs-empty" for finding in analysis.findings))
         empty = {section: set() for section in membership.SECTIONS}
         stderr = io.StringIO()
         with contextlib.redirect_stderr(stderr):
@@ -419,7 +449,7 @@ class ParserMutations(FixtureCase):
                 allowlist_label="fixture allowlist",
             )
         self.assertEqual(rc, 0)
-        self.assertIn("WARN: [jobs-empty]", stderr.getvalue())
+        self.assertNotIn("jobs-empty", stderr.getvalue())
 
     def test_jobs_comment_rule4_debt_is_warn_only_with_real_analysis(self) -> None:
         workflow = self.root / ".github/workflows/ci-main.yml"

--- a/tests/test_check_pg_test_lane_membership.py
+++ b/tests/test_check_pg_test_lane_membership.py
@@ -475,16 +475,19 @@ class ParserMutations(FixtureCase):
 
     def test_supported_extended_job_headers_are_enumerated(self) -> None:
         cases = {
-            "anchor-alias": (
+            "mixed-anchor": (
                 "jobs:\n"
-                "  call: &base_job\n"
-                "    uses: octo-org/example/.github/workflows/called.yml@main\n"
-                "  call2: *base_job\n",
-                ["call", "call2"],
+                "  build: &base\n"
+                "    runs-on: ubuntu-latest\n"
+                "  test:\n"
+                "    runs-on: ubuntu-latest\n",
+                ["build", "test"],
             ),
-            "space-before-colon": (
-                "jobs:\n  bypass :\n    steps:\n      - run: echo ok\n",
-                ["bypass"],
+            "mixed-space-before-colon": (
+                "jobs:\n"
+                "  bypass :\n    steps:\n      - run: echo bypass\n"
+                "  ordinary:\n    steps:\n      - run: echo ordinary\n",
+                ["bypass", "ordinary"],
             ),
         }
         workflow = self.root / ".github/workflows/extended-job-headers.yml"
@@ -514,64 +517,7 @@ class ParserMutations(FixtureCase):
                         allowlist_label="fixture allowlist",
                     )
                 self.assertEqual(rc, 0)
-                self.assertNotIn("jobs-key-mismatch", stderr.getvalue())
-
-    def test_partial_job_key_enumeration_is_configuration_error(self) -> None:
-        payload = (
-            "    steps:\n"
-            "      - run: ./scripts/ci/postgres-service.sh start\n"
-            "      - run: cargo test postgres_\n"
-        )
-        cases = {
-            "space-before-colon-mixed": (
-                "jobs:\n  bypass :\n" + payload
-                + "  ordinary:\n    steps:\n      - run: echo ok\n",
-                ["bypass"],
-                {".github/workflows/job-key-mismatch.yml:bypass"},
-            ),
-            "anchor-mixed": (
-                "jobs:\n  bypass: &pg\n" + payload
-                + "  ordinary:\n    steps:\n      - run: echo ok\n",
-                ["bypass"],
-                {".github/workflows/job-key-mismatch.yml:bypass"},
-            ),
-            "flow-mixed": (
-                "jobs:\n"
-                "  bypass: {steps: [{run: './scripts/ci/postgres-service.sh start'}, "
-                "{run: 'cargo test postgres_'}]}\n"
-                "  ordinary:\n    steps:\n      - run: echo ok\n",
-                ["ordinary"],
-                set(),
-            ),
-        }
-        workflow = self.root / ".github/workflows/job-key-mismatch.yml"
-        empty = {section: set() for section in membership.SECTIONS}
-        for shape, (text, expected_jobs, expected_rule4) in cases.items():
-            with self.subTest(shape=shape):
-                workflow.write_text(text, "utf-8")
-                analysis = self.fx.analysis()
-                self.assertEqual(
-                    [job.name for job in membership.parse_jobs(workflow, self.root)],
-                    expected_jobs,
-                )
-                self.assertEqual(analysis.debts["rule4"], expected_rule4)
-                findings = [
-                    finding.kind for finding in analysis.findings
-                    if finding.source == ".github/workflows/job-key-mismatch.yml"
-                ]
-                self.assertEqual(findings, ["jobs-key-mismatch"])
-                stderr = io.StringIO()
-                with contextlib.redirect_stderr(stderr):
-                    rc = membership.check_analysis(
-                        analysis,
-                        empty,
-                        empty,
-                        membership.render_manifest(analysis.inventory),
-                        reference_label="fixture base",
-                        allowlist_label="fixture allowlist",
-                    )
-                self.assertEqual(rc, 2)
-                self.assertIn("FAIL: [jobs-key-mismatch]", stderr.getvalue())
+                self.assertNotIn("jobs-empty", stderr.getvalue())
 
     def test_workflow_without_jobs_key_is_not_configuration_error(self) -> None:
         workflow = self.root / ".github/workflows/no-jobs.yml"

--- a/tests/test_check_pg_test_lane_membership.py
+++ b/tests/test_check_pg_test_lane_membership.py
@@ -473,6 +473,106 @@ class ParserMutations(FixtureCase):
                 self.assertEqual(rc, 2)
                 self.assertIn("FAIL: [jobs-empty]", stderr.getvalue())
 
+    def test_supported_extended_job_headers_are_enumerated(self) -> None:
+        cases = {
+            "anchor-alias": (
+                "jobs:\n"
+                "  call: &base_job\n"
+                "    uses: octo-org/example/.github/workflows/called.yml@main\n"
+                "  call2: *base_job\n",
+                ["call", "call2"],
+            ),
+            "space-before-colon": (
+                "jobs:\n  bypass :\n    steps:\n      - run: echo ok\n",
+                ["bypass"],
+            ),
+        }
+        workflow = self.root / ".github/workflows/extended-job-headers.yml"
+        empty = {section: set() for section in membership.SECTIONS}
+        for shape, (text, expected_jobs) in cases.items():
+            with self.subTest(shape=shape):
+                loaded = yaml.safe_load(text)
+                self.assertEqual(list(loaded["jobs"]), expected_jobs)
+                workflow.write_text(text, "utf-8")
+                analysis = self.fx.analysis()
+                self.assertEqual(
+                    [job.name for job in membership.parse_jobs(workflow, self.root)],
+                    expected_jobs,
+                )
+                self.assertFalse(any(
+                    finding.source == ".github/workflows/extended-job-headers.yml"
+                    for finding in analysis.findings
+                ))
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    rc = membership.check_analysis(
+                        analysis,
+                        empty,
+                        empty,
+                        membership.render_manifest(analysis.inventory),
+                        reference_label="fixture base",
+                        allowlist_label="fixture allowlist",
+                    )
+                self.assertEqual(rc, 0)
+                self.assertNotIn("jobs-key-mismatch", stderr.getvalue())
+
+    def test_partial_job_key_enumeration_is_configuration_error(self) -> None:
+        payload = (
+            "    steps:\n"
+            "      - run: ./scripts/ci/postgres-service.sh start\n"
+            "      - run: cargo test postgres_\n"
+        )
+        cases = {
+            "space-before-colon-mixed": (
+                "jobs:\n  bypass :\n" + payload
+                + "  ordinary:\n    steps:\n      - run: echo ok\n",
+                ["bypass"],
+                {".github/workflows/job-key-mismatch.yml:bypass"},
+            ),
+            "anchor-mixed": (
+                "jobs:\n  bypass: &pg\n" + payload
+                + "  ordinary:\n    steps:\n      - run: echo ok\n",
+                ["bypass"],
+                {".github/workflows/job-key-mismatch.yml:bypass"},
+            ),
+            "flow-mixed": (
+                "jobs:\n"
+                "  bypass: {steps: [{run: './scripts/ci/postgres-service.sh start'}, "
+                "{run: 'cargo test postgres_'}]}\n"
+                "  ordinary:\n    steps:\n      - run: echo ok\n",
+                ["ordinary"],
+                set(),
+            ),
+        }
+        workflow = self.root / ".github/workflows/job-key-mismatch.yml"
+        empty = {section: set() for section in membership.SECTIONS}
+        for shape, (text, expected_jobs, expected_rule4) in cases.items():
+            with self.subTest(shape=shape):
+                workflow.write_text(text, "utf-8")
+                analysis = self.fx.analysis()
+                self.assertEqual(
+                    [job.name for job in membership.parse_jobs(workflow, self.root)],
+                    expected_jobs,
+                )
+                self.assertEqual(analysis.debts["rule4"], expected_rule4)
+                findings = [
+                    finding.kind for finding in analysis.findings
+                    if finding.source == ".github/workflows/job-key-mismatch.yml"
+                ]
+                self.assertEqual(findings, ["jobs-key-mismatch"])
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    rc = membership.check_analysis(
+                        analysis,
+                        empty,
+                        empty,
+                        membership.render_manifest(analysis.inventory),
+                        reference_label="fixture base",
+                        allowlist_label="fixture allowlist",
+                    )
+                self.assertEqual(rc, 2)
+                self.assertIn("FAIL: [jobs-key-mismatch]", stderr.getvalue())
+
     def test_workflow_without_jobs_key_is_not_configuration_error(self) -> None:
         workflow = self.root / ".github/workflows/no-jobs.yml"
         workflow.write_text("on:\n  push:\n", "utf-8")
@@ -502,6 +602,13 @@ class ParserMutations(FixtureCase):
                 "jobs:\n  lane:\n    steps:\n      - run: |\n"
                 "          printf '%s\\n' 'jobs:'\n",
                 ["lane"],
+            ),
+            "jobs-summary": ("jobs_summary:\n  bypass:\n", []),
+            "jobs-prefix": ("jobsfoo:\n  bypass:\n", []),
+            "comment": ("# jobs:\n#   bypass:\n", []),
+            "quoted-and-block-scalars": (
+                "name: \"jobs:\"\ndescription: |\n  jobs:\n    bypass:\n",
+                [],
             ),
         }
         workflow = self.root / ".github/workflows/non-top-level.yml"

--- a/tests/test_check_pg_test_lane_membership.py
+++ b/tests/test_check_pg_test_lane_membership.py
@@ -432,6 +432,47 @@ class ParserMutations(FixtureCase):
                 self.assertEqual(rc, 2)
                 self.assertIn("FAIL: [jobs-empty]", stderr.getvalue())
 
+    def test_unsupported_top_level_jobs_shapes_are_configuration_errors(self) -> None:
+        payload = (
+            "    steps:\n"
+            "      - run: ./scripts/ci/postgres-service.sh start\n"
+            "      - run: cargo test postgres_\n"
+        )
+        cases = {
+            "flow-empty": "jobs: {}\n",
+            "bom-nonempty": "\ufeffjobs:\n  bypass:\n" + payload,
+            "flow-nonempty": (
+                "jobs: {bypass: {steps: "
+                "[{run: './scripts/ci/postgres-service.sh start'}, "
+                "{run: 'cargo test postgres_'}]}}\n"
+            ),
+            "space-before-colon": "jobs :\n  bypass:\n" + payload,
+        }
+        workflow = self.root / ".github/workflows/unsupported.yml"
+        empty = {section: set() for section in membership.SECTIONS}
+        for shape, text in cases.items():
+            with self.subTest(shape=shape):
+                workflow.write_text(text, "utf-8")
+                analysis = self.fx.analysis()
+                findings = [
+                    finding.kind for finding in analysis.findings
+                    if finding.source == ".github/workflows/unsupported.yml"
+                ]
+                self.assertEqual(findings, ["jobs-empty"])
+                self.assertEqual(membership.parse_jobs(workflow, self.root), [])
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    rc = membership.check_analysis(
+                        analysis,
+                        empty,
+                        empty,
+                        membership.render_manifest(analysis.inventory),
+                        reference_label="fixture base",
+                        allowlist_label="fixture allowlist",
+                    )
+                self.assertEqual(rc, 2)
+                self.assertIn("FAIL: [jobs-empty]", stderr.getvalue())
+
     def test_workflow_without_jobs_key_is_not_configuration_error(self) -> None:
         workflow = self.root / ".github/workflows/no-jobs.yml"
         workflow.write_text("on:\n  push:\n", "utf-8")
@@ -450,6 +491,46 @@ class ParserMutations(FixtureCase):
             )
         self.assertEqual(rc, 0)
         self.assertNotIn("jobs-empty", stderr.getvalue())
+
+    def test_non_top_level_jobs_text_is_not_configuration_error(self) -> None:
+        cases = {
+            "indented": (
+                "  jobs:\n    bypass:\n      steps:\n        - run: echo ok\n",
+                [],
+            ),
+            "nested-run": (
+                "jobs:\n  lane:\n    steps:\n      - run: |\n"
+                "          printf '%s\\n' 'jobs:'\n",
+                ["lane"],
+            ),
+        }
+        workflow = self.root / ".github/workflows/non-top-level.yml"
+        empty = {section: set() for section in membership.SECTIONS}
+        for shape, (text, expected_jobs) in cases.items():
+            with self.subTest(shape=shape):
+                workflow.write_text(text, "utf-8")
+                analysis = self.fx.analysis()
+                self.assertFalse(any(
+                    finding.kind == "jobs-empty"
+                    and finding.source == ".github/workflows/non-top-level.yml"
+                    for finding in analysis.findings
+                ))
+                self.assertEqual(
+                    [job.name for job in membership.parse_jobs(workflow, self.root)],
+                    expected_jobs,
+                )
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    rc = membership.check_analysis(
+                        analysis,
+                        empty,
+                        empty,
+                        membership.render_manifest(analysis.inventory),
+                        reference_label="fixture base",
+                        allowlist_label="fixture allowlist",
+                    )
+                self.assertEqual(rc, 0)
+                self.assertNotIn("jobs-empty", stderr.getvalue())
 
     def test_jobs_comment_rule4_debt_is_warn_only_with_real_analysis(self) -> None:
         workflow = self.root / ".github/workflows/ci-main.yml"

--- a/tests/test_check_pg_test_lane_membership.py
+++ b/tests/test_check_pg_test_lane_membership.py
@@ -519,6 +519,46 @@ class ParserMutations(FixtureCase):
                 self.assertEqual(rc, 0)
                 self.assertNotIn("jobs-empty", stderr.getvalue())
 
+    def test_top_level_jobs_anchor_is_enumerated(self) -> None:
+        workflow = self.root / ".github/workflows/anchored-jobs-map.yml"
+        text = (
+            "name: anchored-jobs-map\n"
+            "on: push\n"
+            "jobs: &workflow_jobs\n"
+            "  build:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: echo build\n"
+            "  test:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: echo test\n"
+        )
+        expected_jobs = list(yaml.safe_load(text)["jobs"])
+        workflow.write_text(text, "utf-8")
+        analysis = self.fx.analysis()
+        self.assertEqual(
+            [job.name for job in membership.parse_jobs(workflow, self.root)],
+            expected_jobs,
+        )
+        self.assertFalse(any(
+            finding.source == ".github/workflows/anchored-jobs-map.yml"
+            for finding in analysis.findings
+        ))
+        empty = {section: set() for section in membership.SECTIONS}
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = membership.check_analysis(
+                analysis,
+                empty,
+                empty,
+                membership.render_manifest(analysis.inventory),
+                reference_label="fixture base",
+                allowlist_label="fixture allowlist",
+            )
+        self.assertEqual(rc, 0)
+        self.assertNotIn("jobs-empty", stderr.getvalue())
+
     def test_workflow_without_jobs_key_is_not_configuration_error(self) -> None:
         workflow = self.root / ".github/workflows/no-jobs.yml"
         workflow.write_text("on:\n  push:\n", "utf-8")


### PR DESCRIPTION
## 무엇을

`check_pg_test_lane_membership.py` 가 최상위 `jobs` 를 **리터럴 철자로 찾았지만 그 아래 job 을 하나도 열거하지 못한** 워크플로를 조용히 통과시켰다. PG 테스트를 실행하는 job 이 거기 들어 있어도 lane membership 검사가 아예 안 돌았다.

이제 그 경우 `jobs-empty` finding 을 내고 configuration error 로 분류해 `rc=2` 로 끝난다.

## 실측 — main 대비 (격리 재현, 저장소 전체 복사본에 fixture 하나만 설치)

Python 3.14.4 / PyYAML 6.0.3, 진입점은 `python3 scripts/check_pg_test_lane_membership.py`.

| 형태 | PyYAML 이 job 을 보는가 | main | 이 PR |
|---|---|---|---|
| `jobs: {}` (flow-empty) | 아니오 (`jobs_keys=[]`) | rc=0, finding 없음 | **rc=2 `jobs-empty`** |
| `jobs: {bypass: {…}}` (flow-nonempty) | **예** (`['bypass']`) | rc=0, finding 없음 | **rc=2 `jobs-empty`** |
| `jobs :` (콜론 앞 공백) | **예** (`['bypass']`) | rc=0, finding 없음 | **rc=2 `jobs-empty`** |
| BOM + `jobs:` | **예** (`['bypass']`) | rc=0, finding 없음 | **rc=2 `jobs-empty`** |

BOM 은 바이트로 확인했다: `00000000: efbb bf6e 616d 653a ...`

아래 셋은 PyYAML 이 job 을 실제로 읽는데 게이트만 못 보던 **진짜 우회**다. 첫 줄은 빈 설정이라 우회는 아니지만 같은 fail-closed 로 묶었다.

## 무엇을 닫지 못하는가 (정직하게)

**최상위 `jobs` 탐지가 철자 기반이다.** YAML 이 `jobs` 로 해석하지만 그렇게 적히지 않은 키 — escaped `\"jobs\"`, `? jobs`, `!!str jobs` — 는 probe 가 아예 못 보고, 못 보면 `return []` 이라 `jobs-empty` 조차 안 난다. **main 과 이 PR 이 동일하게 `rc=0`** 이다(같은 fixture 로 양쪽 대조 완료). 즉 이 PR 이 만든 갭이 아니라 기존 성질이다.

**두 번째 갭**: 리터럴 `jobs:` 블록을 찾은 뒤에도 개별 job 은 지원되는 block header 만 열거된다. 지원 밖 표기의 job 은 형제 job 들이 정상 보고되는 와중에 조용히 빠진다.

두 갭 모두 `parse_jobs` docstring 에 계약으로 적었고 umbrella #5071 에 사이트로 등재했다([issuecomment-5154438266](https://github.com/itismyfield/AgentDesk/issues/5071#issuecomment-5154438266)). 근본 해결은 진짜 YAML 파서인데 script-check 환경이 PyYAML 을 보장하지 않는다.

**왜 정규식을 더 넓히지 않았나**: r2→r3 에서 표면이 55 → 167 → 310 줄로 커지는 동안 결함이 매 라운드 한 층씩 아래로 내려갔다. 정규식으로 YAML 을 파싱하는 한 닫히지 않는 부류라, 사용자 승인 하에 범위를 축소하고 r3 계층(job-key mismatch)을 되돌렸다.

## 현행 저장소 영향 없음

7개 워크플로의 job 이름·순서가 PyYAML 과 완전히 일치한다 — `3/5/9/1/14/1/1`, 합계 34. 위 갭들은 잠재적 우회이지 현행 오탐/누락이 아니다.

## 뮤테이션 증명

| 뮤테이션 | `py_compile` | 결과 |
|---|---:|---|
| `jobs-empty` finding 제거 | 0 | `AssertionError: 0 != 1`, FAILED 4 → 복원 후 rc=0 |
| configuration `return 2` 제거 | 0 | `AssertionError: 0 != 2`, FAILED 4 → 복원 후 rc=0 |

둘 다 syntax/import 사망이 아니라 fixture 자기 assertion 실패다.

## 게이트

`unittest` 41건 · `check_pg_test_lane_membership.py` · `ci-script-checks.sh` · `check_test_lane_coverage.py` · `generate_inventory_docs.py` · `check_agent_maintenance_docs.py` · `git diff --check` — 전부 rc=0.

baseline/cap 변경 없음. 신규 production import 없음.

Closes #5024