### PR TITLE
fix(policy): batch long-turn KV cleanup

### DIFF
--- a/docs/generated/policy-db-inventory.md
+++ b/docs/generated/policy-db-inventory.md
@@ -33,8 +33,8 @@ Measured on branch head with the command above (excludes `policies/__tests__/`):
 
 | op | count |
 |---|---|
-| `agentdesk.db.query` (read) | 120 |
-| `agentdesk.db.execute` (mutation) | 46 |
+| `agentdesk.db.query` (read) | 122 |
+| `agentdesk.db.execute` (mutation) | 44 |
 | **total** | **166** |
 
 These 166 callsites are spread across 29 policy files under `policies/`. One
@@ -52,6 +52,9 @@ migration debt total.
   moved 18 raw-DB callsites (7 reads, 11 mutations) behind
   `agentdesk.timeouts.*` and `agentdesk.kv.*`. Its adjacent capability
   manifest now sets `db.raw_sql.mode: forbidden`.
+- **Long-turn cleanup slice**: `policies/timeouts/long-turn-monitor.js` batches
+  stale tier and watchdog-extension exact-key deletes through
+  `agentdesk.kv.deleteMany`, removing two scalar raw-DB mutation callsites.
 - **Capability-manifest first rollout**: `policies/review-automation.js` and
   `policies/merge-automation.js` still have adjacent `*.cap.yaml` manifests in
   `db.raw_sql.mode: legacy` with pinned `no_silent_growth` baselines.

--- a/docs/policy-typed-facade.md
+++ b/docs/policy-typed-facade.md
@@ -38,7 +38,8 @@ Current typed facade entrypoints:
 | `agentdesk.timeouts` | `cleanupDeadlockCountersForInactiveSessions()` | Deletes `deadlock_check:*` markers whose sessions are no longer active. |
 | `agentdesk.timeouts` | `cleanupDeadlockHistoryBefore(cutoff_ms)` | Deletes old `deadlock_history:*` markers by timestamp suffix. |
 | `agentdesk.dispatch` | `create(...)` | Existing typed command, retained as-is. |
-| `agentdesk.kv` | `get/set/delete(...)` | Existing typed KV facade, preferred over `kv_meta` SQL. |
+| `agentdesk.kv` | `get/set/delete(...)` | Typed exact-key KV facade, preferred over `kv_meta` SQL. |
+| `agentdesk.kv` | `deleteMany(keys)` | Deletes exact keys with one PostgreSQL `TEXT[]` bind and returns `{ ok, deleted }`. |
 
 ## Return Shape Conventions
 
@@ -62,7 +63,7 @@ Other scalar columns keep the same shape as `query`; the difference is limited t
 - Prefer `agentdesk.cards.assign(...)` and `agentdesk.cards.setPriority(...)` over direct `UPDATE kanban_cards`.
 - Prefer `agentdesk.review.entryContext(...)` and `agentdesk.review.recordEntry(...)` for review round planning over ad hoc `task_dispatches`/`kanban_cards.review_round` SQL.
 - Prefer `agentdesk.timeouts.*` for active-monitor stale-session scans, session idle transitions, deadlock cleanup, dispatch-type lookups, and termination audits.
-- Prefer `agentdesk.kv.*` over `kv_meta` SQL.
+- Prefer `agentdesk.kv.*` over `kv_meta` SQL; use `deleteMany(keys)` for exact-key batches instead of scalar delete loops.
 - Keep `agentdesk.db.*` for gaps, debugging, or transitional policy code only.
 
 ## First Migration Slice

--- a/justfile
+++ b/justfile
@@ -28,6 +28,8 @@ test-active-usage-4631:
 # Stage 1 keeps the existing CI-safe subset. The broad non-PG sweep currently
 # fails legacy/full integration route tests; see docs/ci/rust-quality-gates.md.
 test-non-pg:
+    # Typed KV bulk deletion must keep its array-bound payload contract covered.
+    cargo test --lib engine::ops::kv_ops::tests -- --skip _pg --skip pg_ --skip postgres
     # #4878: keep the generated queue docs on the canonical thread-group contract.
     cargo test --lib server::routes::docs::inventory::endpoints::part_0 -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib services::task_completion_v1::tests -- --skip _pg --skip pg_ --skip postgres

--- a/policies/__tests__/support/harness.js
+++ b/policies/__tests__/support/harness.js
@@ -161,7 +161,8 @@ function createAgentdeskMock(options) {
     escalations: [],
     manualInterventions: [],
     flushedEscalations: 0,
-    kv: new Map()
+    kv: new Map(),
+    kvDeleteManyCalls: []
   };
 
   const dbQuery = settings.dbQuery || (() => []);
@@ -430,6 +431,21 @@ function createAgentdeskMock(options) {
       },
       delete(key) {
         state.kv.delete(key);
+      },
+      deleteMany(keys) {
+        if (!Array.isArray(keys)) {
+          throw new TypeError("kv.deleteMany expects an array of keys");
+        }
+        if (keys.some((key) => typeof key !== "string")) {
+          throw new TypeError("kv.deleteMany expects every key to be a string");
+        }
+        const copiedKeys = clone(keys);
+        state.kvDeleteManyCalls.push(copiedKeys);
+        let deleted = 0;
+        for (const key of copiedKeys) {
+          if (state.kv.delete(key)) deleted += 1;
+        }
+        return { ok: true, deleted };
       }
     },
     autoQueue: {

--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -1053,6 +1053,69 @@ test("timeouts long turn monitor module skips synthetic reattach placeholders", 
   assert.equal(bulkAlertDeletes.length, 1);
 });
 
+test("timeouts long turn monitor batches stale KV cleanup through the typed facade", () => {
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    inflights: [
+      {
+        provider: "codex",
+        channel_id: "active-channel:thread",
+        started_at: null
+      }
+    ],
+    dbQuery: createSqlRouter([
+      {
+        match: "SELECT key FROM kv_meta WHERE key LIKE 'long_turn_tier:%'",
+        result: [
+          { key: "long_turn_tier:codex:active-channel:thread" },
+          { key: "long_turn_tier:codex:stale-channel-1" },
+          { key: "long_turn_tier:claude:stale-channel-2" }
+        ]
+      },
+      {
+        match: "SELECT key FROM kv_meta WHERE key LIKE 'long_turn_watchdog_extension:%'",
+        result: [
+          { key: "long_turn_watchdog_extension:codex:active-channel:thread" },
+          { key: "long_turn_watchdog_extension:codex:stale-channel-1" }
+        ]
+      }
+    ])
+  });
+  const keys = [
+    "long_turn_tier:codex:active-channel:thread",
+    "long_turn_tier:codex:stale-channel-1",
+    "long_turn_tier:claude:stale-channel-2",
+    "long_turn_watchdog_extension:codex:active-channel:thread",
+    "long_turn_watchdog_extension:codex:stale-channel-1"
+  ];
+  for (const key of keys) state.kv.set(key, "present");
+
+  policy._section_L();
+
+  assert.deepEqual(state.kvDeleteManyCalls, [
+    [
+      "long_turn_tier:codex:stale-channel-1",
+      "long_turn_tier:claude:stale-channel-2"
+    ],
+    ["long_turn_watchdog_extension:codex:stale-channel-1"]
+  ]);
+  assert.equal(
+    state.kv.has("long_turn_tier:codex:active-channel:thread"),
+    true
+  );
+  assert.equal(
+    state.kv.has("long_turn_watchdog_extension:codex:active-channel:thread"),
+    true
+  );
+  assert.equal(state.kv.has("long_turn_tier:codex:stale-channel-1"), false);
+  assert.equal(state.kv.has("long_turn_tier:claude:stale-channel-2"), false);
+  assert.equal(state.kv.has("long_turn_watchdog_extension:codex:stale-channel-1"), false);
+  assert.equal(
+    state.executions.some((execution) => /WHERE key = \?/.test(execution.sql)),
+    false,
+    "policy cleanup must not bypass the typed KV facade with scalar deletes"
+  );
+});
+
 test("timeouts long turn monitor module skips repeated 30-minute threshold", () => {
   const { policy, state } = loadPolicy("policies/timeouts.js", {
     inflights: [

--- a/policies/timeouts/long-turn-monitor.js
+++ b/policies/timeouts/long-turn-monitor.js
@@ -1,3 +1,13 @@
+function inactiveInflightKvKeys(rows, prefix, activeInflightSet) {
+  var keys = [];
+  for (var index = 0; index < rows.length; index++) {
+    var key = rows[index] && rows[index].key;
+    if (typeof key !== "string" || key.indexOf(prefix) !== 0) continue;
+    if (!activeInflightSet[key.slice(prefix.length)]) keys.push(key);
+  }
+  return keys;
+}
+
 module.exports = function attachLongTurnMonitor(timeouts, helpers) {
   var sendDeadlockAlert = helpers.sendDeadlockAlert;
   var MAX_DISPATCH_RETRIES = helpers.MAX_DISPATCH_RETRIES;
@@ -154,7 +164,7 @@ module.exports = function attachLongTurnMonitor(timeouts, helpers) {
           agentdesk.log.warn("[long-turn] " + (inf.channel_name || inf.channel_id) + " — " + Math.round(elapsedMin) + "min (" + currentThreshold + "min threshold)");
         }
         // Pre-compute active inflight keys for O(1) lookups
-        var activeInflightSet = {};
+        var activeInflightSet = Object.create(null);
         for (var si = 0; si < inflights.length; si++) {
           if (inflights[si].provider && inflights[si].channel_id) {
             activeInflightSet[inflights[si].provider + ":" + inflights[si].channel_id] = true;
@@ -163,25 +173,21 @@ module.exports = function attachLongTurnMonitor(timeouts, helpers) {
 
         // Clean up tier keys for inflights that no longer exist
         var tierKeys = agentdesk.db.query("SELECT key FROM kv_meta WHERE key LIKE 'long_turn_tier:%'");
-        for (var tk = 0; tk < tierKeys.length; tk++) {
-          var parts = tierKeys[tk].key.split(":");
-          var tkProvider = parts[1];
-          var tkChannel = parts[2];
-          if (!activeInflightSet[tkProvider + ":" + tkChannel]) {
-            agentdesk.db.execute("DELETE FROM kv_meta WHERE key = ?", [tierKeys[tk].key]);
-          }
+        var tierKeysToDelete = inactiveInflightKvKeys(tierKeys, "long_turn_tier:", activeInflightSet);
+        if (tierKeysToDelete.length > 0) {
+          agentdesk.kv.deleteMany(tierKeysToDelete);
         }
         // Also clean up old cooldown keys
         agentdesk.db.execute("DELETE FROM kv_meta WHERE key LIKE 'long_turn_alert:%'");
 
         var extensionKeys = agentdesk.db.query("SELECT key FROM kv_meta WHERE key LIKE 'long_turn_watchdog_extension:%'");
-        for (var ek = 0; ek < extensionKeys.length; ek++) {
-          var eParts = extensionKeys[ek].key.split(":");
-          var eProvider = eParts[1];
-          var eChannel = eParts[2];
-          if (!activeInflightSet[eProvider + ":" + eChannel]) {
-            agentdesk.db.execute("DELETE FROM kv_meta WHERE key = ?", [extensionKeys[ek].key]);
-          }
+        var extensionKeysToDelete = inactiveInflightKvKeys(
+          extensionKeys,
+          "long_turn_watchdog_extension:",
+          activeInflightSet
+        );
+        if (extensionKeysToDelete.length > 0) {
+          agentdesk.kv.deleteMany(extensionKeysToDelete);
         }
       } catch(de) {
         agentdesk.log.warn("[long-turn] inflight scan error: " + de);

--- a/src/engine/ops/kv_ops.rs
+++ b/src/engine/ops/kv_ops.rs
@@ -6,6 +6,7 @@ use sqlx::PgPool;
 // agentdesk.kv.set(key, value, ttlSeconds) — set with optional TTL
 // agentdesk.kv.get(key) → value or null (filters expired)
 // agentdesk.kv.delete(key) — delete a key
+// agentdesk.kv.deleteMany(keys) — delete exact keys with one array-bound query
 
 pub(super) fn register_kv_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
@@ -50,6 +51,19 @@ pub(super) fn register_kv_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>) -> J
         })?,
     )?;
 
+    // PostgreSQL receives one TEXT[] bind parameter, so the number of keys
+    // cannot exhaust the scalar bind-parameter limit.
+    let pg_delete_many = pg_pool.clone();
+    kv_obj.set(
+        "__deleteManyRaw",
+        Function::new(ctx.clone(), move |keys_json: String| -> String {
+            if let Some(pool) = pg_delete_many.as_ref() {
+                return kv_delete_many_raw_pg(pool, &keys_json);
+            }
+            r#"{"error":"postgres backend is required for kv.deleteMany"}"#.to_string()
+        })?,
+    )?;
+
     ad.set("kv", kv_obj)?;
 
     // JS wrappers for optional TTL and null semantics
@@ -62,6 +76,14 @@ pub(super) fn register_kv_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>) -> J
             agentdesk.kv.get = function(key) {
                 var r = JSON.parse(agentdesk.kv.__getRaw(key));
                 return r.found ? r.value : null;
+            };
+            agentdesk.kv.deleteMany = function(keys) {
+                if (!Array.isArray(keys)) {
+                    throw new TypeError("kv.deleteMany expects an array of keys");
+                }
+                var r = JSON.parse(agentdesk.kv.__deleteManyRaw(JSON.stringify(keys)));
+                if (r.error) throw new Error(r.error);
+                return r;
             };
         })();
     "#,
@@ -198,5 +220,62 @@ fn kv_delete_raw_pg(pool: &PgPool, key: &str) -> String {
     ) {
         Ok(result) => result,
         Err(raw) => crate::engine::ops::ensure_js_error_json(raw),
+    }
+}
+
+fn parse_delete_many_keys(keys_json: &str) -> Result<Vec<String>, String> {
+    serde_json::from_str(keys_json)
+        .map_err(|error| format!("invalid keys for kv.deleteMany: {error}"))
+}
+
+fn kv_delete_many_raw_pg(pool: &PgPool, keys_json: &str) -> String {
+    let keys = match parse_delete_many_keys(keys_json) {
+        Ok(keys) => keys,
+        Err(error) => return serde_json::json!({ "error": error }).to_string(),
+    };
+    if keys.is_empty() {
+        return r#"{"ok":true,"deleted":0}"#.to_string();
+    }
+
+    match crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        move |bridge_pool| async move {
+            let deleted = sqlx::query("DELETE FROM kv_meta WHERE key = ANY($1)")
+                .bind(&keys)
+                .execute(&bridge_pool)
+                .await
+                .map_err(|error| format!("bulk delete postgres kv_meta keys: {error}"))?
+                .rows_affected();
+            Ok(serde_json::json!({ "ok": true, "deleted": deleted }).to_string())
+        },
+        |error| serde_json::json!({ "error": error }).to_string(),
+    ) {
+        Ok(result) => result,
+        Err(raw) => crate::engine::ops::ensure_js_error_json(raw),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_delete_many_keys;
+
+    #[test]
+    fn delete_many_payload_is_not_limited_by_scalar_bind_count() {
+        let keys: Vec<String> = (0..65_536)
+            .map(|index| format!("long_turn_tier:codex:channel-{index}"))
+            .collect();
+        let payload = serde_json::to_string(&keys).expect("serialize delete-many keys");
+
+        let parsed = parse_delete_many_keys(&payload).expect("parse delete-many keys");
+
+        assert_eq!(parsed, keys);
+    }
+
+    #[test]
+    fn delete_many_payload_rejects_non_string_keys() {
+        let error = parse_delete_many_keys(r#"["valid",42]"#)
+            .expect_err("non-string keys must be rejected");
+
+        assert!(error.contains("invalid keys for kv.deleteMany"));
     }
 }

--- a/tests/test_fast_check_ci_wiring.py
+++ b/tests/test_fast_check_ci_wiring.py
@@ -24,6 +24,7 @@ BUSY_RETRY_4888_TEST_COMMAND = (
 # update this test deliberately. The duplication is a drift-prevention gate, not an
 # attempt to derive the expected coverage from the justfile under test.
 EXPECTED_TEST_NON_PG_COMMANDS = (
+    "cargo test --lib engine::ops::kv_ops::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib server::routes::docs::inventory::endpoints::part_0 -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib services::task_completion_v1::tests -- --skip _pg --skip pg_ --skip postgres",
     "cargo test --lib source_registry -- --skip _pg --skip pg_ --skip postgres",


### PR DESCRIPTION
## 목표

long-turn stale KV 정리의 키별 SQL 반복을 재사용 가능한 typed batch API로 대체해, round trip과 부분 적용 위험을 줄이고 정책 코드에서 raw DB 의존을 제거합니다.

## 쉬운 설명

삭제할 키가 많을 때 하나씩 데이터베이스에 요청하던 작업을 배열 한 번으로 처리합니다. 정책은 SQL을 직접 알 필요 없이 `agentdesk.kv.deleteMany(keys)`만 호출합니다.

## 개선되는 것

### Fix 1 — 재사용 가능한 typed KV batch 삭제

- `agentdesk.kv.deleteMany(string[])` facade를 추가했습니다.
- PostgreSQL `TEXT[]` bind 한 번으로 정확한 key 집합을 삭제하고 실제 삭제 행 수를 반환합니다.
- 빈 배열은 no-op이며 문자열이 아닌 key는 경계에서 거부합니다.

### Fix 2 — long-turn 정책의 scalar 삭제 루프 제거

- tier와 watchdog extension의 stale key 선별을 공통 pure selector로 분리했습니다.
- 식별자를 `:`로 재분해하지 않아 colon이 포함된 ID도 안전하며 기존 정리 순서를 보존합니다.

### Fix 3 — 테스트·harness·문서 계약 확장

- 65,536개 key payload, 잘못된 타입, stale key 선택과 호출 순서를 검증합니다.
- policy harness와 curated non-PG lane, typed facade 문서 및 DB inventory를 함께 갱신했습니다.

## Before → After

| 항목 | Before | After |
|---|---|---|
| N개 key 삭제 | raw SQL 최대 N회 | typed facade + batch SQL 1회 |
| 정책과 DB 결합 | 정책이 scalar DB 호출을 반복 | 정책은 facade만 사용 |
| 실패 경계 | 앞 key가 먼저 삭제될 수 있음 | 단일 statement 성공/실패 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| 빈 key 배열 | SQL 없이 deleted=0 | 불필요한 DB 접근 없음 |
| 문자열이 아닌 key | 명시적 예외 | 잘못된 payload fail-closed |
| colon 포함 식별자 | 원본 key 그대로 비교 | 오분해 없음 |
| 일부 key가 존재하지 않음 | 존재하는 row만 삭제·집계 | 반환값 정확성 유지 |

## 해결한 내용

- `src/engine/ops/kv_ops.rs`: typed `deleteMany` facade와 입력/반환 계약을 추가했습니다.
- `policies/timeouts/long-turn-monitor.js`: key별 삭제 루프를 공통 selector + batch 호출로 교체했습니다.
- policy harness·timeouts 테스트·CI lane·typed facade 문서·생성 inventory를 함께 갱신했습니다.
- raw-policy DB inventory는 29개 파일, 읽기 122회 + 변경 44회 = 166개 호출부와 일치합니다.

## 검증

- [x] Rust KV 테스트 2/2, long-turn 테스트 38/38, 전체 policy 테스트 218/218 성공
- [x] `cargo check --all-targets`
- [x] policy DB capability 15/15 및 manifest/raw callsite 검사 성공
- [x] test-lane coverage — 886개 모듈 / 6,025개 테스트, 신규 부채 0
- [x] 문서 테스트 71/71, 유지보수·생성 문서·포맷·diff 위생 검사 성공
- [x] GitHub Actions — PostgreSQL 포함 15/15 성공, 충돌 없음(`MERGEABLE / CLEAN`)
- [x] Dashboard·schema·queue lifecycle 변경 없음