### PR TITLE
ci(#5071): add relay-authority-contract lane with selection floors (1/2)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -954,3 +954,56 @@ jobs:
           path: target/maintainability-audit.yaml
           if-no-files-found: ignore
           retention-days: 14
+
+  # #5071 T0: this required-context candidate is intentionally unconditional.
+  # Its version-controlled manifest names every current T1-T5 contract target,
+  # records explicit GAP rows, and owns the selection floors. Condition-3 fixed
+  # mutations attach as a later step in this same job after target verification.
+  relay-authority-contract:
+    name: relay-authority-contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94.1"
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+          cache-bin: false
+          shared-key: cargo-dependencies-v2
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Verify named relay-authority targets and selection floors
+        env:
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
+        run: python3 scripts/check_relay_authority_contract.py
+
+      - name: Run named relay-authority contract targets
+        env:
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
+        run: |
+          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::session_relay_sink -- --test-threads=1
+          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::relay_recovery::tests -- --test-threads=1
+          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tui_prompt_relay::local_model_queue_wake_e2e -- --test-threads=1
+
+      # Condition-3 fixed mutations attach here. They must mutate production
+      # wiring, rerun the named targets above, require red, then restore sources.
+      # Keeping the hook after the positive run prevents mutation failures from
+      # being confused with baseline target failures.
+      - name: Run fixed relay-authority mutations
+        if: ${{ hashFiles('scripts/run_relay_authority_mutations.sh') != '' }}
+        run: bash scripts/run_relay_authority_mutations.sh
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -962,6 +962,7 @@ jobs:
   relay-authority-contract:
     name: relay-authority-contract
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -996,13 +997,10 @@ jobs:
           env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::relay_recovery::tests -- --test-threads=1
           env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tui_prompt_relay::local_model_queue_wake_e2e -- --test-threads=1
 
-      # Condition-3 fixed mutations attach here. They must mutate production
-      # wiring, rerun the named targets above, require red, then restore sources.
-      # Keeping the hook after the positive run prevents mutation failures from
-      # being confused with baseline target failures.
-      - name: Run fixed relay-authority mutations
-        if: ${{ hashFiles('scripts/run_relay_authority_mutations.sh') != '' }}
-        run: bash scripts/run_relay_authority_mutations.sh
+      # Condition-3 fixed mutations attach here after the positive run. The same
+      # change must flip condition3_mutations_present to true and add an
+      # unconditional `bash scripts/run_relay_authority_mutations.sh` step.
+      # The Script checks lane rejects either the script or the flag landing alone.
 
       - name: sccache stats
         if: always()

--- a/scripts/check_relay_authority_contract.py
+++ b/scripts/check_relay_authority_contract.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Run the explicitly declared relay-authority contract lanes and enforce floors."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Sequence
+
+DEFAULT_MANIFEST = Path("scripts/relay_authority_contract_targets.json")
+TEST_ID_SUFFIX = ": test"
+
+
+class ManifestError(ValueError):
+    """The checked-in relay-authority lane manifest is invalid."""
+
+
+@dataclass(frozen=True)
+class Lane:
+    name: str
+    boundary: str
+    module: str
+    command: tuple[str, ...]
+    minimum: int
+
+
+@dataclass(frozen=True)
+class LaneResult:
+    lane: Lane
+    selected: int
+    returncode: int
+    command: tuple[str, ...]
+    output: str
+
+
+def load_active_lanes(path: Path) -> tuple[list[Lane], list[dict[str, object]]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ManifestError(f"cannot read manifest {path}: {error}") from error
+
+    if payload.get("schema_version") != 1 or not isinstance(payload.get("lanes"), list):
+        raise ManifestError("manifest must contain schema_version=1 and a lanes array")
+
+    active: list[Lane] = []
+    gaps: list[dict[str, object]] = []
+    names: set[str] = set()
+    for index, raw in enumerate(payload["lanes"]):
+        if not isinstance(raw, dict):
+            raise ManifestError(f"lane {index} must be an object")
+        name = raw.get("name")
+        status = raw.get("status")
+        if not isinstance(name, str) or not name:
+            raise ManifestError(f"lane {index} has no non-empty name")
+        if name in names:
+            raise ManifestError(f"duplicate lane name: {name}")
+        names.add(name)
+        if status == "gap":
+            if not isinstance(raw.get("reason"), str) or not raw["reason"]:
+                raise ManifestError(f"gap lane {name} must state a reason")
+            gaps.append(raw)
+            continue
+        if status != "active":
+            raise ManifestError(f"lane {name} has unsupported status {status!r}")
+
+        command = raw.get("command")
+        minimum = raw.get("minimum")
+        module = raw.get("module")
+        boundary = raw.get("boundary")
+        if (
+            not isinstance(command, list)
+            or not command
+            or not all(isinstance(item, str) and item for item in command)
+        ):
+            raise ManifestError(f"active lane {name} must have a non-empty command array")
+        if command[:2] != ["cargo", "test"]:
+            raise ManifestError(f"active lane {name} command must begin with cargo test")
+        if "--lib" not in command or "--all-targets" in command:
+            raise ManifestError(f"active lane {name} must select --lib and may not use --all-targets")
+        if "--" in command:
+            raise ManifestError(f"active lane {name} command must omit the libtest separator")
+        filters = [item for item in command[2:] if not item.startswith("-")]
+        if not filters:
+            raise ManifestError(f"active lane {name} must contain an explicit test filter")
+        if not isinstance(minimum, int) or isinstance(minimum, bool) or minimum < 1:
+            raise ManifestError(f"active lane {name} minimum must be an integer >= 1")
+        if not isinstance(module, str) or not module:
+            raise ManifestError(f"active lane {name} must name its source module")
+        if not isinstance(boundary, str) or not boundary:
+            raise ManifestError(f"active lane {name} must name its boundary")
+        active.append(Lane(name, boundary, module, tuple(command), minimum))
+
+    if not active:
+        raise ManifestError("manifest must declare at least one active lane")
+    return active, gaps
+
+
+def count_test_ids(output: str) -> int:
+    return sum(1 for line in output.splitlines() if line.strip().endswith(TEST_ID_SUFFIX))
+
+
+def list_command(lane: Lane) -> tuple[str, ...]:
+    return lane.command + ("--", "--list")
+
+
+def run_lane(
+    lane: Lane,
+    repo_root: Path,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> LaneResult:
+    command = list_command(lane)
+    env = os.environ.copy()
+    env.pop("AGENTDESK_ROOT_DIR", None)
+    proc = runner(
+        command,
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    output = f"{proc.stdout}{proc.stderr}"
+    return LaneResult(lane, count_test_ids(proc.stdout), proc.returncode, command, output)
+
+
+def failures_for(result: LaneResult) -> list[str]:
+    failures: list[str] = []
+    if result.returncode != 0:
+        failures.append(f"cargo list command exited {result.returncode}")
+    if result.selected == 0:
+        failures.append("selected 0 tests")
+    if result.selected < result.lane.minimum:
+        failures.append(
+            f"selected {result.selected} below declared minimum {result.lane.minimum}"
+        )
+    return failures
+
+
+def shell_join(command: Sequence[str]) -> str:
+    import shlex
+
+    return shlex.join(command)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument(
+        "--check-manifest",
+        action="store_true",
+        help="validate declarations without invoking cargo",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    manifest = args.manifest
+    if not manifest.is_absolute():
+        manifest = repo_root / manifest
+
+    try:
+        lanes, gaps = load_active_lanes(manifest)
+    except ManifestError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+
+    print(
+        f"relay-authority manifest: active={len(lanes)} gaps={len(gaps)} "
+        f"path={manifest.relative_to(repo_root) if manifest.is_relative_to(repo_root) else manifest}"
+    )
+    for gap in gaps:
+        print(
+            f"GAP boundary={gap['boundary']} lane={gap['name']} "
+            f"module={gap['module']}: {gap['reason']}"
+        )
+    if args.check_manifest:
+        return 0
+
+    failed = False
+    for lane in lanes:
+        result = run_lane(lane, repo_root)
+        failures = failures_for(result)
+        print(
+            f"selection boundary={lane.boundary} lane={lane.name} "
+            f"selected={result.selected} minimum={lane.minimum} "
+            f"rc={result.returncode} command={shell_join(result.command)}"
+        )
+        if failures:
+            failed = True
+            print(
+                f"ERROR: lane {lane.name}: {'; '.join(failures)}",
+                file=sys.stderr,
+            )
+            if result.output:
+                print(result.output[-4000:], file=sys.stderr)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_relay_authority_contract.py
+++ b/scripts/check_relay_authority_contract.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Callable, Sequence
 
 DEFAULT_MANIFEST = Path("scripts/relay_authority_contract_targets.json")
+CONDITION3_MUTATION_SCRIPT = Path("scripts/run_relay_authority_mutations.sh")
 TEST_ID_SUFFIX = ": test"
 
 
@@ -38,7 +39,10 @@ class LaneResult:
     output: str
 
 
-def load_active_lanes(path: Path) -> tuple[list[Lane], list[dict[str, object]]]:
+def load_active_lanes(
+    path: Path,
+    repo_root: Path | None = None,
+) -> tuple[list[Lane], list[dict[str, object]]]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
@@ -46,6 +50,21 @@ def load_active_lanes(path: Path) -> tuple[list[Lane], list[dict[str, object]]]:
 
     if payload.get("schema_version") != 1 or not isinstance(payload.get("lanes"), list):
         raise ManifestError("manifest must contain schema_version=1 and a lanes array")
+
+    mutations_present = payload.get("condition3_mutations_present")
+    if not isinstance(mutations_present, bool):
+        raise ManifestError("manifest condition3_mutations_present must be boolean")
+    if repo_root is not None:
+        mutation_script = repo_root / CONDITION3_MUTATION_SCRIPT
+        script_exists = mutation_script.is_file()
+        if mutations_present and not script_exists:
+            raise ManifestError(
+                f"condition3_mutations_present is true but {CONDITION3_MUTATION_SCRIPT} is missing"
+            )
+        if not mutations_present and script_exists:
+            raise ManifestError(
+                f"condition3_mutations_present is false but {CONDITION3_MUTATION_SCRIPT} exists"
+            )
 
     active: list[Lane] = []
     gaps: list[dict[str, object]] = []
@@ -170,7 +189,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         manifest = repo_root / manifest
 
     try:
-        lanes, gaps = load_active_lanes(manifest)
+        lanes, gaps = load_active_lanes(manifest, repo_root)
     except ManifestError as error:
         print(f"ERROR: {error}", file=sys.stderr)
         return 2

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -117,6 +117,10 @@ echo "=== Relay recovery targeted-lane wiring contract (#4423) ==="
 echo "=== TUI relay assertion unit tests (#5065) ==="
 "$PYTHON" -m unittest scripts.e2e.tui_relay.test_assertions
 
+echo "=== Relay-authority named-target floor contract (#5071) ==="
+"$PYTHON" scripts/check_relay_authority_contract.py --check-manifest
+"$PYTHON" -m unittest tests.test_check_relay_authority_contract
+
 echo "=== Fast compile check PR/main/nightly split contract (#4747) ==="
 "$PYTHON" -m unittest tests.test_fast_check_ci_wiring
 

--- a/scripts/relay_authority_contract_targets.json
+++ b/scripts/relay_authority_contract_targets.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "lanes": [
+    {
+      "name": "t1-sink-terminal-handoff",
+      "boundary": "T1",
+      "status": "active",
+      "module": "services::discord::session_relay_sink",
+      "command": [
+        "cargo",
+        "test",
+        "--lib",
+        "services::discord::session_relay_sink"
+      ],
+      "minimum": 94,
+      "derivation": "Measured on origin/main 0ae1c5b77 with the declared command plus -- --list. This is the current sink handoff and delivery-authority test surface; the future DeliveryJournal single-writer mutation contract is not present yet."
+    },
+    {
+      "name": "t2-intake-dispatched-terminal-receipt",
+      "boundary": "T2",
+      "status": "gap",
+      "module": "services::cluster::intake_worker",
+      "reason": "No T2 contract target exists yet: the current worker still advances spawned directly to done after execute_intake_turn_core returns, and neither dispatched nor a terminal-receipt-owned done transition exists."
+    },
+    {
+      "name": "t3-execution-registry-nonce",
+      "boundary": "T3",
+      "status": "gap",
+      "module": "services::discord::inflight",
+      "reason": "No T3 contract target exists yet: the current InflightTurnIdentity seam has no durable execution_id registry or nonce contract."
+    },
+    {
+      "name": "t4-single-actor-recovery-decision",
+      "boundary": "T4",
+      "status": "active",
+      "module": "services::discord::relay_recovery::tests",
+      "command": [
+        "cargo",
+        "test",
+        "--lib",
+        "services::discord::relay_recovery::tests"
+      ],
+      "minimum": 43,
+      "derivation": "Measured on origin/main 0ae1c5b77 with the declared command plus -- --list. This is the existing recovery planner/apply contract module around plan_relay_recovery."
+    },
+    {
+      "name": "t5-structural-signal-authority-teardown",
+      "boundary": "T5",
+      "status": "gap",
+      "module": "services::discord::inflight",
+      "reason": "No T5 contract target exists yet: structural signals and inflight still participate in recovery/lifecycle authority, so authority teardown has not been implemented or tested."
+    },
+    {
+      "name": "relay-e2e-local-model-queue-wake",
+      "boundary": "relay-e2e",
+      "status": "active",
+      "module": "services::discord::tui_prompt_relay::local_model_queue_wake_e2e",
+      "command": [
+        "cargo",
+        "test",
+        "--lib",
+        "services::discord::tui_prompt_relay::local_model_queue_wake_e2e"
+      ],
+      "minimum": 5,
+      "derivation": "Measured on origin/main 0ae1c5b77 with the declared command plus -- --list. This Rust production-path E2E drives the local Discord mock, mailbox lifecycle, durable queue wake, and production workers; dashboard Playwright is unrelated and nightly-only."
+    }
+  ]
+}

--- a/scripts/relay_authority_contract_targets.json
+++ b/scripts/relay_authority_contract_targets.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 1,
+  "condition3_mutations_present": false,
   "lanes": [
     {
       "name": "t1-sink-terminal-handoff",

--- a/scripts/test_lane_coverage_baseline.txt
+++ b/scripts/test_lane_coverage_baseline.txt
@@ -371,11 +371,6 @@ services::discord::runtime_store::atomic_write_logging_tests
 services::discord::runtime_store::runtime_root_tests
 services::discord::session_banner::tests
 services::discord::session_identity::tests
-services::discord::session_relay_sink::delivery_outcome_classify::tests
-services::discord::session_relay_sink::idle_jsonl::tests
-services::discord::session_relay_sink::orphan_reclaim::tests
-services::discord::session_relay_sink::relay_state_contract_refs
-services::discord::session_relay_sink::tests
 services::discord::session_runtime::channel_routing::tests
 services::discord::session_runtime::resume_launch_binding_tests
 services::discord::session_runtime::select_restored_session_path_tests

--- a/tests/test_check_relay_authority_contract.py
+++ b/tests/test_check_relay_authority_contract.py
@@ -1,0 +1,155 @@
+"""Tests for the relay-authority named-target selection-floor gate (#5071)."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "check_relay_authority_contract.py"
+_spec = importlib.util.spec_from_file_location("check_relay_authority_contract", SCRIPT)
+assert _spec and _spec.loader
+contract = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = contract
+_spec.loader.exec_module(contract)
+
+
+def active_lane(*, command: list[str] | None = None, minimum: int = 2) -> dict[str, object]:
+    return {
+        "name": "t1-fixture",
+        "boundary": "T1",
+        "status": "active",
+        "module": "fixture::module",
+        "command": command or ["cargo", "test", "--lib", "fixture::module"],
+        "minimum": minimum,
+        "derivation": "fixture",
+    }
+
+
+def manifest_path(lanes: list[dict[str, object]]) -> tuple[tempfile.TemporaryDirectory[str], Path]:
+    temporary = tempfile.TemporaryDirectory()
+    path = Path(temporary.name) / "targets.json"
+    path.write_text(json.dumps({"schema_version": 1, "lanes": lanes}), encoding="utf-8")
+    return temporary, path
+
+
+class ManifestContract(unittest.TestCase):
+    def test_checked_in_manifest_declares_active_and_gap_rows(self) -> None:
+        lanes, gaps = contract.load_active_lanes(
+            REPO_ROOT / "scripts" / "relay_authority_contract_targets.json"
+        )
+        self.assertEqual([lane.name for lane in lanes], [
+            "t1-sink-terminal-handoff",
+            "t4-single-actor-recovery-decision",
+            "relay-e2e-local-model-queue-wake",
+        ])
+        self.assertEqual({gap["boundary"] for gap in gaps}, {"T2", "T3", "T5"})
+        self.assertTrue(all(lane.minimum > 0 for lane in lanes))
+
+    def test_unfiltered_command_is_rejected(self) -> None:
+        temporary, path = manifest_path([active_lane(command=["cargo", "test", "--lib"])])
+        with temporary:
+            with self.assertRaisesRegex(contract.ManifestError, "explicit test filter"):
+                contract.load_active_lanes(path)
+
+    def test_all_targets_command_is_rejected(self) -> None:
+        temporary, path = manifest_path([
+            active_lane(command=["cargo", "test", "--lib", "--all-targets", "fixture"])
+        ])
+        with temporary:
+            with self.assertRaisesRegex(contract.ManifestError, "--all-targets"):
+                contract.load_active_lanes(path)
+
+    def test_zero_floor_is_rejected(self) -> None:
+        temporary, path = manifest_path([active_lane(minimum=0)])
+        with temporary:
+            with self.assertRaisesRegex(contract.ManifestError, "integer >= 1"):
+                contract.load_active_lanes(path)
+
+
+class SelectionContract(unittest.TestCase):
+    def test_list_count_uses_test_ids_not_cargo_summary(self) -> None:
+        output = "a::one: test\na::two: test\n2 tests, 0 benchmarks\n"
+        self.assertEqual(contract.count_test_ids(output), 2)
+
+    def test_zero_selection_is_fatal_even_when_cargo_exits_zero(self) -> None:
+        lane = contract.Lane("zero", "T1", "fixture", ("cargo", "test", "--lib", "missing"), 1)
+        result = contract.LaneResult(lane, 0, 0, contract.list_command(lane), "0 tests")
+        self.assertEqual(contract.failures_for(result), [
+            "selected 0 tests",
+            "selected 0 below declared minimum 1",
+        ])
+
+    def test_selection_below_floor_is_fatal(self) -> None:
+        lane = contract.Lane("floor", "T4", "fixture", ("cargo", "test", "--lib", "fixture"), 3)
+        result = contract.LaneResult(lane, 2, 0, contract.list_command(lane), "")
+        self.assertEqual(contract.failures_for(result), [
+            "selected 2 below declared minimum 3"
+        ])
+
+    def test_run_lane_appends_list_and_removes_agentdesk_root(self) -> None:
+        lane = contract.Lane("lane", "T1", "fixture", ("cargo", "test", "--lib", "fixture"), 1)
+        observed: dict[str, object] = {}
+
+        def runner(command, **kwargs):
+            observed["command"] = command
+            observed["env"] = kwargs["env"]
+            return subprocess.CompletedProcess(command, 0, "fixture::one: test\n", "")
+
+        with mock.patch.dict("os.environ", {"AGENTDESK_ROOT_DIR": "/wrong"}):
+            result = contract.run_lane(lane, REPO_ROOT, runner=runner)
+        self.assertEqual(tuple(observed["command"]), contract.list_command(lane))
+        self.assertNotIn("AGENTDESK_ROOT_DIR", observed["env"])
+        self.assertEqual(result.selected, 1)
+
+
+class MainContract(unittest.TestCase):
+    def _run(self, result: contract.LaneResult) -> tuple[int, str, str]:
+        temporary, manifest = manifest_path([active_lane(minimum=result.lane.minimum)])
+        with temporary, mock.patch.object(contract, "run_lane", return_value=result):
+            stdout, stderr = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                rc = contract.main([
+                    "--repo-root", str(REPO_ROOT),
+                    "--manifest", str(manifest),
+                ])
+        return rc, stdout.getvalue(), stderr.getvalue()
+
+    def test_zero_selection_main_returns_one(self) -> None:
+        lane = contract.Lane("t1-fixture", "T1", "fixture", ("cargo", "test", "--lib", "missing"), 1)
+        rc, stdout, stderr = self._run(
+            contract.LaneResult(lane, 0, 0, contract.list_command(lane), "0 tests")
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("selected=0 minimum=1 rc=0", stdout)
+        self.assertIn("selected 0 tests", stderr)
+
+    def test_floor_failure_main_returns_one(self) -> None:
+        lane = contract.Lane("t1-fixture", "T1", "fixture", ("cargo", "test", "--lib", "fixture"), 3)
+        rc, stdout, stderr = self._run(
+            contract.LaneResult(lane, 2, 0, contract.list_command(lane), "")
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("selected=2 minimum=3", stdout)
+        self.assertIn("below declared minimum 3", stderr)
+
+    def test_clean_selection_main_returns_zero(self) -> None:
+        lane = contract.Lane("t1-fixture", "T1", "fixture", ("cargo", "test", "--lib", "fixture"), 2)
+        rc, stdout, stderr = self._run(
+            contract.LaneResult(lane, 2, 0, contract.list_command(lane), "")
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("selected=2 minimum=2", stdout)
+        self.assertEqual(stderr, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_check_relay_authority_contract.py
+++ b/tests/test_check_relay_authority_contract.py
@@ -34,17 +34,29 @@ def active_lane(*, command: list[str] | None = None, minimum: int = 2) -> dict[s
     }
 
 
-def manifest_path(lanes: list[dict[str, object]]) -> tuple[tempfile.TemporaryDirectory[str], Path]:
+def manifest_path(
+    lanes: list[dict[str, object]],
+    *,
+    condition3_mutations_present: bool = False,
+) -> tuple[tempfile.TemporaryDirectory[str], Path]:
     temporary = tempfile.TemporaryDirectory()
     path = Path(temporary.name) / "targets.json"
-    path.write_text(json.dumps({"schema_version": 1, "lanes": lanes}), encoding="utf-8")
+    path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "condition3_mutations_present": condition3_mutations_present,
+            "lanes": lanes,
+        }),
+        encoding="utf-8",
+    )
     return temporary, path
 
 
 class ManifestContract(unittest.TestCase):
     def test_checked_in_manifest_declares_active_and_gap_rows(self) -> None:
         lanes, gaps = contract.load_active_lanes(
-            REPO_ROOT / "scripts" / "relay_authority_contract_targets.json"
+            REPO_ROOT / "scripts" / "relay_authority_contract_targets.json",
+            REPO_ROOT,
         )
         self.assertEqual([lane.name for lane in lanes], [
             "t1-sink-terminal-handoff",
@@ -53,6 +65,30 @@ class ManifestContract(unittest.TestCase):
         ])
         self.assertEqual({gap["boundary"] for gap in gaps}, {"T2", "T3", "T5"})
         self.assertTrue(all(lane.minimum > 0 for lane in lanes))
+
+    def test_condition3_false_rejects_existing_mutation_script(self) -> None:
+        temporary, path = manifest_path([active_lane()])
+        with temporary:
+            repo_root = Path(temporary.name)
+            mutation_script = repo_root / "scripts" / "run_relay_authority_mutations.sh"
+            mutation_script.parent.mkdir()
+            mutation_script.touch()
+            with self.assertRaisesRegex(
+                contract.ManifestError,
+                "condition3_mutations_present is false but .*run_relay_authority_mutations.sh exists",
+            ):
+                contract.load_active_lanes(path, repo_root)
+
+    def test_condition3_true_rejects_missing_mutation_script(self) -> None:
+        temporary, path = manifest_path(
+            [active_lane()], condition3_mutations_present=True
+        )
+        with temporary:
+            with self.assertRaisesRegex(
+                contract.ManifestError,
+                "condition3_mutations_present is true but .*run_relay_authority_mutations.sh is missing",
+            ):
+                contract.load_active_lanes(path, Path(temporary.name))
 
     def test_unfiltered_command_is_rejected(self) -> None:
         temporary, path = manifest_path([active_lane(command=["cargo", "test", "--lib"])])

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -337,6 +337,35 @@ class FastCheckCiWiringTests(unittest.TestCase):
             job_block(nightly, "full_windows"),
         )
 
+    def test_relay_authority_contract_job_uses_pinned_recipe(self) -> None:
+        job = job_block(
+            PR_WORKFLOW.read_text(encoding="utf-8"), "relay-authority-contract"
+        )
+        self.assertRegex(
+            job,
+            r"(?m)^  relay-authority-contract:\n"
+            r"    name: relay-authority-contract\n"
+            r"    runs-on: ubuntu-latest\n"
+            r"    timeout-minutes: 30\n"
+            r"    steps:\n"
+            r"      - uses: actions/checkout@v4\n\n"
+            r"      - name: Install Rust toolchain\n"
+            r"        uses: dtolnay/rust-toolchain@master\n"
+            r"        with:\n"
+            r'          toolchain: "1\.94\.1"$',
+        )
+        self.assertRegex(
+            job,
+            r"(?m)^      - name: Run named relay-authority contract targets\n"
+            r"        env:\n"
+            r'          CARGO_PROFILE_DEV_DEBUG: "0"\n'
+            r'          CARGO_PROFILE_TEST_DEBUG: "0"\n'
+            r"        run: \|\n"
+            r"          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::session_relay_sink -- --test-threads=1\n"
+            r"          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::relay_recovery::tests -- --test-threads=1\n"
+            r"          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tui_prompt_relay::local_model_queue_wake_e2e -- --test-threads=1$",
+        )
+
     def test_trusted_macos_runs_busy_retry_regressions_on_both_runner_paths(self) -> None:
         workflow = MACOS_TRUSTED_WORKFLOW.read_text(encoding="utf-8")
         hosted = job_block(workflow, "macos_hosted")


### PR DESCRIPTION
Part 1 of 2 for #5071 T0 condition 1. Adds the `relay-authority-contract` lane: named relay-authority test targets, per-lane selection floors, and a fail-closed interlock for the not-yet-present mutation gate.

Part 2 (`feat/5071-relay-authority-contract`, stacked on this branch) pins the lane against silent disablement. **Neither branch should be registered as a required status check until both have merged** — this branch alone creates a check that can still be disabled by workflow-key edits.

## What this adds

- `scripts/check_relay_authority_contract.py` — resolves each declared lane to real test targets and enforces a declared per-lane `minimum`. A lane that selects fewer targets than declared exits 1; a lane declaring `minimum` < 1 or a non-integer is rejected at parse time.
- `scripts/relay_authority_contract_targets.json` — the lane declarations, each carrying a `derivation` note recording how the floor was measured.
- `.github/workflows/ci-pr.yml` — the `relay-authority-contract` job.
- Fail-closed interlock: `condition3_mutations_present` is `false` today. The hand-written mutation gate (T0 condition 3) is not in the tree yet, and this flag makes its absence explicit rather than silently unchecked.

## Why a selection floor at all

A test filter that matches nothing exits 0. Every "rc=0" this lane reports would otherwise be indistinguishable from "the lane ran nothing". The floors are the smallest primitive that makes a `success` here mean the relay-authority tests actually ran.

Measured floors: 94/94, 43/43, 5/5.

## Verification at this commit

| Gate | Result |
|---|---|
| `scripts/check-ci-runner-hardening.sh` | rc=0 |
| `tests.test_fast_check_ci_wiring` | 25 tests, rc=0 |
| `tests.test_check_relay_authority_contract` | rc=0 |
| `git status --porcelain` | empty |

## Known limitation, stated plainly

The lane's own executor chain is `ci-pr.yml` → `scripts/ci-script-checks.sh`, i.e. the protected context checks itself. That is not airtight and is not claimed to be. It raises the bar; part 2 raises it further by pinning the job's structure and step inventory. The residual environment/file-rewrite family is tracked as follow-up work, not silently dropped.

Refs #5071
