### PR TITLE
perf(auto-queue): batch status counts

### DIFF
--- a/scripts/pg_test_lane_manifest.txt
+++ b/scripts/pg_test_lane_manifest.txt
@@ -76,6 +76,7 @@ db::auto_queue::entries::dispatch_failure::tests
 db::auto_queue::phase_gates::current_batch_phase_pg_tests
 db::auto_queue::phase_gates::reconcile_phase_gate_pg_tests
 db::auto_queue::tests::dispatch_terminal_sync_pg_tests
+db::auto_queue::tests::grouped_card_count_pg_tests
 db::dispatched_session_rebind_override::tests
 db::dispatched_sessions::selector_cleanup_tests::session_authority_pg_tests
 db::dispatches::delivery_events::tests
@@ -212,6 +213,7 @@ db::auto_queue::tests::dispatch_terminal_sync_pg_tests::phase_gate_state_save_is
 db::auto_queue::tests::dispatch_terminal_sync_pg_tests::phase_gate_state_save_rolls_back_stale_cleanup_when_write_fails_pg
 db::auto_queue::tests::dispatch_terminal_sync_pg_tests::slot_has_recent_terminal_auto_queue_dispatch_pg_respects_cooldown
 db::auto_queue::tests::dispatch_terminal_sync_pg_tests::user_cancelled_entry_does_not_finalize_review_disabled_run_pg
+db::auto_queue::tests::grouped_card_count_pg_tests::grouped_counts_use_one_status_array_and_preserve_filters_pg
 db::dispatched_session_rebind_override::tests::health_rebind_override_upserts_selectors_with_recorded_at_guard_pg
 db::dispatched_sessions::selector_cleanup_tests::session_authority_pg_tests::clearing_session_ids_resets_raw_transcript_watermark_evidence
 db::dispatched_sessions::selector_cleanup_tests::session_authority_pg_tests::disconnect_session_and_prepare_retry_pg_preserves_provider_selectors

--- a/src/db/auto_queue/queries.rs
+++ b/src/db/auto_queue/queries.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use sqlx::{PgPool, Row as SqlxRow};
 
 #[derive(Debug, Clone, Default)]
@@ -449,24 +451,31 @@ pub async fn list_generate_candidates_pg(
         .collect()
 }
 
-pub async fn count_cards_by_status_pg(
+pub async fn count_cards_by_statuses_pg(
     pool: &PgPool,
     repo: Option<&str>,
     agent_id: Option<&str>,
-    status: &str,
-) -> Result<i64, sqlx::Error> {
-    sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*)::BIGINT
+    statuses: &[String],
+) -> Result<HashMap<String, i64>, sqlx::Error> {
+    if statuses.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let rows = sqlx::query_as::<_, (String, i64)>(
+        "SELECT status, COUNT(*)::BIGINT
          FROM kanban_cards
-         WHERE status = $1
+         WHERE status = ANY($1::TEXT[])
            AND ($2::TEXT IS NULL OR repo_id = $2)
-           AND ($3::TEXT IS NULL OR assigned_agent_id = $3)",
+           AND ($3::TEXT IS NULL OR assigned_agent_id = $3)
+         GROUP BY status",
     )
-    .bind(status)
+    .bind(statuses)
     .bind(repo.filter(|value| !value.is_empty()))
     .bind(agent_id.filter(|value| !value.is_empty()))
-    .fetch_one(pool)
-    .await
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().collect())
 }
 
 fn auto_queue_run_record_from_pg_row(

--- a/src/db/auto_queue/tests.rs
+++ b/src/db/auto_queue/tests.rs
@@ -40,6 +40,15 @@ mod grouped_card_count_pg_tests {
         let pg_db = TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
         sqlx::query(
+            "INSERT INTO agents (id, name, provider, discord_channel_id)
+             VALUES
+                ('agent-1', 'Grouped Count Agent 1', 'claude', 'count-agent-1'),
+                ('agent-2', 'Grouped Count Agent 2', 'codex', 'count-agent-2')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed grouped count agents");
+        sqlx::query(
             "INSERT INTO kanban_cards
                 (id, title, status, repo_id, assigned_agent_id)
              VALUES

--- a/src/db/auto_queue/tests.rs
+++ b/src/db/auto_queue/tests.rs
@@ -31,6 +31,68 @@ mod resume_session_context_tests {
 }
 
 #[cfg(test)]
+mod grouped_card_count_pg_tests {
+    use super::count_cards_by_statuses_pg;
+    use crate::db::auto_queue::test_support::TestPostgresDb;
+
+    #[tokio::test]
+    async fn grouped_counts_use_one_status_array_and_preserve_filters_pg() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        sqlx::query(
+            "INSERT INTO kanban_cards
+                (id, title, status, repo_id, assigned_agent_id)
+             VALUES
+                ('count-ready-a1-1', 'Ready A1 1', 'ready', 'repo-a', 'agent-1'),
+                ('count-ready-a1-2', 'Ready A1 2', 'ready', 'repo-a', 'agent-1'),
+                ('count-review-a1', 'Review A1', 'review', 'repo-a', 'agent-1'),
+                ('count-done-a1', 'Done A1', 'done', 'repo-a', 'agent-1'),
+                ('count-ready-a2', 'Ready A2', 'ready', 'repo-a', 'agent-2'),
+                ('count-ready-b1', 'Ready B1', 'ready', 'repo-b', 'agent-1')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed grouped count cards");
+        let statuses = vec![
+            "ready".to_string(),
+            "review".to_string(),
+            "requested".to_string(),
+        ];
+
+        let all_counts = count_cards_by_statuses_pg(&pool, None, None, &statuses)
+            .await
+            .expect("count all requested statuses");
+        assert_eq!(all_counts.get("ready"), Some(&4));
+        assert_eq!(all_counts.get("review"), Some(&1));
+        assert!(!all_counts.contains_key("requested"));
+        assert!(!all_counts.contains_key("done"));
+
+        let filtered_counts =
+            count_cards_by_statuses_pg(&pool, Some("repo-a"), Some("agent-1"), &statuses)
+                .await
+                .expect("count filtered requested statuses");
+        assert_eq!(filtered_counts.get("ready"), Some(&2));
+        assert_eq!(filtered_counts.get("review"), Some(&1));
+        assert!(!filtered_counts.contains_key("requested"));
+
+        let unfiltered_empty_values =
+            count_cards_by_statuses_pg(&pool, Some(""), Some(""), &statuses)
+                .await
+                .expect("empty filters retain unfiltered semantics");
+        assert_eq!(unfiltered_empty_values, all_counts);
+        assert!(
+            count_cards_by_statuses_pg(&pool, None, None, &[])
+                .await
+                .expect("empty status list is a no-op")
+                .is_empty()
+        );
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+}
+
+#[cfg(test)]
 mod dispatch_terminal_sync_pg_tests {
     use super::{
         ENTRY_STATUS_DONE, ENTRY_STATUS_FAILED, ENTRY_STATUS_SKIPPED, ENTRY_STATUS_USER_CANCELLED,

--- a/src/services/auto_queue.rs
+++ b/src/services/auto_queue.rs
@@ -536,20 +536,20 @@ impl AutoQueueService {
         Ok(cards.into_iter().map(GenerateCandidate::from).collect())
     }
 
-    pub async fn count_cards_by_status_with_pg(
+    pub async fn count_cards_by_statuses_with_pg(
         &self,
         pool: &PgPool,
         repo: Option<&str>,
         agent_id: Option<&str>,
-        status: &str,
-    ) -> ServiceResult<i64> {
-        auto_queue::count_cards_by_status_pg(pool, repo, agent_id, status)
+        statuses: &[String],
+    ) -> ServiceResult<HashMap<String, i64>> {
+        auto_queue::count_cards_by_statuses_pg(pool, repo, agent_id, statuses)
             .await
             .map_err(|error| {
-                ServiceError::internal(format!("count cards: {error}"))
+                ServiceError::internal(format!("count cards by statuses: {error}"))
                     .with_code(ErrorCode::Database)
-                    .with_operation("count_cards_by_status_with_pg")
-                    .with_context("status", status)
+                    .with_operation("count_cards_by_statuses_with_pg")
+                    .with_context("status_count", statuses.len())
             })
     }
 

--- a/src/services/auto_queue/route_generate.rs
+++ b/src/services/auto_queue/route_generate.rs
@@ -268,24 +268,39 @@ pub async fn generate(
     }
 
     if cards.is_empty() {
-        let mut counts_map = serde_json::Map::new();
-        if let Some(pipeline) = crate::pipeline::try_get() {
-            for pipeline_state in &pipeline.states {
-                if !pipeline_state.terminal {
-                    let c = state
-                        .auto_queue_service()
-                        .count_cards_by_status_with_pg(
-                            pool,
-                            body.repo.as_deref(),
-                            body.agent_id.as_deref(),
-                            &pipeline_state.id,
-                        )
-                        .await
-                        .unwrap_or(0);
-                    counts_map.insert(pipeline_state.id.clone(), serde_json::json!(c));
-                }
+        let statuses: Vec<String> = crate::pipeline::try_get()
+            .map(|pipeline| {
+                pipeline
+                    .states
+                    .iter()
+                    .filter(|pipeline_state| !pipeline_state.terminal)
+                    .map(|pipeline_state| pipeline_state.id.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let counts = match state
+            .auto_queue_service()
+            .count_cards_by_statuses_with_pg(
+                pool,
+                body.repo.as_deref(),
+                body.agent_id.as_deref(),
+                &statuses,
+            )
+            .await
+        {
+            Ok(counts) => counts,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    status_count = statuses.len(),
+                    repo = ?body.repo,
+                    agent_id = ?body.agent_id,
+                    "failed to load empty-generate status counts"
+                );
+                HashMap::new()
             }
-        }
+        };
+        let counts_map = empty_generate_status_counts(&statuses, &counts);
         return Ok((
             StatusCode::OK,
             Json(json!({
@@ -592,6 +607,21 @@ pub async fn generate(
     ))
 }
 
+fn empty_generate_status_counts(
+    statuses: &[String],
+    counts: &HashMap<String, i64>,
+) -> serde_json::Map<String, serde_json::Value> {
+    statuses
+        .iter()
+        .map(|status| {
+            (
+                status.clone(),
+                serde_json::json!(counts.get(status).copied().unwrap_or(0)),
+            )
+        })
+        .collect()
+}
+
 /// Structured skip-reason breakdown for `/api/queue/generate` (#1442).
 #[derive(Debug, Default)]
 pub(crate) struct GenerateSkipBreakdown {
@@ -717,6 +747,25 @@ pub(crate) async fn active_dispatch_id_for_card_pg(
     .bind(card_id)
     .fetch_optional(pool)
     .await
+}
+
+#[cfg(test)]
+mod empty_generate_status_count_tests {
+    use super::empty_generate_status_counts;
+    use std::collections::HashMap;
+
+    #[test]
+    fn requested_states_keep_zero_counts_and_ignore_unrequested_rows() {
+        let statuses = vec!["ready".to_string(), "review".to_string()];
+        let counts = HashMap::from([("ready".to_string(), 3), ("done".to_string(), 9)]);
+
+        let result = empty_generate_status_counts(&statuses, &counts);
+
+        assert_eq!(
+            serde_json::Value::Object(result),
+            serde_json::json!({ "ready": 3, "review": 0 })
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 목표

`/api/queue/generate`의 빈 결과 진단에서 non-terminal state마다 반복하던 PostgreSQL COUNT를 단일 grouped query로 바꿔, 상태 수가 늘어도 DB round trip이 증가하지 않도록 합니다.

## 쉬운 설명

생성할 card가 없을 때 상태별 개수를 하나씩 묻지 않고 한 번에 가져옵니다. API 응답 모양과 0 채움 규칙은 그대로 유지됩니다.

## 개선되는 것

### Fix 1 — N+1 COUNT를 단일 typed query로 교체

- `status = ANY($1::TEXT[]) ... GROUP BY status` 한 문장으로 요청한 상태를 집계합니다.
- DB 경계에서 `(String, i64)` row를 typed `HashMap`으로 변환합니다.
- 빈 status 배열은 query 없이 빈 결과를 반환합니다.

### Fix 2 — 기존 API/fallback 의미 보존

- 응답은 요청한 모든 non-terminal state key를 유지하고 DB 결과에 없는 state를 0으로 채웁니다.
- repo/agent의 빈 문자열 filter 의미를 유지합니다.
- DB 오류 시 기존처럼 0으로 저하시키되 오류·filter·상태 수를 warning 로그로 남깁니다.

### Fix 3 — 사용하지 않는 scalar surface 제거

- 더 이상 필요한 곳이 없는 상태별 scalar count DB/service API를 제거해 두 구현이 다시 갈라지지 않게 했습니다.
- pure 응답 조립 테스트와 실제 PostgreSQL array-bind/filter 테스트를 추가했습니다.

### Fix 4 — 리뷰 fixture 무결성 수정

- PostgreSQL 리뷰에서 확인된 FK 위반을 막기 위해 card보다 `agent-1`, `agent-2`를 먼저 seed합니다.
- 원격 PostgreSQL lane 성공으로 테스트가 setup을 넘어 실제 assertion까지 실행됨을 확인했습니다.

## Before → After

| 항목 | Before | After |
|---|---|---|
| K개 non-terminal 상태 | COUNT 최대 K회 | grouped COUNT 1회 |
| 빈 상태 배열 | 호출 경로에 의존 | DB query 없이 빈 map |
| 누락 group | route별 보정 | 공통 조립에서 0 채움 |
| DB 오류 진단 | 조용한 0 fallback | 같은 fallback + 구조화된 warning |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| 일부 상태에 card 없음 | 해당 key를 0으로 채움 | 응답 shape 유지 |
| repo/agent filter가 빈 문자열 | 기존 query 의미 유지 | 호환성 유지 |
| DB query 실패 | 모든 count를 0으로 반환하고 로그 | 기존 가용성 정책 유지 |
| terminal/unrequested state 존재 | array 조건에서 제외 | 응답 오염 없음 |

## 해결한 내용

- DB query, service 경계, route 응답 조립을 batch typed 계약으로 정리했습니다.
- scalar count surface를 제거하고 pure/실제 PostgreSQL 회귀 테스트를 추가했습니다.
- PostgreSQL manifest에 새 테스트를 등록하고 FK fixture 리뷰 피드백을 반영했습니다.

## 포트 메모

- fork의 병합된 `kunkunGames/AgentDesk#1338` 아이디어를 최신 upstream에서 재검토했습니다.
- typed decode, 빈 입력 no-query, 오류 문맥, scalar surface 제거, pure/PG 회귀 테스트를 보강했습니다.
- 열린 upstream PR에서 같은 query/route를 변경하는 중복 후보는 없습니다.

## 검증

- [x] pure fallback 테스트 1/1 성공
- [x] `cargo check --all-targets`
- [x] test-lane coverage — 887개 모듈 / 6,025개 테스트, 신규 부채 0
- [x] PostgreSQL lane membership — 444개 테스트 / 71파일, rule4 0
- [x] 문서 테스트 71/71, 유지보수·생성 문서·포맷·diff 위생 성공
- [x] GitHub Actions — 실제 PostgreSQL 테스트 포함 15/15 성공, 충돌 없음(`MERGEABLE / CLEAN`)
- [x] Dashboard·DB schema·card 선택/실행 lifecycle 변경 없음