### PR TITLE
ci(#5071): pin relay-authority-contract against silent disablement (2/2)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -963,6 +963,9 @@ jobs:
     name: relay-authority-contract
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
       - uses: actions/checkout@v4
 
@@ -984,14 +987,20 @@ jobs:
 
       - name: Verify named relay-authority targets and selection floors
         env:
+          BASH_ENV: /dev/null
           CARGO_PROFILE_DEV_DEBUG: "0"
           CARGO_PROFILE_TEST_DEBUG: "0"
+        shell: bash
+        timeout-minutes: 30
         run: python3 scripts/check_relay_authority_contract.py
 
       - name: Run named relay-authority contract targets
         env:
+          BASH_ENV: /dev/null
           CARGO_PROFILE_DEV_DEBUG: "0"
           CARGO_PROFILE_TEST_DEBUG: "0"
+        shell: bash
+        timeout-minutes: 30
         run: |
           env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::session_relay_sink -- --test-threads=1
           env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::relay_recovery::tests -- --test-threads=1

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -76,6 +76,24 @@ unless trigger_events == ["pull_request"]
   exit 1
 end
 
+# The required Script checks job is intentionally high-churn: concurrent lanes
+# regularly add gates to its step inventory. Protect only the job-level fields
+# that can silently disable the required context, rather than whole-job hashing
+# that would force unrelated hash re-pins for every new script check.
+script_checks_job = jobs["scripts"]
+unless script_checks_job.is_a?(Hash)
+  warn "#{path}: Script checks job (scripts) must be a YAML mapping"
+  exit 1
+end
+if script_checks_job.key?("if")
+  warn "#{path}: Script checks job must not define a job-level if condition"
+  exit 1
+end
+if script_checks_job["continue-on-error"]
+  warn "#{path}: Script checks job must not be allowed to continue on error"
+  exit 1
+end
+
 targets = {
   # The independent explicit step-inventory layer was removed. What remains
   # splits into two mechanisms of very different strength, and conflating them

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -175,6 +175,30 @@ targets = {
       },
     },
   },
+  "relay-authority-contract" => {
+    "label" => "relay-authority contract job",
+    "name" => "relay-authority-contract",
+    "needs" => nil,
+    "if" => nil,
+    "runs_on" => "ubuntu-latest",
+    # #5071 registers this unconditional candidate in the existing semantic
+    # hardening registry so order-independent job keys cannot disable it silently.
+    "job_sha256" => "ab2b82266fde9b81d83ef4403435b66acf9c7336be454110d2e5e2ed4a34a553",
+    "cargo_steps" => {
+      "Verify named relay-authority targets and selection floors" => {
+        "commands" => ["python3 scripts/check_relay_authority_contract.py"],
+        "timeout_minutes" => 30,
+      },
+      "Run named relay-authority contract targets" => {
+        "commands" => [
+          "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::session_relay_sink -- --test-threads=1",
+          "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::relay_recovery::tests -- --test-threads=1",
+          "env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tui_prompt_relay::local_model_queue_wake_e2e -- --test-threads=1",
+        ],
+        "timeout_minutes" => 30,
+      },
+    },
+  },
   "high-risk-recovery" => {
     "label" => "High-risk recovery job",
     "name" => "High-risk recovery",

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -77,9 +77,9 @@ unless trigger_events == ["pull_request"]
 end
 
 # The required Script checks job is intentionally high-churn: concurrent lanes
-# regularly add gates to its step inventory. Protect only the job-level fields
-# that can silently disable the required context, rather than whole-job hashing
-# that would force unrelated hash re-pins for every new script check.
+# regularly add gates to its step inventory. Protect only the job and aggregate
+# step fields that can silently disable the required context, rather than
+# whole-job hashing that would force unrelated hash re-pins for every new check.
 script_checks_job = jobs["scripts"]
 unless script_checks_job.is_a?(Hash)
   warn "#{path}: Script checks job (scripts) must be a YAML mapping"
@@ -91,6 +91,30 @@ if script_checks_job.key?("if")
 end
 if script_checks_job["continue-on-error"]
   warn "#{path}: Script checks job must not be allowed to continue on error"
+  exit 1
+end
+unless script_checks_job["needs"] == "changes"
+  warn "#{path}: Script checks job must retain exact needs: changes"
+  exit 1
+end
+script_check_steps = Array(script_checks_job["steps"]).select do |step|
+  step.is_a?(Hash) && step["name"] == "Run script checks"
+end
+unless script_check_steps.length == 1
+  warn "#{path}: Script checks job must retain exactly one \"Run script checks\" step"
+  exit 1
+end
+script_check_step = script_check_steps.fetch(0)
+if script_check_step.key?("if")
+  warn "#{path}: Script checks job \"Run script checks\" step must not define if"
+  exit 1
+end
+if script_check_step["continue-on-error"]
+  warn "#{path}: Script checks job \"Run script checks\" step must not continue on error"
+  exit 1
+end
+unless script_check_step["run"] == "./scripts/ci-script-checks.sh"
+  warn "#{path}: Script checks job \"Run script checks\" step must run exactly ./scripts/ci-script-checks.sh"
   exit 1
 end
 

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -93,7 +93,8 @@ if script_checks_job["continue-on-error"]
   warn "#{path}: Script checks job must not be allowed to continue on error"
   exit 1
 end
-unless script_checks_job["needs"] == "changes"
+script_checks_needs = script_checks_job["needs"]
+unless script_checks_needs == "changes" || script_checks_needs == ["changes"]
   warn "#{path}: Script checks job must retain exact needs: changes"
   exit 1
 end
@@ -342,8 +343,7 @@ targets.each do |job_id, spec|
       unless step["if"] == step_spec.fetch("if_condition", nil)
         errors << "#{label} #{name.inspect} must retain exact if policy"
       end
-      if step_spec.key?("continue_on_error") &&
-         step["continue-on-error"] != step_spec.fetch("continue_on_error")
+      unless step["continue-on-error"] == step_spec.fetch("continue_on_error", nil)
         errors << "#{label} #{name.inspect} must retain exact continue-on-error policy"
       end
       unless step["timeout-minutes"] == step_spec.fetch("timeout_minutes")

--- a/scripts/check_relay_authority_contract.py
+++ b/scripts/check_relay_authority_contract.py
@@ -105,6 +105,7 @@ def validate_workflow_contract(
         if isinstance(step, dict)
         and step.get("run") == CONDITION3_MUTATION_COMMAND
         and "if" not in step
+        and not step.get("continue-on-error")
     ]
     if mutations_present and len(mutation_steps) != 1:
         raise ManifestError(

--- a/scripts/check_relay_authority_contract.py
+++ b/scripts/check_relay_authority_contract.py
@@ -6,14 +6,21 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Sequence
 
+import yaml
+
 DEFAULT_MANIFEST = Path("scripts/relay_authority_contract_targets.json")
+PR_WORKFLOW = Path(".github/workflows/ci-pr.yml")
+RELAY_AUTHORITY_JOB = "relay-authority-contract"
 CONDITION3_MUTATION_SCRIPT = Path("scripts/run_relay_authority_mutations.sh")
+CONDITION3_MUTATION_COMMAND = f"bash {CONDITION3_MUTATION_SCRIPT}"
+RELAY_TARGET_STEP = "Run named relay-authority contract targets"
 TEST_ID_SUFFIX = ": test"
 
 
@@ -39,6 +46,101 @@ class LaneResult:
     output: str
 
 
+def load_relay_authority_job(repo_root: Path) -> dict[str, object]:
+    workflow = repo_root / PR_WORKFLOW
+    try:
+        payload = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as error:
+        raise ManifestError(f"cannot read workflow {PR_WORKFLOW}: {error}") from error
+    jobs = payload.get("jobs") if isinstance(payload, dict) else None
+    job = jobs.get(RELAY_AUTHORITY_JOB) if isinstance(jobs, dict) else None
+    if not isinstance(job, dict):
+        raise ManifestError(
+            f"workflow {PR_WORKFLOW} must contain jobs.{RELAY_AUTHORITY_JOB}"
+        )
+    return job
+
+
+def expected_workflow_command(lane: Lane) -> str:
+    return f"env -u AGENTDESK_ROOT_DIR {shlex.join(lane.command)} -- --test-threads=1"
+
+
+def validate_workflow_contract(
+    repo_root: Path,
+    lanes: Sequence[Lane],
+    mutations_present: bool,
+) -> None:
+    job = load_relay_authority_job(repo_root)
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        raise ManifestError(
+            f"workflow jobs.{RELAY_AUTHORITY_JOB}.steps must be an array"
+        )
+
+    target_steps = [
+        step for step in steps
+        if isinstance(step, dict) and step.get("name") == RELAY_TARGET_STEP
+    ]
+    if len(target_steps) != 1:
+        raise ManifestError(
+            f"workflow jobs.{RELAY_AUTHORITY_JOB} must contain exactly one "
+            f"{RELAY_TARGET_STEP!r} step"
+        )
+    run = target_steps[0].get("run")
+    actual_commands = (
+        [line.strip() for line in run.splitlines() if line.strip()]
+        if isinstance(run, str)
+        else []
+    )
+    expected_commands = [expected_workflow_command(lane) for lane in lanes]
+    if actual_commands != expected_commands:
+        raise ManifestError(
+            f"workflow jobs.{RELAY_AUTHORITY_JOB} target commands must exactly match "
+            "the manifest argv with AGENTDESK_ROOT_DIR unset and "
+            "-- --test-threads=1 appended"
+        )
+
+    mutation_steps = [
+        step for step in steps
+        if isinstance(step, dict)
+        and step.get("run") == CONDITION3_MUTATION_COMMAND
+        and "if" not in step
+    ]
+    if mutations_present and len(mutation_steps) != 1:
+        raise ManifestError(
+            f"condition3_mutations_present is true but workflow "
+            f"jobs.{RELAY_AUTHORITY_JOB} must contain exactly one unconditional "
+            f"run step invoking {CONDITION3_MUTATION_COMMAND}"
+        )
+
+
+def validate_condition3_script(mutation_script: Path) -> None:
+    # This proves only that the checked path is a non-symlink, non-empty,
+    # executable regular file. It does not prove that the script mutates the
+    # intended contract or that its assertions are effective.
+    if mutation_script.is_symlink():
+        raise ManifestError(
+            f"{CONDITION3_MUTATION_SCRIPT} must not be a symlink"
+        )
+    if not mutation_script.is_file():
+        raise ManifestError(
+            f"condition3_mutations_present is true but {CONDITION3_MUTATION_SCRIPT} is missing"
+        )
+    if mutation_script.stat().st_size == 0:
+        raise ManifestError(f"{CONDITION3_MUTATION_SCRIPT} must not be empty")
+    if not os.access(mutation_script, os.X_OK):
+        raise ManifestError(f"{CONDITION3_MUTATION_SCRIPT} must be executable")
+    commands = [
+        line.strip()
+        for line in mutation_script.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    if commands == ["exit 0"]:
+        raise ManifestError(
+            f"{CONDITION3_MUTATION_SCRIPT} must not be an exit-0-only placeholder"
+        )
+
+
 def load_active_lanes(
     path: Path,
     repo_root: Path | None = None,
@@ -56,12 +158,10 @@ def load_active_lanes(
         raise ManifestError("manifest condition3_mutations_present must be boolean")
     if repo_root is not None:
         mutation_script = repo_root / CONDITION3_MUTATION_SCRIPT
-        script_exists = mutation_script.is_file()
-        if mutations_present and not script_exists:
-            raise ManifestError(
-                f"condition3_mutations_present is true but {CONDITION3_MUTATION_SCRIPT} is missing"
-            )
-        if not mutations_present and script_exists:
+        script_path_present = mutation_script.exists() or mutation_script.is_symlink()
+        if mutations_present:
+            validate_condition3_script(mutation_script)
+        elif script_path_present:
             raise ManifestError(
                 f"condition3_mutations_present is false but {CONDITION3_MUTATION_SCRIPT} exists"
             )
@@ -116,6 +216,8 @@ def load_active_lanes(
 
     if not active:
         raise ManifestError("manifest must declare at least one active lane")
+    if repo_root is not None:
+        validate_workflow_contract(repo_root, active, mutations_present)
     return active, gaps
 
 
@@ -160,8 +262,6 @@ def failures_for(result: LaneResult) -> list[str]:
 
 
 def shell_join(command: Sequence[str]) -> str:
-    import shlex
-
     return shlex.join(command)
 
 

--- a/scripts/relay_authority_contract_targets.json
+++ b/scripts/relay_authority_contract_targets.json
@@ -28,7 +28,7 @@
       "boundary": "T3",
       "status": "gap",
       "module": "services::discord::inflight",
-      "reason": "No T3 contract target exists yet: the current InflightTurnIdentity seam has no durable execution_id registry or nonce contract."
+      "reason": "No T3 contract target exists yet: durable turn_nonce values are persisted, but the execution registry and contract/registry admission wiring that T3 will add do not exist."
     },
     {
       "name": "t4-single-actor-recovery-decision",

--- a/tests/test_check_relay_authority_contract.py
+++ b/tests/test_check_relay_authority_contract.py
@@ -34,13 +34,51 @@ def active_lane(*, command: list[str] | None = None, minimum: int = 2) -> dict[s
     }
 
 
+def write_workflow(
+    repo_root: Path,
+    lanes: list[dict[str, object]],
+    *,
+    mutation_step: str | None = None,
+) -> None:
+    commands = [
+        "env -u AGENTDESK_ROOT_DIR "
+        + " ".join(lane["command"])
+        + " -- --test-threads=1"
+        for lane in lanes
+        if lane.get("status") == "active"
+    ]
+    steps: list[dict[str, object]] = [{
+        "name": contract.RELAY_TARGET_STEP,
+        "run": "\n".join(commands) + "\n",
+    }]
+    if mutation_step is not None:
+        steps.append({"name": "Run condition-3 mutations", "run": mutation_step})
+    workflow = repo_root / contract.PR_WORKFLOW
+    workflow.parent.mkdir(parents=True, exist_ok=True)
+    workflow.write_text(
+        "jobs:\n"
+        f"  {contract.RELAY_AUTHORITY_JOB}:\n"
+        "    steps:\n"
+        + "".join(
+            f"      - name: {step['name']}\n        run:"
+            + (f" |\n          {str(step['run']).replace(chr(10), chr(10) + '          ').rstrip()}\n"
+               if "\n" in str(step["run"])
+               else f" {step['run']}\n")
+            for step in steps
+        ),
+        encoding="utf-8",
+    )
+
+
 def manifest_path(
     lanes: list[dict[str, object]],
     *,
     condition3_mutations_present: bool = False,
+    mutation_step: str | None = None,
 ) -> tuple[tempfile.TemporaryDirectory[str], Path]:
     temporary = tempfile.TemporaryDirectory()
-    path = Path(temporary.name) / "targets.json"
+    repo_root = Path(temporary.name)
+    path = repo_root / "targets.json"
     path.write_text(
         json.dumps({
             "schema_version": 1,
@@ -49,6 +87,7 @@ def manifest_path(
         }),
         encoding="utf-8",
     )
+    write_workflow(repo_root, lanes, mutation_step=mutation_step)
     return temporary, path
 
 
@@ -71,7 +110,7 @@ class ManifestContract(unittest.TestCase):
         with temporary:
             repo_root = Path(temporary.name)
             mutation_script = repo_root / "scripts" / "run_relay_authority_mutations.sh"
-            mutation_script.parent.mkdir()
+            mutation_script.parent.mkdir(exist_ok=True)
             mutation_script.touch()
             with self.assertRaisesRegex(
                 contract.ManifestError,
@@ -88,6 +127,133 @@ class ManifestContract(unittest.TestCase):
                 contract.ManifestError,
                 "condition3_mutations_present is true but .*run_relay_authority_mutations.sh is missing",
             ):
+                contract.load_active_lanes(path, Path(temporary.name))
+
+    def test_condition3_true_rejects_missing_unconditional_workflow_step(self) -> None:
+        temporary, path = manifest_path(
+            [active_lane()], condition3_mutations_present=True
+        )
+        with temporary:
+            repo_root = Path(temporary.name)
+            mutation_script = repo_root / contract.CONDITION3_MUTATION_SCRIPT
+            mutation_script.parent.mkdir(exist_ok=True)
+            mutation_script.write_text("#!/usr/bin/env bash\nset -euo pipefail\ntrue\n", encoding="utf-8")
+            mutation_script.chmod(0o755)
+            with self.assertRaisesRegex(
+                contract.ManifestError,
+                "must contain exactly one unconditional run step",
+            ):
+                contract.load_active_lanes(path, repo_root)
+
+    def test_condition3_true_accepts_script_and_unconditional_workflow_step(self) -> None:
+        temporary, path = manifest_path(
+            [active_lane()],
+            condition3_mutations_present=True,
+            mutation_step=contract.CONDITION3_MUTATION_COMMAND,
+        )
+        with temporary:
+            repo_root = Path(temporary.name)
+            mutation_script = repo_root / contract.CONDITION3_MUTATION_SCRIPT
+            mutation_script.parent.mkdir(exist_ok=True)
+            mutation_script.write_text("#!/usr/bin/env bash\nset -euo pipefail\ntrue\n", encoding="utf-8")
+            mutation_script.chmod(0o755)
+            lanes, _ = contract.load_active_lanes(path, repo_root)
+            self.assertEqual([lane.name for lane in lanes], ["t1-fixture"])
+
+    def test_condition3_true_rejects_if_guarded_workflow_step(self) -> None:
+        temporary, path = manifest_path(
+            [active_lane()], condition3_mutations_present=True
+        )
+        with temporary:
+            repo_root = Path(temporary.name)
+            mutation_script = repo_root / contract.CONDITION3_MUTATION_SCRIPT
+            mutation_script.parent.mkdir(exist_ok=True)
+            mutation_script.write_text("#!/usr/bin/env bash\nset -euo pipefail\ntrue\n", encoding="utf-8")
+            mutation_script.chmod(0o755)
+            workflow = repo_root / contract.PR_WORKFLOW
+            text = workflow.read_text(encoding="utf-8")
+            workflow.write_text(
+                text + (
+                    "      - name: Run condition-3 mutations\n"
+                    "        if: ${{ false }}\n"
+                    f"        run: {contract.CONDITION3_MUTATION_COMMAND}\n"
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                contract.ManifestError,
+                "must contain exactly one unconditional run step",
+            ):
+                contract.load_active_lanes(path, repo_root)
+
+    def test_condition3_true_rejects_empty_script(self) -> None:
+        temporary, path = manifest_path(
+            [active_lane()],
+            condition3_mutations_present=True,
+            mutation_step=contract.CONDITION3_MUTATION_COMMAND,
+        )
+        with temporary:
+            repo_root = Path(temporary.name)
+            mutation_script = repo_root / contract.CONDITION3_MUTATION_SCRIPT
+            mutation_script.parent.mkdir(exist_ok=True)
+            mutation_script.touch(mode=0o755)
+            with self.assertRaisesRegex(contract.ManifestError, "must not be empty"):
+                contract.load_active_lanes(path, repo_root)
+
+    def test_condition3_true_rejects_exit_zero_only_script(self) -> None:
+        temporary, path = manifest_path(
+            [active_lane()],
+            condition3_mutations_present=True,
+            mutation_step=contract.CONDITION3_MUTATION_COMMAND,
+        )
+        with temporary:
+            repo_root = Path(temporary.name)
+            mutation_script = repo_root / contract.CONDITION3_MUTATION_SCRIPT
+            mutation_script.parent.mkdir(exist_ok=True)
+            mutation_script.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            mutation_script.chmod(0o755)
+            with self.assertRaisesRegex(contract.ManifestError, "exit-0-only placeholder"):
+                contract.load_active_lanes(path, repo_root)
+
+    def test_condition3_true_rejects_non_executable_script(self) -> None:
+        temporary, path = manifest_path(
+            [active_lane()],
+            condition3_mutations_present=True,
+            mutation_step=contract.CONDITION3_MUTATION_COMMAND,
+        )
+        with temporary:
+            repo_root = Path(temporary.name)
+            mutation_script = repo_root / contract.CONDITION3_MUTATION_SCRIPT
+            mutation_script.parent.mkdir(exist_ok=True)
+            mutation_script.write_text("#!/usr/bin/env bash\ntrue\n", encoding="utf-8")
+            mutation_script.chmod(0o644)
+            with self.assertRaisesRegex(contract.ManifestError, "must be executable"):
+                contract.load_active_lanes(path, repo_root)
+
+    def test_condition3_true_rejects_symlink_script(self) -> None:
+        temporary, path = manifest_path(
+            [active_lane()],
+            condition3_mutations_present=True,
+            mutation_step=contract.CONDITION3_MUTATION_COMMAND,
+        )
+        with temporary:
+            repo_root = Path(temporary.name)
+            target = repo_root / "unrelated.sh"
+            target.write_text("#!/usr/bin/env bash\ntrue\n", encoding="utf-8")
+            target.chmod(0o755)
+            mutation_script = repo_root / contract.CONDITION3_MUTATION_SCRIPT
+            mutation_script.parent.mkdir(exist_ok=True)
+            mutation_script.symlink_to(target)
+            with self.assertRaisesRegex(contract.ManifestError, "must not be a symlink"):
+                contract.load_active_lanes(path, repo_root)
+
+    def test_manifest_command_must_match_workflow_command(self) -> None:
+        temporary, path = manifest_path([active_lane()])
+        with temporary:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            payload["lanes"][0]["command"][-1] = "fixture::other"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaisesRegex(contract.ManifestError, "must exactly match"):
                 contract.load_active_lanes(path, Path(temporary.name))
 
     def test_unfiltered_command_is_rejected(self) -> None:
@@ -154,7 +320,7 @@ class MainContract(unittest.TestCase):
             stdout, stderr = io.StringIO(), io.StringIO()
             with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
                 rc = contract.main([
-                    "--repo-root", str(REPO_ROOT),
+                    "--repo-root", str(Path(temporary.name)),
                     "--manifest", str(manifest),
                 ])
         return rc, stdout.getvalue(), stderr.getvalue()

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -347,6 +347,9 @@ class FastCheckCiWiringTests(unittest.TestCase):
             r"    name: relay-authority-contract\n"
             r"    runs-on: ubuntu-latest\n"
             r"    timeout-minutes: 30\n"
+            r"    env:\n"
+            r'      CARGO_PROFILE_DEV_DEBUG: "0"\n'
+            r'      CARGO_PROFILE_TEST_DEBUG: "0"\n'
             r"    steps:\n"
             r"      - uses: actions/checkout@v4\n\n"
             r"      - name: Install Rust toolchain\n"
@@ -358,8 +361,11 @@ class FastCheckCiWiringTests(unittest.TestCase):
             job,
             r"(?m)^      - name: Run named relay-authority contract targets\n"
             r"        env:\n"
+            r"          BASH_ENV: /dev/null\n"
             r'          CARGO_PROFILE_DEV_DEBUG: "0"\n'
             r'          CARGO_PROFILE_TEST_DEBUG: "0"\n'
+            r"        shell: bash\n"
+            r"        timeout-minutes: 30\n"
             r"        run: \|\n"
             r"          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::session_relay_sink -- --test-threads=1\n"
             r"          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::relay_recovery::tests -- --test-threads=1\n"

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -8,6 +8,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import yaml
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PR_WORKFLOW = REPO_ROOT / ".github/workflows/ci-pr.yml"
@@ -371,6 +373,97 @@ class FastCheckCiWiringTests(unittest.TestCase):
             r"          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::relay_recovery::tests -- --test-threads=1\n"
             r"          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tui_prompt_relay::local_model_queue_wake_e2e -- --test-threads=1$",
         )
+
+    def test_required_pr_steps_cannot_be_silently_disabled(self) -> None:
+        workflow = PR_WORKFLOW.read_text(encoding="utf-8")
+        jobs = yaml.safe_load(workflow)["jobs"]
+        protected_steps = {
+            "scripts": (
+                ("Run script checks", "must not continue on error"),
+            ),
+            "relay-authority-contract": (
+                (
+                    "Verify named relay-authority targets and selection floors",
+                    "must retain exact continue-on-error policy",
+                ),
+                (
+                    "Run named relay-authority contract targets",
+                    "must retain exact continue-on-error policy",
+                ),
+            ),
+        }
+
+        for job_name, step_specs in protected_steps.items():
+            for step_name, expected_error in step_specs:
+                with self.subTest(job=job_name, step=step_name):
+                    step = next(
+                        candidate
+                        for candidate in jobs[job_name]["steps"]
+                        if candidate.get("name") == step_name
+                    )
+                    self.assertFalse(
+                        step.get("continue-on-error", False),
+                        f"required PR job {job_name!r} step {step_name!r} defines "
+                        "truthy key 'continue-on-error'",
+                    )
+
+                    mutated = workflow.replace(
+                        f"      - name: {step_name}\n",
+                        f"      - name: {step_name}\n        continue-on-error: true\n",
+                        1,
+                    )
+                    self.assertNotEqual(mutated, workflow)
+                    result = self.run_hardening_fixture(mutated)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(expected_error, result.stderr)
+
+    def test_registered_step_continue_policy_is_typed_and_exact(self) -> None:
+        workflow = PR_WORKFLOW.read_text(encoding="utf-8")
+        step_name = "Run named relay-authority contract targets"
+        for label, yaml_value in (
+            ("boolean-false", "false"),
+            ("string-false", '"false"'),
+        ):
+            with self.subTest(value=label):
+                mutated = workflow.replace(
+                    f"      - name: {step_name}\n",
+                    f"      - name: {step_name}\n"
+                    f"        continue-on-error: {yaml_value}\n",
+                    1,
+                )
+                self.assertNotEqual(mutated, workflow)
+                result = self.run_hardening_fixture(mutated)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "must retain exact continue-on-error policy", result.stderr
+                )
+
+    def test_script_checks_needs_accepts_equivalent_scalar_and_list_forms(self) -> None:
+        workflow = PR_WORKFLOW.read_text(encoding="utf-8")
+        scripts_job = job_block(workflow, "scripts")
+        cases = {
+            "scalar": "    needs: changes\n",
+            "single-element-list": "    needs: [changes]\n",
+        }
+        for form, replacement in cases.items():
+            with self.subTest(form=form):
+                mutated_job = scripts_job.replace(
+                    "    needs: changes\n", replacement, 1
+                )
+                if form != "scalar":
+                    self.assertNotEqual(mutated_job, scripts_job)
+                mutated = workflow.replace(scripts_job, mutated_job, 1)
+                result = self.run_hardening_fixture(mutated)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+        mutated_job = scripts_job.replace(
+            "    needs: changes\n", "    needs: [changes, other]\n", 1
+        )
+        self.assertNotEqual(mutated_job, scripts_job)
+        mutated = workflow.replace(scripts_job, mutated_job, 1)
+        result = self.run_hardening_fixture(mutated)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must retain exact needs: changes", result.stderr)
 
     def test_trusted_macos_runs_busy_retry_regressions_on_both_runner_paths(self) -> None:
         workflow = MACOS_TRUSTED_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
> Supersedes #5117, which GitHub auto-closed when its stacked base branch was deleted on merge of #5116. Part 1 is now on `main` (merge commit `7d6b8a9b0`), so this PR targets `main` directly and its diff is exactly the pinning layer.

Part 2 of 2 for #5071 T0 condition 1. **Stacked on `feat/5071-relay-authority-lane`** — review that one first; this PR's diff is only the pinning layer.

Part 1 creates the `relay-authority-contract` check. This PR makes it hard to neuter. After both merge and the job runs green on `main` once, `relay-authority-contract` is intended to become a required status check.

## The defect this closes

A required check can be silently defeated without ever touching its logic:

- a job skipped by `if:` **counts as passing** for required checks
- step-level `continue-on-error: true` or `run: … || true` yields a genuine **`success`** — strictly harder to notice than `skipped`

The step-inventory registry in `scripts/check-ci-runner-hardening.sh` guarded against this, but its `continue-on-error` check was gated behind `if step_spec.key?("continue_on_error")`, which made it **inert for 8 of the 12 registered steps — including both `relay-authority-contract` steps**. Re-pinning `job_sha256` for the same diff defeated the only remaining guard, so the exploit produced a real green.

This PR replaces the key-gated predicate with a direct comparison, so every registered step is covered regardless of whether its spec entry mentions the key.

## Measured proof, both directions

The hash guard was neutered during the probe so the digest could not decide the row (`hash_msgs=0`), isolating the `continue-on-error` guard itself:

| ref | `continue-on-error: true` on both relay-authority steps | result |
|---|---|---|
| parent `a9ffce96` | both | **rc=0** — the exploit was genuinely green |
| this head | both | **rc=1**, direct message: `… must retain exact continue-on-error policy` |

All 12 registered steps were attacked individually at this head: every one rc=1 with the direct message. 16 workflow-key disablement vectors (job/step `if:` in every spelling, `needs` manipulation, `defaults.run.shell`, `container:`, `$GITHUB_PATH` shim, aggregate rewrite, `exit 1`→`exit 0`) all rc=1.

`needs` was also normalized so `changes`, `[changes]`, and `["changes"]` are all accepted while multi-dependency is still rejected — a legitimate spelling should not produce a red.

## Verification

| Gate | Result |
|---|---|
| `scripts/check-ci-runner-hardening.sh` | rc=0 |
| `tests.test_fast_check_ci_wiring` | 28 tests, rc=0 |
| `tests.test_check_relay_authority_contract` | rc=0, floors 94/94 · 43/43 · 5/5 |
| relay/thread unit targets | 25 tests, rc=0 |
| full `scripts/ci-script-checks.sh` (foreground, no shim) | rc=0, 44 stages, shellcheck ran |
| signal-sensitive timeout suite | 21/21 |
| `git status --porcelain` | empty |

## Follow-ups, recorded not hidden

Independent adversarial review returned **safe to push and safe to register**, with three non-blocking findings that are tracked and will land in the condition-3 wiring commit (which touches these same files and must re-pin `job_sha256` anyway):

1. **False positive**: the registered-step predicate compares against a nil default, and Ruby's `false == nil` is false, so an explicit `continue-on-error: false` is rejected — even though `false` is GitHub's default and writing it is a semantic no-op. Three job-level sites in the same file accept it. Fix: normalize both sides. The four `"continue_on_error" => nil` spec entries are dead code under the current predicate and should be removed with it.
2. **Second false positive of the same family**: `run` is normalized for registered steps but compared by exact identity for the aggregate, so rewriting a `run` as a YAML block scalar is rejected.
3. **Three guards added by an earlier commit in this stack are unpinned** — deleting `exactly-one`, `must not define if`, or `must run exactly …` leaves every gate green. No current false green, but a future deletion would not be caught by tests.

The environment-variable and file-rewrite disablement family remains open by design and is documented, not silently dropped. The executor chain is still the protected context checking itself; this is not claimed to be airtight.

Refs #5071
