### PR TITLE
fix(e2e): separate relay wire and body surfaces in the TUI relay smoke (#5065)

### DIFF
--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -114,6 +114,9 @@ echo "=== CI timeout wrapper tests (#4413) ==="
 echo "=== Relay recovery targeted-lane wiring contract (#4423) ==="
 "$PYTHON" -m unittest tests.test_relay_recovery_ci_wiring
 
+echo "=== TUI relay assertion unit tests (#5065) ==="
+"$PYTHON" -m unittest scripts.e2e.tui_relay.test_assertions
+
 echo "=== Fast compile check PR/main/nightly split contract (#4747) ==="
 "$PYTHON" -m unittest tests.test_fast_check_ci_wiring
 

--- a/scripts/e2e/run_multi_provider_matrix.py
+++ b/scripts/e2e/run_multi_provider_matrix.py
@@ -873,8 +873,7 @@ def run_cross_channel_scenario(
             key = _participant_key(participant)
             marker = participant["marker"]
             predicate = lambda message: (  # noqa: E731
-                assertions.is_relay_response(message)
-                and marker in (message.get("content") or "")
+                (body := assertions.relay_body(message)) is not None and marker in body
             )
             found, observed = clients[key].wait_for_message(
                 participant["channel_id"],

--- a/scripts/e2e/run_tui_relay.py
+++ b/scripts/e2e/run_tui_relay.py
@@ -2239,7 +2239,7 @@ def _marker_presence(
         relay_hits = [
             str(message.get("id") or "")
             for message in window.messages
-            if marker in (message.get("content") or "")
+            if (body := assertions.relay_body(message)) is not None and marker in body
         ]
         raw_hits = [
             str(message.get("id") or "")
@@ -2328,13 +2328,16 @@ def _classify_wait_timeout(
         return "prompt_not_submitted_input_buffer_still_contains_prompt"
 
     raw_has_needle = any(needle in (m.get("content") or "") for m in window.raw_messages)
-    relay_has_needle = any(needle in (m.get("content") or "") for m in window.messages)
+    relay_has_needle = any(
+        (body := assertions.relay_body(message)) is not None and needle in body
+        for message in window.messages
+    )
     if raw_has_needle and not relay_has_needle:
         return "relay_surface_filter_miss_raw_contains_needle"
 
     if head:
         for message in window.messages:
-            body = message.get("content") or ""
+            body = assertions.relay_body(message) or ""
             head_at = body.find(head)
             if head_at != -1 and body.find(needle, head_at + len(head)) == -1:
                 return "body_truncated_or_tail_missing_after_head"
@@ -2467,8 +2470,7 @@ def wait_for_discord_text_with_tui_idle_draft_guard(
     observed: list[dict[str, Any]] = []
     observed_by_id: dict[str, dict[str, Any]] = {}
     predicate = lambda message: (  # noqa: E731
-        assertions.is_relay_response(message)
-        and needle in (message.get("content") or "")
+        (body := assertions.relay_body(message)) is not None and needle in body
     )
     while time.monotonic() < deadline:
         messages = client.fetch_messages(channel_id, after_id=after_id, limit=100)

--- a/scripts/e2e/tui_relay/assertions.py
+++ b/scripts/e2e/tui_relay/assertions.py
@@ -44,6 +44,30 @@ _COMPLETION_PANEL_CHROME_PATTERN = re.compile(r"^-# ✅ 완료(?:\n|$)")
 # the leading `^✅` status family below.
 _IDLE_RECAP_COMPLETION_PATTERN = re.compile(r"^📦 응답 완료 ·")
 
+# A single-message completion/status footer is appended at an exact ``\n\n``
+# boundary (``single_message_panel::compose_completion_footer_text``).  Keep
+# this list tied to the producer shapes rather than treating every ``-#`` line
+# as chrome: ordinary markdown in an answer is still relay body.  The first
+# two labels come from ``freshness::render_activity_line``; the remaining
+# shapes are the completion block's first lines after
+# ``completion_footer_subtext`` adds Discord's ``-#`` prefix.
+_COMPLETION_FOOTER_HEAD_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^-# ✅ (?:완료|백그라운드 완료)$"),
+    re.compile(r"^-# (?:⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏) ✅ (?:완료|백그라운드 완료)$"),
+    re.compile(r"^-# (?:💤 monitor 대기|⏰ scheduled wakeup(?: \([^\n]*\))?)$"),
+    re.compile(r"^-# (?:🔧 마지막 도구|🧵 subagent 실행 중|🧬 workflow 실행 중) \([^\n]*\)$"),
+    re.compile(r"^-# (?:⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏) "
+               r"(?:💤 monitor 대기|⏰ scheduled wakeup(?: \([^\n]*\))?|"
+               r"🔧 마지막 도구|🧵 subagent 실행 중|🧬 workflow 실행 중)"
+               r"(?: \([^\n]*\))?$"),
+    re.compile(r"^-# Task     "),
+    re.compile(r"^-# 턴 트리거: https://discord\.com/channels/"),
+    re.compile(r"^-# (?:📦|⚠️|⚠ ) .+ · auto-compact(?: |$)"),
+    re.compile(r"^-# (?:Tasks|Subagents|Background agents)$"),
+    re.compile(r"^-# (?:⏱ |⏳ |🖥️ )"),
+    re.compile(r"^-# ⚠️ \*\*턴을 완료하기 전에 커밋되지 않은 변경사항을 확인하세요\.\*\*$"),
+)
+
 _STATUS_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"Processing\.\.\."),
     re.compile(r"^🟢"),
@@ -122,7 +146,10 @@ def relay_body(message: dict[str, Any]) -> str | None:
     evidence that the answer was delivered.  A banner-shaped post with any
     other separator is treated as bodyless (fail closed for malformed relay
     output).  Messages without a banner retain their historical full-content
-    behavior.
+    behavior.  The product may append a completion/status footer to that same
+    post; only a recognized footer at the message tail is removed.  A prose
+    body that merely starts with a banner label but lacks the required blank
+    separator remains fail-closed, because no product path emits that shape.
     """
 
     if not is_relay_response(message):
@@ -130,11 +157,43 @@ def relay_body(message: dict[str, Any]) -> str | None:
     content = message.get("content") or ""
     prefix = _SESSION_BANNER_PREFIX_PATTERN.match(content)
     if prefix is None:
-        return content
+        return _strip_relay_body_chrome(content)
     remainder = content[prefix.end() :]
     if not remainder.startswith("\n\n"):
         return None
-    return remainder[2:]
+    return _strip_relay_body_chrome(remainder[2:])
+
+
+def _is_completion_footer_head(line: str) -> bool:
+    line = line.strip()
+    return any(pattern.search(line) for pattern in _COMPLETION_FOOTER_HEAD_PATTERNS)
+
+
+def _strip_completion_chrome_tail(body: str) -> str:
+    """Drop a producer-shaped completion/status block after the answer body."""
+
+    for boundary in re.finditer(r"\n\n(?=-# )", body):
+        footer = body[boundary.end() :]
+        first = next((line for line in footer.splitlines() if line.strip()), "")
+        if _is_completion_footer_head(first):
+            return body[: boundary.start()].rstrip()
+    return body
+
+
+def _strip_relay_body_chrome(body: str) -> str:
+    body = _strip_completion_chrome_tail(body)
+    # Session-banner claims are one-shot in the product, but a repeated banner
+    # is a useful fail-closed regression fixture.  Remove only another exact
+    # banner + blank separator at the *start* of the already-isolated body; a
+    # normal body mentioning a banner later is untouched.
+    while True:
+        prefix = _SESSION_BANNER_PREFIX_PATTERN.match(body)
+        if prefix is None:
+            return body
+        remainder = body[prefix.end() :]
+        if not remainder.startswith("\n\n"):
+            return body
+        body = _strip_completion_chrome_tail(remainder[2:])
 
 
 @dataclasses.dataclass
@@ -624,8 +683,10 @@ def no_suppressed_label_chrome(window: Window) -> None:
 def no_control_chars(window: Window) -> None:
     forbidden = {chr(c) for c in (0x07, 0x08, 0x0C, 0x1B, 0x7F, 0x85)}
     for message in window.messages:
-        body = relay_body(message) or ""
-        leaked = forbidden.intersection(body)
+        # This is a wire-surface invariant, not a body-marker invariant.  A
+        # control byte in a session banner is still leaked Discord content.
+        content = message.get("content") or ""
+        leaked = forbidden.intersection(content)
         if leaked:
             raise AssertionError(f"control byte leaked into Discord message: {sorted(leaked)!r}")
 
@@ -648,7 +709,10 @@ def no_resume_prompt_chrome(window: Window) -> None:
     auto-prompt was still being prepended every turn — the assistant would
     answer the meta prompt with \"No response requested.\" and glue the real
     marker onto the same Discord message. Substring `text_present` still
-    passed, masking the regression.
+    passed, masking the regression.  Unlike control-byte scanning, this stays
+    body-scoped: the CLI chrome is emitted after the session-banner separator
+    and is exactly the answer-surface leak the marker contract is meant to
+    reject.
     """
 
     for message in window.messages:

--- a/scripts/e2e/tui_relay/assertions.py
+++ b/scripts/e2e/tui_relay/assertions.py
@@ -46,26 +46,55 @@ _IDLE_RECAP_COMPLETION_PATTERN = re.compile(r"^📦 응답 완료 ·")
 
 # A single-message completion/status footer is appended at an exact ``\n\n``
 # boundary (``single_message_panel::compose_completion_footer_text``).  Keep
-# this list tied to the producer shapes rather than treating every ``-#`` line
-# as chrome: ordinary markdown in an answer is still relay body.  The first
-# two labels come from ``freshness::render_activity_line``; the remaining
-# shapes are the completion block's first lines after
+# this list tied to producer shapes rather than treating every ``-#`` line as
+# chrome: ordinary markdown in an answer is still relay body.  The footer's
+# first line may be a terminal status or a spinner-merged activity label; the
+# remaining shapes are the completion block's lines after
 # ``completion_footer_subtext`` adds Discord's ``-#`` prefix.
 _COMPLETION_FOOTER_HEAD_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^-# ✅ (?:완료|백그라운드 완료)$"),
-    re.compile(r"^-# (?:⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏) ✅ (?:완료|백그라운드 완료)$"),
+    # ``strip_panel_header_status_marker`` removes the leading status emoji
+    # before the spinner is prepended, so the live merged form is
+    # ``-# ⠸ 완료`` / ``-# ⠸ 진행 중`` rather than ``⠸ ✅ 완료``.
+    re.compile(
+        r"^-# (?:⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏) "
+        r"(?:진행 중(?: — [^\n]+)?|완료|백그라운드 완료|"
+        r"monitor 대기|scheduled wakeup(?: \([^\n]*\))?|"
+        r"응답 지연(?: · [^\n]+)?|"
+        r"마지막 도구 \([^\n]*\)|도구 실행 중 \([^\n]*\)|"
+        r"subagent 실행 중 \([^\n]*\)|workflow 실행 중 \([^\n]*\))$"
+    ),
+    # Non-merged status panels remain valid footer heads for providers that
+    # emit the activity label without the single-message spinner merge.
     re.compile(r"^-# (?:💤 monitor 대기|⏰ scheduled wakeup(?: \([^\n]*\))?)$"),
-    re.compile(r"^-# (?:🔧 마지막 도구|🧵 subagent 실행 중|🧬 workflow 실행 중) \([^\n]*\)$"),
-    re.compile(r"^-# (?:⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏) "
-               r"(?:💤 monitor 대기|⏰ scheduled wakeup(?: \([^\n]*\))?|"
-               r"🔧 마지막 도구|🧵 subagent 실행 중|🧬 workflow 실행 중)"
-               r"(?: \([^\n]*\))?$"),
+    re.compile(
+        r"^-# (?:🔧 마지막 도구|🧵 subagent 실행 중|🧬 workflow 실행 중) "
+        r"\([^\n]*\)$"
+    ),
+    re.compile(r"^-# 🟡 응답 지연(?: · [^\n]+)?$"),
+    re.compile(
+        r"^(?:⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏) 계속 처리 중$"
+    ),
     re.compile(r"^-# Task     "),
     re.compile(r"^-# 턴 트리거: https://discord\.com/channels/"),
     re.compile(r"^-# (?:📦|⚠️|⚠ ) .+ · auto-compact(?: |$)"),
-    re.compile(r"^-# (?:Tasks|Subagents|Background agents)$"),
+    re.compile(r"^-# (?:Tasks|Subagents|Background agents)(?: · .+)?$"),
     re.compile(r"^-# (?:⏱ |⏳ |🖥️ )"),
     re.compile(r"^-# ⚠️ \*\*턴을 완료하기 전에 커밋되지 않은 변경사항을 확인하세요\.\*\*$"),
+)
+
+# Lines that can continue a recognized footer head.  They are deliberately
+# narrower than a generic ``-#`` test: a provider may quote or author arbitrary
+# subtext in the answer, and that must not turn an interior paragraph into a
+# footer boundary.  These are the metadata/section/slot shapes emitted by the
+# completion-footer producers (plus the anonymized fixture form used by E-1).
+_COMPLETION_FOOTER_CONTINUATION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^-# (?:턴 시작|마지막 업데이트)\s*:\s*[^\n]+$"),
+    re.compile(r"^-# 턴 트리거: https://discord\.com/channels/"),
+    re.compile(r"^-# └ .+$"),
+    re.compile(r"^-# (?:📦|⚠️|⚠ ) .+$"),
+    re.compile(r"^-# (?:⏱ |⏳ |🖥️ )"),
+    re.compile(r"^-# Task     .+$"),
 )
 
 _STATUS_PATTERNS: tuple[re.Pattern[str], ...] = (
@@ -147,9 +176,10 @@ def relay_body(message: dict[str, Any]) -> str | None:
     other separator is treated as bodyless (fail closed for malformed relay
     output).  Messages without a banner retain their historical full-content
     behavior.  The product may append a completion/status footer to that same
-    post; only a recognized footer at the message tail is removed.  A prose
-    body that merely starts with a banner label but lacks the required blank
-    separator remains fail-closed, because no product path emits that shape.
+    post; only a recognized footer at the message tail is removed.  A
+    banner-shaped prefix without the required blank separator remains
+    fail-closed as a malformed boundary, while provider prose itself is allowed
+    to be arbitrary.
     """
 
     if not is_relay_response(message):
@@ -169,14 +199,37 @@ def _is_completion_footer_head(line: str) -> bool:
     return any(pattern.search(line) for pattern in _COMPLETION_FOOTER_HEAD_PATTERNS)
 
 
-def _strip_completion_chrome_tail(body: str) -> str:
-    """Drop a producer-shaped completion/status block after the answer body."""
+def _is_completion_footer_line(line: str) -> bool:
+    line = line.strip()
+    if not line:
+        return True
+    if _is_completion_footer_head(line):
+        return True
+    return any(
+        pattern.search(line) for pattern in _COMPLETION_FOOTER_CONTINUATION_PATTERNS
+    )
 
-    for boundary in re.finditer(r"\n\n(?=-# )", body):
+
+def _strip_completion_chrome_tail(body: str) -> str:
+    """Drop only the maximal producer-shaped completion/status run at the tail.
+
+    A footer-looking block quoted in the middle of an answer is followed by
+    non-footer prose and therefore fails the all-lines check.  When several
+    candidate boundaries are valid (for example, a status head followed by
+    blank-separated Tasks/Subagents sections), choose the earliest valid one
+    so the whole trailing chrome run is removed.
+    """
+
+    valid_boundaries: list[int] = []
+    for boundary in re.finditer(r"\n\n", body):
         footer = body[boundary.end() :]
         first = next((line for line in footer.splitlines() if line.strip()), "")
-        if _is_completion_footer_head(first):
-            return body[: boundary.start()].rstrip()
+        if _is_completion_footer_head(first) and all(
+            _is_completion_footer_line(line) for line in footer.splitlines()
+        ):
+            valid_boundaries.append(boundary.start())
+    if valid_boundaries:
+        return body[: min(valid_boundaries)].rstrip()
     return body
 
 

--- a/scripts/e2e/tui_relay/assertions.py
+++ b/scripts/e2e/tui_relay/assertions.py
@@ -26,6 +26,16 @@ OUR_BOT_ID = os.environ.get("AGENTDESK_E2E_OUR_BOT_ID", "1479017284805722200")
 # legitimate ADK output but they repeat across turns by design, so excluding
 # them from `no_duplicate_content` keeps the assertion focused on actual
 # response bodies. (See #2702 / #2625 for the chrome format.)
+# Session banners are chrome only when the whole message has the panel shape.
+# The first answer message deliberately uses `<banner>\n\n<body>`, so this
+# anchored pattern must not consume a banner that has a non-empty body below it.
+_SESSION_PANEL_CHROME_PATTERN = re.compile(
+    r"^(?:🆕 새 세션 시작|기존 세션 복원|Lifecycle fallback)"
+    r"(?: · [^\n]+)?"
+    r"(?:\n\(최근 대화 \d+개를 읽어들였습니다\))?$"
+)
+_COMPLETION_PANEL_CHROME_PATTERN = re.compile(r"^-# ✅ 완료(?:\n|$)")
+
 _STATUS_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"Processing\.\.\."),
     re.compile(r"^🟢"),
@@ -39,7 +49,8 @@ _STATUS_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^⚠️"),
     re.compile(r"진행 중"),
     re.compile(r"응답 완료"),
-    re.compile(r"세션 복원"),
+    _SESSION_PANEL_CHROME_PATTERN,
+    _COMPLETION_PANEL_CHROME_PATTERN,
     re.compile(r"세션 초기화"),
     re.compile(r"\[Stopped\]"),
 )
@@ -47,6 +58,7 @@ _STATUS_PATTERNS: tuple[re.Pattern[str], ...] = (
 _COMPLETION_CHROME_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^✅"),
     re.compile(r"응답 완료"),
+    _COMPLETION_PANEL_CHROME_PATTERN,
 )
 
 _SUPPRESSED_LABEL_PATTERNS: tuple[re.Pattern[str], ...] = (

--- a/scripts/e2e/tui_relay/assertions.py
+++ b/scripts/e2e/tui_relay/assertions.py
@@ -29,12 +29,20 @@ OUR_BOT_ID = os.environ.get("AGENTDESK_E2E_OUR_BOT_ID", "1479017284805722200")
 # Session banners are chrome only when the whole message has the panel shape.
 # The first answer message deliberately uses `<banner>\n\n<body>`, so this
 # anchored pattern must not consume a banner that has a non-empty body below it.
-_SESSION_PANEL_CHROME_PATTERN = re.compile(
+_SESSION_BANNER_PREFIX_PATTERN = re.compile(
     r"^(?:🆕 새 세션 시작|기존 세션 복원|Lifecycle fallback)"
     r"(?: · [^\n]+)?"
-    r"(?:\n\(최근 대화 \d+개를 읽어들였습니다\))?$"
+    r"(?:\n\(최근 대화 \d+개를 읽어들였습니다\))?"
+)
+_SESSION_PANEL_CHROME_PATTERN = re.compile(
+    _SESSION_BANNER_PREFIX_PATTERN.pattern + r"$"
 )
 _COMPLETION_PANEL_CHROME_PATTERN = re.compile(r"^-# ✅ 완료(?:\n|$)")
+# The only current non-emoji-led producer is the idle-recap card. Keep this
+# anchored to its complete header shape so prose such as "응답 완료를
+# 설명합니다" remains a relay body. Monitor-handoff completion is covered by
+# the leading `^✅` status family below.
+_IDLE_RECAP_COMPLETION_PATTERN = re.compile(r"^📦 응답 완료 ·")
 
 _STATUS_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"Processing\.\.\."),
@@ -48,7 +56,7 @@ _STATUS_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^▶️"),
     re.compile(r"^⚠️"),
     re.compile(r"진행 중"),
-    re.compile(r"응답 완료"),
+    _IDLE_RECAP_COMPLETION_PATTERN,
     _SESSION_PANEL_CHROME_PATTERN,
     _COMPLETION_PANEL_CHROME_PATTERN,
     re.compile(r"세션 초기화"),
@@ -57,7 +65,7 @@ _STATUS_PATTERNS: tuple[re.Pattern[str], ...] = (
 
 _COMPLETION_CHROME_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^✅"),
-    re.compile(r"응답 완료"),
+    _IDLE_RECAP_COMPLETION_PATTERN,
     _COMPLETION_PANEL_CHROME_PATTERN,
 )
 
@@ -103,6 +111,30 @@ def is_relay_response(message: dict[str, Any]) -> bool:
     if is_status_chrome(message):
         return False
     return True
+
+
+def relay_body(message: dict[str, Any]) -> str | None:
+    """Return the body used by relay-marker assertions for one message.
+
+    A first answer may carry a session banner and body in one Discord post,
+    joined by the product's exact ``<banner>\n\n<body>`` contract.  Marker
+    assertions must search only the body: a marker in the banner is not
+    evidence that the answer was delivered.  A banner-shaped post with any
+    other separator is treated as bodyless (fail closed for malformed relay
+    output).  Messages without a banner retain their historical full-content
+    behavior.
+    """
+
+    if not is_relay_response(message):
+        return None
+    content = message.get("content") or ""
+    prefix = _SESSION_BANNER_PREFIX_PATTERN.match(content)
+    if prefix is None:
+        return content
+    remainder = content[prefix.end() :]
+    if not remainder.startswith("\n\n"):
+        return None
+    return remainder[2:]
 
 
 @dataclasses.dataclass
@@ -220,7 +252,7 @@ def no_duplicate_content(window: Window) -> None:
 
     seen: set[str] = set()
     for message in window.messages:
-        body = (message.get("content") or "").strip()
+        body = (relay_body(message) or "").strip()
         if not body:
             continue
         if body in seen:
@@ -230,7 +262,8 @@ def no_duplicate_content(window: Window) -> None:
 
 def text_present(window: Window, *, needle: str) -> None:
     for message in window.messages:
-        if needle in (message.get("content") or ""):
+        body = relay_body(message)
+        if body is not None and needle in body:
             return
     raise AssertionError(
         f"expected to find {needle!r} in relay window, got {len(window.messages)} "
@@ -266,7 +299,14 @@ def marker_absent(
         messages = _raw_assertion_messages(window, include_our_send=include_our_send)
     else:
         raise AssertionError(f"marker_absent surface must be relay or raw, got {surface!r}")
-    hits = [message for message in messages if marker in (message.get("content") or "")]
+    if surface == "relay":
+        hits = [
+            message
+            for message in messages
+            if (body := relay_body(message)) is not None and marker in body
+        ]
+    else:
+        hits = [message for message in messages if marker in (message.get("content") or "")]
     if hits:
         raise AssertionError(
             f"unexpected marker {marker!r} appeared on {surface} surface "
@@ -298,7 +338,7 @@ def ordered_text_present(window: Window, *, needles: Sequence[str]) -> None:
     and out-of-order delivery that single-needle :func:`text_present` passes.
     """
 
-    bodies = [(message.get("content") or "") for message in window.messages]
+    bodies = [relay_body(message) or "" for message in window.messages]
     cursor_msg = 0
     cursor_pos = 0
     for needle in needles:
@@ -329,7 +369,11 @@ def no_duplicate_marker(window: Window, *, marker: str) -> None:
     (e.g. ``[E2E:E2:TURN-2]``) is expected exactly once per turn.
     """
 
-    hits = sum(1 for m in window.messages if marker in (m.get("content") or ""))
+    hits = sum(
+        1
+        for message in window.messages
+        if (body := relay_body(message)) is not None and marker in body
+    )
     if hits > 1:
         raise AssertionError(
             f"E2E marker {marker!r} appeared in {hits} relay messages "
@@ -345,7 +389,7 @@ def body_complete(window: Window, *, head: str, tail: str) -> None:
     """
 
     for message in window.messages:
-        body = message.get("content") or ""
+        body = relay_body(message) or ""
         head_at = body.find(head)
         if head_at != -1:
             if body.find(tail, head_at + len(head)) != -1:
@@ -465,7 +509,7 @@ def status_panel_after_body(
     body_messages = [
         message
         for message in _raw_assertion_messages(window)
-        if body_marker in (message.get("content") or "")
+        if (body := relay_body(message)) is not None and body_marker in body
     ]
     if not body_messages:
         raise AssertionError(f"body marker {body_marker!r} not found in raw window")
@@ -525,7 +569,7 @@ def completion_chrome_after_body(
     body_messages = [
         message
         for message in _raw_assertion_messages(window)
-        if body_marker in (message.get("content") or "")
+        if (body := relay_body(message)) is not None and body_marker in body
     ]
     if not body_messages:
         raise AssertionError(f"body marker {body_marker!r} not found in raw window")
@@ -557,7 +601,7 @@ def body_not_overwritten(window: Window, *, marker: str) -> None:
     hits = [
         m
         for m in _raw_assertion_messages(window)
-        if marker in (m.get("content") or "")
+        if (body := relay_body(m)) is not None and marker in body
     ]
     if not hits:
         raise AssertionError(
@@ -580,7 +624,7 @@ def no_suppressed_label_chrome(window: Window) -> None:
 def no_control_chars(window: Window) -> None:
     forbidden = {chr(c) for c in (0x07, 0x08, 0x0C, 0x1B, 0x7F, 0x85)}
     for message in window.messages:
-        body = message.get("content") or ""
+        body = relay_body(message) or ""
         leaked = forbidden.intersection(body)
         if leaked:
             raise AssertionError(f"control byte leaked into Discord message: {sorted(leaked)!r}")
@@ -608,7 +652,7 @@ def no_resume_prompt_chrome(window: Window) -> None:
     """
 
     for message in window.messages:
-        body = message.get("content") or ""
+        body = relay_body(message) or ""
         for chrome in _RESUME_PROMPT_CHROME:
             if chrome in body:
                 raise AssertionError(

--- a/scripts/e2e/tui_relay/assertions.py
+++ b/scripts/e2e/tui_relay/assertions.py
@@ -218,11 +218,22 @@ def _strip_completion_chrome_tail(body: str) -> str:
     candidate boundaries are valid (for example, a status head followed by
     blank-separated Tasks/Subagents sections), choose the earliest valid one
     so the whole trailing chrome run is removed.
+
+    Stripping takes evidence away from the body-scoped detectors, so it fails
+    closed: a candidate suffix carrying #2718 resume-prompt chrome is never a
+    strip candidate.  Some footer shapes (`-# └ {label} {summary}`, the icon-led
+    metadata lines) render provider-supplied free text, so without this guard a
+    forbidden string placed on such a line would be cut away before
+    `no_resume_prompt_chrome` ever sees it.  Keeping it means a tool label that
+    happens to quote the phrase turns the smoke red — the safe direction for a
+    leak detector.
     """
 
     valid_boundaries: list[int] = []
     for boundary in re.finditer(r"\n\n", body):
         footer = body[boundary.end() :]
+        if any(chrome in footer for chrome in _RESUME_PROMPT_CHROME):
+            continue
         first = next((line for line in footer.splitlines() if line.strip()), "")
         if _is_completion_footer_head(first) and all(
             _is_completion_footer_line(line) for line in footer.splitlines()

--- a/scripts/e2e/tui_relay/test_assertions.py
+++ b/scripts/e2e/tui_relay/test_assertions.py
@@ -71,6 +71,16 @@ def _window(*messages: dict) -> assertions.Window:
     return window
 
 
+def _wait_predicate(window: assertions.Window, needle: str) -> bool:
+    """Mirror the driver's per-message relay wait predicate."""
+
+    return any(
+        assertions.is_relay_response(message)
+        and needle in (message.get("content") or "")
+        for message in window.raw_messages
+    )
+
+
 class OrderedTextPresent(unittest.TestCase):
     def test_passes_in_order_across_messages(self):
         window = _window(_relay_msg(1, "alpha part"), _relay_msg(2, "beta part"))
@@ -325,6 +335,67 @@ class RawChromeAndEditAssertions(unittest.TestCase):
             assertions.completion_chrome_after_body(
                 no_completion, body_marker="[BODY]", required=True
             )
+
+
+class SessionAndCompletionChromeRegression(unittest.TestCase):
+    """Pin the wire shapes that the post-deploy E-1 smoke actually observes."""
+
+    MARKER = "[E2E:E1:OK]"
+    RESUMED_BANNER = "기존 세션 복원 · provider session claude#anon…"
+
+    def test_resumed_banner_and_body_stay_one_relay_response(self):
+        message = _raw_bot_msg(1, f"{self.RESUMED_BANNER}\n\n{self.MARKER}")
+
+        self.assertEqual(assertions.is_relay_response(message), True)
+        window = _window(message)
+        self.assertEqual(window.messages, [message])
+        assertions.text_present(window, needle=self.MARKER)
+
+    def test_fresh_banner_and_body_stay_one_relay_response(self):
+        message = _raw_bot_msg(1, f"🆕 새 세션 시작\n\n{self.MARKER}")
+
+        self.assertEqual(assertions.is_relay_response(message), True)
+        assertions.text_present(_window(message), needle=self.MARKER)
+
+    def test_completion_panel_is_chrome_and_completion_after_body(self):
+        body = _relay_msg(1, self.MARKER)
+        completion = _raw_bot_msg(
+            2,
+            "-# ✅ 완료\n-# 턴 시작 : anonymized\n\n-# 📦 usage anonymized",
+        )
+        window = _window(body, completion)
+
+        self.assertEqual(assertions.is_relay_response(completion), False)
+        self.assertEqual(window.messages, [body])
+        assertions.completion_chrome_after_body(
+            window, body_marker=self.MARKER, required=True
+        )
+
+    def test_missing_marker_body_fails_the_relay_wait_predicate(self):
+        window = _window(
+            _raw_bot_msg(1, self.RESUMED_BANNER),
+            _raw_bot_msg(2, "-# ✅ 완료\n-# 턴 시작 : anonymized"),
+        )
+
+        self.assertEqual(window.messages, [])
+        self.assertEqual(_wait_predicate(window, self.MARKER), False)
+        with self.assertRaises(assertions.AssertionError):
+            assertions.text_present(window, needle=self.MARKER)
+
+    def test_marker_in_pure_completion_chrome_never_promotes_to_relay(self):
+        completion = _raw_bot_msg(1, f"-# ✅ 완료\n{self.MARKER}")
+        window = _window(completion)
+
+        assertions.raw_text_present(window, needle=self.MARKER)
+        assertions.marker_absent(window, marker=self.MARKER, surface="relay")
+        self.assertEqual(_wait_predicate(window, self.MARKER), False)
+        with self.assertRaises(assertions.AssertionError):
+            assertions.text_present(window, needle=self.MARKER)
+
+    def test_session_phrase_inside_body_is_not_session_panel_chrome(self):
+        message = _raw_bot_msg(1, f"답변 본문에서 {self.RESUMED_BANNER}를 언급함")
+
+        self.assertEqual(assertions.is_relay_response(message), True)
 
 
 class RunAssertionDispatch(unittest.TestCase):

--- a/scripts/e2e/tui_relay/test_assertions.py
+++ b/scripts/e2e/tui_relay/test_assertions.py
@@ -474,6 +474,41 @@ class SessionAndCompletionChromeRegression(unittest.TestCase):
         with self.assertRaisesRegex(assertions.AssertionError, "No response requested"):
             assertions.no_resume_prompt_chrome(window)
 
+    def test_resume_chrome_inside_footer_shaped_line_is_never_stripped(self):
+        # `-# └ {label} {summary}` and the icon-led metadata lines render
+        # provider free text, so a forbidden string can sit on a line that is
+        # otherwise footer-shaped.  Stripping it would hide #2718 chrome from
+        # the body-scoped detector, so the whole suffix stops being a strip
+        # candidate.
+        for footer in (
+            "-# Tasks\n-# └ Bash No response requested. ✓",
+            "-# ⏱ No response requested.",
+            "-# Task     No response requested.",
+            "-# Tasks\n-# └ Bash Continue from where you left off. ✓",
+        ):
+            with self.subTest(footer=footer):
+                message = _raw_bot_msg(1, f"{self.MARKER}\n\n{footer}")
+                window = _window(message)
+
+                self.assertEqual(assertions.relay_body(message), message["content"])
+                assertions.text_present(window, needle=self.MARKER)
+                with self.assertRaises(assertions.AssertionError):
+                    assertions.no_resume_prompt_chrome(window)
+
+    def test_clean_footer_of_same_shape_is_still_stripped(self):
+        # The guard must key on the forbidden string, not on the footer shape:
+        # the identical shapes without resume chrome still strip normally.
+        for footer in (
+            "-# Tasks\n-# └ Bash (3s) ✓",
+            "-# ⏱ 2m 34s",
+            "-# Task     빌드",
+        ):
+            with self.subTest(footer=footer):
+                body = f"{self.MARKER}\n\n{footer}"
+                self.assertEqual(
+                    assertions._strip_completion_chrome_tail(body), self.MARKER
+                )
+
     def test_real_spinner_merged_footer_shapes_are_tail_chrome(self):
         for footer in (
             "-# ⠸ 완료",

--- a/scripts/e2e/tui_relay/test_assertions.py
+++ b/scripts/e2e/tui_relay/test_assertions.py
@@ -75,8 +75,7 @@ def _wait_predicate(window: assertions.Window, needle: str) -> bool:
     """Mirror the driver's per-message relay wait predicate."""
 
     return any(
-        assertions.is_relay_response(message)
-        and needle in (message.get("content") or "")
+        (body := assertions.relay_body(message)) is not None and needle in body
         for message in window.raw_messages
     )
 
@@ -345,17 +344,88 @@ class SessionAndCompletionChromeRegression(unittest.TestCase):
 
     def test_resumed_banner_and_body_stay_one_relay_response(self):
         message = _raw_bot_msg(1, f"{self.RESUMED_BANNER}\n\n{self.MARKER}")
+        completion = _raw_bot_msg(2, "-# ✅ 완료\n-# 턴 시작 : anonymized")
 
         self.assertEqual(assertions.is_relay_response(message), True)
-        window = _window(message)
+        window = _window(message, completion)
         self.assertEqual(window.messages, [message])
+        self.assertEqual(_wait_predicate(window, self.MARKER), True)
         assertions.text_present(window, needle=self.MARKER)
+        assertions.completion_chrome_after_body(
+            window, body_marker=self.MARKER, required=True
+        )
 
     def test_fresh_banner_and_body_stay_one_relay_response(self):
         message = _raw_bot_msg(1, f"🆕 새 세션 시작\n\n{self.MARKER}")
 
         self.assertEqual(assertions.is_relay_response(message), True)
-        assertions.text_present(_window(message), needle=self.MARKER)
+        window = _window(message)
+        self.assertEqual(_wait_predicate(window, self.MARKER), True)
+        assertions.text_present(window, needle=self.MARKER)
+
+    def test_marker_attached_with_single_newline_is_not_a_relay_body(self):
+        message = _raw_bot_msg(1, f"기존 세션 복원\n{self.MARKER}")
+        completion = _raw_bot_msg(2, "-# ✅ 완료\n-# 턴 시작 : anonymized")
+        window = _window(message, completion)
+
+        # The malformed banner-shaped post is still observable raw output, but
+        # its marker is not evidence of a delivered answer body.
+        self.assertEqual(assertions.is_relay_response(message), True)
+        self.assertEqual(_wait_predicate(window, self.MARKER), False)
+        with self.assertRaises(assertions.AssertionError):
+            assertions.text_present(window, needle=self.MARKER)
+        with self.assertRaises(assertions.AssertionError):
+            assertions.completion_chrome_after_body(
+                window, body_marker=self.MARKER, required=True
+            )
+
+    def test_marker_in_banner_prefix_is_not_a_relay_body(self):
+        message = _raw_bot_msg(
+            1,
+            "기존 세션 복원 · provider session "
+            f"{self.MARKER}\n\nwrong response body",
+        )
+        completion = _raw_bot_msg(2, "-# ✅ 완료\n-# 턴 시작 : anonymized")
+        window = _window(message, completion)
+
+        self.assertEqual(_wait_predicate(window, self.MARKER), False)
+        with self.assertRaises(assertions.AssertionError):
+            assertions.text_present(window, needle=self.MARKER)
+        with self.assertRaises(assertions.AssertionError):
+            assertions.completion_chrome_after_body(
+                window, body_marker=self.MARKER, required=True
+            )
+
+    def test_marker_in_normal_body_without_banner_stays_a_relay_body(self):
+        message = _raw_bot_msg(1, self.MARKER)
+        completion = _raw_bot_msg(2, "-# ✅ 완료\n-# 턴 시작 : anonymized")
+        window = _window(message, completion)
+
+        self.assertEqual(_wait_predicate(window, self.MARKER), True)
+        assertions.text_present(window, needle=self.MARKER)
+        assertions.completion_chrome_after_body(
+            window, body_marker=self.MARKER, required=True
+        )
+
+    def test_response_completion_phrase_inside_normal_body_stays_a_relay(self):
+        message = _raw_bot_msg(
+            1,
+            f"정상 응답 본문: 응답 완료를 설명합니다 {self.MARKER}",
+        )
+        window = _window(message)
+
+        self.assertEqual(assertions.is_relay_response(message), True)
+        self.assertEqual(_wait_predicate(window, self.MARKER), True)
+        assertions.text_present(window, needle=self.MARKER)
+
+    def test_current_completion_producer_shapes_stay_chrome(self):
+        for content in (
+            "✅ **응답 완료**\n> **시작**: <t:1700000000:R>",
+            "📦 응답 완료 · resumed\n세션: claude · context unknown · idle 1분",
+        ):
+            message = _raw_bot_msg(1, content)
+            self.assertEqual(assertions.is_relay_response(message), False)
+            self.assertEqual(assertions.relay_body(message), None)
 
     def test_completion_panel_is_chrome_and_completion_after_body(self):
         body = _relay_msg(1, self.MARKER)

--- a/scripts/e2e/tui_relay/test_assertions.py
+++ b/scripts/e2e/tui_relay/test_assertions.py
@@ -407,6 +407,78 @@ class SessionAndCompletionChromeRegression(unittest.TestCase):
             window, body_marker=self.MARKER, required=True
         )
 
+    def test_normal_body_marker_with_completion_footer_stays_body(self):
+        message = _raw_bot_msg(
+            1,
+            f"normal answer {self.MARKER}\n\n"
+            "-# ✅ 완료\n"
+            "-# Tasks\n"
+            "-# └ Bash finished ✓",
+        )
+
+        self.assertEqual(assertions.relay_body(message), f"normal answer {self.MARKER}")
+        assertions.text_present(_window(message), needle=self.MARKER)
+
+    def test_banner_body_marker_with_completion_footer_stays_body(self):
+        message = _raw_bot_msg(
+            1,
+            f"{self.RESUMED_BANNER}\n\n{self.MARKER}\n\n"
+            "-# ✅ 완료\n"
+            "-# 턴 시작 : anonymized",
+        )
+
+        self.assertEqual(assertions.relay_body(message), self.MARKER)
+        assertions.text_present(_window(message), needle=self.MARKER)
+
+    def test_repeated_banner_marker_is_not_body_evidence(self):
+        message = _raw_bot_msg(
+            1,
+            "기존 세션 복원\n\n"
+            f"{self.RESUMED_BANNER} {self.MARKER}\n\n",
+        )
+        window = _window(message)
+
+        # This shape is not product-emitted (session claims are one-shot), but
+        # the body boundary remains fail-closed if a regression recreates it.
+        self.assertEqual(assertions.relay_body(message), "")
+        self.assertEqual(_wait_predicate(window, self.MARKER), False)
+        with self.assertRaises(assertions.AssertionError):
+            assertions.text_present(window, needle=self.MARKER)
+
+    def test_completion_panel_marker_is_not_body_evidence(self):
+        message = _raw_bot_msg(
+            1,
+            f"wrong body\n\n-# ✅ 완료\n-# Tasks · {self.MARKER}",
+        )
+        window = _window(message)
+
+        self.assertEqual(assertions.relay_body(message), "wrong body")
+        self.assertEqual(_wait_predicate(window, self.MARKER), False)
+        with self.assertRaises(assertions.AssertionError):
+            assertions.text_present(window, needle=self.MARKER)
+
+    def test_no_control_chars_scans_full_wire_message_including_banner(self):
+        message = _raw_bot_msg(
+            1,
+            f"기존 세션 복원 · provider session claude#bad\x1b\n\n{self.MARKER}",
+        )
+        window = _window(message)
+
+        # The marker body is valid; the wire-level ESC must still fail.
+        self.assertEqual(assertions.relay_body(message), self.MARKER)
+        with self.assertRaisesRegex(assertions.AssertionError, "control byte"):
+            assertions.no_control_chars(window)
+
+    def test_no_resume_prompt_chrome_remains_body_scoped(self):
+        message = _raw_bot_msg(
+            1,
+            f"기존 세션 복원\n\nNo response requested. {self.MARKER}",
+        )
+        window = _window(message)
+
+        with self.assertRaisesRegex(assertions.AssertionError, "No response requested"):
+            assertions.no_resume_prompt_chrome(window)
+
     def test_response_completion_phrase_inside_normal_body_stays_a_relay(self):
         message = _raw_bot_msg(
             1,

--- a/scripts/e2e/tui_relay/test_assertions.py
+++ b/scripts/e2e/tui_relay/test_assertions.py
@@ -430,6 +430,76 @@ class SessionAndCompletionChromeRegression(unittest.TestCase):
         self.assertEqual(assertions.relay_body(message), self.MARKER)
         assertions.text_present(_window(message), needle=self.MARKER)
 
+    def test_completion_footer_is_tail_anchored_after_mid_body_chrome_like_text(self):
+        message = _raw_bot_msg(
+            1,
+            "정상 응답: 아래는 UI 예시입니다.\n\n"
+            "-# ✅ 완료\n"
+            f"설명 계속 {self.MARKER}\n\n"
+            "-# ✅ 완료\n"
+            "-# 턴 시작 : anonymized",
+        )
+        window = _window(message)
+
+        expected = (
+            "정상 응답: 아래는 UI 예시입니다.\n\n"
+            "-# ✅ 완료\n"
+            f"설명 계속 {self.MARKER}"
+        )
+        self.assertEqual(assertions.relay_body(message), expected)
+        self.assertEqual(_wait_predicate(window, self.MARKER), True)
+        assertions.text_present(window, needle=self.MARKER)
+        assertions.ordered_text_present(
+            window,
+            needles=["정상 응답: 아래는 UI 예시입니다.", self.MARKER],
+        )
+        assertions.body_complete(
+            window,
+            head="정상 응답: 아래는 UI 예시입니다.",
+            tail=self.MARKER,
+        )
+
+    def test_non_chrome_tail_keeps_resume_prompt_visible_to_body_assertion(self):
+        message = _raw_bot_msg(
+            1,
+            f"{self.MARKER}\n\n-# ✅ 완료\nNo response requested.",
+        )
+        window = _window(message)
+
+        # Marker presence alone still passes; the body-scoped #2718 check must
+        # see the non-chrome tail instead of losing it to an early cut.
+        self.assertEqual(assertions.relay_body(message), message["content"])
+        self.assertEqual(_wait_predicate(window, self.MARKER), True)
+        assertions.text_present(window, needle=self.MARKER)
+        with self.assertRaisesRegex(assertions.AssertionError, "No response requested"):
+            assertions.no_resume_prompt_chrome(window)
+
+    def test_real_spinner_merged_footer_shapes_are_tail_chrome(self):
+        for footer in (
+            "-# ⠸ 완료",
+            "-# ⠸ monitor 대기",
+            "-# ⠸ 진행 중",
+            "⠸ 계속 처리 중",
+            "-# 🟡 응답 지연 · 조사 권장",
+        ):
+            with self.subTest(footer=footer):
+                body = f"{self.MARKER}\n\n{footer}"
+                self.assertEqual(
+                    assertions._strip_completion_chrome_tail(body), self.MARKER
+                )
+
+    def test_body_prose_with_subtext_and_completion_words_is_not_cut(self):
+        message = _raw_bot_msg(
+            1,
+            f"설명 속 리터럴 -# 줄과 ✅ 완료 문구\n{self.MARKER}",
+        )
+        window = _window(message)
+
+        self.assertEqual(assertions.relay_body(message), message["content"])
+        assertions.text_present(window, needle=self.MARKER)
+        assertions.ordered_text_present(window, needles=["-# ", "✅", self.MARKER])
+        assertions.body_complete(window, head="설명 속 리터럴", tail=self.MARKER)
+
     def test_repeated_banner_marker_is_not_body_evidence(self):
         message = _raw_bot_msg(
             1,


### PR DESCRIPTION
Fixes #5065.

## 문제

`scripts/e2e/tui_relay/` 릴레이 스모크가 영구 red 였다. 원인은 제품이 아니라 **스모크가 Discord wire 표면과 body 표면을 구분하지 않은 것**이다.

제품은 첫 답변을 `<배너>\n\n<본문>` 한 메시지로 합치고(`src/services/discord/session_banner.rs:99-118`), 완료 footer 를 같은 메시지 꼬리에 붙인다(`single_message_panel.rs`). 스모크는 wire 전문에서 마커를 찾았으므로, 배너나 footer 안의 문자열도 "배달 증거" 로 인정하거나 반대로 정상 응답을 chrome 으로 오판했다.

**`src/` 는 건드리지 않는다** — 제품 동작은 정상이고 관측 계층만 고친다.

## 표면 분리 계약

| 탐지기 | 보는 표면 | 근거 |
|---|---|---|
| `no_control_chars` | **wire 전문** | 배너 안의 제어 바이트도 유출된 Discord 콘텐츠다 |
| 억제 라벨 스캔 | **wire 전문** | 같은 이유 |
| marker 배달 증거 (`text_present` 등) | **body** | 배너 안의 마커는 답변이 배달됐다는 증거가 아니다 |
| `no_resume_prompt_chrome` (#2718) | **body** | CLI chrome 은 배너 구분자 뒤에 나오며 답변 표면 유출이다 |

`relay_body()` 가 배너 접두와 tail chrome 을 벗겨 body 를 만든다. 배너 형태인데 `\n\n` 구분자가 없으면 fail-closed 로 bodyless 처리한다.

## tail-anchored 절단

`_strip_completion_chrome_tail()` 은 **suffix 전체가 footer 형태인 `\n\n` 경계** 만 유효 후보로 인정한다. 중간에 비-chrome 산문이 한 줄이라도 끼면 그 경계는 무효다.

이는 제품 자신의 판정과 동일하다 — `single_message_panel.rs:398-405`:

> The footer is the **maximal trailing run** of footer-shaped lines … its first line must open a footer (a status line or section header) so an unrelated `└ ` quote alone cannot trigger it.

`min(valid_boundaries)` 가 maximal trailing run 의 시작점이고, head 요건이 "first line must open a footer" 에 대응한다.

## fail-closed 가드

절단은 body-scoped 탐지기에서 증거를 빼앗는 행위다. 일부 footer 형태(`-# └ {label} {summary}`, 아이콘 선행 metadata 라인)는 **provider 자유 텍스트를 렌더링**하므로, 가드가 없으면 금지 문자열을 그런 라인에 실어 `no_resume_prompt_chrome` 이 보기 전에 잘라낼 수 있다.

→ **#2718 resume chrome 을 품은 suffix 는 절단 후보에서 제외한다.** tool 라벨이 우연히 그 문구를 인용하면 스모크가 red 가 되는데, 누출 탐지기에서는 그 방향이 안전하다.

## footer 허용 목록

producer shape 를 이모지 variation-selector 까지 바이트 단위로 대조했다. `strip_panel_header_status_marker`(`single_message_panel.rs:204-242`)가 선행 상태 이모지를 제거한 뒤 스피너를 붙이므로 실제 merged 형태는 `-# ⠸ 완료` 이며, label 집합이 `freshness.rs:84-113` `render_activity_line` 및 `is_panel_activity_status_label`(`:842-852`)과 동집합임을 확인했다.

## 검증

- `python3 -m unittest scripts.e2e.tui_relay.test_assertions` — **57 tests, rc=0**
- `TEST_LANE_BASELINE_REF=origin/main bash scripts/ci-script-checks.sh` — rc=0
- 뮤테이션: 첫-경계-절단으로 되돌리면 tail-anchor/은폐 테스트가 자기 assert 로 실패 (rc=1). fail-closed 가드 2줄을 제거하면 `test_resume_chrome_inside_footer_shaped_line_is_never_stripped` 의 4개 subTest 가 전부 실패 (rc=1). 각각 원복 시 57 OK
- `test_clean_footer_of_same_shape_is_still_stripped` 는 가드 뮤테이션에도 통과 — 가드가 shape 가 아니라 **문자열**을 키로 삼는다는 증거
- 기존 테스트 삭제/약화 **0줄**

## 리뷰

교차 공급자 dual review 양쪽 `VERDICT: CLEAN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
