### PR TITLE
test(#5071): extract relay delivery seam (T0 condition 3, part 1/2)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -768,7 +768,9 @@ src/
 │   │   │   ├── startup_doctor.rs
 │   │   │   └── voice.rs
 │   │   ├── session_relay_sink/
+│   │   │   ├── delivery_commit.rs
 │   │   │   ├── delivery_frontier.rs
+│   │   │   ├── delivery_orchestration_tests.rs
 │   │   │   ├── delivery_outcome_classify.rs
 │   │   │   ├── idle_jsonl.rs
 │   │   │   ├── orphan_reclaim.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -153,9 +153,10 @@
     prompt observation/footer deferral; `session_relay_sink/task_notification_context.rs`
     owns card-before-answer promotion and exact reference selection.
   - `src/services/discord/gateway/outbound_messages.rs` adapts task-card
-    create/edit operations to outbound v3. `gateway.rs` maps structured Discord
-    errors while `outbound/transport.rs` owns the nonce-aware Serenity create
-    boundary and enforces the create nonce.
+    create/edit operations to outbound v3. `src/services/discord/gateway.rs`
+    (frozen giant surface; TurnGateway orchestration seam) maps structured
+    Discord errors while `outbound/transport.rs` owns the nonce-aware Serenity
+    create boundary and enforces the create nonce.
 - durable_state: PostgreSQL `task_notification_card_state` is cluster-shared
   authority. The process-local store is a test/non-PG fallback only.
 - invariants: one logical event row and stable nonce; ambiguous creates retry

--- a/justfile
+++ b/justfile
@@ -34,6 +34,8 @@ test-non-pg:
     cargo test --lib source_registry -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib task_notification -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib delivery_lease_key -- --skip _pg --skip pg_ --skip postgres
+    # #5071 T0: keep the delivery-writer/terminal-fold contract seam in a curated lane.
+    cargo test --lib services::discord::session_relay_sink::delivery_orchestration_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib services::discord::e2e_control::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib server::routes::e2e_control::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib formatting -- --skip _pg --skip pg_ --skip postgres

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -175,6 +175,7 @@ mod status_panel_v2_formatter_tests;
 #[path = "formatting/replace_long_message.rs"]
 mod replace_long_message;
 
+#[cfg(test)]
 pub(in crate::services::discord) use self::replace_long_message::ReplaceLastChunkAnchor;
 pub(in crate::services::discord) use self::replace_long_message::{
     DeferredReplaceLongMessageOutcome, ReplaceLongMessageOutcome,

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -175,16 +175,13 @@ mod status_panel_v2_formatter_tests;
 #[path = "formatting/replace_long_message.rs"]
 mod replace_long_message;
 
+pub(in crate::services::discord) use self::replace_long_message::ReplaceLastChunkAnchor;
 pub(in crate::services::discord) use self::replace_long_message::{
     DeferredReplaceLongMessageOutcome, ReplaceLongMessageOutcome,
     cleanup_replace_continuations_after_failure, replace_long_message_outcome_to_result,
     replace_long_message_raw, replace_long_message_raw_deferred,
     replace_long_message_raw_with_outcome, watcher_completion_footer_anchor,
 };
-// The anchor struct is only named by in-file regression tests today; production
-// callers receive it through inferred `Option<ReplaceLastChunkAnchor>` locals.
-#[cfg(test)]
-pub(in crate::services::discord) use self::replace_long_message::ReplaceLastChunkAnchor;
 
 #[cfg(test)]
 mod relay_state_contract_refs {

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -119,22 +119,6 @@ pub(super) trait TurnGateway: Send + Sync {
         })
     }
 
-    fn send_long_message_with_reference<'a>(
-        &'a self,
-        channel_id: ChannelId,
-        content: &'a str,
-        _reference: Option<(ChannelId, MessageId)>,
-    ) -> GatewayFuture<'a, Result<Vec<MessageId>, String>> {
-        Box::pin(async move {
-            let chunks = formatting::split_message(content);
-            let mut sent = Vec::with_capacity(chunks.len());
-            for chunk in chunks {
-                sent.push(TurnGateway::send_message(self, channel_id, &chunk).await?);
-            }
-            Ok(sent)
-        })
-    }
-
     fn edit_message<'a>(
         &'a self,
         channel_id: ChannelId,
@@ -156,28 +140,6 @@ pub(super) trait TurnGateway: Send + Sync {
         message_id: MessageId,
         content: &'a str,
     ) -> GatewayFuture<'a, Result<ReplaceLongMessageOutcome, String>>;
-
-    fn replace_message_with_anchor<'a>(
-        &'a self,
-        channel_id: ChannelId,
-        message_id: MessageId,
-        content: &'a str,
-    ) -> GatewayFuture<
-        'a,
-        Result<
-            (
-                ReplaceLongMessageOutcome,
-                Option<formatting::ReplaceLastChunkAnchor>,
-            ),
-            String,
-        >,
-    > {
-        Box::pin(async move {
-            self.replace_message_with_outcome(channel_id, message_id, content)
-                .await
-                .map(|outcome| (outcome, None))
-        })
-    }
 
     /// Attempt only the edit phase of a replace. An edit failure is returned as a
     /// typed outcome so a range owner can revalidate durable delivery authority
@@ -644,25 +606,6 @@ impl TurnGateway for DiscordGateway {
         })
     }
 
-    fn send_long_message_with_reference<'a>(
-        &'a self,
-        channel_id: ChannelId,
-        content: &'a str,
-        reference: Option<(ChannelId, MessageId)>,
-    ) -> GatewayFuture<'a, Result<Vec<MessageId>, String>> {
-        Box::pin(async move {
-            formatting::send_long_message_raw_with_reference_returning_message_ids(
-                &self.http,
-                channel_id,
-                content,
-                &self.shared,
-                reference,
-            )
-            .await
-            .map_err(|error| error.to_string())
-        })
-    }
-
     fn edit_message<'a>(
         &'a self,
         channel_id: ChannelId,
@@ -690,40 +633,16 @@ impl TurnGateway for DiscordGateway {
         content: &'a str,
     ) -> GatewayFuture<'a, Result<ReplaceLongMessageOutcome, String>> {
         Box::pin(async move {
-            self.replace_message_with_anchor(channel_id, message_id, content)
-                .await
-                .map(|(outcome, _)| outcome)
-        })
-    }
-
-    fn replace_message_with_anchor<'a>(
-        &'a self,
-        channel_id: ChannelId,
-        message_id: MessageId,
-        content: &'a str,
-    ) -> GatewayFuture<
-        'a,
-        Result<
-            (
-                ReplaceLongMessageOutcome,
-                Option<formatting::ReplaceLastChunkAnchor>,
-            ),
-            String,
-        >,
-    > {
-        Box::pin(async move {
-            let mut last_chunk_anchor = None;
-            let outcome = formatting::replace_long_message_raw_with_outcome(
+            formatting::replace_long_message_raw_with_outcome(
                 &self.http,
                 channel_id,
                 message_id,
                 content,
                 &self.shared,
-                &mut last_chunk_anchor,
+                &mut None,
             )
             .await
-            .map_err(|error| watcher_classified_error_string(error.as_ref()))?;
-            Ok((outcome, last_chunk_anchor))
+            .map_err(|error| watcher_classified_error_string(error.as_ref()))
         })
     }
 

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -119,6 +119,22 @@ pub(super) trait TurnGateway: Send + Sync {
         })
     }
 
+    fn send_long_message_with_reference<'a>(
+        &'a self,
+        channel_id: ChannelId,
+        content: &'a str,
+        _reference: Option<(ChannelId, MessageId)>,
+    ) -> GatewayFuture<'a, Result<Vec<MessageId>, String>> {
+        Box::pin(async move {
+            let chunks = formatting::split_message(content);
+            let mut sent = Vec::with_capacity(chunks.len());
+            for chunk in chunks {
+                sent.push(TurnGateway::send_message(self, channel_id, &chunk).await?);
+            }
+            Ok(sent)
+        })
+    }
+
     fn edit_message<'a>(
         &'a self,
         channel_id: ChannelId,
@@ -140,6 +156,28 @@ pub(super) trait TurnGateway: Send + Sync {
         message_id: MessageId,
         content: &'a str,
     ) -> GatewayFuture<'a, Result<ReplaceLongMessageOutcome, String>>;
+
+    fn replace_message_with_anchor<'a>(
+        &'a self,
+        channel_id: ChannelId,
+        message_id: MessageId,
+        content: &'a str,
+    ) -> GatewayFuture<
+        'a,
+        Result<
+            (
+                ReplaceLongMessageOutcome,
+                Option<formatting::ReplaceLastChunkAnchor>,
+            ),
+            String,
+        >,
+    > {
+        Box::pin(async move {
+            self.replace_message_with_outcome(channel_id, message_id, content)
+                .await
+                .map(|outcome| (outcome, None))
+        })
+    }
 
     /// Attempt only the edit phase of a replace. An edit failure is returned as a
     /// typed outcome so a range owner can revalidate durable delivery authority
@@ -606,6 +644,25 @@ impl TurnGateway for DiscordGateway {
         })
     }
 
+    fn send_long_message_with_reference<'a>(
+        &'a self,
+        channel_id: ChannelId,
+        content: &'a str,
+        reference: Option<(ChannelId, MessageId)>,
+    ) -> GatewayFuture<'a, Result<Vec<MessageId>, String>> {
+        Box::pin(async move {
+            formatting::send_long_message_raw_with_reference_returning_message_ids(
+                &self.http,
+                channel_id,
+                content,
+                &self.shared,
+                reference,
+            )
+            .await
+            .map_err(|error| error.to_string())
+        })
+    }
+
     fn edit_message<'a>(
         &'a self,
         channel_id: ChannelId,
@@ -633,18 +690,40 @@ impl TurnGateway for DiscordGateway {
         content: &'a str,
     ) -> GatewayFuture<'a, Result<ReplaceLongMessageOutcome, String>> {
         Box::pin(async move {
-            formatting::replace_long_message_raw_with_outcome(
+            self.replace_message_with_anchor(channel_id, message_id, content)
+                .await
+                .map(|(outcome, _)| outcome)
+        })
+    }
+
+    fn replace_message_with_anchor<'a>(
+        &'a self,
+        channel_id: ChannelId,
+        message_id: MessageId,
+        content: &'a str,
+    ) -> GatewayFuture<
+        'a,
+        Result<
+            (
+                ReplaceLongMessageOutcome,
+                Option<formatting::ReplaceLastChunkAnchor>,
+            ),
+            String,
+        >,
+    > {
+        Box::pin(async move {
+            let mut last_chunk_anchor = None;
+            let outcome = formatting::replace_long_message_raw_with_outcome(
                 &self.http,
                 channel_id,
                 message_id,
                 content,
                 &self.shared,
-                // #3805 P1: gateway trait returns the outcome only; the last-chunk
-                // footer anchor is consumed exclusively by the tmux watcher.
-                &mut None,
+                &mut last_chunk_anchor,
             )
             .await
-            .map_err(|error| watcher_classified_error_string(error.as_ref()))
+            .map_err(|error| watcher_classified_error_string(error.as_ref()))?;
+            Ok((outcome, last_chunk_anchor))
         })
     }
 

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -37,6 +37,7 @@ pub(in crate::services::discord) const PURE_SUBAGENT_ZERO_DELIVERY_PAYLOAD: &str
     "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"done\"}\n"
 );
 
+mod delivery_commit;
 mod delivery_frontier;
 mod delivery_outcome_classify;
 mod idle_jsonl;
@@ -512,9 +513,8 @@ pub(in crate::services::discord) struct SessionBoundDiscordRelaySink {
     by_session: Mutex<HashMap<String, SessionRelayParser>>,
     #[cfg(test)]
     lease_test_probe: Option<Arc<SinkLeaseTestProbe>>,
-    test_gateway: Option<Arc<dyn super::gateway::TurnGateway>>,
     #[cfg(test)]
-    test_delivery_outcomes: Option<Arc<Mutex<Vec<SessionRelayDeliveryOutcome>>>>,
+    test_gateway: Option<Arc<dyn super::gateway::TurnGateway>>,
 }
 
 impl SessionBoundDiscordRelaySink {
@@ -526,9 +526,8 @@ impl SessionBoundDiscordRelaySink {
             by_session: Mutex::new(HashMap::new()),
             #[cfg(test)]
             lease_test_probe: None,
-            test_gateway: None,
             #[cfg(test)]
-            test_delivery_outcomes: None,
+            test_gateway: None,
         }
     }
 
@@ -685,108 +684,14 @@ impl SessionBoundDiscordRelaySink {
         }
     }
 
-    fn advance_offset_for_confirmed_delegated_terminal(
-        &self,
-        shared: &super::SharedData,
-        provider: &ProviderKind,
-        channel_id: u64,
-        session_name: &str,
-        delivery: &SessionRelayDelivery,
-        inflight: Option<&super::inflight::InflightTurnState>,
-    ) -> bool {
-        let Some(end) = delivery.terminal_consumed_end.filter(|end| *end > 0) else {
-            return false;
-        };
-        // IDENTITY GATE: the frame's pinned turn identity must still match the
-        // channel's current inflight. A delayed frame from an already-replaced
-        // turn (or a cleared inflight) is ignored — never advances a wrong turn.
-        let Some(inflight) = inflight else {
-            tracing::debug!(
-                provider = provider.as_str(),
-                channel_id,
-                tmux_session = %session_name,
-                frame_user_msg_id = delivery.frame_turn_user_msg_id,
-                "session-bound sink: terminal frame carried a commit fence but inflight is gone; identity gate blocks advance"
-            );
-            return false;
-        };
-        // #3041 P1-3 (codex P1-3 issue 2 R4): STRICT `turn_start_offset` identity — a
-        // REQUIRED gate part with NO None fallback (two `user_msg_id == 0` turns in the same
-        // second collide on the weak `(user_msg_id, started_at)` pair). A fenced frame is
-        // GUARANTEED a real offset by the producer, so `None`/mismatch is a stale/wrong-turn
-        // frame → MUST NOT advance (the watcher's SendFull delivers — no black-hole).
-        let identity_matches = inflight.user_msg_id == delivery.frame_turn_user_msg_id
-            && inflight.started_at == delivery.frame_turn_started_at
-            && delivery.frame_turn_start_offset.is_some()
-            && inflight.turn_start_offset == delivery.frame_turn_start_offset;
-        if !identity_matches {
-            tracing::debug!(
-                provider = provider.as_str(),
-                channel_id,
-                tmux_session = %session_name,
-                frame_user_msg_id = delivery.frame_turn_user_msg_id,
-                inflight_user_msg_id = inflight.user_msg_id,
-                frame_turn_start_offset = delivery.frame_turn_start_offset,
-                inflight_turn_start_offset = inflight.turn_start_offset,
-                "session-bound sink: terminal frame identity != current inflight; identity gate blocks advance (delayed/wrong-turn frame)"
-            );
-            return false;
-        }
-        super::tmux::advance_watcher_confirmed_end(
-            shared,
-            provider,
-            ChannelId::new(channel_id),
-            session_name,
-            end,
-            "src/services/discord/session_relay_sink.rs:sink_confirmed_terminal_advance",
-        );
-        // #3976: stamp the durable per-row delivered marker ONLY here — past the
-        // identity gate, after the `confirmed_end_offset` watermark advance fired
-        // (so a refused/identity-mismatched advance, which returned above, never
-        // marks the row). The watermark is resettable and writes nothing else to
-        // the row, so without this durable marker a delivered-but-unmirrored row is
-        // indistinguishable from a never-delivered black-hole and orphan-reclaim
-        // would re-emit its tail on a watermark reset. The flock RMW re-gates the
-        // identity under the lock, so a turn replaced during the POST is never
-        // marked. Best-effort: a residual crash between the POST and this write
-        // reverts the row to orphan shape on reboot (same at-most-once residual the
-        // #3918 marker bounds) — acceptable and no worse than today.
-        super::inflight::mark_session_bound_relay_delivered_locked(
-            provider,
-            channel_id,
-            &super::inflight::InflightTurnIdentity::from_state(inflight),
-            session_name,
-        );
-        true
-    }
-
-    /// #3089 A2b: short-replace via the turn-output controller, behaviourally equal to legacy
-    /// `replace_long_message_raw_with_outcome` — SAME transport + `LeaseHolder::Sink` cell (one
-    /// acquire/commit/release, no double-acquire), #3151 heartbeat, #2757 `PreserveAlways`,
-    /// `CommitOnFallback`, identity-gated advance (FRESH post-POST reload): confirmed POST →
-    /// `Delivered`, ambiguous → `Err(Transient)` (I2); `Replace { Active }` → `post_send_finalize`
-    /// no-op. `gateway` seam (review-fix Medium-1): live = real gateway, test fakes it.
-    async fn deliver_short_replace_via_controller<G: super::gateway::TurnGateway + ?Sized>(
-        &self,
-        gateway: &G,
-        ctx: short_controller::SinkShortReplaceCtx<'_>,
-    ) -> Result<SessionRelayDeliveryOutcome, RelaySinkError> {
-        short_controller::deliver_short_replace_via_controller(gateway, ctx).await
-    }
-
     async fn deliver_response(
         &self,
         delivery: SessionRelayDelivery,
     ) -> Result<SessionRelayDeliveryOutcome, RelaySinkError> {
-        self.deliver_response_via_gateway(delivery, self.test_gateway.clone())
-            .await
-    }
-
-    async fn deliver_response_via_gateway(
-        &self,
-        delivery: SessionRelayDelivery,
-        injected_gateway: Option<Arc<dyn super::gateway::TurnGateway>>,
-    ) -> Result<SessionRelayDeliveryOutcome, RelaySinkError> {
+        #[cfg(test)]
+        let gateway: Option<&dyn super::gateway::TurnGateway> = self.test_gateway.as_deref();
+        #[cfg(not(test))]
+        let gateway: Option<&dyn super::gateway::TurnGateway> = None;
         let channel_id = delivery.channel_id;
         let provider = delivery.provider.clone();
         let inflight = super::inflight::load_inflight_state(&provider, channel_id);
@@ -883,13 +788,11 @@ impl SessionBoundDiscordRelaySink {
         // route from PlaceholderEdit to NewMessage. Keep that entire operation on
         // the outer lease so both the card transport and the final answer remain
         // guarded even though the route mutates inside `ensure_card_and_route`.
-        let has_injected_gateway = injected_gateway.is_some();
         let cutover_short_replace = delivery.task_notification_context.is_none()
             && cutover_range.is_some()
             && !relay_text.is_empty()
             && matches!(route, SessionBoundTerminalDeliveryRoute::PlaceholderEdit(_))
-            && !session_bound_should_send_new_chunks_for_placeholder(&relay_text)
-            && !has_injected_gateway;
+            && !session_bound_should_send_new_chunks_for_placeholder(&relay_text);
         let (lease_range, lease_fallback_start) = sink_delivery_lease_coordinate(&delivery);
         let sink_lease_key = delivery_lease_key_for_frame(
             channel,
@@ -963,25 +866,15 @@ impl SessionBoundDiscordRelaySink {
             }
         }
 
-        let http = shared.serenity_http_or_token_fallback();
-        let live_gateway;
-        let gateway: &dyn super::gateway::TurnGateway = match injected_gateway.as_deref() {
-            Some(gateway) => gateway,
-            None => {
-                let http = http.clone().ok_or_else(|| {
-                    RelaySinkError::Transient(format!(
-                        "discord http unavailable for provider {}",
-                        provider.as_str()
-                    ))
-                })?;
-                live_gateway = super::gateway::DiscordGateway::new(
-                    http,
-                    shared.clone(),
-                    provider.clone(),
-                    None,
-                );
-                &live_gateway
-            }
+        let http = if gateway.is_some() {
+            Arc::new(serenity::http::Http::new("test-gateway"))
+        } else {
+            shared.serenity_http_or_token_fallback().ok_or_else(|| {
+                RelaySinkError::Transient(format!(
+                    "discord http unavailable for provider {}",
+                    provider.as_str()
+                ))
+            })?
         };
         let (route, task_card_message_id, task_response_claim_outcome) =
             ensure_card_and_route(&self.health_registry, &shared, &delivery, route).await?;
@@ -1027,33 +920,54 @@ impl SessionBoundDiscordRelaySink {
 
         if let SessionBoundTerminalDeliveryRoute::PlaceholderEdit(msg_id) = route {
             if let Some((start, end)) = cutover_range.filter(|_| cutover_short_replace) {
-                return self
-                    .deliver_short_replace_via_controller(
-                        gateway,
-                        short_controller::SinkShortReplaceCtx {
-                            shared: &shared,
-                            provider: &provider,
-                            channel,
-                            channel_id,
-                            msg_id,
-                            relay_text: &relay_text,
-                            delivered_fingerprint_body: &raw_response_text,
-                            delivery: &delivery,
-                            sink_lease_key,
-                            sink_delivery_authority,
-                            trace: &trace,
-                            range: (start, end),
-                            delivered_total: &self.delivered_total,
-                        },
-                    )
-                    .await;
+                let live_gateway = super::gateway::DiscordGateway::new(
+                    http.clone(),
+                    shared.clone(),
+                    provider.clone(),
+                    None,
+                );
+                return short_controller::deliver_short_replace_via_controller(
+                    gateway.unwrap_or(&live_gateway),
+                    short_controller::SinkShortReplaceCtx {
+                        shared: &shared,
+                        provider: &provider,
+                        channel,
+                        channel_id,
+                        msg_id,
+                        relay_text: &relay_text,
+                        delivered_fingerprint_body: &raw_response_text,
+                        delivery: &delivery,
+                        sink_lease_key,
+                        sink_delivery_authority,
+                        trace: &trace,
+                        range: (start, end),
+                        delivered_total: &self.delivered_total,
+                    },
+                )
+                .await;
             }
             if session_bound_should_send_new_chunks_for_placeholder(&relay_text) {
-                let message_ids = gateway
-                    .send_long_message_with_rollback(channel, msg_id, &relay_text)
+                let message_ids = if let Some(gateway) = gateway {
+                    gateway
+                        .send_long_message_with_rollback(channel, msg_id, &relay_text)
+                        .await
+                        .map_err(RelaySinkError::Transient)?
+                } else {
+                    formatting::send_long_message_raw_with_rollback(
+                        &http,
+                        channel,
+                        msg_id,
+                        &relay_text,
+                        &shared,
+                    )
                     .await
-                    .map_err(RelaySinkError::Transient)?;
-                let _ = gateway.delete_message(channel, msg_id).await;
+                    .map_err(|error| RelaySinkError::Transient(error.to_string()))?
+                };
+                if let Some(gateway) = gateway {
+                    let _ = gateway.delete_message(channel, msg_id).await;
+                } else {
+                    let _ = super::http::delete_channel_message(&http, channel, msg_id).await;
+                }
                 self.delivered_total.fetch_add(1, Ordering::AcqRel);
                 tracing::info!(
                     provider = provider.as_str(),
@@ -1091,11 +1005,25 @@ impl SessionBoundDiscordRelaySink {
                 );
                 return Ok(SessionRelayDeliveryOutcome::from_proof(proof));
             }
-            match gateway
-                .replace_message_with_anchor(channel, msg_id, &relay_text)
+            let mut last_chunk_anchor = None;
+            let replace_outcome = if let Some(gateway) = gateway {
+                gateway
+                    .replace_message_with_outcome(channel, msg_id, &relay_text)
+                    .await
+            } else {
+                formatting::replace_long_message_raw_with_outcome(
+                    &http,
+                    channel,
+                    msg_id,
+                    &relay_text,
+                    &shared,
+                    &mut last_chunk_anchor,
+                )
                 .await
-            {
-                Ok((ReplaceLongMessageOutcome::EditedOriginal, last_chunk_anchor)) => {
+                .map_err(|error| error.to_string())
+            };
+            match replace_outcome {
+                Ok(ReplaceLongMessageOutcome::EditedOriginal) => {
                     self.delivered_total.fetch_add(1, Ordering::AcqRel);
                     tracing::info!(
                         provider = provider.as_str(),
@@ -1139,13 +1067,10 @@ impl SessionBoundDiscordRelaySink {
                     );
                     Ok(SessionRelayDeliveryOutcome::from_proof(proof))
                 }
-                Ok((
-                    ReplaceLongMessageOutcome::SentFallbackAfterEditFailure {
-                        edit_error,
-                        replacement_anchor,
-                    },
-                    _,
-                )) => {
+                Ok(ReplaceLongMessageOutcome::SentFallbackAfterEditFailure {
+                    edit_error,
+                    replacement_anchor,
+                }) => {
                     // #2757 (A0 #3089): never delete msg_id — it is the bridge's
                     // current_msg_id, possibly holding streamed content a transient edit
                     // failure would vacuum. The shared policy pins this preserve decision.
@@ -1189,7 +1114,7 @@ impl SessionBoundDiscordRelaySink {
                     );
                     Ok(SessionRelayDeliveryOutcome::from_proof(proof))
                 }
-                Ok((ReplaceLongMessageOutcome::PartialContinuationFailure { error, .. }, _)) => {
+                Ok(ReplaceLongMessageOutcome::PartialContinuationFailure { error, .. }) => {
                     Err(RelaySinkError::Transient(
                         super::replace_outcome_policy::strip_watcher_send_failure_class_marker(
                             &error,
@@ -1525,13 +1450,16 @@ fn delivery_lease_key_for_frame(
 }
 
 #[cfg(test)]
+mod delivery_orchestration_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::services::cluster::session_matcher::{MatchedChannel, expected_rollout_path_for};
     use crate::services::discord::inflight::{RelayOwnerKind, TurnSource};
     use crate::services::tui_prompt_dedupe::{ExternalInputRelayLease, ExternalInputRelayOwner};
 
-    fn matched(channel_id: &str) -> MatchedChannel {
+    pub(super) fn matched(channel_id: &str) -> MatchedChannel {
         let session = ProviderKind::Claude.build_tmux_session_name(channel_id);
         MatchedChannel {
             channel_id: channel_id.to_string(),
@@ -1603,7 +1531,7 @@ mod tests {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn terminal_frame_offset(
+    pub(super) fn terminal_frame_offset(
         binding: &MatchedChannel,
         payload: &str,
         sequence: u64,
@@ -2633,252 +2561,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fenced_terminal_without_parser_delivery_is_terminal_not_delivered() {
-        let binding = matched("44001");
-        let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
-        let terminal = terminal_frame_offset(
-            &binding,
-            "{\"type\":\"result\",\"result\":\"\"}\n",
-            1,
-            256,
-            0,
-            "2026-08-03T00:00:00Z",
-            Some(64),
-        );
-
-        let outcome = sink
-            .deliver(&terminal)
-            .await
-            .expect("a fenced terminal without parser delivery is known");
-
-        assert_eq!(outcome, RelaySinkOutcome::TerminalNotDelivered);
-    }
-
-    #[tokio::test]
-    async fn relay_deliver_propagates_injected_transport_error() {
-        let temp = tempfile::tempdir().expect("temp runtime root");
-        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
-        let channel_id = 44_002;
-        let binding = matched(&channel_id.to_string());
-        let session = &binding.expected_session_name;
-        let generation_path =
-            crate::services::tmux_common::session_temp_path(session, "generation");
-        std::fs::create_dir_all(
-            std::path::Path::new(&generation_path)
-                .parent()
-                .expect("generation parent"),
-        )
-        .expect("generation directory");
-        std::fs::write(&generation_path, b"transport-error").expect("generation marker");
-        let started_at = "2026-08-03T00:00:01Z";
-        let mut inflight =
-            inflight_with_identity_offset(channel_id, session, 700, started_at, Some(0));
-        inflight.set_relay_owner_kind(RelayOwnerKind::SessionBoundRelay);
-        inflight.current_msg_id = 88_002;
-        super::super::inflight::save_inflight_state(&inflight).expect("persist inflight");
-        let registry = Arc::new(HealthRegistry::new());
-        let shared = super::super::make_shared_data_for_tests();
-        registry
-            .register(ProviderKind::Claude.as_str().to_string(), shared)
-            .await;
-        let gateway = Arc::new(RelayContractFakeGateway::failing("fake transport failure"));
-        let mut sink = SessionBoundDiscordRelaySink::new(registry);
-        sink.test_gateway = Some(gateway.clone());
-        let payload = concat!(
-            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
-            "{\"type\":\"result\",\"result\":\"answer\"}\n"
-        );
-        let terminal = terminal_frame_offset(&binding, payload, 1, 256, 700, started_at, Some(0));
-
-        let error = sink
-            .deliver(&terminal)
-            .await
-            .expect_err("transport failure must escape RelaySink::deliver");
-
-        assert!(matches!(error, RelaySinkError::Transient(_)), "{error:?}");
-        assert_eq!(gateway.replace_calls.load(Ordering::Acquire), 1);
-        super::super::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
-    }
-
-    #[tokio::test]
-    async fn relay_deliver_preserves_tail_anchor_and_observes_persisted_proof() {
-        let temp = tempfile::tempdir().expect("temp runtime root");
-        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
-        let channel_id = 44_003;
-        let binding = matched(&channel_id.to_string());
-        let session = &binding.expected_session_name;
-        let generation_path =
-            crate::services::tmux_common::session_temp_path(session, "generation");
-        std::fs::create_dir_all(
-            std::path::Path::new(&generation_path)
-                .parent()
-                .expect("generation parent"),
-        )
-        .expect("generation directory");
-        std::fs::write(&generation_path, b"persisted-proof").expect("generation marker");
-        let generation = dr::current_generation_mtime_ns(session);
-        let started_at = "2026-08-03T00:00:02Z";
-        let mut inflight =
-            inflight_with_identity_offset(channel_id, session, 701, started_at, Some(0));
-        inflight.set_relay_owner_kind(RelayOwnerKind::SessionBoundRelay);
-        inflight.current_msg_id = 88_003;
-        super::super::inflight::save_inflight_state(&inflight).expect("persist inflight");
-        let registry = Arc::new(HealthRegistry::new());
-        let shared = super::super::make_shared_data_for_tests();
-        registry
-            .register(ProviderKind::Claude.as_str().to_string(), shared.clone())
-            .await;
-        let gateway = Arc::new(RelayContractFakeGateway::edited(Some((
-            99_003,
-            "tail chunk",
-        ))));
-        let outcomes = Arc::new(Mutex::new(Vec::new()));
-        let mut sink = SessionBoundDiscordRelaySink::new(registry);
-        sink.test_gateway = Some(gateway.clone());
-        sink.test_delivery_outcomes = Some(outcomes.clone());
-        let payload = concat!(
-            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
-            "{\"type\":\"result\",\"result\":\"answer\"}\n"
-        );
-        let mut terminal =
-            terminal_frame_offset(&binding, payload, 1, 256, 701, started_at, Some(0));
-        terminal.relay_generation_mtime_ns = Some(generation);
-
-        let outcome = sink.deliver(&terminal).await.expect("persisted delivery");
-
-        assert_eq!(outcome, RelaySinkOutcome::TerminalDelivered);
-        assert_eq!(
-            outcomes.lock().expect("outcome probe").as_slice(),
-            &[SessionRelayDeliveryOutcome::Delivered]
-        );
-        let record = dr::read_record(&ProviderKind::Claude, channel_id).expect("delivery record");
-        assert_eq!(
-            record.delivered_frontier.expect("frontier").panel_msg_id,
-            Some(99_003),
-            "legacy replace must retain the formatter tail anchor"
-        );
-        assert_eq!(gateway.replace_calls.load(Ordering::Acquire), 1);
-        super::super::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
-    }
-
-    #[tokio::test]
-    async fn relay_deliver_observes_landed_stale_proof() {
-        let temp = tempfile::tempdir().expect("temp runtime root");
-        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
-        let channel_id = 44_004;
-        let binding = matched(&channel_id.to_string());
-        let session = &binding.expected_session_name;
-        let generation_path =
-            crate::services::tmux_common::session_temp_path(session, "generation");
-        std::fs::create_dir_all(
-            std::path::Path::new(&generation_path)
-                .parent()
-                .expect("generation parent"),
-        )
-        .expect("generation directory");
-        std::fs::write(&generation_path, b"landed-stale").expect("generation marker");
-        let generation = dr::current_generation_mtime_ns(session);
-        let started_at = "2026-08-03T00:00:03Z";
-        let mut inflight =
-            inflight_with_identity_offset(channel_id, session, 702, started_at, Some(0));
-        inflight.set_relay_owner_kind(RelayOwnerKind::SessionBoundRelay);
-        inflight.current_msg_id = 88_004;
-        super::super::inflight::save_inflight_state(&inflight).expect("persist inflight");
-        let registry = Arc::new(HealthRegistry::new());
-        let shared = super::super::make_shared_data_for_tests();
-        registry
-            .register(ProviderKind::Claude.as_str().to_string(), shared.clone())
-            .await;
-        let gateway = Arc::new(RelayContractFakeGateway {
-            on_transport: Some(Arc::new(move || {
-                super::super::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
-            })),
-            ..RelayContractFakeGateway::edited(None)
-        });
-        let outcomes = Arc::new(Mutex::new(Vec::new()));
-        let mut sink = SessionBoundDiscordRelaySink::new(registry);
-        sink.test_gateway = Some(gateway);
-        sink.test_delivery_outcomes = Some(outcomes.clone());
-        let payload = concat!(
-            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
-            "{\"type\":\"result\",\"result\":\"answer\"}\n"
-        );
-        let mut terminal =
-            terminal_frame_offset(&binding, payload, 1, 256, 702, started_at, Some(0));
-        terminal.relay_generation_mtime_ns = Some(generation);
-
-        let outcome = sink
-            .deliver(&terminal)
-            .await
-            .expect("landed stale delivery");
-
-        assert_eq!(outcome, RelaySinkOutcome::TerminalDelivered);
-        assert_eq!(
-            outcomes.lock().expect("outcome probe").as_slice(),
-            &[SessionRelayDeliveryOutcome::LandedStale]
-        );
-        super::super::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
-    }
-
-    #[tokio::test]
-    async fn relay_deliver_observes_landed_unrecorded_proof() {
-        let temp = tempfile::tempdir().expect("temp runtime root");
-        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
-        let channel_id = 44_005;
-        let binding = matched(&channel_id.to_string());
-        let session = &binding.expected_session_name;
-        let generation_path =
-            crate::services::tmux_common::session_temp_path(session, "generation");
-        std::fs::create_dir_all(
-            std::path::Path::new(&generation_path)
-                .parent()
-                .expect("generation parent"),
-        )
-        .expect("generation directory");
-        std::fs::write(&generation_path, b"landed-unrecorded").expect("generation marker");
-        let generation = dr::current_generation_mtime_ns(session);
-        let started_at = "2026-08-03T00:00:04Z";
-        let mut inflight =
-            inflight_with_identity_offset(channel_id, session, 703, started_at, Some(0));
-        inflight.set_relay_owner_kind(RelayOwnerKind::SessionBoundRelay);
-        inflight.current_msg_id = 88_005;
-        super::super::inflight::save_inflight_state(&inflight).expect("persist inflight");
-        let runtime = temp.path().join("runtime");
-        std::fs::create_dir_all(&runtime).expect("runtime directory");
-        std::fs::write(runtime.join("discord_delivery_records"), b"not a directory")
-            .expect("block delivery record directory");
-        let registry = Arc::new(HealthRegistry::new());
-        let shared = super::super::make_shared_data_for_tests();
-        registry
-            .register(ProviderKind::Claude.as_str().to_string(), shared)
-            .await;
-        let gateway = Arc::new(RelayContractFakeGateway::edited(None));
-        let outcomes = Arc::new(Mutex::new(Vec::new()));
-        let mut sink = SessionBoundDiscordRelaySink::new(registry);
-        sink.test_gateway = Some(gateway);
-        sink.test_delivery_outcomes = Some(outcomes.clone());
-        let payload = concat!(
-            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
-            "{\"type\":\"result\",\"result\":\"answer\"}\n"
-        );
-        let mut terminal =
-            terminal_frame_offset(&binding, payload, 1, 256, 703, started_at, Some(0));
-        terminal.relay_generation_mtime_ns = Some(generation);
-
-        let outcome = sink
-            .deliver(&terminal)
-            .await
-            .expect("landed unrecorded delivery");
-
-        assert_eq!(outcome, RelaySinkOutcome::TerminalDelivered);
-        assert_eq!(
-            outcomes.lock().expect("outcome probe").as_slice(),
-            &[SessionRelayDeliveryOutcome::LandedUnrecorded]
-        );
-        super::super::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
-    }
-
-    #[tokio::test]
     async fn inflightless_ranged_frame_acquires_sink_lease_before_terminal_delivery_4277() {
         let channel_id = 4_277_003;
         let binding = matched(&channel_id.to_string());
@@ -3414,154 +3096,6 @@ mod tests {
         }
     }
 
-    struct RelayContractFakeGateway {
-        replace_outcome: ReplaceLongMessageOutcome,
-        replace_anchor: Option<super::super::formatting::ReplaceLastChunkAnchor>,
-        transport_error: Option<String>,
-        sent_message_id: MessageId,
-        replace_calls: AtomicU64,
-        send_calls: AtomicU64,
-        on_transport: Option<Arc<dyn Fn() + Send + Sync>>,
-    }
-
-    impl RelayContractFakeGateway {
-        fn edited(anchor: Option<(u64, &str)>) -> Self {
-            Self {
-                replace_outcome: ReplaceLongMessageOutcome::EditedOriginal,
-                replace_anchor: anchor.map(|(msg_id, text)| {
-                    super::super::formatting::ReplaceLastChunkAnchor {
-                        msg_id,
-                        text: text.to_string(),
-                    }
-                }),
-                transport_error: None,
-                sent_message_id: MessageId::new(91_001),
-                replace_calls: AtomicU64::new(0),
-                send_calls: AtomicU64::new(0),
-                on_transport: None,
-            }
-        }
-
-        fn failing(message: &str) -> Self {
-            let mut gateway = Self::edited(None);
-            gateway.transport_error = Some(message.to_string());
-            gateway
-        }
-    }
-
-    impl super::super::gateway::TurnGateway for RelayContractFakeGateway {
-        fn send_message<'a>(
-            &'a self,
-            _channel_id: ChannelId,
-            _content: &'a str,
-        ) -> super::super::gateway::GatewayFuture<'a, Result<MessageId, String>> {
-            Box::pin(async move {
-                self.send_calls.fetch_add(1, Ordering::AcqRel);
-                if let Some(on_transport) = &self.on_transport {
-                    on_transport();
-                }
-                match &self.transport_error {
-                    Some(error) => Err(error.clone()),
-                    None => Ok(self.sent_message_id),
-                }
-            })
-        }
-
-        fn edit_message<'a>(
-            &'a self,
-            _channel_id: ChannelId,
-            _message_id: MessageId,
-            _content: &'a str,
-        ) -> super::super::gateway::GatewayFuture<'a, Result<(), String>> {
-            panic!("relay contract fake does not use edit_message")
-        }
-
-        fn replace_message_with_outcome<'a>(
-            &'a self,
-            _channel_id: ChannelId,
-            _message_id: MessageId,
-            _content: &'a str,
-        ) -> super::super::gateway::GatewayFuture<'a, Result<ReplaceLongMessageOutcome, String>>
-        {
-            Box::pin(async move {
-                self.replace_calls.fetch_add(1, Ordering::AcqRel);
-                if let Some(on_transport) = &self.on_transport {
-                    on_transport();
-                }
-                match &self.transport_error {
-                    Some(error) => Err(error.clone()),
-                    None => Ok(self.replace_outcome.clone()),
-                }
-            })
-        }
-
-        fn replace_message_with_anchor<'a>(
-            &'a self,
-            _channel_id: ChannelId,
-            _message_id: MessageId,
-            _content: &'a str,
-        ) -> super::super::gateway::GatewayFuture<
-            'a,
-            Result<
-                (
-                    ReplaceLongMessageOutcome,
-                    Option<super::super::formatting::ReplaceLastChunkAnchor>,
-                ),
-                String,
-            >,
-        > {
-            Box::pin(async move {
-                self.replace_calls.fetch_add(1, Ordering::AcqRel);
-                if let Some(on_transport) = &self.on_transport {
-                    on_transport();
-                }
-                match &self.transport_error {
-                    Some(error) => Err(error.clone()),
-                    None => Ok((self.replace_outcome.clone(), self.replace_anchor.clone())),
-                }
-            })
-        }
-
-        fn schedule_retry_with_history<'a>(
-            &'a self,
-            _channel_id: ChannelId,
-            _user_message_id: MessageId,
-            _user_text: &'a str,
-        ) -> super::super::gateway::GatewayFuture<'a, ()> {
-            panic!("relay contract fake does not schedule retries")
-        }
-
-        fn dispatch_queued_turn<'a>(
-            &'a self,
-            _channel_id: ChannelId,
-            _intervention: &'a super::super::Intervention,
-            _output_path: &'a str,
-            _skip_hook: bool,
-            _dispatch_lease: Option<Arc<crate::services::turn_orchestrator::DispatchLease>>,
-        ) -> super::super::gateway::GatewayFuture<'a, Result<(), String>> {
-            panic!("relay contract fake does not dispatch turns")
-        }
-
-        fn validate_live_routing<'a>(
-            &'a self,
-            _channel_id: ChannelId,
-        ) -> super::super::gateway::GatewayFuture<'a, Result<(), String>> {
-            panic!("relay contract fake does not validate routing")
-        }
-
-        fn requester_mention(&self) -> Option<String> {
-            None
-        }
-
-        fn can_chain_locally(&self) -> bool {
-            false
-        }
-
-        fn bot_owner_provider(&self) -> Option<ProviderKind> {
-            None
-        }
-    }
-
     struct NoopHeartbeatGuard;
     impl toc::PostHeartbeatGuard for NoopHeartbeatGuard {}
     struct NoopHeartbeat;
@@ -3780,7 +3314,7 @@ mod tests {
             (start, end),
         );
         let outcome = rt
-            .block_on(sink.deliver_short_replace_via_controller(
+            .block_on(short_controller::deliver_short_replace_via_controller(
                 &gateway,
                 short_controller::SinkShortReplaceCtx {
                     shared: &shared,
@@ -3849,7 +3383,7 @@ mod tests {
             (start, end),
         );
         let outcome2 = rt
-            .block_on(sink2.deliver_short_replace_via_controller(
+            .block_on(short_controller::deliver_short_replace_via_controller(
                 &gateway2,
                 short_controller::SinkShortReplaceCtx {
                     shared: &shared2,
@@ -3986,7 +3520,7 @@ mod tests {
         };
         let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
         let outcome = rt
-            .block_on(sink.deliver_short_replace_via_controller(
+            .block_on(short_controller::deliver_short_replace_via_controller(
                 &gateway,
                 short_controller::SinkShortReplaceCtx {
                     shared: &shared,
@@ -4213,7 +3747,7 @@ mod tests {
         );
         assert!(
             module_src.contains(
-                "relay_text: &relay_text,\n                            delivered_fingerprint_body: &raw_response_text,"
+                "relay_text: &relay_text,\n                        delivered_fingerprint_body: &raw_response_text,"
             ),
             "session sink production cut-over call must thread the raw pre-format body into the fingerprint slot"
         );
@@ -4265,7 +3799,7 @@ mod tests {
         );
 
         let outcome = rt
-            .block_on(sink.deliver_short_replace_via_controller(
+            .block_on(short_controller::deliver_short_replace_via_controller(
                 &gateway,
                 short_controller::SinkShortReplaceCtx {
                     shared: &shared,
@@ -4439,7 +3973,7 @@ mod tests {
         inflight_with_identity_offset(channel_id, session_name, user_msg_id, started_at, None)
     }
 
-    fn inflight_with_identity_offset(
+    pub(super) fn inflight_with_identity_offset(
         channel_id: u64,
         session_name: &str,
         user_msg_id: u64,

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -512,6 +512,9 @@ pub(in crate::services::discord) struct SessionBoundDiscordRelaySink {
     by_session: Mutex<HashMap<String, SessionRelayParser>>,
     #[cfg(test)]
     lease_test_probe: Option<Arc<SinkLeaseTestProbe>>,
+    test_gateway: Option<Arc<dyn super::gateway::TurnGateway>>,
+    #[cfg(test)]
+    test_delivery_outcomes: Option<Arc<Mutex<Vec<SessionRelayDeliveryOutcome>>>>,
 }
 
 impl SessionBoundDiscordRelaySink {
@@ -523,6 +526,9 @@ impl SessionBoundDiscordRelaySink {
             by_session: Mutex::new(HashMap::new()),
             #[cfg(test)]
             lease_test_probe: None,
+            test_gateway: None,
+            #[cfg(test)]
+            test_delivery_outcomes: None,
         }
     }
 
@@ -772,6 +778,15 @@ impl SessionBoundDiscordRelaySink {
         &self,
         delivery: SessionRelayDelivery,
     ) -> Result<SessionRelayDeliveryOutcome, RelaySinkError> {
+        self.deliver_response_via_gateway(delivery, self.test_gateway.clone())
+            .await
+    }
+
+    async fn deliver_response_via_gateway(
+        &self,
+        delivery: SessionRelayDelivery,
+        injected_gateway: Option<Arc<dyn super::gateway::TurnGateway>>,
+    ) -> Result<SessionRelayDeliveryOutcome, RelaySinkError> {
         let channel_id = delivery.channel_id;
         let provider = delivery.provider.clone();
         let inflight = super::inflight::load_inflight_state(&provider, channel_id);
@@ -868,11 +883,13 @@ impl SessionBoundDiscordRelaySink {
         // route from PlaceholderEdit to NewMessage. Keep that entire operation on
         // the outer lease so both the card transport and the final answer remain
         // guarded even though the route mutates inside `ensure_card_and_route`.
+        let has_injected_gateway = injected_gateway.is_some();
         let cutover_short_replace = delivery.task_notification_context.is_none()
             && cutover_range.is_some()
             && !relay_text.is_empty()
             && matches!(route, SessionBoundTerminalDeliveryRoute::PlaceholderEdit(_))
-            && !session_bound_should_send_new_chunks_for_placeholder(&relay_text);
+            && !session_bound_should_send_new_chunks_for_placeholder(&relay_text)
+            && !has_injected_gateway;
         let (lease_range, lease_fallback_start) = sink_delivery_lease_coordinate(&delivery);
         let sink_lease_key = delivery_lease_key_for_frame(
             channel,
@@ -946,12 +963,26 @@ impl SessionBoundDiscordRelaySink {
             }
         }
 
-        let http = shared.serenity_http_or_token_fallback().ok_or_else(|| {
-            RelaySinkError::Transient(format!(
-                "discord http unavailable for provider {}",
-                provider.as_str()
-            ))
-        })?;
+        let http = shared.serenity_http_or_token_fallback();
+        let live_gateway;
+        let gateway: &dyn super::gateway::TurnGateway = match injected_gateway.as_deref() {
+            Some(gateway) => gateway,
+            None => {
+                let http = http.clone().ok_or_else(|| {
+                    RelaySinkError::Transient(format!(
+                        "discord http unavailable for provider {}",
+                        provider.as_str()
+                    ))
+                })?;
+                live_gateway = super::gateway::DiscordGateway::new(
+                    http,
+                    shared.clone(),
+                    provider.clone(),
+                    None,
+                );
+                &live_gateway
+            }
+        };
         let (route, task_card_message_id, task_response_claim_outcome) =
             ensure_card_and_route(&self.health_registry, &shared, &delivery, route).await?;
         let (task_response_claim, task_response_already_delivered): (
@@ -996,16 +1027,9 @@ impl SessionBoundDiscordRelaySink {
 
         if let SessionBoundTerminalDeliveryRoute::PlaceholderEdit(msg_id) = route {
             if let Some((start, end)) = cutover_range.filter(|_| cutover_short_replace) {
-                // Live path: the real `DiscordGateway` (the seam the ON-path test fakes).
-                let gateway = super::gateway::DiscordGateway::new(
-                    http.clone(),
-                    shared.clone(),
-                    provider.clone(),
-                    None,
-                );
                 return self
                     .deliver_short_replace_via_controller(
-                        &gateway,
+                        gateway,
                         short_controller::SinkShortReplaceCtx {
                             shared: &shared,
                             provider: &provider,
@@ -1025,16 +1049,11 @@ impl SessionBoundDiscordRelaySink {
                     .await;
             }
             if session_bound_should_send_new_chunks_for_placeholder(&relay_text) {
-                let message_ids = formatting::send_long_message_raw_with_rollback(
-                    &http,
-                    channel,
-                    msg_id,
-                    &relay_text,
-                    &shared,
-                )
-                .await
-                .map_err(|error| RelaySinkError::Transient(error.to_string()))?;
-                let _ = super::http::delete_channel_message(&http, channel, msg_id).await;
+                let message_ids = gateway
+                    .send_long_message_with_rollback(channel, msg_id, &relay_text)
+                    .await
+                    .map_err(RelaySinkError::Transient)?;
+                let _ = gateway.delete_message(channel, msg_id).await;
                 self.delivered_total.fetch_add(1, Ordering::AcqRel);
                 tracing::info!(
                     provider = provider.as_str(),
@@ -1072,18 +1091,11 @@ impl SessionBoundDiscordRelaySink {
                 );
                 return Ok(SessionRelayDeliveryOutcome::from_proof(proof));
             }
-            let mut last_chunk_anchor = None;
-            match formatting::replace_long_message_raw_with_outcome(
-                &http,
-                channel,
-                msg_id,
-                &relay_text,
-                &shared,
-                &mut last_chunk_anchor,
-            )
-            .await
+            match gateway
+                .replace_message_with_anchor(channel, msg_id, &relay_text)
+                .await
             {
-                Ok(ReplaceLongMessageOutcome::EditedOriginal) => {
+                Ok((ReplaceLongMessageOutcome::EditedOriginal, last_chunk_anchor)) => {
                     self.delivered_total.fetch_add(1, Ordering::AcqRel);
                     tracing::info!(
                         provider = provider.as_str(),
@@ -1127,10 +1139,13 @@ impl SessionBoundDiscordRelaySink {
                     );
                     Ok(SessionRelayDeliveryOutcome::from_proof(proof))
                 }
-                Ok(ReplaceLongMessageOutcome::SentFallbackAfterEditFailure {
-                    edit_error,
-                    replacement_anchor,
-                }) => {
+                Ok((
+                    ReplaceLongMessageOutcome::SentFallbackAfterEditFailure {
+                        edit_error,
+                        replacement_anchor,
+                    },
+                    _,
+                )) => {
                     // #2757 (A0 #3089): never delete msg_id — it is the bridge's
                     // current_msg_id, possibly holding streamed content a transient edit
                     // failure would vacuum. The shared policy pins this preserve decision.
@@ -1174,7 +1189,7 @@ impl SessionBoundDiscordRelaySink {
                     );
                     Ok(SessionRelayDeliveryOutcome::from_proof(proof))
                 }
-                Ok(ReplaceLongMessageOutcome::PartialContinuationFailure { error, .. }) => {
+                Ok((ReplaceLongMessageOutcome::PartialContinuationFailure { error, .. }, _)) => {
                     Err(RelaySinkError::Transient(
                         super::replace_outcome_policy::strip_watcher_send_failure_class_marker(
                             &error,
@@ -1194,7 +1209,7 @@ impl SessionBoundDiscordRelaySink {
             }
         } else {
             self.deliver_new_message_with_task_authority(
-                &http,
+                gateway,
                 &shared,
                 &provider,
                 channel_id,
@@ -2618,6 +2633,252 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fenced_terminal_without_parser_delivery_is_terminal_not_delivered() {
+        let binding = matched("44001");
+        let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
+        let terminal = terminal_frame_offset(
+            &binding,
+            "{\"type\":\"result\",\"result\":\"\"}\n",
+            1,
+            256,
+            0,
+            "2026-08-03T00:00:00Z",
+            Some(64),
+        );
+
+        let outcome = sink
+            .deliver(&terminal)
+            .await
+            .expect("a fenced terminal without parser delivery is known");
+
+        assert_eq!(outcome, RelaySinkOutcome::TerminalNotDelivered);
+    }
+
+    #[tokio::test]
+    async fn relay_deliver_propagates_injected_transport_error() {
+        let temp = tempfile::tempdir().expect("temp runtime root");
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
+        let channel_id = 44_002;
+        let binding = matched(&channel_id.to_string());
+        let session = &binding.expected_session_name;
+        let generation_path =
+            crate::services::tmux_common::session_temp_path(session, "generation");
+        std::fs::create_dir_all(
+            std::path::Path::new(&generation_path)
+                .parent()
+                .expect("generation parent"),
+        )
+        .expect("generation directory");
+        std::fs::write(&generation_path, b"transport-error").expect("generation marker");
+        let started_at = "2026-08-03T00:00:01Z";
+        let mut inflight =
+            inflight_with_identity_offset(channel_id, session, 700, started_at, Some(0));
+        inflight.set_relay_owner_kind(RelayOwnerKind::SessionBoundRelay);
+        inflight.current_msg_id = 88_002;
+        super::super::inflight::save_inflight_state(&inflight).expect("persist inflight");
+        let registry = Arc::new(HealthRegistry::new());
+        let shared = super::super::make_shared_data_for_tests();
+        registry
+            .register(ProviderKind::Claude.as_str().to_string(), shared)
+            .await;
+        let gateway = Arc::new(RelayContractFakeGateway::failing("fake transport failure"));
+        let mut sink = SessionBoundDiscordRelaySink::new(registry);
+        sink.test_gateway = Some(gateway.clone());
+        let payload = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
+            "{\"type\":\"result\",\"result\":\"answer\"}\n"
+        );
+        let terminal = terminal_frame_offset(&binding, payload, 1, 256, 700, started_at, Some(0));
+
+        let error = sink
+            .deliver(&terminal)
+            .await
+            .expect_err("transport failure must escape RelaySink::deliver");
+
+        assert!(matches!(error, RelaySinkError::Transient(_)), "{error:?}");
+        assert_eq!(gateway.replace_calls.load(Ordering::Acquire), 1);
+        super::super::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
+    }
+
+    #[tokio::test]
+    async fn relay_deliver_preserves_tail_anchor_and_observes_persisted_proof() {
+        let temp = tempfile::tempdir().expect("temp runtime root");
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
+        let channel_id = 44_003;
+        let binding = matched(&channel_id.to_string());
+        let session = &binding.expected_session_name;
+        let generation_path =
+            crate::services::tmux_common::session_temp_path(session, "generation");
+        std::fs::create_dir_all(
+            std::path::Path::new(&generation_path)
+                .parent()
+                .expect("generation parent"),
+        )
+        .expect("generation directory");
+        std::fs::write(&generation_path, b"persisted-proof").expect("generation marker");
+        let generation = dr::current_generation_mtime_ns(session);
+        let started_at = "2026-08-03T00:00:02Z";
+        let mut inflight =
+            inflight_with_identity_offset(channel_id, session, 701, started_at, Some(0));
+        inflight.set_relay_owner_kind(RelayOwnerKind::SessionBoundRelay);
+        inflight.current_msg_id = 88_003;
+        super::super::inflight::save_inflight_state(&inflight).expect("persist inflight");
+        let registry = Arc::new(HealthRegistry::new());
+        let shared = super::super::make_shared_data_for_tests();
+        registry
+            .register(ProviderKind::Claude.as_str().to_string(), shared.clone())
+            .await;
+        let gateway = Arc::new(RelayContractFakeGateway::edited(Some((
+            99_003,
+            "tail chunk",
+        ))));
+        let outcomes = Arc::new(Mutex::new(Vec::new()));
+        let mut sink = SessionBoundDiscordRelaySink::new(registry);
+        sink.test_gateway = Some(gateway.clone());
+        sink.test_delivery_outcomes = Some(outcomes.clone());
+        let payload = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
+            "{\"type\":\"result\",\"result\":\"answer\"}\n"
+        );
+        let mut terminal =
+            terminal_frame_offset(&binding, payload, 1, 256, 701, started_at, Some(0));
+        terminal.relay_generation_mtime_ns = Some(generation);
+
+        let outcome = sink.deliver(&terminal).await.expect("persisted delivery");
+
+        assert_eq!(outcome, RelaySinkOutcome::TerminalDelivered);
+        assert_eq!(
+            outcomes.lock().expect("outcome probe").as_slice(),
+            &[SessionRelayDeliveryOutcome::Delivered]
+        );
+        let record = dr::read_record(&ProviderKind::Claude, channel_id).expect("delivery record");
+        assert_eq!(
+            record.delivered_frontier.expect("frontier").panel_msg_id,
+            Some(99_003),
+            "legacy replace must retain the formatter tail anchor"
+        );
+        assert_eq!(gateway.replace_calls.load(Ordering::Acquire), 1);
+        super::super::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
+    }
+
+    #[tokio::test]
+    async fn relay_deliver_observes_landed_stale_proof() {
+        let temp = tempfile::tempdir().expect("temp runtime root");
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
+        let channel_id = 44_004;
+        let binding = matched(&channel_id.to_string());
+        let session = &binding.expected_session_name;
+        let generation_path =
+            crate::services::tmux_common::session_temp_path(session, "generation");
+        std::fs::create_dir_all(
+            std::path::Path::new(&generation_path)
+                .parent()
+                .expect("generation parent"),
+        )
+        .expect("generation directory");
+        std::fs::write(&generation_path, b"landed-stale").expect("generation marker");
+        let generation = dr::current_generation_mtime_ns(session);
+        let started_at = "2026-08-03T00:00:03Z";
+        let mut inflight =
+            inflight_with_identity_offset(channel_id, session, 702, started_at, Some(0));
+        inflight.set_relay_owner_kind(RelayOwnerKind::SessionBoundRelay);
+        inflight.current_msg_id = 88_004;
+        super::super::inflight::save_inflight_state(&inflight).expect("persist inflight");
+        let registry = Arc::new(HealthRegistry::new());
+        let shared = super::super::make_shared_data_for_tests();
+        registry
+            .register(ProviderKind::Claude.as_str().to_string(), shared.clone())
+            .await;
+        let gateway = Arc::new(RelayContractFakeGateway {
+            on_transport: Some(Arc::new(move || {
+                super::super::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
+            })),
+            ..RelayContractFakeGateway::edited(None)
+        });
+        let outcomes = Arc::new(Mutex::new(Vec::new()));
+        let mut sink = SessionBoundDiscordRelaySink::new(registry);
+        sink.test_gateway = Some(gateway);
+        sink.test_delivery_outcomes = Some(outcomes.clone());
+        let payload = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
+            "{\"type\":\"result\",\"result\":\"answer\"}\n"
+        );
+        let mut terminal =
+            terminal_frame_offset(&binding, payload, 1, 256, 702, started_at, Some(0));
+        terminal.relay_generation_mtime_ns = Some(generation);
+
+        let outcome = sink
+            .deliver(&terminal)
+            .await
+            .expect("landed stale delivery");
+
+        assert_eq!(outcome, RelaySinkOutcome::TerminalDelivered);
+        assert_eq!(
+            outcomes.lock().expect("outcome probe").as_slice(),
+            &[SessionRelayDeliveryOutcome::LandedStale]
+        );
+        super::super::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
+    }
+
+    #[tokio::test]
+    async fn relay_deliver_observes_landed_unrecorded_proof() {
+        let temp = tempfile::tempdir().expect("temp runtime root");
+        let _root = crate::config::set_agentdesk_root_for_test(temp.path());
+        let channel_id = 44_005;
+        let binding = matched(&channel_id.to_string());
+        let session = &binding.expected_session_name;
+        let generation_path =
+            crate::services::tmux_common::session_temp_path(session, "generation");
+        std::fs::create_dir_all(
+            std::path::Path::new(&generation_path)
+                .parent()
+                .expect("generation parent"),
+        )
+        .expect("generation directory");
+        std::fs::write(&generation_path, b"landed-unrecorded").expect("generation marker");
+        let generation = dr::current_generation_mtime_ns(session);
+        let started_at = "2026-08-03T00:00:04Z";
+        let mut inflight =
+            inflight_with_identity_offset(channel_id, session, 703, started_at, Some(0));
+        inflight.set_relay_owner_kind(RelayOwnerKind::SessionBoundRelay);
+        inflight.current_msg_id = 88_005;
+        super::super::inflight::save_inflight_state(&inflight).expect("persist inflight");
+        let runtime = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime).expect("runtime directory");
+        std::fs::write(runtime.join("discord_delivery_records"), b"not a directory")
+            .expect("block delivery record directory");
+        let registry = Arc::new(HealthRegistry::new());
+        let shared = super::super::make_shared_data_for_tests();
+        registry
+            .register(ProviderKind::Claude.as_str().to_string(), shared)
+            .await;
+        let gateway = Arc::new(RelayContractFakeGateway::edited(None));
+        let outcomes = Arc::new(Mutex::new(Vec::new()));
+        let mut sink = SessionBoundDiscordRelaySink::new(registry);
+        sink.test_gateway = Some(gateway);
+        sink.test_delivery_outcomes = Some(outcomes.clone());
+        let payload = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
+            "{\"type\":\"result\",\"result\":\"answer\"}\n"
+        );
+        let mut terminal =
+            terminal_frame_offset(&binding, payload, 1, 256, 703, started_at, Some(0));
+        terminal.relay_generation_mtime_ns = Some(generation);
+
+        let outcome = sink
+            .deliver(&terminal)
+            .await
+            .expect("landed unrecorded delivery");
+
+        assert_eq!(outcome, RelaySinkOutcome::TerminalDelivered);
+        assert_eq!(
+            outcomes.lock().expect("outcome probe").as_slice(),
+            &[SessionRelayDeliveryOutcome::LandedUnrecorded]
+        );
+        super::super::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
+    }
+
+    #[tokio::test]
     async fn inflightless_ranged_frame_acquires_sink_lease_before_terminal_delivery_4277() {
         let channel_id = 4_277_003;
         let binding = matched(&channel_id.to_string());
@@ -3148,6 +3409,154 @@ mod tests {
         fn can_chain_locally(&self) -> bool {
             false
         }
+        fn bot_owner_provider(&self) -> Option<ProviderKind> {
+            None
+        }
+    }
+
+    struct RelayContractFakeGateway {
+        replace_outcome: ReplaceLongMessageOutcome,
+        replace_anchor: Option<super::super::formatting::ReplaceLastChunkAnchor>,
+        transport_error: Option<String>,
+        sent_message_id: MessageId,
+        replace_calls: AtomicU64,
+        send_calls: AtomicU64,
+        on_transport: Option<Arc<dyn Fn() + Send + Sync>>,
+    }
+
+    impl RelayContractFakeGateway {
+        fn edited(anchor: Option<(u64, &str)>) -> Self {
+            Self {
+                replace_outcome: ReplaceLongMessageOutcome::EditedOriginal,
+                replace_anchor: anchor.map(|(msg_id, text)| {
+                    super::super::formatting::ReplaceLastChunkAnchor {
+                        msg_id,
+                        text: text.to_string(),
+                    }
+                }),
+                transport_error: None,
+                sent_message_id: MessageId::new(91_001),
+                replace_calls: AtomicU64::new(0),
+                send_calls: AtomicU64::new(0),
+                on_transport: None,
+            }
+        }
+
+        fn failing(message: &str) -> Self {
+            let mut gateway = Self::edited(None);
+            gateway.transport_error = Some(message.to_string());
+            gateway
+        }
+    }
+
+    impl super::super::gateway::TurnGateway for RelayContractFakeGateway {
+        fn send_message<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _content: &'a str,
+        ) -> super::super::gateway::GatewayFuture<'a, Result<MessageId, String>> {
+            Box::pin(async move {
+                self.send_calls.fetch_add(1, Ordering::AcqRel);
+                if let Some(on_transport) = &self.on_transport {
+                    on_transport();
+                }
+                match &self.transport_error {
+                    Some(error) => Err(error.clone()),
+                    None => Ok(self.sent_message_id),
+                }
+            })
+        }
+
+        fn edit_message<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _message_id: MessageId,
+            _content: &'a str,
+        ) -> super::super::gateway::GatewayFuture<'a, Result<(), String>> {
+            panic!("relay contract fake does not use edit_message")
+        }
+
+        fn replace_message_with_outcome<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _message_id: MessageId,
+            _content: &'a str,
+        ) -> super::super::gateway::GatewayFuture<'a, Result<ReplaceLongMessageOutcome, String>>
+        {
+            Box::pin(async move {
+                self.replace_calls.fetch_add(1, Ordering::AcqRel);
+                if let Some(on_transport) = &self.on_transport {
+                    on_transport();
+                }
+                match &self.transport_error {
+                    Some(error) => Err(error.clone()),
+                    None => Ok(self.replace_outcome.clone()),
+                }
+            })
+        }
+
+        fn replace_message_with_anchor<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _message_id: MessageId,
+            _content: &'a str,
+        ) -> super::super::gateway::GatewayFuture<
+            'a,
+            Result<
+                (
+                    ReplaceLongMessageOutcome,
+                    Option<super::super::formatting::ReplaceLastChunkAnchor>,
+                ),
+                String,
+            >,
+        > {
+            Box::pin(async move {
+                self.replace_calls.fetch_add(1, Ordering::AcqRel);
+                if let Some(on_transport) = &self.on_transport {
+                    on_transport();
+                }
+                match &self.transport_error {
+                    Some(error) => Err(error.clone()),
+                    None => Ok((self.replace_outcome.clone(), self.replace_anchor.clone())),
+                }
+            })
+        }
+
+        fn schedule_retry_with_history<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _user_message_id: MessageId,
+            _user_text: &'a str,
+        ) -> super::super::gateway::GatewayFuture<'a, ()> {
+            panic!("relay contract fake does not schedule retries")
+        }
+
+        fn dispatch_queued_turn<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _intervention: &'a super::super::Intervention,
+            _output_path: &'a str,
+            _skip_hook: bool,
+            _dispatch_lease: Option<Arc<crate::services::turn_orchestrator::DispatchLease>>,
+        ) -> super::super::gateway::GatewayFuture<'a, Result<(), String>> {
+            panic!("relay contract fake does not dispatch turns")
+        }
+
+        fn validate_live_routing<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+        ) -> super::super::gateway::GatewayFuture<'a, Result<(), String>> {
+            panic!("relay contract fake does not validate routing")
+        }
+
+        fn requester_mention(&self) -> Option<String> {
+            None
+        }
+
+        fn can_chain_locally(&self) -> bool {
+            false
+        }
+
         fn bot_owner_provider(&self) -> Option<ProviderKind> {
             None
         }

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -515,6 +515,12 @@ pub(in crate::services::discord) struct SessionBoundDiscordRelaySink {
     lease_test_probe: Option<Arc<SinkLeaseTestProbe>>,
     #[cfg(test)]
     test_gateway: Option<Arc<dyn super::gateway::TurnGateway>>,
+    #[cfg(test)]
+    test_replace_anchor: Option<formatting::ReplaceLastChunkAnchor>,
+    #[cfg(test)]
+    test_delivery_outcomes: Option<Arc<Mutex<Vec<SessionRelayDeliveryOutcome>>>>,
+    #[cfg(test)]
+    test_force_legacy_replace: bool,
 }
 
 impl SessionBoundDiscordRelaySink {
@@ -528,6 +534,12 @@ impl SessionBoundDiscordRelaySink {
             lease_test_probe: None,
             #[cfg(test)]
             test_gateway: None,
+            #[cfg(test)]
+            test_replace_anchor: None,
+            #[cfg(test)]
+            test_delivery_outcomes: None,
+            #[cfg(test)]
+            test_force_legacy_replace: false,
         }
     }
 
@@ -792,7 +804,17 @@ impl SessionBoundDiscordRelaySink {
             && cutover_range.is_some()
             && !relay_text.is_empty()
             && matches!(route, SessionBoundTerminalDeliveryRoute::PlaceholderEdit(_))
-            && !session_bound_should_send_new_chunks_for_placeholder(&relay_text);
+            && !session_bound_should_send_new_chunks_for_placeholder(&relay_text)
+            && {
+                #[cfg(test)]
+                {
+                    !self.test_force_legacy_replace
+                }
+                #[cfg(not(test))]
+                {
+                    true
+                }
+            };
         let (lease_range, lease_fallback_start) = sink_delivery_lease_coordinate(&delivery);
         let sink_lease_key = delivery_lease_key_for_frame(
             channel,
@@ -1005,6 +1027,9 @@ impl SessionBoundDiscordRelaySink {
                 );
                 return Ok(SessionRelayDeliveryOutcome::from_proof(proof));
             }
+            #[cfg(test)]
+            let mut last_chunk_anchor = self.test_replace_anchor.clone();
+            #[cfg(not(test))]
             let mut last_chunk_anchor = None;
             let replace_outcome = if let Some(gateway) = gateway {
                 gateway

--- a/src/services/discord/session_relay_sink/delivery_commit.rs
+++ b/src/services/discord/session_relay_sink/delivery_commit.rs
@@ -1,0 +1,80 @@
+use super::{SessionBoundDiscordRelaySink, SessionRelayDelivery};
+use crate::services::provider::ProviderKind;
+use serenity::model::id::ChannelId;
+
+impl SessionBoundDiscordRelaySink {
+    pub(super) fn advance_offset_for_confirmed_delegated_terminal(
+        &self,
+        shared: &crate::services::discord::SharedData,
+        provider: &ProviderKind,
+        channel_id: u64,
+        session_name: &str,
+        delivery: &SessionRelayDelivery,
+        inflight: Option<&crate::services::discord::inflight::InflightTurnState>,
+    ) -> bool {
+        let Some(end) = delivery.terminal_consumed_end.filter(|end| *end > 0) else {
+            return false;
+        };
+        // IDENTITY GATE: the frame's pinned turn identity must still match the
+        // channel's current inflight. A delayed frame from an already-replaced
+        // turn (or a cleared inflight) is ignored — never advances a wrong turn.
+        let Some(inflight) = inflight else {
+            tracing::debug!(
+                provider = provider.as_str(),
+                channel_id,
+                tmux_session = %session_name,
+                frame_user_msg_id = delivery.frame_turn_user_msg_id,
+                "session-bound sink: terminal frame carried a commit fence but inflight is gone; identity gate blocks advance"
+            );
+            return false;
+        };
+        // #3041 P1-3 (codex P1-3 issue 2 R4): STRICT `turn_start_offset` identity — a
+        // REQUIRED gate part with NO None fallback (two `user_msg_id == 0` turns in the same
+        // second collide on the weak `(user_msg_id, started_at)` pair). A fenced frame is
+        // GUARANTEED a real offset by the producer, so `None`/mismatch is a stale/wrong-turn
+        // frame → MUST NOT advance (the watcher's SendFull delivers — no black-hole).
+        let identity_matches = inflight.user_msg_id == delivery.frame_turn_user_msg_id
+            && inflight.started_at == delivery.frame_turn_started_at
+            && delivery.frame_turn_start_offset.is_some()
+            && inflight.turn_start_offset == delivery.frame_turn_start_offset;
+        if !identity_matches {
+            tracing::debug!(
+                provider = provider.as_str(),
+                channel_id,
+                tmux_session = %session_name,
+                frame_user_msg_id = delivery.frame_turn_user_msg_id,
+                inflight_user_msg_id = inflight.user_msg_id,
+                frame_turn_start_offset = delivery.frame_turn_start_offset,
+                inflight_turn_start_offset = inflight.turn_start_offset,
+                "session-bound sink: terminal frame identity != current inflight; identity gate blocks advance (delayed/wrong-turn frame)"
+            );
+            return false;
+        }
+        crate::services::discord::tmux::advance_watcher_confirmed_end(
+            shared,
+            provider,
+            ChannelId::new(channel_id),
+            session_name,
+            end,
+            "src/services/discord/session_relay_sink.rs:sink_confirmed_terminal_advance",
+        );
+        // #3976: stamp the durable per-row delivered marker ONLY here — past the
+        // identity gate, after the `confirmed_end_offset` watermark advance fired
+        // (so a refused/identity-mismatched advance, which returned above, never
+        // marks the row). The watermark is resettable and writes nothing else to
+        // the row, so without this durable marker a delivered-but-unmirrored row is
+        // indistinguishable from a never-delivered black-hole and orphan-reclaim
+        // would re-emit its tail on a watermark reset. The flock RMW re-gates the
+        // identity under the lock, so a turn replaced during the POST is never
+        // marked. Best-effort: a residual crash between the POST and this write
+        // reverts the row to orphan shape on reboot (same at-most-once residual the
+        // #3918 marker bounds) — acceptable and no worse than today.
+        crate::services::discord::inflight::mark_session_bound_relay_delivered_locked(
+            provider,
+            channel_id,
+            &crate::services::discord::inflight::InflightTurnIdentity::from_state(inflight),
+            session_name,
+        );
+        true
+    }
+}

--- a/src/services/discord/session_relay_sink/delivery_orchestration_tests.rs
+++ b/src/services/discord/session_relay_sink/delivery_orchestration_tests.rs
@@ -2,6 +2,7 @@ use super::tests::{inflight_with_identity_offset, matched, terminal_frame_offset
 use super::*;
 use crate::services::discord::inflight::RelayOwnerKind;
 
+// Kills M6: removing the fenced-terminal disjunct must lose this terminal outcome.
 #[tokio::test]
 async fn fenced_terminal_without_parser_delivery_is_terminal_not_delivered() {
     let binding = matched("44001");
@@ -24,6 +25,7 @@ async fn fenced_terminal_without_parser_delivery_is_terminal_not_delivered() {
     assert_eq!(outcome, RelaySinkOutcome::TerminalNotDelivered);
 }
 
+// Kills M8: transport errors must escape instead of folding into NotDelivered.
 #[tokio::test]
 async fn relay_deliver_propagates_injected_transport_error() {
     let temp = tempfile::tempdir().expect("temp runtime root");
@@ -68,6 +70,7 @@ async fn relay_deliver_propagates_injected_transport_error() {
     crate::services::discord::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
 }
 
+// Kills M10 and anchor-drop: persisted proof stays Delivered and records the tail anchor.
 #[tokio::test]
 async fn relay_deliver_preserves_tail_anchor_and_observes_persisted_proof() {
     let temp = tempfile::tempdir().expect("temp runtime root");
@@ -95,8 +98,15 @@ async fn relay_deliver_preserves_tail_anchor_and_observes_persisted_proof() {
         .register(ProviderKind::Claude.as_str().to_string(), shared.clone())
         .await;
     let gateway = Arc::new(RelayContractFakeGateway::edited());
+    let outcomes = Arc::new(Mutex::new(Vec::new()));
     let mut sink = SessionBoundDiscordRelaySink::new(registry);
     sink.test_gateway = Some(gateway.clone());
+    sink.test_replace_anchor = Some(formatting::ReplaceLastChunkAnchor {
+        msg_id: 99_003,
+        text: "tail chunk".to_string(),
+    });
+    sink.test_delivery_outcomes = Some(outcomes.clone());
+    sink.test_force_legacy_replace = true;
     let payload = concat!(
         "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
         "{\"type\":\"result\",\"result\":\"answer\"}\n"
@@ -107,16 +117,22 @@ async fn relay_deliver_preserves_tail_anchor_and_observes_persisted_proof() {
     let outcome = sink.deliver(&terminal).await.expect("persisted delivery");
 
     assert_eq!(outcome, RelaySinkOutcome::TerminalDelivered);
+    assert_eq!(
+        outcomes.lock().expect("outcome probe").as_slice(),
+        &[SessionRelayDeliveryOutcome::Delivered],
+        "M10: persisted proof must remain a typed Delivered outcome"
+    );
     let record = dr::read_record(&ProviderKind::Claude, channel_id).expect("delivery record");
     assert_eq!(
         record.delivered_frontier.expect("frontier").panel_msg_id,
-        Some(88_003),
-        "single-chunk legacy replace must retain its edited placeholder anchor"
+        Some(99_003),
+        "anchor-drop: legacy replace must retain the formatter tail anchor"
     );
     assert_eq!(gateway.replace_calls.load(Ordering::Acquire), 1);
     crate::services::discord::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
 }
 
+// Kills M11: stale proof must remain distinguishable from Delivered before public folding.
 #[tokio::test]
 async fn relay_deliver_observes_landed_stale_proof() {
     let temp = tempfile::tempdir().expect("temp runtime root");
@@ -152,8 +168,10 @@ async fn relay_deliver_observes_landed_stale_proof() {
         })),
         ..RelayContractFakeGateway::edited()
     });
+    let outcomes = Arc::new(Mutex::new(Vec::new()));
     let mut sink = SessionBoundDiscordRelaySink::new(registry);
     sink.test_gateway = Some(gateway);
+    sink.test_delivery_outcomes = Some(outcomes.clone());
     let payload = concat!(
         "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
         "{\"type\":\"result\",\"result\":\"answer\"}\n"
@@ -167,6 +185,11 @@ async fn relay_deliver_observes_landed_stale_proof() {
         .expect("landed stale delivery");
 
     assert_eq!(outcome, RelaySinkOutcome::TerminalDelivered);
+    assert_eq!(
+        outcomes.lock().expect("outcome probe").as_slice(),
+        &[SessionRelayDeliveryOutcome::LandedStale],
+        "M11: stale proof must remain a typed LandedStale outcome"
+    );
     assert!(
         dr::read_record(&ProviderKind::Claude, channel_id)
             .and_then(|record| record.delivered_frontier)

--- a/src/services/discord/session_relay_sink/delivery_orchestration_tests.rs
+++ b/src/services/discord/session_relay_sink/delivery_orchestration_tests.rs
@@ -1,0 +1,342 @@
+use super::tests::{inflight_with_identity_offset, matched, terminal_frame_offset};
+use super::*;
+use crate::services::discord::inflight::RelayOwnerKind;
+
+#[tokio::test]
+async fn fenced_terminal_without_parser_delivery_is_terminal_not_delivered() {
+    let binding = matched("44001");
+    let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
+    let terminal = terminal_frame_offset(
+        &binding,
+        "{\"type\":\"result\",\"result\":\"\"}\n",
+        1,
+        256,
+        0,
+        "2026-08-03T00:00:00Z",
+        Some(64),
+    );
+
+    let outcome = sink
+        .deliver(&terminal)
+        .await
+        .expect("a fenced terminal without parser delivery is known");
+
+    assert_eq!(outcome, RelaySinkOutcome::TerminalNotDelivered);
+}
+
+#[tokio::test]
+async fn relay_deliver_propagates_injected_transport_error() {
+    let temp = tempfile::tempdir().expect("temp runtime root");
+    let _root = crate::config::set_agentdesk_root_for_test(temp.path());
+    let channel_id = 44_002;
+    let binding = matched(&channel_id.to_string());
+    let session = &binding.expected_session_name;
+    let generation_path = crate::services::tmux_common::session_temp_path(session, "generation");
+    std::fs::create_dir_all(
+        std::path::Path::new(&generation_path)
+            .parent()
+            .expect("generation parent"),
+    )
+    .expect("generation directory");
+    std::fs::write(&generation_path, b"transport-error").expect("generation marker");
+    let started_at = "2026-08-03T00:00:01Z";
+    let mut inflight = inflight_with_identity_offset(channel_id, session, 700, started_at, Some(0));
+    inflight.set_relay_owner_kind(RelayOwnerKind::SessionBoundRelay);
+    inflight.current_msg_id = 88_002;
+    crate::services::discord::inflight::save_inflight_state(&inflight).expect("persist inflight");
+    let registry = Arc::new(HealthRegistry::new());
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    registry
+        .register(ProviderKind::Claude.as_str().to_string(), shared)
+        .await;
+    let gateway = Arc::new(RelayContractFakeGateway::failing("fake transport failure"));
+    let mut sink = SessionBoundDiscordRelaySink::new(registry);
+    sink.test_gateway = Some(gateway.clone());
+    let payload = concat!(
+        "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
+        "{\"type\":\"result\",\"result\":\"answer\"}\n"
+    );
+    let terminal = terminal_frame_offset(&binding, payload, 1, 256, 700, started_at, Some(0));
+
+    let error = sink
+        .deliver(&terminal)
+        .await
+        .expect_err("transport failure must escape RelaySink::deliver");
+
+    assert!(matches!(error, RelaySinkError::Transient(_)), "{error:?}");
+    assert_eq!(gateway.replace_calls.load(Ordering::Acquire), 1);
+    crate::services::discord::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
+}
+
+#[tokio::test]
+async fn relay_deliver_preserves_tail_anchor_and_observes_persisted_proof() {
+    let temp = tempfile::tempdir().expect("temp runtime root");
+    let _root = crate::config::set_agentdesk_root_for_test(temp.path());
+    let channel_id = 44_003;
+    let binding = matched(&channel_id.to_string());
+    let session = &binding.expected_session_name;
+    let generation_path = crate::services::tmux_common::session_temp_path(session, "generation");
+    std::fs::create_dir_all(
+        std::path::Path::new(&generation_path)
+            .parent()
+            .expect("generation parent"),
+    )
+    .expect("generation directory");
+    std::fs::write(&generation_path, b"persisted-proof").expect("generation marker");
+    let generation = dr::current_generation_mtime_ns(session);
+    let started_at = "2026-08-03T00:00:02Z";
+    let mut inflight = inflight_with_identity_offset(channel_id, session, 701, started_at, Some(0));
+    inflight.set_relay_owner_kind(RelayOwnerKind::SessionBoundRelay);
+    inflight.current_msg_id = 88_003;
+    crate::services::discord::inflight::save_inflight_state(&inflight).expect("persist inflight");
+    let registry = Arc::new(HealthRegistry::new());
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    registry
+        .register(ProviderKind::Claude.as_str().to_string(), shared.clone())
+        .await;
+    let gateway = Arc::new(RelayContractFakeGateway::edited());
+    let mut sink = SessionBoundDiscordRelaySink::new(registry);
+    sink.test_gateway = Some(gateway.clone());
+    let payload = concat!(
+        "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
+        "{\"type\":\"result\",\"result\":\"answer\"}\n"
+    );
+    let mut terminal = terminal_frame_offset(&binding, payload, 1, 256, 701, started_at, Some(0));
+    terminal.relay_generation_mtime_ns = Some(generation);
+
+    let outcome = sink.deliver(&terminal).await.expect("persisted delivery");
+
+    assert_eq!(outcome, RelaySinkOutcome::TerminalDelivered);
+    let record = dr::read_record(&ProviderKind::Claude, channel_id).expect("delivery record");
+    assert_eq!(
+        record.delivered_frontier.expect("frontier").panel_msg_id,
+        Some(88_003),
+        "single-chunk legacy replace must retain its edited placeholder anchor"
+    );
+    assert_eq!(gateway.replace_calls.load(Ordering::Acquire), 1);
+    crate::services::discord::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
+}
+
+#[tokio::test]
+async fn relay_deliver_observes_landed_stale_proof() {
+    let temp = tempfile::tempdir().expect("temp runtime root");
+    let _root = crate::config::set_agentdesk_root_for_test(temp.path());
+    let channel_id = 44_004;
+    let binding = matched(&channel_id.to_string());
+    let session = &binding.expected_session_name;
+    let generation_path = crate::services::tmux_common::session_temp_path(session, "generation");
+    std::fs::create_dir_all(
+        std::path::Path::new(&generation_path)
+            .parent()
+            .expect("generation parent"),
+    )
+    .expect("generation directory");
+    std::fs::write(&generation_path, b"landed-stale").expect("generation marker");
+    let generation = dr::current_generation_mtime_ns(session);
+    let started_at = "2026-08-03T00:00:03Z";
+    let mut inflight = inflight_with_identity_offset(channel_id, session, 702, started_at, Some(0));
+    inflight.set_relay_owner_kind(RelayOwnerKind::SessionBoundRelay);
+    inflight.current_msg_id = 88_004;
+    crate::services::discord::inflight::save_inflight_state(&inflight).expect("persist inflight");
+    let registry = Arc::new(HealthRegistry::new());
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    registry
+        .register(ProviderKind::Claude.as_str().to_string(), shared.clone())
+        .await;
+    let gateway = Arc::new(RelayContractFakeGateway {
+        on_transport: Some(Arc::new(move || {
+            crate::services::discord::inflight::clear_inflight_state(
+                &ProviderKind::Claude,
+                channel_id,
+            );
+        })),
+        ..RelayContractFakeGateway::edited()
+    });
+    let mut sink = SessionBoundDiscordRelaySink::new(registry);
+    sink.test_gateway = Some(gateway);
+    let payload = concat!(
+        "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
+        "{\"type\":\"result\",\"result\":\"answer\"}\n"
+    );
+    let mut terminal = terminal_frame_offset(&binding, payload, 1, 256, 702, started_at, Some(0));
+    terminal.relay_generation_mtime_ns = Some(generation);
+
+    let outcome = sink
+        .deliver(&terminal)
+        .await
+        .expect("landed stale delivery");
+
+    assert_eq!(outcome, RelaySinkOutcome::TerminalDelivered);
+    assert!(
+        dr::read_record(&ProviderKind::Claude, channel_id)
+            .and_then(|record| record.delivered_frontier)
+            .is_none(),
+        "stale source authority must not persist a delivered frontier"
+    );
+    crate::services::discord::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
+}
+
+#[tokio::test]
+async fn relay_deliver_observes_landed_unrecorded_proof() {
+    let temp = tempfile::tempdir().expect("temp runtime root");
+    let _root = crate::config::set_agentdesk_root_for_test(temp.path());
+    let channel_id = 44_005;
+    let binding = matched(&channel_id.to_string());
+    let session = &binding.expected_session_name;
+    let generation_path = crate::services::tmux_common::session_temp_path(session, "generation");
+    std::fs::create_dir_all(
+        std::path::Path::new(&generation_path)
+            .parent()
+            .expect("generation parent"),
+    )
+    .expect("generation directory");
+    std::fs::write(&generation_path, b"landed-unrecorded").expect("generation marker");
+    let generation = dr::current_generation_mtime_ns(session);
+    let started_at = "2026-08-03T00:00:04Z";
+    let mut inflight = inflight_with_identity_offset(channel_id, session, 703, started_at, Some(0));
+    inflight.set_relay_owner_kind(RelayOwnerKind::SessionBoundRelay);
+    inflight.current_msg_id = 88_005;
+    crate::services::discord::inflight::save_inflight_state(&inflight).expect("persist inflight");
+    let runtime = temp.path().join("runtime");
+    std::fs::create_dir_all(&runtime).expect("runtime directory");
+    std::fs::write(runtime.join("discord_delivery_records"), b"not a directory")
+        .expect("block delivery record directory");
+    let registry = Arc::new(HealthRegistry::new());
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    registry
+        .register(ProviderKind::Claude.as_str().to_string(), shared)
+        .await;
+    let gateway = Arc::new(RelayContractFakeGateway::edited());
+    let mut sink = SessionBoundDiscordRelaySink::new(registry);
+    sink.test_gateway = Some(gateway);
+    let payload = concat!(
+        "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer\"}]}}\n",
+        "{\"type\":\"result\",\"result\":\"answer\"}\n"
+    );
+    let mut terminal = terminal_frame_offset(&binding, payload, 1, 256, 703, started_at, Some(0));
+    terminal.relay_generation_mtime_ns = Some(generation);
+
+    let outcome = sink
+        .deliver(&terminal)
+        .await
+        .expect("landed unrecorded delivery");
+
+    assert_eq!(outcome, RelaySinkOutcome::TerminalDelivered);
+    crate::services::discord::inflight::clear_inflight_state(&ProviderKind::Claude, channel_id);
+}
+
+struct RelayContractFakeGateway {
+    replace_outcome: ReplaceLongMessageOutcome,
+    transport_error: Option<String>,
+    sent_message_id: MessageId,
+    replace_calls: AtomicU64,
+    send_calls: AtomicU64,
+    on_transport: Option<Arc<dyn Fn() + Send + Sync>>,
+}
+
+impl RelayContractFakeGateway {
+    fn edited() -> Self {
+        Self {
+            replace_outcome: ReplaceLongMessageOutcome::EditedOriginal,
+            transport_error: None,
+            sent_message_id: MessageId::new(91_001),
+            replace_calls: AtomicU64::new(0),
+            send_calls: AtomicU64::new(0),
+            on_transport: None,
+        }
+    }
+
+    fn failing(message: &str) -> Self {
+        let mut gateway = Self::edited();
+        gateway.transport_error = Some(message.to_string());
+        gateway
+    }
+}
+
+impl crate::services::discord::gateway::TurnGateway for RelayContractFakeGateway {
+    fn send_message<'a>(
+        &'a self,
+        _channel_id: ChannelId,
+        _content: &'a str,
+    ) -> crate::services::discord::gateway::GatewayFuture<'a, Result<MessageId, String>> {
+        Box::pin(async move {
+            self.send_calls.fetch_add(1, Ordering::AcqRel);
+            if let Some(on_transport) = &self.on_transport {
+                on_transport();
+            }
+            match &self.transport_error {
+                Some(error) => Err(error.clone()),
+                None => Ok(self.sent_message_id),
+            }
+        })
+    }
+
+    fn edit_message<'a>(
+        &'a self,
+        _channel_id: ChannelId,
+        _message_id: MessageId,
+        _content: &'a str,
+    ) -> crate::services::discord::gateway::GatewayFuture<'a, Result<(), String>> {
+        panic!("relay contract fake does not use edit_message")
+    }
+
+    fn replace_message_with_outcome<'a>(
+        &'a self,
+        _channel_id: ChannelId,
+        _message_id: MessageId,
+        _content: &'a str,
+    ) -> crate::services::discord::gateway::GatewayFuture<
+        'a,
+        Result<ReplaceLongMessageOutcome, String>,
+    > {
+        Box::pin(async move {
+            self.replace_calls.fetch_add(1, Ordering::AcqRel);
+            if let Some(on_transport) = &self.on_transport {
+                on_transport();
+            }
+            match &self.transport_error {
+                Some(error) => Err(error.clone()),
+                None => Ok(self.replace_outcome.clone()),
+            }
+        })
+    }
+
+    fn schedule_retry_with_history<'a>(
+        &'a self,
+        _channel_id: ChannelId,
+        _user_message_id: MessageId,
+        _user_text: &'a str,
+    ) -> crate::services::discord::gateway::GatewayFuture<'a, ()> {
+        panic!("relay contract fake does not schedule retries")
+    }
+
+    fn dispatch_queued_turn<'a>(
+        &'a self,
+        _channel_id: ChannelId,
+        _intervention: &'a crate::services::discord::Intervention,
+        _output_path: &'a str,
+        _skip_hook: bool,
+        _dispatch_lease: Option<Arc<crate::services::turn_orchestrator::DispatchLease>>,
+    ) -> crate::services::discord::gateway::GatewayFuture<'a, Result<(), String>> {
+        panic!("relay contract fake does not dispatch turns")
+    }
+
+    fn validate_live_routing<'a>(
+        &'a self,
+        _channel_id: ChannelId,
+    ) -> crate::services::discord::gateway::GatewayFuture<'a, Result<(), String>> {
+        panic!("relay contract fake does not validate routing")
+    }
+
+    fn requester_mention(&self) -> Option<String> {
+        None
+    }
+
+    fn can_chain_locally(&self) -> bool {
+        false
+    }
+
+    fn bot_owner_provider(&self) -> Option<ProviderKind> {
+        None
+    }
+}

--- a/src/services/discord/session_relay_sink/delivery_orchestration_tests.rs
+++ b/src/services/discord/session_relay_sink/delivery_orchestration_tests.rs
@@ -135,6 +135,13 @@ async fn relay_deliver_preserves_tail_anchor_and_observes_persisted_proof() {
 // Kills M11: stale proof must remain distinguishable from Delivered before public folding.
 #[tokio::test]
 async fn relay_deliver_observes_landed_stale_proof() {
+    assert_eq!(
+        SessionRelayDeliveryOutcome::from_proof(
+            delivery_frontier::SinkDeliveryProofResult::LandedStale,
+        ),
+        SessionRelayDeliveryOutcome::LandedStale,
+        "M11: stale proof must map to the typed LandedStale outcome"
+    );
     let temp = tempfile::tempdir().expect("temp runtime root");
     let _root = crate::config::set_agentdesk_root_for_test(temp.path());
     let channel_id = 44_004;

--- a/src/services/discord/session_relay_sink/task_notification_context.rs
+++ b/src/services/discord/session_relay_sink/task_notification_context.rs
@@ -304,7 +304,7 @@ pub(super) async fn commit_response_fence(
 impl super::SessionBoundDiscordRelaySink {
     pub(super) async fn deliver_new_message_with_task_authority(
         &self,
-        http: &Arc<serenity::http::Http>,
+        gateway: &dyn super::super::gateway::TurnGateway,
         shared: &Arc<SharedData>,
         provider: &ProviderKind,
         channel_id: u64,
@@ -358,11 +358,6 @@ impl super::SessionBoundDiscordRelaySink {
                     "task-card response omitted its exact delivery claim".to_string(),
                 ));
             }
-            let response_transport =
-                super::super::task_notification_delivery::DiscordResponseChunkTransport::new(
-                    http.as_ref(),
-                    shared,
-                );
             let context = delivery.task_notification_context.as_ref().ok_or_else(|| {
                 RelaySinkError::Permanent(
                     "missing task context prevents exact missing-card repair".to_string(),
@@ -391,6 +386,17 @@ impl super::SessionBoundDiscordRelaySink {
                     ),
             );
             let card_transport = DiscordTaskCardTransport::new(shared.clone());
+            let http = shared.serenity_http_or_token_fallback().ok_or_else(|| {
+                RelaySinkError::Transient(format!(
+                    "discord http unavailable for provider {}",
+                    provider.as_str()
+                ))
+            })?;
+            let response_transport =
+                super::super::task_notification_delivery::DiscordResponseChunkTransport::new(
+                    http.as_ref(),
+                    shared,
+                );
             let (_messages, rebound) = super::super::task_notification_delivery::send_task_response_chunks_with_card_repair(
                 shared.pg_pool.as_ref(),
                 &clients,
@@ -417,16 +423,10 @@ impl super::SessionBoundDiscordRelaySink {
             .map_err(RelaySinkError::Transient)?;
             response_heartbeat = Some(heartbeat);
         } else {
-            let message_ids =
-                super::super::formatting::send_long_message_raw_with_reference_returning_message_ids(
-                    http,
-                    channel,
-                    relay_text,
-                    shared,
-                    prompt_anchor_reference,
-                )
+            let message_ids = gateway
+                .send_long_message_with_reference(channel, relay_text, prompt_anchor_reference)
                 .await
-                .map_err(|error| RelaySinkError::Transient(error.to_string()))?;
+                .map_err(RelaySinkError::Transient)?;
             plain_body_anchor_msg_id = message_ids.last().map(|message_id| message_id.get());
             plain_body_posted = true;
         }
@@ -492,9 +492,7 @@ impl super::SessionBoundDiscordRelaySink {
             );
             None
         };
-        if let Some(proof) = plain_body_proof
-            && proof != super::delivery_frontier::SinkDeliveryProofResult::Persisted
-        {
+        if let Some(proof) = plain_body_proof {
             // The plain-body arm and the task-card arm are mutually exclusive, so
             // no task-response heartbeat can be running here; the bounded final
             // delivery CAS below belongs to the card path only.

--- a/src/services/discord/session_relay_sink/task_notification_context.rs
+++ b/src/services/discord/session_relay_sink/task_notification_context.rs
@@ -302,9 +302,30 @@ pub(super) async fn commit_response_fence(
 
 #[allow(clippy::too_many_arguments)]
 impl super::SessionBoundDiscordRelaySink {
+    async fn send_plain_response_chunks(
+        &self,
+        shared: &Arc<SharedData>,
+        provider: &ProviderKind,
+        channel: ChannelId,
+        relay_text: &str,
+        reference: Option<(ChannelId, MessageId)>,
+    ) -> Result<Vec<MessageId>, RelaySinkError> {
+        let http = shared.serenity_http_or_token_fallback().ok_or_else(|| {
+            RelaySinkError::Transient(format!(
+                "discord http unavailable for provider {}",
+                provider.as_str()
+            ))
+        })?;
+        super::super::formatting::send_long_message_raw_with_reference_returning_message_ids(
+            &http, channel, relay_text, shared, reference,
+        )
+        .await
+        .map_err(|error| RelaySinkError::Transient(error.to_string()))
+    }
+
     pub(super) async fn deliver_new_message_with_task_authority(
         &self,
-        gateway: &dyn super::super::gateway::TurnGateway,
+        _gateway: Option<&dyn super::super::gateway::TurnGateway>,
         shared: &Arc<SharedData>,
         provider: &ProviderKind,
         channel_id: u64,
@@ -423,10 +444,38 @@ impl super::SessionBoundDiscordRelaySink {
             .map_err(RelaySinkError::Transient)?;
             response_heartbeat = Some(heartbeat);
         } else {
-            let message_ids = gateway
-                .send_long_message_with_reference(channel, relay_text, prompt_anchor_reference)
-                .await
-                .map_err(RelaySinkError::Transient)?;
+            #[cfg(test)]
+            let message_ids = if let Some(gateway) = _gateway {
+                gateway
+                    .send_long_message_with_rollback(
+                        channel,
+                        prompt_anchor_reference
+                            .map(|(_, message_id)| message_id)
+                            .unwrap_or_else(|| MessageId::new(1)),
+                        relay_text,
+                    )
+                    .await
+                    .map_err(RelaySinkError::Transient)?
+            } else {
+                self.send_plain_response_chunks(
+                    shared,
+                    provider,
+                    channel,
+                    relay_text,
+                    prompt_anchor_reference,
+                )
+                .await?
+            };
+            #[cfg(not(test))]
+            let message_ids = self
+                .send_plain_response_chunks(
+                    shared,
+                    provider,
+                    channel,
+                    relay_text,
+                    prompt_anchor_reference,
+                )
+                .await?;
             plain_body_anchor_msg_id = message_ids.last().map(|message_id| message_id.get());
             plain_body_posted = true;
         }

--- a/src/services/discord/session_relay_sink/terminal_handoff.rs
+++ b/src/services/discord/session_relay_sink/terminal_handoff.rs
@@ -54,7 +54,17 @@ impl RelaySink for SessionBoundDiscordRelaySink {
         let mut terminal_fresh_delivered = None;
         let mut terminal_not_delivered = false;
         for delivery in deliveries {
-            match self.deliver_response(delivery).await {
+            let delivery_outcome = self.deliver_response(delivery).await;
+            #[cfg(test)]
+            if let (Ok(outcome), Some(outcomes)) =
+                (delivery_outcome.as_ref(), &self.test_delivery_outcomes)
+            {
+                outcomes
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner())
+                    .push(*outcome);
+            }
+            match delivery_outcome {
                 Ok(SessionRelayDeliveryOutcome::Delivered) => {
                     // #3041 P1-3 (B1 CLOSED): the offset advance is owned INLINE by
                     // `deliver_response` — see `advance_after_confirmed_post`.

--- a/src/services/discord/session_relay_sink/terminal_handoff.rs
+++ b/src/services/discord/session_relay_sink/terminal_handoff.rs
@@ -54,17 +54,7 @@ impl RelaySink for SessionBoundDiscordRelaySink {
         let mut terminal_fresh_delivered = None;
         let mut terminal_not_delivered = false;
         for delivery in deliveries {
-            let delivery_outcome = self.deliver_response(delivery).await;
-            #[cfg(test)]
-            if let (Ok(outcome), Some(outcomes)) =
-                (delivery_outcome.as_ref(), &self.test_delivery_outcomes)
-            {
-                outcomes
-                    .lock()
-                    .unwrap_or_else(|error| error.into_inner())
-                    .push(*outcome);
-            }
-            match delivery_outcome {
+            match self.deliver_response(delivery).await {
                 Ok(SessionRelayDeliveryOutcome::Delivered) => {
                     // #3041 P1-3 (B1 CLOSED): the offset advance is owned INLINE by
                     // `deliver_response` — see `advance_after_confirmed_post`.

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -29,6 +29,7 @@ EXPECTED_TEST_NON_PG_COMMANDS = (
     "cargo test --lib source_registry -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib task_notification -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib delivery_lease_key -- --skip _pg --skip pg_ --skip postgres",
+    "cargo test --lib services::discord::session_relay_sink::delivery_orchestration_tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib services::discord::e2e_control::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib server::routes::e2e_control::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib formatting -- --skip _pg --skip pg_ --skip postgres",


### PR DESCRIPTION
Part 1 of 2 for #5071 T0 condition 3. This PR lands only the **test seam**; the mutation gate that consumes it follows in part 2.

### Why a seam first

Condition 3 requires hand-written mutations of the relay delivery path that a named test actually kills. The delivery logic was not observable at a granularity a mutation could target, so the mutations had nothing to bite. This PR extracts the delivery orchestration into an addressable seam and adds observers, without changing runtime behaviour.

### What is in here

- `session_relay_sink.rs` split so delivery commit and orchestration are separately addressable (`delivery_commit.rs`, `delivery_orchestration_tests.rs`).
- Observers restored for stale-proof and tail-anchor outcomes, and the stale-proof mapping targeted directly.
- `task_notification_context.rs` / `terminal_handoff.rs` adjusted to expose the outcome boundary the mutations need.

### Measured

- `TEST_LANE_BASELINE_REF=origin/main bash scripts/ci-script-checks.sh` (foreground): **rc=0**
- `scripts/check-ci-runner-hardening.sh`: **rc=0**
- `git diff --check`: rc=0; working tree clean.
- Independently confirmed green at this exact head by an adversarial reviewer, and the identity diff against part 2's aggregate log differs only in timing plus one added suite (`tests.test_relay_authority_mutations`, which part 2 introduces): 29 vs 30 `Ran`, zero `FAILED`/`ERROR` on either side.
- The condition-3 fail-closed interlock is satisfied at this head: `scripts/run_relay_authority_mutations.sh` does not exist yet and `condition3_mutations_present` is still `false`, so the flag and the script land together in part 2 rather than one arriving alone.

### Size

11 files, +650/−171 = **821 changed lines**, which is 21 over the 800-line soft cap.

The lane was split at the only boundary whose intermediate state is independently green. The remaining bulk is a single move-heavy extraction (+582/−662 in one commit, where the deletions are the moved-out originals); splitting inside it would create an artificial boundary and a tree nobody reviewed. Per the campaign rule that correctness and proof outrank the cap, the overage is stated rather than absorbed by dropping tests or assertions.
