### PR TITLE
feat(#4754): manual steering core — atomic queue-head claim and injection (slice C)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -98,6 +98,8 @@ jobs:
               - 'src/services/discord/outbound/source_registry.rs'
               - 'src/services/discord/**'
               - '!src/services/discord/placeholder_live_events/**'
+              - 'src/services/turn_orchestrator.rs'
+              - 'src/services/turn_orchestrator/**'
               - 'src/services/message_outbox.rs'
               - 'src/services/message_outbox_recovery.rs'
               - 'src/services/message_outbox_recovery_support.rs'
@@ -718,6 +720,9 @@ jobs:
       # non-PG lane, so test-only fixes could merge without executing it on PRs.
       - name: Local model durable queue wake regression
         run: env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tui_prompt_relay::local_model_queue_wake_e2e -- --test-threads=1
+
+      - name: Manual steer regressions
+        run: just test-manual-steer
 
       - name: Stop PostgreSQL service
         if: always()

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1328,6 +1328,7 @@ src/
 │   │   ├── dispatch_reservation.rs
 │   │   ├── episode_identity.rs
 │   │   ├── front_requeue.rs
+│   │   ├── manual_steer_claim.rs
 │   │   ├── overflow.rs
 │   │   ├── pending_queue_persistence.rs
 │   │   ├── queue_cancellation.rs

--- a/justfile
+++ b/justfile
@@ -25,6 +25,11 @@ test-active-usage-4631:
     cargo test --lib claude_compact_trigger::tests
     cargo test --lib assistant_usage_emits_complete_active_snapshot_before_done
 
+# #4754: PR-time coverage for the core claim and Discord button interaction.
+test-manual-steer:
+    env -u AGENTDESK_ROOT_DIR cargo test --lib services::turn_orchestrator::active_turn_kind_tests::stale_manual_claim_cannot_skip_oldest_queued_head -- --exact --test-threads=1
+    env -u AGENTDESK_ROOT_DIR cargo test --lib manual_steer -- --test-threads=1
+
 # Stage 1 keeps the existing CI-safe subset. The broad non-PG sweep currently
 # fails legacy/full integration route tests; see docs/ci/rust-quality-gates.md.
 test-non-pg:

--- a/src/services/codex_tui/input.rs
+++ b/src/services/codex_tui/input.rs
@@ -1169,18 +1169,32 @@ pub(crate) fn steering_snapshot_decision(
     Ok(())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SteeringPromptInjectionError {
+    NotDelivered(String),
+    PossiblyDelivered(String),
+}
+
 fn steering_submit_outcome_to_result(
     outcome: CodexFollowupPromptSubmitOutcome,
-) -> Result<(), String> {
+) -> Result<(), SteeringPromptInjectionError> {
     match outcome {
         CodexFollowupPromptSubmitOutcome::Submitted => Ok(()),
-        CodexFollowupPromptSubmitOutcome::NotSubmitted { error }
-        | CodexFollowupPromptSubmitOutcome::Unconfirmed { error, .. } => Err(error),
-        CodexFollowupPromptSubmitOutcome::RetrySafeDraft { .. } => {
-            Err("codex tui steering prompt remained in the composer after submit".to_string())
+        CodexFollowupPromptSubmitOutcome::NotSubmitted { error } => {
+            Err(SteeringPromptInjectionError::NotDelivered(error))
         }
         CodexFollowupPromptSubmitOutcome::Cancelled => {
-            Err("codex tui steering prompt submission was cancelled".to_string())
+            Err(SteeringPromptInjectionError::NotDelivered(
+                "codex tui steering prompt submission was cancelled".to_string(),
+            ))
+        }
+        CodexFollowupPromptSubmitOutcome::Unconfirmed { error, .. } => {
+            Err(SteeringPromptInjectionError::PossiblyDelivered(error))
+        }
+        CodexFollowupPromptSubmitOutcome::RetrySafeDraft { .. } => {
+            Err(SteeringPromptInjectionError::PossiblyDelivered(
+                "codex tui steering prompt remained in the composer after submit".to_string(),
+            ))
         }
     }
 }
@@ -1192,17 +1206,18 @@ fn inject_steering_prompt_using<C, R, U, S>(
     mut record_prompt: R,
     mut remove_prompt: U,
     mut submit: S,
-) -> Result<(), String>
+) -> Result<(), SteeringPromptInjectionError>
 where
     C: FnMut(&str) -> PromptReadinessSnapshot,
     R: FnMut(&str, &str, &str),
     U: FnMut(&str, &str, &str),
     S: FnMut(&str, &str) -> CodexFollowupPromptSubmitOutcome,
 {
-    plan_prompt_submit(prompt)?;
+    plan_prompt_submit(prompt).map_err(SteeringPromptInjectionError::NotDelivered)?;
     with_composer_mutation_lock(session_name, || {
         let final_snapshot = capture(session_name);
-        steering_snapshot_decision(&final_snapshot).map_err(str::to_string)?;
+        steering_snapshot_decision(&final_snapshot)
+            .map_err(|error| SteeringPromptInjectionError::NotDelivered(error.to_string()))?;
         record_prompt("codex", session_name, prompt);
         let result = steering_submit_outcome_to_result(submit(session_name, prompt));
         if result.is_err() {
@@ -1212,7 +1227,10 @@ where
     })
 }
 
-pub(crate) fn inject_steering_prompt(session_name: &str, prompt: &str) -> Result<(), String> {
+pub(crate) fn inject_steering_prompt(
+    session_name: &str,
+    prompt: &str,
+) -> Result<(), SteeringPromptInjectionError> {
     inject_steering_prompt_using(
         session_name,
         prompt,
@@ -2380,7 +2398,11 @@ mod tests {
         )
         .expect_err("a stranded draft must not report steering success");
 
-        assert!(error.contains("remained in the composer"));
+        assert!(matches!(
+            error,
+            SteeringPromptInjectionError::PossiblyDelivered(ref reason)
+                if reason.contains("remained in the composer")
+        ));
         assert_eq!(
             *events.lock().unwrap(),
             vec![
@@ -2419,7 +2441,12 @@ mod tests {
         )
         .expect_err("an unconfirmed submit must not report steering success");
 
-        assert_eq!(error, "submit could not be confirmed");
+        assert_eq!(
+            error,
+            SteeringPromptInjectionError::PossiblyDelivered(
+                "submit could not be confirmed".to_string()
+            )
+        );
         assert_eq!(
             *events.lock().unwrap(),
             vec![

--- a/src/services/discord/router/message_handler/tui_followup.rs
+++ b/src/services/discord/router/message_handler/tui_followup.rs
@@ -20,6 +20,9 @@ pub(super) fn claude_tui_busy_followup_refusal_notice(
         Some(crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdAlreadyQueued) => {
             CLAUDE_TUI_BUSY_FOLLOWUP_ALREADY_QUEUED_NOTICE
         }
+        Some(crate::services::turn_orchestrator::EnqueueRefusalReason::QueueCapacityReserved) => {
+            "📬 수동 주입 처리 중이라 큐를 잠시 보호하고 있습니다. 잠시 후 다시 보내 주세요."
+        }
         Some(crate::services::turn_orchestrator::EnqueueRefusalReason::LastItemDedup) => {
             CLAUDE_TUI_BUSY_FOLLOWUP_DEDUP_NOTICE
         }

--- a/src/services/tui_steering.rs
+++ b/src/services/tui_steering.rs
@@ -28,7 +28,8 @@ pub(crate) enum SteeringOutcome {
     ExistingMailbox,
     Injected,
     Unsafe(&'static str),
-    Failed(String),
+    NotDelivered(String),
+    PossiblyDelivered(String),
 }
 
 pub(crate) fn route_input_by_session_driver(selection: &ProviderSessionSelection) -> SteeringRoute {
@@ -61,14 +62,27 @@ fn capture_snapshot(provider: &ProviderKind, session_name: &str) -> Option<Steer
     }
 }
 
-fn inject_once(provider: &ProviderKind, session_name: &str, prompt: &str) -> Result<(), String> {
+fn inject_once(
+    provider: &ProviderKind,
+    session_name: &str,
+    prompt: &str,
+) -> Result<(), SteeringOutcome> {
     match provider {
-        ProviderKind::Claude => claude_tui::input::inject_steering_prompt(session_name, prompt),
-        ProviderKind::Codex => codex_tui::input::inject_steering_prompt(session_name, prompt),
-        _ => Err(format!(
+        ProviderKind::Claude => claude_tui::input::inject_steering_prompt(session_name, prompt)
+            .map_err(SteeringOutcome::NotDelivered),
+        ProviderKind::Codex => codex_tui::input::inject_steering_prompt(session_name, prompt)
+            .map_err(|error| match error {
+                codex_tui::input::SteeringPromptInjectionError::NotDelivered(error) => {
+                    SteeringOutcome::NotDelivered(error)
+                }
+                codex_tui::input::SteeringPromptInjectionError::PossiblyDelivered(error) => {
+                    SteeringOutcome::PossiblyDelivered(error)
+                }
+            }),
+        _ => Err(SteeringOutcome::NotDelivered(format!(
             "native TUI steering unsupported for provider {}",
             provider.as_str()
-        )),
+        ))),
     }
 }
 
@@ -79,7 +93,7 @@ fn inject_with_bounded_retry_using<C, I>(
 ) -> SteeringOutcome
 where
     C: FnMut() -> Option<SteeringSnapshot>,
-    I: FnMut() -> Result<(), String>,
+    I: FnMut() -> Result<(), SteeringOutcome>,
 {
     if route_input_by_session_driver(selection) == SteeringRoute::ExistingMailbox {
         return SteeringOutcome::ExistingMailbox;
@@ -97,7 +111,7 @@ where
             Ok(()) => {
                 return match inject() {
                     Ok(()) => SteeringOutcome::Injected,
-                    Err(error) => SteeringOutcome::Failed(error),
+                    Err(outcome) => outcome,
                 };
             }
             Err(reason) => last_unsafe = reason,

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -16,6 +16,7 @@ mod dispatch_cleanup;
 mod dispatch_reservation;
 mod episode_identity;
 mod front_requeue;
+mod manual_steer_claim;
 mod overflow;
 mod pending_queue_persistence;
 mod queue_cancellation;
@@ -619,6 +620,9 @@ pub(crate) enum EnqueueRefusalReason {
     /// A front-restored source is already reserved for dispatch or active.
     /// Re-inserting it would execute the same message again after that turn.
     SourceIdPendingOrActive,
+    /// A manual steering claim holds the final queue slot for a possible
+    /// front rollback. Accepting new work would make that rollback overflow.
+    QueueCapacityReserved,
     /// The queue's last entry matches the incoming intervention on
     /// `(author_id, text, reply_context, has_reply_boundary)` within
     /// `INTERVENTION_DEDUP_WINDOW` — rapid-resend dedup.
@@ -637,6 +641,7 @@ impl EnqueueRefusalReason {
             EnqueueRefusalReason::AlreadyActiveTurn => "already_active_turn",
             EnqueueRefusalReason::SourceIdAlreadyQueued => "source_id_already_queued",
             EnqueueRefusalReason::SourceIdPendingOrActive => "source_id_pending_or_active",
+            EnqueueRefusalReason::QueueCapacityReserved => "queue_capacity_reserved",
             EnqueueRefusalReason::LastItemDedup => "last_item_dedup",
             EnqueueRefusalReason::ActorUnreachable => "actor_unreachable",
             EnqueueRefusalReason::MailboxClosed => "mailbox_closed",
@@ -1074,7 +1079,7 @@ impl ChannelMailboxHandle {
         &self,
         persistence: QueuePersistenceContext,
     ) -> TakeNextSoftResult {
-        self.take_soft_matching(persistence, None).await
+        manual_steer_claim::take_next_soft(self, persistence).await
     }
 
     pub(crate) async fn take_soft_matching(
@@ -1082,20 +1087,18 @@ impl ChannelMailboxHandle {
         persistence: QueuePersistenceContext,
         primary_message_id: Option<MessageId>,
     ) -> TakeNextSoftResult {
-        self.request(
-            |reply| ChannelMailboxMsg::TakeNextSoft {
-                persistence,
-                primary_message_id,
-                reply,
-            },
-            TakeNextSoftResult {
-                intervention: None,
-                dispatch_lease: None,
-                has_more: false,
-                queue_len_after: 0,
-                queue_exit_events: Vec::new(),
-                persistence_error: None,
-            },
+        manual_steer_claim::take_soft_matching(self, persistence, primary_message_id).await
+    }
+
+    pub(crate) async fn take_queue_head_matching_while_active(
+        &self,
+        persistence: QueuePersistenceContext,
+        primary_message_id: MessageId,
+    ) -> TakeNextSoftResult {
+        manual_steer_claim::take_queue_head_matching_while_active(
+            self,
+            persistence,
+            primary_message_id,
         )
         .await
     }
@@ -1744,6 +1747,8 @@ enum ChannelMailboxMsg {
     TakeNextSoft {
         persistence: QueuePersistenceContext,
         primary_message_id: Option<MessageId>,
+        require_queue_head: bool,
+        require_active_turn: bool,
         reply: oneshot::Sender<TakeNextSoftResult>,
     },
     RequeueFront {
@@ -1945,6 +1950,9 @@ struct ChannelMailboxState {
     /// or by the bounded safety valve below.
     pending_user_dispatch: Option<MessageId>,
     pending_user_dispatch_lease: Option<Arc<DispatchLease>>,
+    /// A manual-steer claim temporarily reserves one queue slot so a failed
+    /// injection can restore its head without evicting newly accepted work.
+    manual_steer_capacity_lease: Option<Arc<DispatchLease>>,
     /// #3167 BLOCKER-2 SAFETY VALVE — consecutive `Background` starts refused
     /// SOLELY because of `pending_user_dispatch` (the queue is already empty).
     /// If a dequeued user turn is lost and never claims nor requeues, the
@@ -2582,6 +2590,16 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                         });
                         continue;
                     }
+                    if manual_steer_claim::queue_capacity_is_reserved(&state) {
+                        let _ = reply.send(EnqueueInterventionResult {
+                            enqueued: false,
+                            merged: false,
+                            refusal_reason: Some(EnqueueRefusalReason::QueueCapacityReserved),
+                            queue_exit_events: Vec::new(),
+                            persistence_error: None,
+                        });
+                        continue;
+                    }
                     let previous_queue = state.intervention_queue.clone();
                     let mut enqueue_result = enqueue_intervention(
                         &mut state.intervention_queue,
@@ -2635,108 +2653,18 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                 ChannelMailboxMsg::TakeNextSoft {
                     persistence,
                     primary_message_id,
+                    require_queue_head,
+                    require_active_turn,
                     reply,
                 } => {
-                    state.last_persistence = Some(persistence.clone());
-                    let _ = clear_stale_pending_dispatch_reservation(&mut state, channel_id);
-                    if let Some(result) = reconcile_pending_dispatch_marker_before_take_next(
+                    let result = manual_steer_claim::take_next_soft_actor(
                         &mut state,
                         channel_id,
-                        &persistence,
-                    ) {
-                        let _ = reply.send(result);
-                        continue;
-                    }
-                    let previous_queue = state.intervention_queue.clone();
-                    let next_result = dequeue_next_soft_intervention(
-                        &mut state.intervention_queue,
+                        persistence,
                         primary_message_id,
+                        require_queue_head,
+                        require_active_turn,
                     );
-                    let queue_len_after = state.intervention_queue.len();
-                    // #3167 BLOCKER-2 — capture the dispatched head id BEFORE the
-                    // intervention is moved into the reply, so we can reserve the
-                    // dequeue→claim window against a racing Background start.
-                    let dispatched_head = next_result.intervention.as_ref().map(|i| i.message_id);
-                    let marker_error = if let Some(intervention) = next_result.intervention.as_ref()
-                    {
-                        save_channel_pending_dispatch_marker(
-                            &persistence.provider,
-                            &persistence.token_hash,
-                            channel_id,
-                            intervention,
-                            persistence.dispatch_role_override,
-                        )
-                        .err()
-                    } else {
-                        None
-                    };
-                    let result = if let Some(error) = marker_error {
-                        state.intervention_queue = previous_queue;
-                        log_queue_persistence_rollback(
-                            "take_next_soft_marker",
-                            channel_id,
-                            &persistence,
-                            &error,
-                        );
-                        TakeNextSoftResult {
-                            intervention: None,
-                            dispatch_lease: None,
-                            has_more: state
-                                .intervention_queue
-                                .iter()
-                                .any(|item| item.mode == InterventionMode::Soft),
-                            queue_len_after: state.intervention_queue.len(),
-                            queue_exit_events: Vec::new(),
-                            persistence_error: Some(error),
-                        }
-                    } else if let Err(error) = persist_queue_or_restore(
-                        &mut state,
-                        channel_id,
-                        &persistence,
-                        previous_queue,
-                        "take_next_soft",
-                    ) {
-                        // Persistence failed → `persist_queue_or_restore` rolled
-                        // the dequeue back (head re-inserted); no dispatch happens,
-                        // so do NOT set the reservation. The marker remains the
-                        // durable backstop for this head until the queue-without-head
-                        // write succeeds.
-                        TakeNextSoftResult {
-                            intervention: None,
-                            dispatch_lease: None,
-                            has_more: state
-                                .intervention_queue
-                                .iter()
-                                .any(|item| item.mode == InterventionMode::Soft),
-                            queue_len_after: state.intervention_queue.len(),
-                            queue_exit_events: Vec::new(),
-                            persistence_error: Some(error),
-                        }
-                    } else {
-                        // #3167 BLOCKER-2 — a head was handed out for dispatch but
-                        // the slot is not claimed until `intake_turn` runs. Reserve
-                        // the window so a Background start cannot slip in ahead.
-                        if let Some(head) = dispatched_head {
-                            let dispatch_lease = set_pending_user_dispatch(&mut state, head);
-                            TakeNextSoftResult {
-                                intervention: next_result.intervention,
-                                dispatch_lease: Some(dispatch_lease),
-                                has_more: next_result.has_more,
-                                queue_len_after,
-                                queue_exit_events: next_result.queue_exit_events,
-                                persistence_error: None,
-                            }
-                        } else {
-                            TakeNextSoftResult {
-                                intervention: next_result.intervention,
-                                dispatch_lease: None,
-                                has_more: next_result.has_more,
-                                queue_len_after,
-                                queue_exit_events: next_result.queue_exit_events,
-                                persistence_error: None,
-                            }
-                        }
-                    };
                     let _ = reply.send(result);
                 }
                 ChannelMailboxMsg::RequeueFront {
@@ -2791,6 +2719,10 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                             );
                             clear_pending_user_dispatch(&mut state);
                         }
+                        manual_steer_claim::clear_manual_capacity_if_matches(
+                            &mut state,
+                            dispatch_lease.as_ref(),
+                        );
                         RequeueInterventionResult {
                             enqueued: true,
                             refusal_reason: None,
@@ -2828,6 +2760,10 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                             } else {
                                 "clear_pending_dispatch_reservation"
                             },
+                        );
+                        manual_steer_claim::clear_manual_capacity_if_matches(
+                            &mut state,
+                            dispatch_lease.as_ref(),
                         );
                     }
                     let _ = reply.send(authorized);
@@ -4751,6 +4687,89 @@ mod active_turn_kind_tests {
         assert!(
             !bg.cancel_active_background_turn_if_current().await,
             "repeated supersede of an already-cancelling slot stays false"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_manual_claim_cannot_skip_oldest_queued_head() {
+        let _lock = lock_test_env();
+        let _env_guard = EnvGuard;
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path().to_str().unwrap()) };
+
+        let registry = ChannelMailboxRegistry::default();
+        let handle = registry.handle(ChannelId::new(4_754_001));
+        for message_id in [101, 102, 103] {
+            assert!(
+                handle
+                    .enqueue(test_intervention(message_id), test_persistence())
+                    .await
+                    .enqueued
+            );
+        }
+
+        let active = Arc::new(CancelToken::new());
+        handle
+            .restore_active_turn(active, UserId::new(1), MessageId::new(99))
+            .await;
+        let stale = handle
+            .take_queue_head_matching_while_active(test_persistence(), MessageId::new(102))
+            .await;
+        assert!(
+            stale.intervention.is_none(),
+            "a card for a later item must not skip the oldest queued message"
+        );
+        assert_eq!(
+            handle
+                .snapshot()
+                .await
+                .intervention_queue
+                .iter()
+                .map(|item| item.message_id)
+                .collect::<Vec<_>>(),
+            vec![
+                MessageId::new(101),
+                MessageId::new(102),
+                MessageId::new(103)
+            ]
+        );
+
+        let first =
+            handle.take_queue_head_matching_while_active(test_persistence(), MessageId::new(101));
+        let second =
+            handle.take_queue_head_matching_while_active(test_persistence(), MessageId::new(101));
+        let (first, second) = tokio::join!(first, second);
+        let results = [first, second];
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| result.intervention.is_some())
+                .count(),
+            1,
+            "two clicks for the head must have exactly one atomic claimant"
+        );
+        let winner = results
+            .iter()
+            .find(|result| result.intervention.is_some())
+            .expect("one claimant");
+        assert_eq!(
+            winner.intervention.as_ref().map(|item| item.message_id),
+            Some(MessageId::new(101))
+        );
+        assert!(
+            winner.dispatch_lease.is_some(),
+            "the winner needs the rollback lease"
+        );
+        assert_eq!(
+            handle
+                .snapshot()
+                .await
+                .intervention_queue
+                .iter()
+                .map(|item| item.message_id)
+                .collect::<Vec<_>>(),
+            vec![MessageId::new(102), MessageId::new(103)],
+            "head claim must preserve FIFO among remaining entries"
         );
     }
 

--- a/src/services/turn_orchestrator/manual_steer_claim.rs
+++ b/src/services/turn_orchestrator/manual_steer_claim.rs
@@ -1,0 +1,188 @@
+//! Actor-side manual-steer head claim.
+//!
+//! The manual card may claim only the oldest soft intervention while a live
+//! foreground owner exists. The actor persists the dequeue and keeps one queue
+//! slot reserved until its lease is either restored or consumed.
+
+use super::*;
+
+async fn request_take_soft(
+    handle: &ChannelMailboxHandle,
+    persistence: QueuePersistenceContext,
+    primary_message_id: Option<MessageId>,
+    require_queue_head: bool,
+    require_active_turn: bool,
+) -> TakeNextSoftResult {
+    handle
+        .request(
+            |reply| ChannelMailboxMsg::TakeNextSoft {
+                persistence,
+                primary_message_id,
+                require_queue_head,
+                require_active_turn,
+                reply,
+            },
+            TakeNextSoftResult {
+                intervention: None,
+                dispatch_lease: None,
+                has_more: false,
+                queue_len_after: 0,
+                queue_exit_events: Vec::new(),
+                persistence_error: None,
+            },
+        )
+        .await
+}
+
+pub(super) async fn take_next_soft(
+    handle: &ChannelMailboxHandle,
+    persistence: QueuePersistenceContext,
+) -> TakeNextSoftResult {
+    request_take_soft(handle, persistence, None, false, false).await
+}
+
+pub(super) async fn take_soft_matching(
+    handle: &ChannelMailboxHandle,
+    persistence: QueuePersistenceContext,
+    primary_message_id: Option<MessageId>,
+) -> TakeNextSoftResult {
+    request_take_soft(handle, persistence, primary_message_id, false, false).await
+}
+
+pub(super) async fn take_queue_head_matching_while_active(
+    handle: &ChannelMailboxHandle,
+    persistence: QueuePersistenceContext,
+    primary_message_id: MessageId,
+) -> TakeNextSoftResult {
+    request_take_soft(handle, persistence, Some(primary_message_id), true, true).await
+}
+
+pub(super) fn take_next_soft_actor(
+    state: &mut ChannelMailboxState,
+    channel_id: ChannelId,
+    persistence: QueuePersistenceContext,
+    primary_message_id: Option<MessageId>,
+    require_queue_head: bool,
+    require_active_turn: bool,
+) -> TakeNextSoftResult {
+    state.last_persistence = Some(persistence.clone());
+    if require_active_turn && state.cancel_token.is_none() {
+        return reject_without_active_turn(state);
+    }
+    let _ = clear_stale_pending_dispatch_reservation(state, channel_id);
+    if let Some(result) =
+        reconcile_pending_dispatch_marker_before_take_next(state, channel_id, &persistence)
+    {
+        return result;
+    }
+    let previous_queue = state.intervention_queue.clone();
+    let next_result = dequeue_next_soft_intervention(
+        &mut state.intervention_queue,
+        primary_message_id,
+        require_queue_head,
+    );
+    let queue_len_after = state.intervention_queue.len();
+    let dispatched_head = next_result.intervention.as_ref().map(|i| i.message_id);
+    let marker_error = if let Some(intervention) = next_result.intervention.as_ref() {
+        save_channel_pending_dispatch_marker(
+            &persistence.provider,
+            &persistence.token_hash,
+            channel_id,
+            intervention,
+            persistence.dispatch_role_override,
+        )
+        .err()
+    } else {
+        None
+    };
+    if let Some(error) = marker_error {
+        state.intervention_queue = previous_queue;
+        log_queue_persistence_rollback("take_next_soft_marker", channel_id, &persistence, &error);
+        return failed_claim(state, error);
+    }
+    if let Err(error) = persist_queue_or_restore(
+        state,
+        channel_id,
+        &persistence,
+        previous_queue,
+        "take_next_soft",
+    ) {
+        return failed_claim(state, error);
+    }
+    if let Some(head) = dispatched_head {
+        let dispatch_lease = set_pending_user_dispatch(state, head);
+        if require_queue_head {
+            reserve_capacity_for_manual_claim(state, &dispatch_lease);
+        }
+        TakeNextSoftResult {
+            intervention: next_result.intervention,
+            dispatch_lease: Some(dispatch_lease),
+            has_more: next_result.has_more,
+            queue_len_after,
+            queue_exit_events: next_result.queue_exit_events,
+            persistence_error: None,
+        }
+    } else {
+        TakeNextSoftResult {
+            intervention: next_result.intervention,
+            dispatch_lease: None,
+            has_more: next_result.has_more,
+            queue_len_after,
+            queue_exit_events: next_result.queue_exit_events,
+            persistence_error: None,
+        }
+    }
+}
+
+fn failed_claim(state: &ChannelMailboxState, error: String) -> TakeNextSoftResult {
+    TakeNextSoftResult {
+        intervention: None,
+        dispatch_lease: None,
+        has_more: state
+            .intervention_queue
+            .iter()
+            .any(|item| item.mode == InterventionMode::Soft),
+        queue_len_after: state.intervention_queue.len(),
+        queue_exit_events: Vec::new(),
+        persistence_error: Some(error),
+    }
+}
+
+pub(super) fn reject_without_active_turn(state: &ChannelMailboxState) -> TakeNextSoftResult {
+    TakeNextSoftResult {
+        intervention: None,
+        dispatch_lease: None,
+        has_more: state
+            .intervention_queue
+            .iter()
+            .any(|item| item.mode == InterventionMode::Soft),
+        queue_len_after: state.intervention_queue.len(),
+        queue_exit_events: Vec::new(),
+        persistence_error: None,
+    }
+}
+
+pub(super) fn reserve_capacity_for_manual_claim(
+    state: &mut ChannelMailboxState,
+    lease: &Arc<DispatchLease>,
+) {
+    state.manual_steer_capacity_lease = Some(Arc::clone(lease));
+}
+
+pub(super) fn clear_manual_capacity_if_matches(
+    state: &mut ChannelMailboxState,
+    candidate: Option<&Arc<DispatchLease>>,
+) {
+    if state
+        .manual_steer_capacity_lease
+        .as_ref()
+        .is_some_and(|lease| candidate.is_some_and(|candidate| Arc::ptr_eq(lease, candidate)))
+    {
+        state.manual_steer_capacity_lease = None;
+    }
+}
+
+pub(super) fn queue_capacity_is_reserved(state: &ChannelMailboxState) -> bool {
+    state.intervention_queue.len() >= MAX_INTERVENTIONS_PER_CHANNEL - 1
+        && state.manual_steer_capacity_lease.is_some()
+}

--- a/src/services/turn_orchestrator/queue_cancellation.rs
+++ b/src/services/turn_orchestrator/queue_cancellation.rs
@@ -36,15 +36,27 @@ pub(crate) fn has_soft_intervention(queue: &mut Vec<Intervention>) -> HasPending
 pub(crate) fn dequeue_next_soft_intervention(
     queue: &mut Vec<Intervention>,
     primary_message_id: Option<MessageId>,
+    require_queue_head: bool,
 ) -> TakeNextSoftResult {
     let queue_exit_events = super::prune_interventions(queue);
-    let intervention = queue
-        .iter()
-        .position(|item| {
-            item.mode == InterventionMode::Soft
-                && primary_message_id.is_none_or(|message_id| item.message_id == message_id)
-        })
-        .map(|index| queue.remove(index));
+    let intervention = if require_queue_head {
+        queue
+            .first()
+            .filter(|item| {
+                item.mode == InterventionMode::Soft
+                    && primary_message_id.is_some_and(|message_id| item.message_id == message_id)
+            })
+            .is_some()
+            .then(|| queue.remove(0))
+    } else {
+        queue
+            .iter()
+            .position(|item| {
+                item.mode == InterventionMode::Soft
+                    && primary_message_id.is_none_or(|message_id| item.message_id == message_id)
+            })
+            .map(|index| queue.remove(index))
+    };
     let has_more = queue.iter().any(|item| item.mode == InterventionMode::Soft);
     TakeNextSoftResult {
         intervention,
@@ -126,7 +138,7 @@ mod tests {
     fn matching_dequeue_preserves_blocked_head_and_fifo_of_remaining_items() {
         let mut queue = vec![intervention(10), intervention(11), intervention(12)];
 
-        let result = dequeue_next_soft_intervention(&mut queue, Some(MessageId::new(11)));
+        let result = dequeue_next_soft_intervention(&mut queue, Some(MessageId::new(11)), false);
 
         assert_eq!(
             result.intervention.as_ref().map(|item| item.message_id),

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -337,6 +337,23 @@ class FastCheckCiWiringTests(unittest.TestCase):
             job_block(nightly, "full_windows"),
         )
 
+    def test_manual_steer_changes_run_the_pr_time_regressions(self) -> None:
+        workflow = PR_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("- 'src/services/turn_orchestrator.rs'", workflow)
+        self.assertIn("- 'src/services/turn_orchestrator/**'", workflow)
+        high_risk = job_block(workflow, "high-risk-recovery")
+        self.assertIn("- name: Manual steer regressions", high_risk)
+        self.assertIn("\n        run: just test-manual-steer\n", high_risk)
+
+        justfile = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
+        self.assertEqual(
+            just_recipe_commands(justfile, "test-manual-steer"),
+            (
+                "env -u AGENTDESK_ROOT_DIR cargo test --lib services::turn_orchestrator::active_turn_kind_tests::stale_manual_claim_cannot_skip_oldest_queued_head -- --exact --test-threads=1",
+                "env -u AGENTDESK_ROOT_DIR cargo test --lib manual_steer -- --test-threads=1",
+            ),
+        )
+
     def test_trusted_macos_runs_busy_retry_regressions_on_both_runner_paths(self) -> None:
         workflow = MACOS_TRUSTED_WORKFLOW.read_text(encoding="utf-8")
         hosted = job_block(workflow, "macos_hosted")


### PR DESCRIPTION
#4754 slice C. 버튼 UI 없이 **claim/주입 코어만** 담는다. UI 는 후속 PR (stacked).

PR #5032 가 r5 까지 갔다가 실결함 3건과 크기 상한 초과로 재기동됐고, 그 결과를 두 조각으로 나눈 첫 번째다.

## 범위

10파일 `+430/−139`.

| | |
|---|---|
| `turn_orchestrator/manual_steer_claim.rs` | 신규 188줄 — queue head claim (actor 직렬화) |
| `turn_orchestrator.rs` | claim 경로 배선 |
| `tui_steering.rs` | `SteeringOutcome::Failed` → `NotDelivered` / `PossiblyDelivered` |
| `codex_tui/input.rs`, `queue_cancellation.rs`, `tui_followup.rs` | 호출부 |
| `ci-pr.yml`, `justfile`, `test_fast_check_ci_wiring.py` | 테스트 레인 배선 |

## `SteeringOutcome` 2분할

main 의 `Failed(String)` 을 `NotDelivered` / `PossiblyDelivered` 로 나눈다. 주입이 실패했는지 **실패했는지 모르는지**를 구분해야 롤백 판단이 가능하다 — 후자를 실패로 처리하면 중복 주입이 된다.

`Failed` 의 생산지는 `tui_steering.rs` 한 곳뿐이었고 파일 밖 소비자는 0개라 적응 코드가 없다.

## 테스트가 실제로 도는지

⚠️ `scripts/test_lane_coverage_baseline.txt` 는 **부채 목록**이라 등재만 하면 게이트는 통과하지만 아무 데서도 안 돈다. 그래서 **부채 등재가 아니라 실제 PR-time 레인에 배선**했다: `ci-pr.yml` paths-filter → high-risk job → `justfile` recipe → 모듈.

**뮤테이션 증명**: workflow 명령을 `test-manual-steer-MUTATION` 으로 끊으면 wiring gate rc=1, 원복하면 rc=0.

## 게이트

`cargo fmt --check` / `cargo check --lib` / 모듈 테스트 / `local_model_queue_wake_e2e` / inventory 생성 / 문서 freshness / maintainability audit / test-lane coverage / `ci-script-checks.sh` / `git diff --check` — **전부 rc=0**, base `origin/main`.

이 브랜치는 **단독으로 컴파일되고 게이트를 통과한다** — 후속 PR 심볼 참조 0건. giant baseline 은 이 PR 에 없다(UI 쪽 `mod` 등록이 후속에 있으므로).

## 후속

`feat/4754-manual-steer-button-v2` 가 이 브랜치를 base 로 한다. 이 PR 머지 후 그쪽 base 를 `main` 으로 바꾼다.


---

## ⚠️ 정정 (오케스트레이터, 2026-08-02)

**위 표에 원래 "`(entry_id, expected_version)` 원자 claim" 이라고 썼는데 그 메커니즘은 코드에 없다.** `git grep expected_version -- src` 가 **0건**이다. 실제 claim API 가 받는 것은 `primary_message_id` 뿐이고(`manual_steer_claim.rs:52`), active 검증도 `cancel_token.is_some()` 하나뿐이다.

내가 이슈 #4754 의 설계 문구를 **검증 없이 PR 본문으로 옮겼다.** 적대 리뷰가 실측으로 잡았다. 이 PR 은 아래 결함들로 **재작업 중**이며 현 SHA 는 머지 대상이 아니다.

### 리뷰 결과 — dual 양측 ISSUES

| 등급 | 결함 |
|---|---|
| **P0 (양 leg 합의)** | Claude 경로가 **post-Enter 실패**(pane 사망·확인 불가)를 `NotDelivered` 로 일괄 오분류 → 롤백 시 **중복 주입**. codex 는 동형 실패를 `PossiblyDelivered` 로 분류하는데 provider 별로 반대 결론이 난다 |
| **P0** | claim 에 `expected_version` 도 run/session 소유권 검사도 없다. `active_turn_nonce`·session/tmux 이름·`queued_generation`·`ActiveTurnKind` 전부 미비교 → Background/Monitor 턴도 통과하고, claim 응답 직후 턴이 끝나면 **다른 세션에 주입**될 수 있다 |
| **P0** | 외부 제출과 durable marker 소비 사이 **crash 창**. marker 에 idempotency 상태가 없어 재시작 시 이미 제출된 entry 가 큐로 재흡수된다 |
| **P0** | `justfile:31` 의 `cargo test --lib manual_steer` 가 **0개 매칭** — 레인이 공허하게 green (실행 확증: exact 필터 1개 / `manual_steer` 필터 0개). wiring 메타테스트는 recipe 문자열만 봐서 이걸 못 잡는다 |
| **P1 (양 leg 합의)** | manual capacity lease 가 같은 `Arc<DispatchLease>` 를 state 에 **두 번** 저장해 in-state strong count 가 항상 ≥2 → orphan 회수 두 경로(`> 1` 포기 / `== 1` 판정)가 **모두 무력화**. 보유자 소멸 시 10초 self-heal 도 안전밸브도 안 돌고 큐 드레인이 영구 정지한다. `relay_recovery_circuit_breaker` 자기래치와 동형 |
