### PR TITLE
feat(doctor): expose actionable degraded-reason evidence

### DIFF
--- a/src/cli/doctor/health.rs
+++ b/src/cli/doctor/health.rs
@@ -14,6 +14,19 @@ pub(crate) struct ClassifiedReason {
     pub(crate) next_step: String,
 }
 
+impl ClassifiedReason {
+    fn evidence(&self) -> Value {
+        json!({
+            "raw": self.raw,
+            "subsystem": self.subsystem,
+            "severity": self.severity.as_str(),
+            "fix_safety": self.fix_safety.as_str(),
+            "summary": self.summary,
+            "next_step": self.next_step,
+        })
+    }
+}
+
 fn startup_doctor_report_next_step() -> String {
     format!("inspect the startup doctor report via {LATEST_STARTUP_DOCTOR_ENDPOINT}")
 }
@@ -270,14 +283,7 @@ pub(crate) fn reasons_evidence(reasons: &[ClassifiedReason]) -> Value {
     json!({
         "degraded_reasons": reasons
             .iter()
-            .map(|reason| {
-                json!({
-                    "raw": reason.raw,
-                    "subsystem": reason.subsystem,
-                    "severity": reason.severity.as_str(),
-                    "next_step": reason.next_step,
-                })
-            })
+            .map(ClassifiedReason::evidence)
             .collect::<Vec<_>>()
     })
 }
@@ -288,8 +294,10 @@ pub(crate) fn is_loopback_base_url(base: &str) -> bool {
 
 #[cfg(test)]
 mod health_classification_tests {
+    use serde_json::json;
+
     use super::super::contract::{FixSafety, Severity};
-    use super::{LATEST_STARTUP_DOCTOR_ENDPOINT, classify_degraded_reason};
+    use super::{LATEST_STARTUP_DOCTOR_ENDPOINT, classify_degraded_reason, reasons_evidence};
 
     #[test]
     fn startup_doctor_reasons_point_to_latest_report_endpoint() {
@@ -382,6 +390,25 @@ mod health_classification_tests {
         assert_eq!(
             reason.next_step,
             "inspect global active counter tracking in dcserver logs"
+        );
+    }
+
+    #[test]
+    fn reasons_evidence_preserves_actionable_reason_contract() {
+        let reason = classify_degraded_reason("db_unavailable");
+
+        assert_eq!(
+            reasons_evidence(&[reason]),
+            json!({
+                "degraded_reasons": [{
+                    "raw": "db_unavailable",
+                    "subsystem": "postgres",
+                    "severity": "error",
+                    "fix_safety": "not_fixable",
+                    "summary": "database is unavailable",
+                    "next_step": "check Postgres/SQLite availability and server logs",
+                }]
+            })
         );
     }
 }


### PR DESCRIPTION
## 목표

Doctor의 degraded reason JSON에 이미 계산된 실행 가능한 설명과 복구 안전도 정보를 보존해, 운영자가 원인을 다시 해석하지 않고 바로 조치할 수 있게 합니다.

## 쉬운 설명

기존 Doctor는 “무슨 상태가 나쁜지”는 알려줬지만, 내부에서 만든 요약과 안전한 복구 방법을 JSON 응답 직전에 버렸습니다. 이 PR은 그 정보를 기존 응답을 깨뜨리지 않는 추가 필드로 노출합니다.

## 개선되는 것

### Fix 1 — reason 증거 직렬화를 한곳으로 응집

- reason별 `summary`와 `fix_safety` 직렬화를 `ClassifiedReason` 계약에 모았습니다.
- Doctor 호출부가 같은 확장 지점을 사용하므로 reason이 늘어도 출력 규칙이 흩어지지 않습니다.

### Fix 2 — 기존 JSON 호환성을 유지한 증거 확장

- 기존 key와 값은 그대로 두고 degraded reason 증거에 필드만 추가합니다.
- 분류 의미와 복구 실행 동작은 변경하지 않습니다.

### Fix 3 — 실제 분류기 기반 계약 테스트

- `db_unavailable` 분류 결과를 사용해 최종 JSON에 실행 가능한 설명과 안전도 정보가 포함되는지 검증합니다.

## Before → After

| 항목 | Before | After |
|---|---|---|
| degraded reason JSON | 분류 식별 정보만 제공 | `summary`와 `fix_safety`까지 제공 |
| 직렬화 책임 | 호출부에서 정보가 소실됨 | `ClassifiedReason`이 일관되게 증거 생성 |
| 소비자 호환성 | 기존 계약 | 기존 필드 유지 + additive 필드 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| 기존 필드만 읽는 클라이언트 | 기존 key/value가 유지됨 | 호환성 유지 |
| 새로운 reason 추가 | 공통 증거 계약을 통해 직렬화 | 확장 지점 단일화 |
| 복구 명령 실행 | 실행 경로는 변경하지 않음 | 진단 출력만 개선 |

## 해결한 내용

- `src/cli/doctor/health.rs`: reason 증거 생성 책임을 응집하고 additive JSON 필드를 추가했습니다.
- 동일 파일의 health classification 테스트에서 실제 `db_unavailable` 계약을 고정했습니다.
- 열린 upstream PR을 재확인했으며 동일 필드를 다루는 중복 PR은 없습니다.

## 검증

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --lib cli::doctor::health::health_classification_tests -- --test-threads=1` — 6/6 성공
- [x] `cargo check --lib` — 종료 코드 0, 저장소 기존 경고만 존재
- [x] `git diff --check upstream/main...HEAD`
- [x] GitHub Actions — 15/15 성공, 충돌 없음(`MERGEABLE / CLEAN`)
- [x] UI/API 동작 변경 없음 — Doctor JSON의 additive evidence만 변경