### PR TITLE
fix(security): redact Cookie header values

### DIFF
--- a/scripts/check_test_target_integrity.py
+++ b/scripts/check_test_target_integrity.py
@@ -91,9 +91,9 @@ LIB_INVENTORY_KNOWN_CARGO_ONLY = frozenset({
 # Keep the count beside the digest so a failed check reports a signed count
 # delta even though the compact pin deliberately does not embed every identity.
 LIB_INVENTORY_STATIC_IDS_SHA256 = (
-    "700edad866962420a94acb7b8c5471625d6aba6368d9ea81859c89b085b873b6"
+    "3928ebd31e87a81bc24185a69926c6e91f1a544533a678972bb257b7d61a458a"
 )
-LIB_INVENTORY_STATIC_IDS_COUNT = 7410
+LIB_INVENTORY_STATIC_IDS_COUNT = 7443
 
 
 @dataclass(frozen=True)

--- a/src/services/agents/turn.rs
+++ b/src/services/agents/turn.rs
@@ -369,14 +369,6 @@ fn ansi_escape_re() -> &'static Regex {
     RE.get_or_init(|| Regex::new(r"\x1B\[[0-?]*[ -/]*[@-~]").expect("valid ANSI regex"))
 }
 
-fn auth_header_re() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r"(?i)(authorization\s*:\s*(?:[a-z][a-z0-9._~+/-]*\s+)?)[^\r\n]+")
-            .expect("valid auth header regex")
-    })
-}
-
 fn secret_assignment_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
@@ -392,9 +384,9 @@ fn strip_ansi(text: &str) -> String {
 }
 
 fn sanitize_sensitive_text(text: &str) -> String {
-    let masked_auth = auth_header_re().replace_all(text, "$1[REDACTED]");
+    let masked_headers = crate::utils::redact::redact_sensitive_headers(text, "[REDACTED]");
     secret_assignment_re()
-        .replace_all(&masked_auth, "$1$2[REDACTED]")
+        .replace_all(&masked_headers, "$1$2[REDACTED]")
         .into_owned()
 }
 
@@ -775,9 +767,9 @@ mod tests {
     }
 
     #[test]
-    fn normalize_recent_output_masks_auth_headers_and_key_assignments() {
+    fn normalize_recent_output_masks_sensitive_headers_and_key_assignments() {
         let output = normalize_recent_output(
-            "\u{1b}[32mAuthorization: Bearer secret-token\u{1b}[0m\nAuthorization: Bot bot-secret\nauthorization: basic dXNlcjpwYXNz\nauthorization: Digest username=\"u\", nonce=\"nonce-secret\", response=\"digest-secret\"\nauthorization: plain-secret\nOPENAI_API_KEY=sk-secret\nvisible line",
+            "\u{1b}[32mAuthorization: Bearer secret-token\u{1b}[0m\nAuthorization: Bot bot-secret\nauthorization: basic dXNlcjpwYXNz\nauthorization: Digest username=\"u\", nonce=\"nonce-secret\", response=\"digest-secret\"\nauthorization: plain-secret\nCookie: sessionSecret trailing-data\nSet-Cookie: access=xyz; HttpOnly\nOPENAI_API_KEY=sk-secret\nvisible line",
         )
         .expect("normalized output");
 
@@ -786,6 +778,8 @@ mod tests {
         assert!(output.contains("authorization: basic [REDACTED]"));
         assert!(output.contains("authorization: Digest [REDACTED]"));
         assert!(output.contains("authorization: [REDACTED]"));
+        assert!(output.contains("Cookie: [REDACTED]"));
+        assert!(output.contains("Set-Cookie: [REDACTED]"));
         assert!(output.contains("OPENAI_API_KEY=[REDACTED]"));
         assert!(output.contains("visible line"));
         assert!(!output.contains("secret-token"));
@@ -794,6 +788,9 @@ mod tests {
         assert!(!output.contains("nonce-secret"));
         assert!(!output.contains("digest-secret"));
         assert!(!output.contains("plain-secret"));
+        assert!(!output.contains("sessionSecret"));
+        assert!(!output.contains("trailing-data"));
+        assert!(!output.contains("access=xyz"));
         assert!(!output.contains("sk-secret"));
     }
 

--- a/src/services/agents/turn.rs
+++ b/src/services/agents/turn.rs
@@ -401,7 +401,12 @@ fn tail_chars(text: &str, max_chars: usize) -> String {
 
 pub fn normalize_recent_output(text: &str) -> Option<String> {
     let stripped = strip_ansi(text);
-    let lines: Vec<&str> = stripped.lines().collect();
+    // Redact the complete capture before line selection. Header continuation
+    // lines do not repeat `Cookie:`/`Authorization:`, so sanitizing each
+    // physical line independently would expose obs-fold values—especially when
+    // the header begins just before the retained tail window.
+    let sanitized = sanitize_sensitive_text(&stripped);
+    let lines: Vec<&str> = sanitized.lines().collect();
     let start = lines.len().saturating_sub(TURN_CAPTURE_TAIL_LINES);
     let mut out = String::new();
     let mut prev_blank = false;
@@ -421,7 +426,7 @@ pub fn normalize_recent_output(text: &str) -> Option<String> {
         if !out.is_empty() {
             out.push('\n');
         }
-        out.push_str(&sanitize_sensitive_text(trimmed));
+        out.push_str(trimmed);
         prev_blank = false;
     }
 
@@ -792,6 +797,20 @@ mod tests {
         assert!(!output.contains("trailing-data"));
         assert!(!output.contains("access=xyz"));
         assert!(!output.contains("sk-secret"));
+    }
+
+    #[test]
+    fn normalize_recent_output_masks_folded_header_continuations_before_line_selection() {
+        let output = normalize_recent_output(
+            "visible before\nCookie: first=secret\r\n continuation=secret-two\nvisible after",
+        )
+        .expect("normalized folded header output");
+
+        assert!(output.contains("Cookie: [REDACTED]"));
+        assert!(output.contains("visible before"));
+        assert!(output.contains("visible after"));
+        assert!(!output.contains("first=secret"));
+        assert!(!output.contains("continuation=secret-two"));
     }
 
     #[test]

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -134,8 +134,9 @@ use self::tool_markdown::convert_markdown_tables;
 pub(super) use self::tool_markdown::{
     ALL_TOOLS, BUILTIN_SKILLS, canonical_tool_name, escape_for_code_fence,
     extract_skill_description, filter_codex_tool_logs, format_for_discord_with_provider,
-    format_for_discord_with_status_panel, format_tool_input, normalize_empty_lines, risk_badge,
-    shorten_path, strip_codex_tool_log_lines, tool_info, truncate_str,
+    format_for_discord_with_status_panel, format_tool_input, is_command_tool_name,
+    normalize_empty_lines, risk_badge, shorten_path, strip_codex_tool_log_lines, tool_info,
+    truncate_str,
 };
 pub(crate) use self::tool_markdown::{normalize_allowed_tools, redact_sensitive_for_placeholder};
 

--- a/src/services/discord/formatting/tool_markdown.rs
+++ b/src/services/discord/formatting/tool_markdown.rs
@@ -316,10 +316,15 @@ pub(in crate::services::discord) fn format_tool_input(name: &str, input: &str) -
         "Bash" => {
             let desc = v.get("description").and_then(|v| v.as_str()).unwrap_or("");
             let cmd = v.get("command").and_then(|v| v.as_str()).unwrap_or("");
+            // Redact the complete command before truncation and Markdown code
+            // delimiters are added. A delimiter such as backtick is a valid
+            // RFC header-name `tchar`, so wrapping first would intentionally
+            // block the shared suffix-safe Cookie matcher.
+            let cmd = redact_sensitive_for_placeholder(cmd);
             if !desc.is_empty() {
-                format!("{}: `{}`", desc, truncate_str(cmd, 150))
+                format!("{}: `{}`", desc, truncate_str(&cmd, 150))
             } else {
-                format!("`{}`", truncate_str(cmd, 200))
+                format!("`{}`", truncate_str(&cmd, 200))
             }
         }
         "Read" => {

--- a/src/services/discord/formatting/tool_markdown.rs
+++ b/src/services/discord/formatting/tool_markdown.rs
@@ -13,7 +13,11 @@ pub(crate) fn redact_sensitive_for_placeholder(input: &str) -> String {
         Regex::new(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b").expect("valid email regex")
     });
 
-    let redacted = OPENAI_KEY_RE.replace_all(input, "***");
+    // Keep the compact renderer's token-aware Bearer behavior (so command
+    // details after the token remain visible), while sharing the common
+    // whole-value Cookie/Set-Cookie contract with logs and recent output.
+    let redacted = crate::utils::redact::redact_cookie_headers(input, "***");
+    let redacted = OPENAI_KEY_RE.replace_all(&redacted, "***");
     let redacted = BEARER_RE.replace_all(&redacted, "Bearer ***");
     let redacted = ASSIGNMENT_RE.replace_all(&redacted, "${1}=***");
     EMAIL_RE.replace_all(&redacted, "***@***").into_owned()

--- a/src/services/discord/formatting/tool_markdown.rs
+++ b/src/services/discord/formatting/tool_markdown.rs
@@ -302,31 +302,59 @@ pub(in crate::services::discord) fn shorten_path(path: &str) -> String {
 /// compactly removes the newlines so the fallback is always informative.
 fn compact_json_fallback(v: &serde_json::Value, raw: &str) -> String {
     let compact = serde_json::to_string(v).unwrap_or_else(|_| raw.to_string());
-    truncate_str(&compact, 200).to_string()
+    let redacted = redact_sensitive_for_placeholder(&compact);
+    truncate_str(&redacted, 200).to_string()
+}
+
+pub(in crate::services::discord) fn is_command_tool_name(name: &str) -> bool {
+    matches!(
+        name.trim().to_ascii_lowercase().as_str(),
+        "bash" | "command_execution" | "exec" | "exec_command" | "run_cmd" | "shell_command"
+    )
+}
+
+fn format_command_tool_input(v: &serde_json::Value, raw: &str) -> String {
+    let desc = v
+        .get("description")
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+    let cmd = v
+        .get("command")
+        .or_else(|| v.get("cmd"))
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+    if desc.is_empty() && cmd.is_empty() {
+        return compact_json_fallback(v, raw);
+    }
+
+    // Sanitize every direct consumer field before truncation or Markdown
+    // delimiters can split/block the shared header matcher.
+    let desc = redact_sensitive_for_placeholder(desc);
+    let cmd = redact_sensitive_for_placeholder(cmd);
+    if !desc.is_empty() {
+        if cmd.is_empty() {
+            truncate_str(&desc, 200)
+        } else {
+            format!("{}: `{}`", truncate_str(&desc, 45), truncate_str(&cmd, 150))
+        }
+    } else {
+        format!("`{}`", truncate_str(&cmd, 200))
+    }
 }
 
 /// Format tool input JSON into a human-readable summary (without tool name prefix).
 /// The caller adds the tool name, so this returns only the detail part.
 pub(in crate::services::discord) fn format_tool_input(name: &str, input: &str) -> String {
     let Ok(v) = serde_json::from_str::<serde_json::Value>(input) else {
-        return truncate_str(input, 200).to_string();
+        let redacted = redact_sensitive_for_placeholder(input);
+        return truncate_str(&redacted, 200).to_string();
     };
 
-    match name {
-        "Bash" => {
-            let desc = v.get("description").and_then(|v| v.as_str()).unwrap_or("");
-            let cmd = v.get("command").and_then(|v| v.as_str()).unwrap_or("");
-            // Redact the complete command before truncation and Markdown code
-            // delimiters are added. A delimiter such as backtick is a valid
-            // RFC header-name `tchar`, so wrapping first would intentionally
-            // block the shared suffix-safe Cookie matcher.
-            let cmd = redact_sensitive_for_placeholder(cmd);
-            if !desc.is_empty() {
-                format!("{}: `{}`", desc, truncate_str(&cmd, 150))
-            } else {
-                format!("`{}`", truncate_str(&cmd, 200))
-            }
-        }
+    if is_command_tool_name(name) {
+        return format_command_tool_input(&v, input);
+    }
+
+    let summary = match name {
         "Read" => {
             let fp = v.get("file_path").and_then(|v| v.as_str()).unwrap_or("");
             shorten_path(fp).to_string()
@@ -517,12 +545,15 @@ pub(in crate::services::discord) fn format_tool_input(name: &str, input: &str) -
                 // `<short_name>: {` line through the live-event collapse.
                 let short_name = name.rsplit("__").next().unwrap_or(name);
                 let compact = serde_json::to_string(&v).unwrap_or_else(|_| input.to_string());
-                truncate_str(&format!("{}: {}", short_name, compact), 200).to_string()
+                let redacted =
+                    redact_sensitive_for_placeholder(&format!("{}: {}", short_name, compact));
+                truncate_str(&redacted, 200).to_string()
             } else {
                 compact_json_fallback(&v, input)
             }
         }
-    }
+    };
+    redact_sensitive_for_placeholder(&summary)
 }
 
 /// Convert markdown tables to Discord-friendly list format.

--- a/src/services/discord/formatting/tool_markdown.rs
+++ b/src/services/discord/formatting/tool_markdown.rs
@@ -444,21 +444,7 @@ pub(in crate::services::discord) fn format_tool_input(name: &str, input: &str) -
                 format!("\"{}\"", truncate_str(query, 180))
             }
         }
-        "Monitor" => {
-            let desc = v.get("description").and_then(|v| v.as_str()).unwrap_or("");
-            let cmd = v.get("command").and_then(|v| v.as_str()).unwrap_or("");
-            if !desc.is_empty() {
-                if !cmd.is_empty() {
-                    format!("{}: `{}`", desc, truncate_str(cmd, 150))
-                } else {
-                    desc.to_string()
-                }
-            } else if !cmd.is_empty() {
-                format!("`{}`", truncate_str(cmd, 180))
-            } else {
-                compact_json_fallback(&v)
-            }
-        }
+        "Monitor" => format_command_tool_input(&v),
         "Task" | "Agent" => {
             let desc = v.get("description").and_then(|v| v.as_str()).unwrap_or("");
             let subagent_type = v

--- a/src/services/discord/formatting/tool_markdown.rs
+++ b/src/services/discord/formatting/tool_markdown.rs
@@ -300,8 +300,8 @@ pub(in crate::services::discord) fn shorten_path(path: &str) -> String {
 /// that is just `{`, which downstream live-event rendering collapses to a bare
 /// `[ToolSearch] {` / `[Monitor] {`. Re-serializing the already-parsed value
 /// compactly removes the newlines so the fallback is always informative.
-fn compact_json_fallback(v: &serde_json::Value, raw: &str) -> String {
-    let compact = serde_json::to_string(v).unwrap_or_else(|_| raw.to_string());
+fn compact_json_fallback(v: &serde_json::Value) -> String {
+    let compact = crate::utils::redact::serialize_json_with_redacted_cookie_headers(v, "***");
     let redacted = redact_sensitive_for_placeholder(&compact);
     truncate_str(&redacted, 200).to_string()
 }
@@ -313,7 +313,7 @@ pub(in crate::services::discord) fn is_command_tool_name(name: &str) -> bool {
     )
 }
 
-fn format_command_tool_input(v: &serde_json::Value, raw: &str) -> String {
+fn format_command_tool_input(v: &serde_json::Value) -> String {
     let desc = v
         .get("description")
         .and_then(|value| value.as_str())
@@ -324,7 +324,7 @@ fn format_command_tool_input(v: &serde_json::Value, raw: &str) -> String {
         .and_then(|value| value.as_str())
         .unwrap_or("");
     if desc.is_empty() && cmd.is_empty() {
-        return compact_json_fallback(v, raw);
+        return compact_json_fallback(v);
     }
 
     // Sanitize every direct consumer field before truncation or Markdown
@@ -351,7 +351,7 @@ pub(in crate::services::discord) fn format_tool_input(name: &str, input: &str) -
     };
 
     if is_command_tool_name(name) {
-        return format_command_tool_input(&v, input);
+        return format_command_tool_input(&v);
     }
 
     let summary = match name {
@@ -437,7 +437,7 @@ pub(in crate::services::discord) fn format_tool_input(name: &str, input: &str) -
                 .or_else(|| v.get("limit"))
                 .and_then(|v| v.as_u64());
             if query.is_empty() {
-                compact_json_fallback(&v, input)
+                compact_json_fallback(&v)
             } else if let Some(limit) = limit {
                 format!("\"{}\" (limit {})", truncate_str(query, 150), limit)
             } else {
@@ -456,7 +456,7 @@ pub(in crate::services::discord) fn format_tool_input(name: &str, input: &str) -
             } else if !cmd.is_empty() {
                 format!("`{}`", truncate_str(cmd, 180))
             } else {
-                compact_json_fallback(&v, input)
+                compact_json_fallback(&v)
             }
         }
         "Task" | "Agent" => {
@@ -544,12 +544,13 @@ pub(in crate::services::discord) fn format_tool_input(name: &str, input: &str) -
                 // input (#2847) so pretty-printed JSON does not leak a bare
                 // `<short_name>: {` line through the live-event collapse.
                 let short_name = name.rsplit("__").next().unwrap_or(name);
-                let compact = serde_json::to_string(&v).unwrap_or_else(|_| input.to_string());
+                let compact =
+                    crate::utils::redact::serialize_json_with_redacted_cookie_headers(&v, "***");
                 let redacted =
                     redact_sensitive_for_placeholder(&format!("{}: {}", short_name, compact));
                 truncate_str(&redacted, 200).to_string()
             } else {
-                compact_json_fallback(&v, input)
+                compact_json_fallback(&v)
             }
         }
     };

--- a/src/services/discord/placeholder_live_events/common.rs
+++ b/src/services/discord/placeholder_live_events/common.rs
@@ -1,6 +1,8 @@
 use serde_json::Value;
 
-use super::super::formatting::{canonical_tool_name, redact_sensitive_for_placeholder};
+use super::super::formatting::{
+    canonical_tool_name, is_command_tool_name, redact_sensitive_for_placeholder,
+};
 
 pub(super) const CHANNEL_EVENT_CAPACITY: usize = 20;
 pub(super) const EVENT_RENDER_LIMIT: usize = 5;
@@ -102,9 +104,11 @@ pub(super) fn tool_prefix(name: &str) -> &'static str {
         return "[MCP]";
     }
 
+    if is_command_tool_name(trimmed) || matches!(lower.as_str(), "bashoutput" | "killbash") {
+        return "[Bash]";
+    }
+
     match lower.as_str() {
-        "bash" | "bashoutput" | "killbash" | "command_execution" | "exec" | "exec_command"
-        | "run_cmd" => "[Bash]",
         "edit" | "multiedit" | "write" | "notebookedit" => "[Edit]",
         "read" => "[Read]",
         "grep" => "[Grep]",

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -215,9 +215,28 @@ fn events_from_json_redacts_cookie_headers_without_leaking_the_first_token() {
 
     assert_eq!(events.len(), 1);
     let line = events[0].render_line();
-    assert!(line.contains("Cookie: ***"));
+    assert!(line.contains("Cookie: ***"), "rendered line: {line}");
     assert!(!line.contains("sessionSecret"));
     assert!(!line.contains("trailing-data"));
+}
+
+#[test]
+fn events_from_json_redacts_curl_attached_cookie_header_option() {
+    let events = events_from_json(&json!({
+        "type": "assistant",
+        "message": {
+            "content": [{
+                "type": "tool_use",
+                "name": "Bash",
+                "input": {"command": "curl -HCookie:session=secret https://example.test"}
+            }]
+        }
+    }));
+
+    assert_eq!(events.len(), 1);
+    let line = events[0].render_line();
+    assert!(line.contains("-HCookie:***"));
+    assert!(!line.contains("session=secret"));
 }
 
 #[test]

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -201,16 +201,40 @@ fn events_from_json_redacts_and_normalizes_tool_use() {
 }
 
 #[test]
+fn events_from_json_redacts_cookie_headers_without_leaking_the_first_token() {
+    let events = events_from_json(&json!({
+        "type": "assistant",
+        "message": {
+            "content": [{
+                "type": "tool_use",
+                "name": "Bash",
+                "input": {"command": "Cookie: sessionSecret trailing-data"}
+            }]
+        }
+    }));
+
+    assert_eq!(events.len(), 1);
+    let line = events[0].render_line();
+    assert!(line.contains("Cookie: ***"));
+    assert!(!line.contains("sessionSecret"));
+    assert!(!line.contains("trailing-data"));
+}
+
+#[test]
 fn redact_sensitive_for_placeholder_masks_required_patterns() {
     let redacted = redact_sensitive_for_placeholder(
-        "sk-abcdefghijklmnopqrstuvwxyz \
-         Authorization: Bearer live-token \
-         password=hunter2 token=secret api_key=key1 api-key=key2 \
+        "sk-abcdefghijklmnopqrstuvwxyz\n\
+         Authorization: Bearer live-token\n\
+         Cookie: sessionSecret trailing-data\n\
+         Set-Cookie: access=xyz;HttpOnly\n\
+         password=hunter2 token=secret api_key=key1 api-key=key2\n\
          alice@example.com",
     );
 
     assert!(redacted.contains("***"));
     assert!(redacted.contains("Bearer ***"));
+    assert!(redacted.contains("Cookie: ***"));
+    assert!(redacted.contains("Set-Cookie: ***"));
     assert!(redacted.contains("password=***"));
     assert!(redacted.contains("token=***"));
     assert!(redacted.contains("api_key=***"));
@@ -218,6 +242,9 @@ fn redact_sensitive_for_placeholder_masks_required_patterns() {
     assert!(redacted.contains("***@***"));
     assert!(!redacted.contains("sk-abcdefghijklmnopqrstuvwxyz"));
     assert!(!redacted.contains("live-token"));
+    assert!(!redacted.contains("sessionSecret"));
+    assert!(!redacted.contains("trailing-data"));
+    assert!(!redacted.contains("access=xyz"));
     assert!(!redacted.contains("hunter2"));
     assert!(!redacted.contains("alice@example.com"));
     assert!(!redacted.contains("secret"));

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -6794,6 +6794,27 @@ fn compact_json_tool_summaries_redact_nested_cookie_strings_before_serializing()
 }
 
 #[test]
+fn compact_json_tool_summaries_redact_cookie_header_map_values() {
+    let pretty = serde_json::to_string_pretty(&json!({
+        "headers": {
+            "Cookie": "map-secret-one",
+            "Set-Cookie": ["map-secret-two"],
+            "X-Cookie": "visible"
+        }
+    }))
+    .unwrap();
+
+    for tool_name in ["SomeUnknownTool", "mcp__vault__inspect"] {
+        let line = RecentPlaceholderEvent::tool_use(tool_name, &pretty)
+            .expect("non-empty summary")
+            .render_line();
+        assert!(line.contains("***"), "got: {line}");
+        assert!(line.contains("X-Cookie"), "got: {line}");
+        assert!(!line.contains("map-secret"), "got: {line}");
+    }
+}
+
+#[test]
 fn command_tool_summaries_redact_curl_header_and_cookie_option_spellings() {
     let commands = [
         "curl -sHCookie:cluster-secret https://example.test",

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -6774,6 +6774,46 @@ fn tool_use_unknown_pretty_json_falls_back_to_compact_not_brace() {
 }
 
 #[test]
+fn compact_json_tool_summaries_redact_nested_cookie_strings_before_serializing() {
+    let pretty = serde_json::to_string_pretty(&json!({
+        "a": ["curl --cookie option=json-secret-two https://e.test"],
+        "b": "Cookie: session=json-secret",
+        "z": "X-Cookie: visible"
+    }))
+    .unwrap();
+
+    for tool_name in ["SomeUnknownTool", "mcp__vault__inspect"] {
+        let line = RecentPlaceholderEvent::tool_use(tool_name, &pretty)
+            .expect("non-empty summary")
+            .render_line();
+        assert!(line.contains("Cookie: ***"), "got: {line}");
+        assert!(line.contains("--cookie ***"), "got: {line}");
+        assert!(line.contains("X-Cookie: visible"), "got: {line}");
+        assert!(!line.contains("json-secret"), "got: {line}");
+    }
+}
+
+#[test]
+fn command_tool_summaries_redact_curl_header_and_cookie_option_spellings() {
+    let commands = [
+        "curl -sHCookie:cluster-secret https://example.test",
+        "curl --header 'Cookie: long-header-secret' https://example.test",
+        "curl --cookie cookie-option-secret https://example.test",
+        "curl -sb$'ansi-cookie-secret' https://example.test",
+    ];
+
+    for command in commands {
+        let input = json!({ "command": command }).to_string();
+        let line = RecentPlaceholderEvent::tool_use("Bash", &input)
+            .expect("non-empty summary")
+            .render_line();
+        assert!(line.contains("***"), "got: {line}");
+        assert!(line.contains("https://example.test"), "got: {line}");
+        assert!(!line.contains("secret"), "got: {line}");
+    }
+}
+
+#[test]
 fn status_events_toolsearch_pretty_json_args_summary_not_bare_brace() {
     // #2847: the status-panel path (status_events_from_tool_use) shares the same
     // format_tool_input fix, so the ToolStart args summary is no longer "{".

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -240,6 +240,47 @@ fn events_from_json_redacts_curl_attached_cookie_header_option() {
 }
 
 #[test]
+fn events_from_json_redacts_quoted_curl_headers_for_bash_aliases() {
+    for name in [
+        "bash",
+        "command_execution",
+        "exec",
+        "exec_command",
+        "run_cmd",
+        "shell_command",
+    ] {
+        let command_key = if name == "exec_command" || name == "shell_command" {
+            "cmd"
+        } else {
+            "command"
+        };
+        let events = events_from_json(&json!({
+            "type": "assistant",
+            "message": {
+                "content": [{
+                    "type": "tool_use",
+                    "name": name,
+                    "input": {
+                        command_key: "curl -H 'Cookie: session=alias-secret' https://example.test",
+                        "description": "Cookie: description-secret"
+                    }
+                }]
+            }
+        }));
+
+        assert_eq!(events.len(), 1, "tool alias: {name}");
+        let line = events[0].render_line();
+        assert!(line.starts_with("[Bash]"), "tool alias {name}: {line}");
+        assert!(line.contains("Cookie: ***"), "tool alias {name}: {line}");
+        assert!(!line.contains("alias-secret"), "tool alias {name}: {line}");
+        assert!(
+            !line.contains("description-secret"),
+            "tool alias {name}: {line}"
+        );
+    }
+}
+
+#[test]
 fn redact_sensitive_for_placeholder_masks_required_patterns() {
     let redacted = redact_sensitive_for_placeholder(
         "sk-abcdefghijklmnopqrstuvwxyz\n\

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -6814,6 +6814,27 @@ fn command_tool_summaries_redact_curl_header_and_cookie_option_spellings() {
 }
 
 #[test]
+fn monitor_tool_summaries_redact_command_fields_before_markdown() {
+    let inputs = [
+        json!({ "command": "Cookie: session=monitor-one" }).to_string(),
+        json!({
+            "description": "Cookie: session=monitor-description",
+            "command": "curl --cookie session=monitor-two https://example.test"
+        })
+        .to_string(),
+    ];
+
+    for input in inputs {
+        let line = RecentPlaceholderEvent::tool_use("Monitor", &input)
+            .expect("non-empty summary")
+            .render_line();
+        assert!(line.starts_with("[Monitor]"), "got: {line}");
+        assert!(line.contains("***"), "got: {line}");
+        assert!(!line.contains("monitor-"), "got: {line}");
+    }
+}
+
+#[test]
 fn status_events_toolsearch_pretty_json_args_summary_not_bare_brace() {
     // #2847: the status-panel path (status_events_from_tool_use) shares the same
     // format_tool_input fix, so the ToolStart args summary is no longer "{".

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -6794,13 +6794,18 @@ fn compact_json_tool_summaries_redact_nested_cookie_strings_before_serializing()
 }
 
 #[test]
-fn compact_json_tool_summaries_redact_cookie_header_map_values() {
+fn compact_json_tool_summaries_redact_cookie_header_map_and_pair_values() {
     let pretty = serde_json::to_string_pretty(&json!({
         "headers": {
             "Cookie": "map-secret-one",
             "Set-Cookie": ["map-secret-two"],
             "X-Cookie": "visible"
-        }
+        },
+        "header_pairs": [
+            ["Cookie", "pair-secret-three"],
+            ["Set-Cookie", ["pair-secret-four"]],
+            ["X-Cookie", "pair-visible"]
+        ]
     }))
     .unwrap();
 
@@ -6810,7 +6815,9 @@ fn compact_json_tool_summaries_redact_cookie_header_map_values() {
             .render_line();
         assert!(line.contains("***"), "got: {line}");
         assert!(line.contains("X-Cookie"), "got: {line}");
+        assert!(line.contains("pair-visible"), "got: {line}");
         assert!(!line.contains("map-secret"), "got: {line}");
+        assert!(!line.contains("pair-secret"), "got: {line}");
     }
 }
 

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -287,6 +287,10 @@ fn is_auth_scheme_marker(token: &str) -> bool {
 /// public payload never carries this tail at all, so this is defense-in-depth
 /// for the authenticated/local surface.
 fn scrub_startup_secrets(raw: &str) -> String {
+    // Startup diagnostics are a separate authenticated/local projection rather
+    // than a tracing-log path, so apply the shared whole-cookie contract here
+    // explicitly before the existing token-aware assignment/auth scrubber.
+    let raw = crate::utils::redact::redact_cookie_headers(raw, "[REDACTED]");
     let mut out: Vec<String> = Vec::new();
     // When the previous token requested redaction of the following value
     // (`Basic`/`Bearer` scheme, or a secret key with the value in the next
@@ -3019,6 +3023,20 @@ mod tests {
         // A non-secret colon token (e.g. a URL) is left intact.
         let s = scrub_startup_secrets("listening http://127.0.0.1:8080 ready");
         assert!(s.contains("http://127.0.0.1:8080"), "mangled url: {s}");
+    }
+
+    #[test]
+    fn scrub_startup_secrets_redacts_entire_cookie_header_values() {
+        let s = scrub_startup_secrets(
+            "Cookie: sessionSecret trailing-data\nSet-Cookie: access=xyz; HttpOnly\nvisible",
+        );
+
+        assert!(s.contains("Cookie: [REDACTED]"), "got: {s}");
+        assert!(s.contains("Set-Cookie: [REDACTED]"), "got: {s}");
+        assert!(s.contains("visible"), "ordinary next line lost: {s}");
+        assert!(!s.contains("sessionSecret"), "cookie token leaked: {s}");
+        assert!(!s.contains("trailing-data"), "cookie tail leaked: {s}");
+        assert!(!s.contains("access=xyz"), "set-cookie leaked: {s}");
     }
 
     #[test]

--- a/src/services/tool_output_guard.rs
+++ b/src/services/tool_output_guard.rs
@@ -163,16 +163,18 @@ pub fn project_for_relay<'a>(
         };
     }
 
-    let excerpt = if report.bytes <= ERROR_EDGE_BYTES * 2 {
-        crate::services::discord::formatting::redact_sensitive_for_placeholder(content)
+    // Redact the complete error before taking bounded edges. Splitting first
+    // can separate a Cookie header name from the remainder of its value, which
+    // leaves the tail without enough context to recognize and mask the secret.
+    let redacted = crate::services::discord::formatting::redact_sensitive_for_placeholder(content);
+    let excerpt = if redacted.len() <= ERROR_EDGE_BYTES * 2 {
+        redacted
     } else {
-        let head = crate::services::discord::formatting::redact_sensitive_for_placeholder(
-            utf8_head(content, ERROR_EDGE_BYTES),
-        );
-        let tail = crate::services::discord::formatting::redact_sensitive_for_placeholder(
-            utf8_tail(content, ERROR_EDGE_BYTES),
-        );
-        let omitted = report.bytes.saturating_sub(ERROR_EDGE_BYTES * 2);
+        let head = utf8_head(&redacted, ERROR_EDGE_BYTES);
+        let tail = utf8_tail(&redacted, ERROR_EDGE_BYTES);
+        let omitted = redacted
+            .len()
+            .saturating_sub(head.len().saturating_add(tail.len()));
         format!("{head}\n… {omitted} bytes omitted …\n{tail}")
     };
     RelayOutputProjection {
@@ -282,5 +284,25 @@ mod tests {
         assert!(projection.content.contains("password=*** 끝🙂"));
         assert!(!projection.content.contains("top-secret"));
         assert!(!projection.content.contains("hunter2"));
+    }
+
+    #[test]
+    fn large_error_redacts_cookie_before_extracting_head_and_tail() {
+        let cookie_value = "boundary-cookie-secret-".repeat(420);
+        let raw = format!(
+            "{}\nCookie: {cookie_value}\nvisible tail {}",
+            "x".repeat(ERROR_EDGE_BYTES - 16),
+            "y".repeat(64)
+        );
+
+        let projection = project_for_relay(Some("Bash"), true, &raw);
+
+        assert_eq!(
+            projection.disposition,
+            RelayOutputDisposition::SummarizeError
+        );
+        assert!(projection.content.contains("Cookie: ***"));
+        assert!(projection.content.contains("visible tail"));
+        assert!(!projection.content.contains("boundary-cookie-secret"));
     }
 }

--- a/src/services/tool_output_guard.rs
+++ b/src/services/tool_output_guard.rs
@@ -25,6 +25,7 @@ pub const OVERSIZE_BYTE_THRESHOLD: usize = 8 * 1024;
 /// downstream pipelines can grep for oversized outputs without reparsing.
 pub const TRUNCATION_MARKER: &str = "[tool_output_oversize:truncated]";
 const ERROR_EDGE_BYTES: usize = 1024;
+const ERROR_HEADER_CONTEXT_BYTES: usize = 64 * 1024;
 
 static OVERSIZE_COUNT: AtomicU64 = AtomicU64::new(0);
 static TOTAL_OUTPUT_BYTES: AtomicU64 = AtomicU64::new(0);
@@ -105,6 +106,68 @@ fn utf8_tail(content: &str, max_bytes: usize) -> &str {
     &content[start..]
 }
 
+fn bounded_redacted_error_tail(content: &str, max_bytes: usize) -> (String, usize) {
+    let raw_tail = utf8_tail(content, max_bytes);
+    let tail_start = content.len().saturating_sub(raw_tail.len());
+    let mut safe_tail = raw_tail;
+    let mut skipped = 0;
+
+    // A tail that begins in the middle of a physical line can be retained when
+    // its borrowed prefix proves it is not a sensitive header. The prefix-only
+    // scan is allocation-free; if a Cookie/Authorization header or obs-fold
+    // continuation began in the omitted region, fail closed by dropping the
+    // partial line.
+    if tail_start > 0 && content.as_bytes().get(tail_start.wrapping_sub(1)) != Some(&b'\n') {
+        let context_start = tail_start.saturating_sub(ERROR_HEADER_CONTEXT_BYTES);
+        let context = &content[context_start..tail_start];
+        let newline = context.rfind('\n');
+        let has_complete_line_prefix = context_start == 0 || newline.is_some();
+        let line_prefix = newline.map_or(context, |position| &context[position + 1..]);
+        let may_continue_sensitive_header = !has_complete_line_prefix
+            || line_prefix.starts_with([' ', '\t'])
+            || crate::utils::redact::contains_sensitive_header_prefix(line_prefix);
+        if may_continue_sensitive_header {
+            if let Some(line_end) = safe_tail.find('\n') {
+                skipped += line_end + 1;
+                safe_tail = &safe_tail[line_end + 1..];
+            } else {
+                return (
+                    "[… truncated partial line redacted …]".to_string(),
+                    raw_tail.len(),
+                );
+            }
+        }
+    }
+
+    // Leading indented physical lines may be obs-fold continuations of a
+    // sensitive header that began in the omitted region. Fail closed until the
+    // first non-continuation line, then apply the normal redactor to that bounded
+    // suffix only.
+    while safe_tail.starts_with([' ', '\t']) {
+        if let Some(line_end) = safe_tail.find('\n') {
+            skipped += line_end + 1;
+            safe_tail = &safe_tail[line_end + 1..];
+        } else {
+            skipped += safe_tail.len();
+            safe_tail = "";
+            break;
+        }
+    }
+
+    let redacted =
+        crate::services::discord::formatting::redact_sensitive_for_placeholder(safe_tail);
+    if skipped == 0 {
+        (redacted, 0)
+    } else if redacted.is_empty() {
+        ("[… truncated partial line redacted …]".to_string(), skipped)
+    } else {
+        (
+            format!("[… truncated partial line redacted …]\n{redacted}"),
+            skipped,
+        )
+    }
+}
+
 fn normalized_tool_key(name: &str) -> String {
     name.chars()
         .filter(|ch| ch.is_ascii_alphanumeric())
@@ -163,18 +226,21 @@ pub fn project_for_relay<'a>(
         };
     }
 
-    // Redact the complete error before taking bounded edges. Splitting first
-    // can separate a Cookie header name from the remainder of its value, which
-    // leaves the tail without enough context to recognize and mask the secret.
-    let redacted = crate::services::discord::formatting::redact_sensitive_for_placeholder(content);
-    let excerpt = if redacted.len() <= ERROR_EDGE_BYTES * 2 {
-        redacted
+    // Keep both allocation and regex work bounded. Line-heavy errors below the
+    // combined edge budget are sanitized once without duplicating overlapping
+    // head/tail slices. Larger errors use a trusted head plus a tail that drops
+    // an untrusted partial first line and leading obs-fold continuations.
+    let excerpt = if report.bytes <= ERROR_EDGE_BYTES * 2 {
+        crate::services::discord::formatting::redact_sensitive_for_placeholder(content)
     } else {
-        let head = utf8_head(&redacted, ERROR_EDGE_BYTES);
-        let tail = utf8_tail(&redacted, ERROR_EDGE_BYTES);
-        let omitted = redacted
-            .len()
-            .saturating_sub(head.len().saturating_add(tail.len()));
+        let raw_head = utf8_head(content, ERROR_EDGE_BYTES);
+        let head = crate::services::discord::formatting::redact_sensitive_for_placeholder(raw_head);
+        let raw_tail = utf8_tail(content, ERROR_EDGE_BYTES);
+        let (tail, skipped_tail_bytes) = bounded_redacted_error_tail(content, ERROR_EDGE_BYTES);
+        let omitted = report
+            .bytes
+            .saturating_sub(raw_head.len().saturating_add(raw_tail.len()))
+            .saturating_add(skipped_tail_bytes);
         format!("{head}\n… {omitted} bytes omitted …\n{tail}")
     };
     RelayOutputProjection {
@@ -304,5 +370,44 @@ mod tests {
         assert!(projection.content.contains("Cookie: ***"));
         assert!(projection.content.contains("visible tail"));
         assert!(!projection.content.contains("boundary-cookie-secret"));
+    }
+
+    #[test]
+    fn very_large_single_line_error_keeps_projection_memory_bounded() {
+        let raw = format!("Cookie: {}", "bulk-secret".repeat(100_000));
+
+        let projection = project_for_relay(Some("Bash"), true, &raw);
+
+        assert_eq!(
+            projection.disposition,
+            RelayOutputDisposition::SummarizeError
+        );
+        assert!(projection.content.len() < ERROR_EDGE_BYTES * 2 + 512);
+        assert!(projection.content.contains("Cookie: ***"));
+        assert!(
+            projection
+                .content
+                .contains("truncated partial line redacted")
+        );
+        assert!(!projection.content.contains("bulk-secret"));
+    }
+
+    #[test]
+    fn line_heavy_small_error_is_sanitized_once_without_overlapping_edges() {
+        let raw = (0..=OVERSIZE_LINE_THRESHOLD)
+            .map(|index| format!("line-{index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(raw.len() < ERROR_EDGE_BYTES * 2);
+
+        let projection = project_for_relay(Some("Bash"), true, &raw);
+
+        assert_eq!(
+            projection.disposition,
+            RelayOutputDisposition::SummarizeError
+        );
+        assert_eq!(projection.content.matches("line-0\n").count(), 1);
+        assert!(projection.content.ends_with("line-100"));
+        assert!(!projection.content.contains("bytes omitted"));
     }
 }

--- a/src/services/tool_output_guard.rs
+++ b/src/services/tool_output_guard.rs
@@ -118,8 +118,11 @@ fn bounded_redacted_error_tail(content: &str, max_bytes: usize) -> (String, usiz
     // continuation began in the omitted region, fail closed by dropping the
     // partial line.
     if tail_start > 0 && content.as_bytes().get(tail_start.wrapping_sub(1)) != Some(&b'\n') {
-        let context_start = tail_start.saturating_sub(ERROR_HEADER_CONTEXT_BYTES);
-        let context = &content[context_start..tail_start];
+        // Reuse the UTF-8-aware tail helper for the borrowed context window.
+        // Subtracting a byte budget directly can land inside a multibyte code
+        // point even though `tail_start` itself is a valid boundary.
+        let context = utf8_tail(&content[..tail_start], ERROR_HEADER_CONTEXT_BYTES);
+        let context_start = tail_start.saturating_sub(context.len());
         let newline = context.rfind('\n');
         let has_complete_line_prefix = context_start == 0 || newline.is_some();
         let line_prefix = newline.map_or(context, |position| &context[position + 1..]);
@@ -390,6 +393,23 @@ mod tests {
                 .contains("truncated partial line redacted")
         );
         assert!(!projection.content.contains("bulk-secret"));
+    }
+
+    #[test]
+    fn very_large_non_ascii_error_aligns_context_window_to_utf8() {
+        // 64 KiB before a valid tail boundary falls inside one of these
+        // three-byte code points. The bounded context scan must align forward
+        // instead of panicking while slicing the borrowed input.
+        let raw = "€".repeat(30_000);
+
+        let projection = project_for_relay(Some("Bash"), true, &raw);
+
+        assert_eq!(
+            projection.disposition,
+            RelayOutputDisposition::SummarizeError
+        );
+        assert!(projection.content.contains(TRUNCATION_MARKER));
+        assert!(projection.content.len() < ERROR_EDGE_BYTES * 2 + 512);
     }
 
     #[test]

--- a/src/utils/redact.rs
+++ b/src/utils/redact.rs
@@ -30,13 +30,13 @@ static COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     // delimiter and following shell command are not consumed as header value.
     // Multiline mode lets `^` recognize each header line.
     Regex::new(
-        r#"(?im)((?:^|[^"!#$%&'*+.^_`|~a-z0-9\-\r\n])(?:set-cookie|cookie)[ \t]*:[ \t]*)(?:[^\r\n]+(?:\r?\n[ \t]+[^\r\n]+)*|(?:\r?\n[ \t]+[^\r\n]+)+)"#,
+        r#"(?im)((?:^|[^"!#$%&'*+.^_`|~a-z0-9=\-\r\n])(?:set-cookie|cookie)[ \t]*:[ \t]*)(?:[^\r\n]+(?:\r?\n[ \t]+[^\r\n]+)*|(?:\r?\n[ \t]+[^\r\n]+)+)"#,
     )
     .unwrap()
 });
 static SINGLE_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?im)((?:^|[ \t;&|()<>])(?:-H[ \t]*)?'(?:set-cookie|cookie)[ \t]*:[ \t]*)[^'\r\n]*('?)",
+        r"(?m)((?:^|[ \t;&|()<>])(?:(?:-[A-Za-z]*?H[ \t]*|(?i:--header)(?:[ \t]+|=[ \t]*)))?'(?i:set-cookie|cookie)[ \t]*:[ \t]*)[^'\r\n]*('?)",
     )
     .unwrap()
 });
@@ -45,13 +45,13 @@ static ANSI_C_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     // escaped quote inside the header value. Keep this grammar separate from
     // ordinary single quotes, where backslashes have no escape semantics.
     Regex::new(
-        r"(?im)((?:^|[ \t;&|()<>])(?:-H[ \t]*)?\$'(?:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^'\\\r\n])*('?)",
+        r"(?m)((?:^|[ \t;&|()<>])(?:(?:-[A-Za-z]*?H[ \t]*|(?i:--header)(?:[ \t]+|=[ \t]*)))?\$'(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^'\\\r\n])*('?)",
     )
     .unwrap()
 });
 static DOUBLE_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r#"(?im)((?:^|[ \t;&|()<>])(?:-H[ \t]*)?"(?:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^"\\\r\n])*("?)"#,
+        r#"(?m)((?:^|[ \t;&|()<>])(?:(?:-[A-Za-z]*?H[ \t]*|(?i:--header)(?:[ \t]+|=[ \t]*)))?"(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^"\\\r\n])*("?)"#,
     )
     .unwrap()
 });
@@ -59,11 +59,49 @@ static CURL_ATTACHED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     // curl accepts an attached short-option argument (`-HCookie:value`). Keep
     // this command-token rule separate from COOKIE_HEADER_RE: a real header
     // value extends to end-of-line and may obs-fold, while an unquoted shell
-    // argument ends at whitespace, quote, or a shell control operator. Requiring
-    // a shell-token boundary before `-H` prevents suffix matches in tokens such
-    // as `X-HCookie`; quoted values use the dedicated rules above.
+    // argument ends at whitespace, quote, or a shell control operator. Curl
+    // permits boolean short options before the value-taking H (`-sH...`) and
+    // the equivalent `--header=...` spelling. The lazy cluster prefix stops at
+    // the first H, whose remaining token bytes are the header argument.
     Regex::new(
-        r#"(?im)((?:^|[ \t;&|()<>])-H(?:set-cookie|cookie)[ \t]*:[ \t]*)[^ \t\r\n;&|()<>'"]+"#,
+        r#"(?m)((?:^|[ \t;&|()<>])(?:-[A-Za-z]*?H[ \t]*|(?i:--header)(?:[ \t]+|=[ \t]*))(?i:set-cookie|cookie)[ \t]*:[ \t]*)[^ \t\r\n;&|()<>'"]+"#,
+    )
+    .unwrap()
+});
+static SHELL_COOKIE_HEADER_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?m)(?:^|[ \t;&|()<>])(?:-[A-Za-z]*?H[ \t]*|(?i:--header)(?:[ \t]+|=[ \t]*))(?:\$?'|")?(?i:set-cookie|cookie)[ \t]*:"#,
+    )
+    .unwrap()
+});
+static CURL_COMMAND_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?i)(?:^|[ \t;&|()<>/'"\\])curl(?:\.exe)?(?:$|[ \t;&|()<>/'"\\])"#).unwrap()
+});
+static CURL_COOKIE_OPTION_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?m)(?:^|[ \t;&|()<>])(?:-[A-Za-z]*?b(?:[ \t]+)?|(?i:--cookie)(?:[ \t]+|=[ \t]*))")
+        .unwrap()
+});
+static CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?m)((?:^|[ \t;&|()<>])(?:-[A-Za-z]*?b[ \t]*|(?i:--cookie)(?:[ \t]+|=[ \t]*)))[^ \t\r\n;&|()<>'"$]+"#,
+    )
+    .unwrap()
+});
+static SINGLE_QUOTED_CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?m)((?:^|[ \t;&|()<>])(?:-[A-Za-z]*?b[ \t]*|(?i:--cookie)(?:[ \t]+|=[ \t]*))')[^'\r\n]*('?)",
+    )
+    .unwrap()
+});
+static ANSI_C_QUOTED_CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?m)((?:^|[ \t;&|()<>])(?:-[A-Za-z]*?b[ \t]*|(?i:--cookie)(?:[ \t]+|=[ \t]*))\$')(?:\\.|[^'\\\r\n])*('?)",
+    )
+    .unwrap()
+});
+static DOUBLE_QUOTED_CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?m)((?:^|[ \t;&|()<>])(?:-[A-Za-z]*?b[ \t]*|(?i:--cookie)(?:[ \t]+|=[ \t]*))")(?:\\.|[^"\\\r\n])*("?)"#,
     )
     .unwrap()
 });
@@ -71,10 +109,10 @@ static SENSITIVE_HEADER_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
     // Prefix-only detector for a relay tail that begins mid-line. It never
     // materializes the matched value; callers use it only to decide whether an
     // already-bounded partial line must be dropped. Quotes are accepted as
-    // shell delimiters, and curl's `-H` form is explicit so `X-Cookie` remains
-    // distinct from a sensitive header name.
+    // shell delimiters, including clustered/long curl header options, so
+    // `X-Cookie` remains distinct from a sensitive header name.
     Regex::new(
-        r#"(?im)(?:^|[^!#$%&*+.^_`|~a-z0-9\-])(?:(?:authorization|set-cookie|cookie)[ \t]*:|-H[ \t]*['"]?(?:set-cookie|cookie)[ \t]*:)"#,
+        r#"(?m)(?:^|[^!#$%&*+.^_`|~a-z0-9\-])(?:(?i:authorization|set-cookie|cookie)[ \t]*:|(?:-[A-Za-z]*?H[ \t]*|(?i:--header)(?:[ \t]+|=[ \t]*))(?:\$?'|")?(?i:set-cookie|cookie)[ \t]*:)"#,
     )
     .unwrap()
 });
@@ -200,6 +238,76 @@ fn replace_quoted_header_value(input: &str, regex: &Regex, marker: &str) -> Stri
         .into_owned()
 }
 
+fn redact_curl_cookie_options(input: &str, marker: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut continued_curl_command = false;
+
+    for line in input.split_inclusive('\n') {
+        let is_curl_command = CURL_COMMAND_RE.is_match(line) || continued_curl_command;
+        if is_curl_command {
+            let redacted =
+                replace_quoted_header_value(line, &ANSI_C_QUOTED_CURL_COOKIE_OPTION_RE, marker);
+            let redacted = replace_quoted_header_value(
+                &redacted,
+                &SINGLE_QUOTED_CURL_COOKIE_OPTION_RE,
+                marker,
+            );
+            let redacted = replace_quoted_header_value(
+                &redacted,
+                &DOUBLE_QUOTED_CURL_COOKIE_OPTION_RE,
+                marker,
+            );
+            output.push_str(&replace_header_value(
+                &redacted,
+                &CURL_COOKIE_OPTION_RE,
+                marker,
+            ));
+        } else {
+            output.push_str(line);
+        }
+
+        continued_curl_command = is_curl_command
+            && line
+                .trim_end_matches(['\r', '\n'])
+                .trim_end()
+                .ends_with('\\');
+    }
+
+    output
+}
+
+fn replace_generic_cookie_headers(input: &str, marker: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut generic_chunk = String::new();
+    let mut continued_shell_option = false;
+
+    let flush_generic = |output: &mut String, chunk: &mut String| {
+        if !chunk.is_empty() {
+            output.push_str(&replace_header_value(chunk, &COOKIE_HEADER_RE, marker));
+            chunk.clear();
+        }
+    };
+
+    for line in input.split_inclusive('\n') {
+        let is_shell_option =
+            SHELL_COOKIE_HEADER_OPTION_RE.is_match(line) || continued_shell_option;
+        if is_shell_option {
+            flush_generic(&mut output, &mut generic_chunk);
+            output.push_str(line);
+        } else {
+            generic_chunk.push_str(line);
+        }
+
+        continued_shell_option = is_shell_option
+            && line
+                .trim_end_matches(['\r', '\n'])
+                .trim_end()
+                .ends_with('\\');
+    }
+    flush_generic(&mut output, &mut generic_chunk);
+    output
+}
+
 /// Redact sensitive HTTP header values while preserving useful header context.
 ///
 /// Authorization keeps a recognized authentication scheme (for example,
@@ -221,11 +329,70 @@ pub(crate) fn redact_cookie_headers(input: &str, marker: &str) -> String {
     let redacted = replace_quoted_header_value(&redacted, &SINGLE_QUOTED_COOKIE_HEADER_RE, marker);
     let redacted = replace_quoted_header_value(&redacted, &DOUBLE_QUOTED_COOKIE_HEADER_RE, marker);
     let redacted = replace_header_value(&redacted, &CURL_ATTACHED_COOKIE_HEADER_RE, marker);
-    replace_header_value(&redacted, &COOKIE_HEADER_RE, marker)
+    let redacted = redact_curl_cookie_options(&redacted, marker);
+    replace_generic_cookie_headers(&redacted, marker)
 }
 
 pub(crate) fn contains_sensitive_header_prefix(input: &str) -> bool {
     SENSITIVE_HEADER_PREFIX_RE.is_match(input)
+        || (CURL_COMMAND_RE.is_match(input) && CURL_COOKIE_OPTION_PREFIX_RE.is_match(input))
+}
+
+/// Serialize a JSON value compactly after redacting Cookie-bearing strings.
+///
+/// Redacting before serialization avoids JSON quote/escape boundaries blocking
+/// the text matcher. Writing directly to the output also avoids cloning the
+/// complete `Value`, and sanitizes object keys without key-collision loss.
+pub(crate) fn serialize_json_with_redacted_cookie_headers(
+    value: &serde_json::Value,
+    marker: &str,
+) -> String {
+    fn push_value(output: &mut String, value: &serde_json::Value, marker: &str) {
+        match value {
+            serde_json::Value::Null => output.push_str("null"),
+            serde_json::Value::Bool(value) => {
+                output.push_str(if *value { "true" } else { "false" })
+            }
+            serde_json::Value::Number(value) => output.push_str(&value.to_string()),
+            serde_json::Value::String(value) => {
+                let redacted = redact_cookie_headers(value, marker);
+                output.push_str(
+                    &serde_json::to_string(&redacted)
+                        .expect("serializing a JSON string cannot fail"),
+                );
+            }
+            serde_json::Value::Array(values) => {
+                output.push('[');
+                for (index, value) in values.iter().enumerate() {
+                    if index > 0 {
+                        output.push(',');
+                    }
+                    push_value(output, value, marker);
+                }
+                output.push(']');
+            }
+            serde_json::Value::Object(values) => {
+                output.push('{');
+                for (index, (key, value)) in values.iter().enumerate() {
+                    if index > 0 {
+                        output.push(',');
+                    }
+                    let redacted_key = redact_cookie_headers(key, marker);
+                    output.push_str(
+                        &serde_json::to_string(&redacted_key)
+                            .expect("serializing a JSON object key cannot fail"),
+                    );
+                    output.push(':');
+                    push_value(output, value, marker);
+                }
+                output.push('}');
+            }
+        }
+    }
+
+    let mut output = String::new();
+    push_value(&mut output, value, marker);
+    output
 }
 
 pub(crate) fn redact_known_secrets(input: &str) -> String {
@@ -280,6 +447,7 @@ mod tests {
     use super::{
         contains_sensitive_header_prefix, dsn_password, mask_dsn_password, redact_known_secrets,
         redact_sensitive_headers, register_known_secret, register_secret_or_dsn,
+        serialize_json_with_redacted_cookie_headers,
     };
 
     fn redact_known_secret(input: &str) -> String {
@@ -440,14 +608,117 @@ mod tests {
     }
 
     #[test]
+    fn curl_header_option_spellings_share_whole_cookie_redaction() {
+        let redacted = redact_sensitive_headers(
+            r#"curl -sHCookie:cluster-secret --header 'Set-Cookie: long-secret' --header=$'Cookie: ansi-secret\'tail-secret' --header="Cookie: double-secret" --header=Cookie:equals-secret -HX-Cookie:visible https://example.test"#,
+            "***",
+        );
+
+        assert!(redacted.contains("-sHCookie:***"));
+        assert!(redacted.contains("--header 'Set-Cookie: ***'"));
+        assert!(redacted.contains("--header=$'Cookie: ***'"));
+        assert!(redacted.contains("--header=\"Cookie: ***\""));
+        assert!(redacted.contains("--header=Cookie:***"));
+        assert!(
+            redacted.contains("-HX-Cookie:visible"),
+            "distinct header was changed: {redacted}"
+        );
+        assert!(redacted.contains("https://example.test"));
+        for secret in [
+            "cluster-secret",
+            "long-secret",
+            "ansi-secret",
+            "tail-secret",
+            "double-secret",
+            "equals-secret",
+        ] {
+            assert!(
+                !redacted.contains(secret),
+                "cookie leak ({secret}): {redacted}"
+            );
+        }
+    }
+
+    #[test]
+    fn curl_cookie_data_options_are_redacted_without_matching_unrelated_flags() {
+        let redacted = redact_sensitive_headers(
+            "curl --cookie session=one -b \"access=two\" -sb$'third=three\\'tail=four' --cookie='fifth=five' --cookie=sixth=six --cookie-jar visible.jar -c visible-two.jar https://example.test\nother -b visible-non-curl",
+            "***",
+        );
+
+        assert!(redacted.contains("--cookie ***"));
+        assert!(redacted.contains("-b \"***\""));
+        assert!(
+            redacted.contains("-sb$'***'"),
+            "ANSI-C delimiter was changed: {redacted}"
+        );
+        assert!(redacted.contains("--cookie='***'"));
+        assert!(redacted.contains("--cookie=***"));
+        assert!(redacted.contains("--cookie-jar visible.jar"));
+        assert!(redacted.contains("-c visible-two.jar"));
+        assert!(redacted.contains("other -b visible-non-curl"));
+        assert!(redacted.contains("https://example.test"));
+        for secret in [
+            "session=one",
+            "access=two",
+            "third=three",
+            "tail=four",
+            "fifth=five",
+            "sixth=six",
+        ] {
+            assert!(
+                !redacted.contains(secret),
+                "cookie leak ({secret}): {redacted}"
+            );
+        }
+    }
+
+    #[test]
+    fn compact_json_serialization_redacts_nested_cookie_strings_and_keys() {
+        let value = serde_json::json!({
+            "headers": "Cookie: json-secret",
+            "nested": ["curl --cookie option=json-secret-two https://example.test"],
+            "Cookie: key-secret": "Set-Cookie: value-secret",
+            "safe": "X-Cookie: visible"
+        });
+
+        let serialized = serialize_json_with_redacted_cookie_headers(&value, "***");
+        let reparsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+
+        assert!(serialized.contains("Cookie: ***"));
+        assert!(serialized.contains("--cookie ***"));
+        assert!(serialized.contains("X-Cookie: visible"));
+        assert!(reparsed.is_object());
+        for secret in [
+            "json-secret",
+            "json-secret-two",
+            "key-secret",
+            "value-secret",
+        ] {
+            assert!(
+                !serialized.contains(secret),
+                "JSON cookie leak ({secret}): {serialized}"
+            );
+        }
+    }
+
+    #[test]
     fn sensitive_header_prefix_detector_distinguishes_suffix_names() {
         assert!(contains_sensitive_header_prefix("Cookie: partial"));
         assert!(contains_sensitive_header_prefix("curl -H'Cookie: partial"));
+        assert!(contains_sensitive_header_prefix("curl -sHCookie: partial"));
+        assert!(contains_sensitive_header_prefix(
+            "curl --header=$'Cookie: partial"
+        ));
+        assert!(contains_sensitive_header_prefix(
+            "curl --cookie session=partial"
+        ));
         assert!(contains_sensitive_header_prefix(
             "Authorization: Bearer partial"
         ));
         assert!(!contains_sensitive_header_prefix("X-Cookie: visible"));
         assert!(!contains_sensitive_header_prefix("CookieJar: visible"));
+        assert!(!contains_sensitive_header_prefix("other -b visible"));
     }
 
     #[test]

--- a/src/utils/redact.rs
+++ b/src/utils/redact.rs
@@ -34,28 +34,36 @@ static COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     )
     .unwrap()
 });
+const CURL_HEADER_OPTION_PATTERN: &str =
+    r"(?:-[A-Za-z]*?H[ \t]*(?:\\\r?\n[ \t]*)*|(?i:--header)(?:[ \t]+|=[ \t]*)(?:\\\r?\n[ \t]*)*)";
+const CURL_COOKIE_OPTION_PATTERN: &str =
+    r"(?:-[A-Za-z]*?b[ \t]*(?:\\\r?\n[ \t]*)*|(?i:--cookie)(?:[ \t]+|=[ \t]*)(?:\\\r?\n[ \t]*)*)";
+
 static SINGLE_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"(?m)((?:^|[ \t;&|()<>])(?:(?:-[A-Za-z]*?H[ \t]*|(?i:--header)(?:[ \t]+|=[ \t]*)))?'(?i:set-cookie|cookie)[ \t]*:[ \t]*)[^'\r\n]*('?)",
-    )
+    Regex::new(&format!(
+        r"(?m)((?:^|[ \t;&|()<>])(?:{})?'(?i:set-cookie|cookie)[ \t]*:[ \t]*)[^'\r\n]*('?)",
+        CURL_HEADER_OPTION_PATTERN
+    ))
     .unwrap()
 });
 static ANSI_C_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     // Bash ANSI-C strings use `$'…'` and allow backslash escapes, including an
     // escaped quote inside the header value. Keep this grammar separate from
     // ordinary single quotes, where backslashes have no escape semantics.
-    Regex::new(
-        r"(?m)((?:^|[ \t;&|()<>])(?:(?:-[A-Za-z]*?H[ \t]*|(?i:--header)(?:[ \t]+|=[ \t]*)))?\$'(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^'\\\r\n])*('?)",
-    )
+    Regex::new(&format!(
+        r"(?m)((?:^|[ \t;&|()<>])(?:{})?\$'(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^'\\\r\n])*('?)",
+        CURL_HEADER_OPTION_PATTERN
+    ))
     .unwrap()
 });
 static DOUBLE_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r#"(?m)((?:^|[ \t;&|()<>])(?:(?:-[A-Za-z]*?H[ \t]*|(?i:--header)(?:[ \t]+|=[ \t]*)))?"(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^"\\\r\n])*("?)"#,
-    )
+    Regex::new(&format!(
+        r#"(?m)((?:^|[ \t;&|()<>])(?:{})?"(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^"\\\r\n])*("?)"#,
+        CURL_HEADER_OPTION_PATTERN
+    ))
     .unwrap()
 });
-static CURL_ATTACHED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
+static CURL_UNQUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     // curl accepts an attached short-option argument (`-HCookie:value`). Keep
     // this command-token rule separate from COOKIE_HEADER_RE: a real header
     // value extends to end-of-line and may obs-fold, while an unquoted shell
@@ -63,46 +71,55 @@ static CURL_ATTACHED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     // permits boolean short options before the value-taking H (`-sH...`) and
     // the equivalent `--header=...` spelling. The lazy cluster prefix stops at
     // the first H, whose remaining token bytes are the header argument.
-    Regex::new(
-        r#"(?m)((?:^|[ \t;&|()<>])(?:-[A-Za-z]*?H[ \t]*|(?i:--header)(?:[ \t]+|=[ \t]*))(?i:set-cookie|cookie)[ \t]*:[ \t]*)[^ \t\r\n;&|()<>'"]+"#,
-    )
+    Regex::new(&format!(
+        r#"(?m)((?:^|[ \t;&|()<>]){}(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\[^\r\n]|[^ \t\r\n;&|()<>'"$\\])(?:\\(?:\r?\n[ \t]*|[^\r\n])|[^ \t\r\n;&|()<>'"$\\])*"#,
+        CURL_HEADER_OPTION_PATTERN
+    ))
     .unwrap()
 });
 static SHELL_COOKIE_HEADER_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r#"(?m)(?:^|[ \t;&|()<>])(?:-[A-Za-z]*?H[ \t]*|(?i:--header)(?:[ \t]+|=[ \t]*))(?:\$?'|")?(?i:set-cookie|cookie)[ \t]*:"#,
-    )
+    Regex::new(&format!(
+        r#"(?m)(?:^|[ \t;&|()<>]){}(?:\$?'|")?(?i:set-cookie|cookie)[ \t]*:"#,
+        CURL_HEADER_OPTION_PATTERN
+    ))
     .unwrap()
 });
 static CURL_COMMAND_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(?i)(?:^|[ \t;&|()<>/'"\\])curl(?:\.exe)?(?:$|[ \t;&|()<>/'"\\])"#).unwrap()
 });
 static CURL_COOKIE_OPTION_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?m)(?:^|[ \t;&|()<>])(?:-[A-Za-z]*?b(?:[ \t]+)?|(?i:--cookie)(?:[ \t]+|=[ \t]*))")
-        .unwrap()
+    Regex::new(&format!(
+        r"(?m)(?:^|[ \t;&|()<>]){}",
+        CURL_COOKIE_OPTION_PATTERN
+    ))
+    .unwrap()
 });
 static CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r#"(?m)((?:^|[ \t;&|()<>])(?:-[A-Za-z]*?b[ \t]*|(?i:--cookie)(?:[ \t]+|=[ \t]*)))[^ \t\r\n;&|()<>'"$]+"#,
-    )
+    Regex::new(&format!(
+        r#"(?m)((?:^|[ \t;&|()<>]){})(?:\\[^\r\n]|[^ \t\r\n;&|()<>'"$\\])(?:\\(?:\r?\n[ \t]*|[^\r\n])|[^ \t\r\n;&|()<>'"$\\])*"#,
+        CURL_COOKIE_OPTION_PATTERN
+    ))
     .unwrap()
 });
 static SINGLE_QUOTED_CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"(?m)((?:^|[ \t;&|()<>])(?:-[A-Za-z]*?b[ \t]*|(?i:--cookie)(?:[ \t]+|=[ \t]*))')[^'\r\n]*('?)",
-    )
+    Regex::new(&format!(
+        r"(?m)((?:^|[ \t;&|()<>]){}')[^'\r\n]*('?)",
+        CURL_COOKIE_OPTION_PATTERN
+    ))
     .unwrap()
 });
 static ANSI_C_QUOTED_CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"(?m)((?:^|[ \t;&|()<>])(?:-[A-Za-z]*?b[ \t]*|(?i:--cookie)(?:[ \t]+|=[ \t]*))\$')(?:\\.|[^'\\\r\n])*('?)",
-    )
+    Regex::new(&format!(
+        r"(?m)((?:^|[ \t;&|()<>]){}\$')(?:\\.|[^'\\\r\n])*('?)",
+        CURL_COOKIE_OPTION_PATTERN
+    ))
     .unwrap()
 });
 static DOUBLE_QUOTED_CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r#"(?m)((?:^|[ \t;&|()<>])(?:-[A-Za-z]*?b[ \t]*|(?i:--cookie)(?:[ \t]+|=[ \t]*))")(?:\\.|[^"\\\r\n])*("?)"#,
-    )
+    Regex::new(&format!(
+        r#"(?m)((?:^|[ \t;&|()<>]){}")(?:\\.|[^"\\\r\n])*("?)"#,
+        CURL_COOKIE_OPTION_PATTERN
+    ))
     .unwrap()
 });
 static SENSITIVE_HEADER_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -111,9 +128,10 @@ static SENSITIVE_HEADER_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
     // already-bounded partial line must be dropped. Quotes are accepted as
     // shell delimiters, including clustered/long curl header options, so
     // `X-Cookie` remains distinct from a sensitive header name.
-    Regex::new(
-        r#"(?m)(?:^|[^!#$%&*+.^_`|~a-z0-9\-])(?:(?i:authorization|set-cookie|cookie)[ \t]*:|(?:-[A-Za-z]*?H[ \t]*|(?i:--header)(?:[ \t]+|=[ \t]*))(?:\$?'|")?(?i:set-cookie|cookie)[ \t]*:)"#,
-    )
+    Regex::new(&format!(
+        r#"(?m)(?:^|[^!#$%&*+.^_`|~a-z0-9\-])(?:(?i:authorization|set-cookie|cookie)[ \t]*:|{}(?:\$?'|")?(?i:set-cookie|cookie)[ \t]*:)"#,
+        CURL_HEADER_OPTION_PATTERN
+    ))
     .unwrap()
 });
 // Capture group 1 = key (+ optional surrounding `"`/`'` quote) + `=`/`:`
@@ -238,39 +256,54 @@ fn replace_quoted_header_value(input: &str, regex: &Regex, marker: &str) -> Stri
         .into_owned()
 }
 
+fn shell_line_continues(line: &str) -> bool {
+    let trimmed = line.trim_end_matches(['\r', '\n']).trim_end();
+    trimmed
+        .as_bytes()
+        .iter()
+        .rev()
+        .take_while(|&&byte| byte == b'\\')
+        .count()
+        % 2
+        == 1
+}
+
+fn redact_curl_cookie_option_chunk(input: &str, marker: &str) -> String {
+    let redacted = replace_quoted_header_value(input, &ANSI_C_QUOTED_CURL_COOKIE_OPTION_RE, marker);
+    let redacted =
+        replace_quoted_header_value(&redacted, &SINGLE_QUOTED_CURL_COOKIE_OPTION_RE, marker);
+    let redacted =
+        replace_quoted_header_value(&redacted, &DOUBLE_QUOTED_CURL_COOKIE_OPTION_RE, marker);
+    replace_header_value(&redacted, &CURL_COOKIE_OPTION_RE, marker)
+}
+
 fn redact_curl_cookie_options(input: &str, marker: &str) -> String {
     let mut output = String::with_capacity(input.len());
-    let mut continued_curl_command = false;
+    let mut logical_command = String::new();
+    let mut contains_curl = false;
+
+    let flush = |output: &mut String, command: &mut String, contains_curl: bool| {
+        if contains_curl {
+            output.push_str(&redact_curl_cookie_option_chunk(command, marker));
+        } else {
+            output.push_str(command);
+        }
+        command.clear();
+    };
 
     for line in input.split_inclusive('\n') {
-        let is_curl_command = CURL_COMMAND_RE.is_match(line) || continued_curl_command;
-        if is_curl_command {
-            let redacted =
-                replace_quoted_header_value(line, &ANSI_C_QUOTED_CURL_COOKIE_OPTION_RE, marker);
-            let redacted = replace_quoted_header_value(
-                &redacted,
-                &SINGLE_QUOTED_CURL_COOKIE_OPTION_RE,
-                marker,
-            );
-            let redacted = replace_quoted_header_value(
-                &redacted,
-                &DOUBLE_QUOTED_CURL_COOKIE_OPTION_RE,
-                marker,
-            );
-            output.push_str(&replace_header_value(
-                &redacted,
-                &CURL_COOKIE_OPTION_RE,
-                marker,
-            ));
-        } else {
-            output.push_str(line);
+        contains_curl |= CURL_COMMAND_RE.is_match(line);
+        logical_command.push_str(line);
+        if shell_line_continues(line) {
+            continue;
         }
 
-        continued_curl_command = is_curl_command
-            && line
-                .trim_end_matches(['\r', '\n'])
-                .trim_end()
-                .ends_with('\\');
+        flush(&mut output, &mut logical_command, contains_curl);
+        contains_curl = false;
+    }
+
+    if !logical_command.is_empty() {
+        flush(&mut output, &mut logical_command, contains_curl);
     }
 
     output
@@ -278,33 +311,26 @@ fn redact_curl_cookie_options(input: &str, marker: &str) -> String {
 
 fn replace_generic_cookie_headers(input: &str, marker: &str) -> String {
     let mut output = String::with_capacity(input.len());
-    let mut generic_chunk = String::new();
-    let mut continued_shell_option = false;
+    let mut cursor = 0;
 
-    let flush_generic = |output: &mut String, chunk: &mut String| {
-        if !chunk.is_empty() {
-            output.push_str(&replace_header_value(chunk, &COOKIE_HEADER_RE, marker));
-            chunk.clear();
-        }
-    };
-
-    for line in input.split_inclusive('\n') {
-        let is_shell_option =
-            SHELL_COOKIE_HEADER_OPTION_RE.is_match(line) || continued_shell_option;
-        if is_shell_option {
-            flush_generic(&mut output, &mut generic_chunk);
-            output.push_str(line);
-        } else {
-            generic_chunk.push_str(line);
-        }
-
-        continued_shell_option = is_shell_option
-            && line
-                .trim_end_matches(['\r', '\n'])
-                .trim_end()
-                .ends_with('\\');
+    // The specialized passes have already sanitized curl header arguments.
+    // Protect only their option/header prefix from the generic header matcher:
+    // the value and every surrounding span stay visible to generic matching,
+    // so a distinct Cookie header on the same physical line cannot be skipped.
+    for option_prefix in SHELL_COOKIE_HEADER_OPTION_RE.find_iter(input) {
+        output.push_str(&replace_header_value(
+            &input[cursor..option_prefix.start()],
+            &COOKIE_HEADER_RE,
+            marker,
+        ));
+        output.push_str(option_prefix.as_str());
+        cursor = option_prefix.end();
     }
-    flush_generic(&mut output, &mut generic_chunk);
+    output.push_str(&replace_header_value(
+        &input[cursor..],
+        &COOKIE_HEADER_RE,
+        marker,
+    ));
     output
 }
 
@@ -328,7 +354,7 @@ pub(crate) fn redact_cookie_headers(input: &str, marker: &str) -> String {
     let redacted = replace_quoted_header_value(input, &ANSI_C_QUOTED_COOKIE_HEADER_RE, marker);
     let redacted = replace_quoted_header_value(&redacted, &SINGLE_QUOTED_COOKIE_HEADER_RE, marker);
     let redacted = replace_quoted_header_value(&redacted, &DOUBLE_QUOTED_COOKIE_HEADER_RE, marker);
-    let redacted = replace_header_value(&redacted, &CURL_ATTACHED_COOKIE_HEADER_RE, marker);
+    let redacted = replace_header_value(&redacted, &CURL_UNQUOTED_COOKIE_HEADER_RE, marker);
     let redacted = redact_curl_cookie_options(&redacted, marker);
     replace_generic_cookie_headers(&redacted, marker)
 }
@@ -671,6 +697,59 @@ mod tests {
                 "cookie leak ({secret}): {redacted}"
             );
         }
+    }
+
+    #[test]
+    fn curl_cookie_data_options_follow_shell_line_continuations() {
+        let redacted = redact_sensitive_headers(
+            "curl --cookie \\\n session=continued-one https://one.test\ncurl -b \\\r\n \"access=continued-two\" https://two.test",
+            "***",
+        );
+
+        assert!(redacted.contains("--cookie \\\n ***"), "got: {redacted:?}");
+        assert!(redacted.contains("-b \\\r\n \"***\""), "got: {redacted:?}");
+        assert!(redacted.contains("https://one.test"), "got: {redacted:?}");
+        assert!(redacted.contains("https://two.test"), "got: {redacted:?}");
+        assert!(!redacted.contains("continued-one"), "got: {redacted:?}");
+        assert!(!redacted.contains("continued-two"), "got: {redacted:?}");
+    }
+
+    #[test]
+    fn mixed_generic_and_curl_cookie_headers_are_all_redacted() {
+        let redacted = redact_sensitive_headers(
+            "Cookie: first=secret && curl -H 'Cookie: second=secret' https://one.test\ncurl -H Cookie:third=secret https://two.test && Cookie: fourth=secret",
+            "***",
+        );
+
+        assert!(redacted.contains("-H 'Cookie: ***'"));
+        assert!(redacted.contains("-H Cookie:***"));
+        assert!(redacted.contains("https://one.test"));
+        assert!(redacted.contains("https://two.test"));
+        for secret in [
+            "first=secret",
+            "second=secret",
+            "third=secret",
+            "fourth=secret",
+        ] {
+            assert!(
+                !redacted.contains(secret),
+                "mixed Cookie leak ({secret}): {redacted}"
+            );
+        }
+    }
+
+    #[test]
+    fn shell_escaped_curl_header_arguments_redact_the_complete_word() {
+        let redacted = redact_sensitive_headers(
+            r"curl -H Cookie:\ session=escaped-one --header=Set-Cookie:access\ token=escaped-two https://example.test",
+            "***",
+        );
+
+        assert!(redacted.contains("-H Cookie:***"));
+        assert!(redacted.contains("--header=Set-Cookie:***"));
+        assert!(redacted.contains("https://example.test"));
+        assert!(!redacted.contains("escaped-one"));
+        assert!(!redacted.contains("escaped-two"));
     }
 
     #[test]

--- a/src/utils/redact.rs
+++ b/src/utils/redact.rs
@@ -38,12 +38,16 @@ const HEADER_OPTION_PATTERN: &str =
     r"(?:-[A-Za-z]*?H[ \t]*(?:\\\r?\n[ \t]*)*|(?i:--header)(?:[ \t]+|=[ \t]*)(?:\\\r?\n[ \t]*)*)";
 const CURL_COOKIE_OPTION_PATTERN: &str =
     r"(?:-[A-Za-z]*?b[ \t]*(?:\\\r?\n[ \t]*)*|(?i:--cookie)(?:[ \t]+|=[ \t]*)(?:\\\r?\n[ \t]*)*)";
-const SHELL_WORD_SUFFIX_PATTERN: &str = r#"(?:\\(?:\r?\n[ \t]*|[^\r\n])|[^ \t\r\n;&|()<>'"$\\]|'(?:[^'\r\n]*)'|"(?:\\.|[^"\\\r\n])*"|\$'(?:\\.|[^'\\\r\n])*')*"#;
+// A shell word can concatenate unquoted, single-quoted, double-quoted, and
+// ANSI-C-quoted fragments without whitespace. Backslash-newline is part of the
+// same logical word, and quoted fragments may contain literal newlines. Keep
+// this grammar shared so header and curl-cookie options cannot drift apart.
+const SHELL_WORD_FRAGMENT_PATTERN: &str = r#"(?:\\(?:\r?\n[ \t]*|[^\r\n])|[^ \t\r\n;&|()<>'"$\\]|'[^']*'|"(?:\\(?:\r?\n|[^\r\n])|[^"\\])*"|\$'(?:\\(?:\r?\n|[^\r\n])|[^'\\])*')"#;
 
 static SINGLE_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(
-        r"(?m)((?:^|[ \t;&|()<>])(?:{})?'(?i:set-cookie|cookie)[ \t]*:[ \t]*)[^'\r\n]*('?){}",
-        HEADER_OPTION_PATTERN, SHELL_WORD_SUFFIX_PATTERN
+        r"(?m)((?:^|[ \t;&|()<>])(?:{})?'(?i:set-cookie|cookie)[ \t]*:[ \t]*)[^']*('?)(?:{})*",
+        HEADER_OPTION_PATTERN, SHELL_WORD_FRAGMENT_PATTERN
     ))
     .unwrap()
 });
@@ -52,15 +56,15 @@ static ANSI_C_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     // escaped quote inside the header value. Keep this grammar separate from
     // ordinary single quotes, where backslashes have no escape semantics.
     Regex::new(&format!(
-        r"(?m)((?:^|[ \t;&|()<>])(?:{})?\$'(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^'\\\r\n])*('?){}",
-        HEADER_OPTION_PATTERN, SHELL_WORD_SUFFIX_PATTERN
+        r"(?m)((?:^|[ \t;&|()<>])(?:{})?\$'(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\(?:\r?\n|[^\r\n])|[^'\\])*('?)(?:{})*",
+        HEADER_OPTION_PATTERN, SHELL_WORD_FRAGMENT_PATTERN
     ))
     .unwrap()
 });
 static DOUBLE_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(
-        r#"(?m)((?:^|[ \t;&|()<>])(?:{})?"(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^"\\\r\n])*("?){}"#,
-        HEADER_OPTION_PATTERN, SHELL_WORD_SUFFIX_PATTERN
+        r#"(?m)((?:^|[ \t;&|()<>])(?:{})?"(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\(?:\r?\n|[^\r\n])|[^"\\])*("?)(?:{})*"#,
+        HEADER_OPTION_PATTERN, SHELL_WORD_FRAGMENT_PATTERN
     ))
     .unwrap()
 });
@@ -70,8 +74,8 @@ static COMMAND_UNQUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     // COOKIE_HEADER_RE: a real header extends to end-of-line and may obs-fold,
     // while an unquoted command argument ends at an unescaped shell boundary.
     Regex::new(&format!(
-        r#"(?m)((?:^|[ \t;&|()<>]){}(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\[^\r\n]|[^ \t\r\n;&|()<>'"$\\])(?:\\(?:\r?\n[ \t]*|[^\r\n])|[^ \t\r\n;&|()<>'"$\\])*"#,
-        HEADER_OPTION_PATTERN
+        r#"(?m)((?:^|[ \t;&|()<>]){}(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:{})+"#,
+        HEADER_OPTION_PATTERN, SHELL_WORD_FRAGMENT_PATTERN
     ))
     .unwrap()
 });
@@ -94,29 +98,29 @@ static CURL_COOKIE_OPTION_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
 });
 static CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(
-        r#"(?m)((?:^|[ \t;&|()<>]){})(?:\\[^\r\n]|[^ \t\r\n;&|()<>'"$\\])(?:\\(?:\r?\n[ \t]*|[^\r\n])|[^ \t\r\n;&|()<>'"$\\])*"#,
-        CURL_COOKIE_OPTION_PATTERN
+        r#"(?m)((?:^|[ \t;&|()<>]){})(?:\\[^\r\n]|[^ \t\r\n;&|()<>'"$\\])(?:{})*"#,
+        CURL_COOKIE_OPTION_PATTERN, SHELL_WORD_FRAGMENT_PATTERN
     ))
     .unwrap()
 });
 static SINGLE_QUOTED_CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(
-        r"(?m)((?:^|[ \t;&|()<>]){}')[^'\r\n]*('?){}",
-        CURL_COOKIE_OPTION_PATTERN, SHELL_WORD_SUFFIX_PATTERN
+        r"(?m)((?:^|[ \t;&|()<>]){}')[^']*('?)(?:{})*",
+        CURL_COOKIE_OPTION_PATTERN, SHELL_WORD_FRAGMENT_PATTERN
     ))
     .unwrap()
 });
 static ANSI_C_QUOTED_CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(
-        r"(?m)((?:^|[ \t;&|()<>]){}\$')(?:\\.|[^'\\\r\n])*('?){}",
-        CURL_COOKIE_OPTION_PATTERN, SHELL_WORD_SUFFIX_PATTERN
+        r"(?m)((?:^|[ \t;&|()<>]){}\$')(?:\\(?:\r?\n|[^\r\n])|[^'\\])*('?)(?:{})*",
+        CURL_COOKIE_OPTION_PATTERN, SHELL_WORD_FRAGMENT_PATTERN
     ))
     .unwrap()
 });
 static DOUBLE_QUOTED_CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(
-        r#"(?m)((?:^|[ \t;&|()<>]){}")(?:\\.|[^"\\\r\n])*("?){}"#,
-        CURL_COOKIE_OPTION_PATTERN, SHELL_WORD_SUFFIX_PATTERN
+        r#"(?m)((?:^|[ \t;&|()<>]){}")(?:\\(?:\r?\n|[^\r\n])|[^"\\])*("?)(?:{})*"#,
+        CURL_COOKIE_OPTION_PATTERN, SHELL_WORD_FRAGMENT_PATTERN
     ))
     .unwrap()
 });
@@ -370,7 +374,8 @@ fn is_cookie_header_name(name: &str) -> bool {
 /// Serialize a JSON value compactly after redacting Cookie-bearing strings.
 ///
 /// Redacting before serialization avoids JSON quote/escape boundaries blocking
-/// the text matcher. Cookie/Set-Cookie map values are opaque credentials even
+/// the text matcher. Cookie/Set-Cookie map values and contextual array values
+/// (for example `["Cookie", "session=secret"]`) are opaque credentials even
 /// when the value itself lacks a header prefix. Writing directly to the output
 /// also avoids cloning the complete Value, and sanitizes object keys without
 /// key-collision loss.
@@ -378,6 +383,28 @@ pub(crate) fn serialize_json_with_redacted_cookie_headers(
     value: &serde_json::Value,
     marker: &str,
 ) -> String {
+    fn push_redacted_cookie_value(output: &mut String, value: &serde_json::Value, marker: &str) {
+        match value {
+            // Header maps commonly represent repeated Set-Cookie values as an
+            // array. Preserve its arity for useful diagnostics while treating
+            // every element as credential material. Objects remain opaque as a
+            // whole because their keys can themselves contain cookie data.
+            serde_json::Value::Array(values) => {
+                output.push('[');
+                for (index, value) in values.iter().enumerate() {
+                    if index > 0 {
+                        output.push(',');
+                    }
+                    push_redacted_cookie_value(output, value, marker);
+                }
+                output.push(']');
+            }
+            _ => output.push_str(
+                &serde_json::to_string(marker).expect("serializing a JSON marker cannot fail"),
+            ),
+        }
+    }
+
     fn push_value(output: &mut String, value: &serde_json::Value, marker: &str) {
         match value {
             serde_json::Value::Null => output.push_str("null"),
@@ -398,7 +425,15 @@ pub(crate) fn serialize_json_with_redacted_cookie_headers(
                     if index > 0 {
                         output.push(',');
                     }
-                    push_value(output, value, marker);
+                    let follows_cookie_header_name = index
+                        .checked_sub(1)
+                        .and_then(|previous| values[previous].as_str())
+                        .is_some_and(is_cookie_header_name);
+                    if follows_cookie_header_name {
+                        push_redacted_cookie_value(output, value, marker);
+                    } else {
+                        push_value(output, value, marker);
+                    }
                 }
                 output.push(']');
             }
@@ -415,10 +450,7 @@ pub(crate) fn serialize_json_with_redacted_cookie_headers(
                     );
                     output.push(':');
                     if is_cookie_header_name(key) {
-                        output.push_str(
-                            &serde_json::to_string(marker)
-                                .expect("serializing a JSON marker cannot fail"),
-                        );
+                        push_redacted_cookie_value(output, value, marker);
                     } else {
                         push_value(output, value, marker);
                     }
@@ -790,6 +822,52 @@ curl --cookie 'session='adjacent-four https://four.test"#,
     }
 
     #[test]
+    fn unquoted_cookie_header_values_accept_continuations_and_quoted_first_fragments() {
+        let redacted = redact_sensitive_headers(
+            "curl -H Cookie:\\\nsession=continued-one https://one.test\n\
+             curl -H Cookie:'session=quoted-two' https://two.test\n\
+             wget --header=Set-Cookie:\\\r\n\"access=continued-three\" https://three.test",
+            "***",
+        );
+
+        assert!(redacted.contains("-H Cookie:***"), "got: {redacted:?}");
+        assert!(
+            redacted.contains("--header=Set-Cookie:***"),
+            "got: {redacted:?}"
+        );
+        for url in ["https://one.test", "https://two.test", "https://three.test"] {
+            assert!(redacted.contains(url), "missing URL ({url}): {redacted:?}");
+        }
+        for secret in ["continued-one", "quoted-two", "continued-three"] {
+            assert!(
+                !redacted.contains(secret),
+                "continued Cookie leak ({secret}): {redacted:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn multiline_quoted_cookie_header_arguments_are_redacted_as_one_shell_word() {
+        let redacted = redact_sensitive_headers(
+            "curl -H 'Cookie: session=multiline-one\ncontinued=multiline-two' https://one.test\n\
+             curl --header=\"Set-Cookie: access=multiline-three\ncontinued=multiline-four\" https://two.test\n\
+             curl -H $'Cookie: session=multiline-five\ncontinued=multiline-six' https://three.test",
+            "***",
+        );
+
+        assert!(redacted.contains("-H 'Cookie: ***'"), "got: {redacted:?}");
+        assert!(
+            redacted.contains("--header=\"Set-Cookie: ***\""),
+            "got: {redacted:?}"
+        );
+        assert!(redacted.contains("-H $'Cookie: ***'"), "got: {redacted:?}");
+        for url in ["https://one.test", "https://two.test", "https://three.test"] {
+            assert!(redacted.contains(url), "missing URL ({url}): {redacted:?}");
+        }
+        assert!(!redacted.contains("multiline-"), "got: {redacted:?}");
+    }
+
+    #[test]
     fn wget_header_equals_arguments_share_cookie_redaction() {
         let redacted = redact_sensitive_headers(
             "wget --header=Cookie:session=wget-one --header='Set-Cookie: access=wget-two' https://example.test",
@@ -847,10 +925,44 @@ curl --cookie 'session='adjacent-four https://four.test"#,
         let reparsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
 
         assert_eq!(reparsed["headers"]["Cookie"], "***");
-        assert_eq!(reparsed["headers"]["Set-Cookie"], "***");
+        assert_eq!(
+            reparsed["headers"]["Set-Cookie"],
+            serde_json::json!(["***"])
+        );
         assert_eq!(reparsed["headers"]["cookie"], "***");
         assert_eq!(reparsed["headers"]["X-Cookie"], "visible");
         assert!(!serialized.contains("json-map-"), "got: {serialized}");
+    }
+
+    #[test]
+    fn compact_json_serialization_redacts_cookie_values_in_contextual_arrays() {
+        let value = serde_json::json!({
+            "headers": [
+                ["Cookie", "session=json-pair-one"],
+                ["set-cookie", ["access=json-pair-two", "refresh=json-pair-three"]],
+                ["X-Cookie", "visible"]
+            ],
+            "argv_style": ["Cookie", "session=json-argv-four", "safe"]
+        });
+
+        let serialized = serialize_json_with_redacted_cookie_headers(&value, "***");
+        let reparsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(reparsed["headers"][0], serde_json::json!(["Cookie", "***"]));
+        assert_eq!(
+            reparsed["headers"][1],
+            serde_json::json!(["set-cookie", ["***", "***"]])
+        );
+        assert_eq!(
+            reparsed["headers"][2],
+            serde_json::json!(["X-Cookie", "visible"])
+        );
+        assert_eq!(
+            reparsed["argv_style"],
+            serde_json::json!(["Cookie", "***", "safe"])
+        );
+        assert!(!serialized.contains("json-pair-"), "got: {serialized}");
+        assert!(!serialized.contains("json-argv-"), "got: {serialized}");
     }
 
     #[test]

--- a/src/utils/redact.rs
+++ b/src/utils/redact.rs
@@ -16,6 +16,23 @@ static AUTH_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     )
     .unwrap()
 });
+static COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    // Cookie values have no authentication-scheme prefix. Preserve only the
+    // header name, colon, and surrounding horizontal whitespace, then mask the
+    // entire value. Reusing the Authorization prefix rule here would leak the
+    // first whitespace-delimited cookie token as a false "scheme".
+    //
+    // Match the same RFC 7230 obs-fold shapes as AUTH_HEADER_RE while leaving
+    // an ordinary unindented following line untouched.
+    // The leading boundary rejects every RFC `tchar`, preventing a suffix
+    // match inside distinct names such as `X-Cookie` or `CookieJar`. It is part
+    // of capture 1 so quotes/spacing that introduce an embedded header survive
+    // the replacement. Multiline mode lets `^` recognize each header line.
+    Regex::new(
+        r"(?im)((?:^|[^!#$%&'*+.^_`|~a-z0-9\-\r\n])(?:set-cookie|cookie)[ \t]*:[ \t]*)(?:[^\r\n]+(?:\r?\n[ \t]+[^\r\n]+)*|(?:\r?\n[ \t]+[^\r\n]+)+)",
+    )
+    .unwrap()
+});
 // Capture group 1 = key (+ optional surrounding `"`/`'` quote) + `=`/`:`
 // separator; group 2 = the value, EITHER a quoted string (whole body incl.
 // inner spaces, escape-aware so a `\"` inside cannot end the match early and
@@ -119,6 +136,35 @@ pub(crate) fn register_common_env_secrets() {
     }
 }
 
+fn replace_header_value(input: &str, regex: &Regex, marker: &str) -> String {
+    regex
+        .replace_all(input, |captures: &regex::Captures<'_>| {
+            let prefix = captures.get(1).map(|m| m.as_str()).unwrap_or_default();
+            format!("{prefix}{marker}")
+        })
+        .into_owned()
+}
+
+/// Redact sensitive HTTP header values while preserving useful header context.
+///
+/// Authorization keeps a recognized authentication scheme (for example,
+/// `Bearer`) so diagnostics remain actionable. Cookie and Set-Cookie values are
+/// always masked in full because their first token is secret material, not a
+/// scheme. `marker` lets each presentation surface retain its existing
+/// redaction vocabulary without duplicating the parsing rules.
+pub(crate) fn redact_sensitive_headers(input: &str, marker: &str) -> String {
+    let redacted = replace_header_value(input, &AUTH_HEADER_RE, marker);
+    redact_cookie_headers(&redacted, marker)
+}
+
+/// Redact Cookie and Set-Cookie values without applying Authorization parsing.
+///
+/// Compact command renderers use their own token-aware Authorization display
+/// rules, but still share this stricter whole-cookie contract.
+pub(crate) fn redact_cookie_headers(input: &str, marker: &str) -> String {
+    replace_header_value(input, &COOKIE_HEADER_RE, marker)
+}
+
 pub(crate) fn redact_known_secrets(input: &str) -> String {
     // Mask whole PEM private-key blocks first so later single-token rules cannot
     // leave the key body behind, and so the registered-secret pass is unaffected.
@@ -126,7 +172,7 @@ pub(crate) fn redact_known_secrets(input: &str) -> String {
     let redacted = POSTGRES_DSN_RE.replace_all(&redacted, |captures: &regex::Captures<'_>| {
         mask_dsn_password(captures.get(0).map(|m| m.as_str()).unwrap_or_default())
     });
-    let redacted = AUTH_HEADER_RE.replace_all(&redacted, "${1}***");
+    let redacted = redact_sensitive_headers(&redacted, "***");
     let mut redacted = ASSIGNMENT_RE
         .replace_all(&redacted, |captures: &regex::Captures<'_>| {
             let key_sep = captures.get(1).map(|m| m.as_str()).unwrap_or_default();
@@ -169,8 +215,8 @@ pub(crate) fn redact_known_secrets(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        dsn_password, mask_dsn_password, redact_known_secrets, register_known_secret,
-        register_secret_or_dsn,
+        dsn_password, mask_dsn_password, redact_known_secrets, redact_sensitive_headers,
+        register_known_secret, register_secret_or_dsn,
     };
 
     fn redact_known_secret(input: &str) -> String {
@@ -216,6 +262,72 @@ mod tests {
         assert!(!redacted.contains("plain-secret"), "leaked: {redacted}");
         assert!(redacted.contains("authorization: ***"));
         assert!(redacted.contains("visible next line"));
+    }
+
+    #[test]
+    fn cookie_headers_mask_the_entire_value_without_treating_a_token_as_a_scheme() {
+        let redacted = redact_known_secrets(
+            "Cookie: session=abc; theme=dark\n\
+             set-cookie\t:\taccess=xyz; HttpOnly; Secure\n\
+             COOKIE: sessionSecret trailing-data\n\
+             visible next line",
+        );
+
+        assert!(redacted.contains("Cookie: ***"));
+        assert!(redacted.contains("set-cookie\t:\t***"));
+        assert!(redacted.contains("COOKIE: ***"));
+        assert!(redacted.contains("visible next line"));
+        for secret in [
+            "session=abc",
+            "theme=dark",
+            "access=xyz",
+            "sessionSecret",
+            "trailing-data",
+        ] {
+            assert!(
+                !redacted.contains(secret),
+                "cookie leak ({secret}): {redacted}"
+            );
+        }
+    }
+
+    #[test]
+    fn folded_cookie_headers_are_fully_masked_without_consuming_the_next_header() {
+        let redacted = redact_known_secrets(
+            "Cookie: first=secret\r\n second=secret-two\nX-Trace: visible\n\
+             Set-Cookie:\r\n session=empty-first-line\nContent-Type: text/plain",
+        );
+
+        assert!(redacted.contains("Cookie: ***\nX-Trace: visible"));
+        assert!(redacted.contains("Set-Cookie:***\nContent-Type: text/plain"));
+        assert!(!redacted.contains("first=secret"));
+        assert!(!redacted.contains("second=secret-two"));
+        assert!(!redacted.contains("session=empty-first-line"));
+    }
+
+    #[test]
+    fn sensitive_header_redaction_supports_surface_specific_markers() {
+        let redacted = redact_sensitive_headers(
+            "Authorization: Bearer auth-secret\nCookie: cookie-secret",
+            "[REDACTED]",
+        );
+
+        assert_eq!(
+            redacted,
+            "Authorization: Bearer [REDACTED]\nCookie: [REDACTED]"
+        );
+    }
+
+    #[test]
+    fn cookie_header_names_do_not_match_distinct_header_suffixes() {
+        let redacted = redact_known_secrets(
+            "X-Cookie: visible-one\nCookieJar: visible-two\nX-Set-Cookie: visible-three",
+        );
+
+        assert_eq!(
+            redacted,
+            "X-Cookie: visible-one\nCookieJar: visible-two\nX-Set-Cookie: visible-three"
+        );
     }
 
     #[test]

--- a/src/utils/redact.rs
+++ b/src/utils/redact.rs
@@ -40,6 +40,15 @@ static SINGLE_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     )
     .unwrap()
 });
+static ANSI_C_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    // Bash ANSI-C strings use `$'…'` and allow backslash escapes, including an
+    // escaped quote inside the header value. Keep this grammar separate from
+    // ordinary single quotes, where backslashes have no escape semantics.
+    Regex::new(
+        r"(?im)((?:^|[ \t;&|()<>])(?:-H[ \t]*)?\$'(?:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^'\\\r\n])*('?)",
+    )
+    .unwrap()
+});
 static DOUBLE_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r#"(?im)((?:^|[ \t;&|()<>])(?:-H[ \t]*)?"(?:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^"\\\r\n])*("?)"#,
@@ -208,7 +217,8 @@ pub(crate) fn redact_sensitive_headers(input: &str, marker: &str) -> String {
 /// Compact command renderers use their own token-aware Authorization display
 /// rules, but still share this stricter whole-cookie contract.
 pub(crate) fn redact_cookie_headers(input: &str, marker: &str) -> String {
-    let redacted = replace_quoted_header_value(input, &SINGLE_QUOTED_COOKIE_HEADER_RE, marker);
+    let redacted = replace_quoted_header_value(input, &ANSI_C_QUOTED_COOKIE_HEADER_RE, marker);
+    let redacted = replace_quoted_header_value(&redacted, &SINGLE_QUOTED_COOKIE_HEADER_RE, marker);
     let redacted = replace_quoted_header_value(&redacted, &DOUBLE_QUOTED_COOKIE_HEADER_RE, marker);
     let redacted = replace_header_value(&redacted, &CURL_ATTACHED_COOKIE_HEADER_RE, marker);
     replace_header_value(&redacted, &COOKIE_HEADER_RE, marker)
@@ -411,6 +421,22 @@ mod tests {
         assert!(redacted.contains("'X-Cookie: visible'"));
         assert!(!redacted.contains("session=secret"));
         assert!(!redacted.contains("access=secret-two"));
+    }
+
+    #[test]
+    fn ansi_c_quoted_cookie_headers_preserve_delimiters_and_following_command() {
+        let redacted = redact_sensitive_headers(
+            r#"curl -H $'Cookie: session=secret\'tail=secret-two' -H$'Set-Cookie: access=secret-three' -H $'X-Cookie: visible' https://example.test && echo done"#,
+            "***",
+        );
+
+        assert!(redacted.contains("-H $'Cookie: ***'"));
+        assert!(redacted.contains("-H$'Set-Cookie: ***'"));
+        assert!(redacted.contains("-H $'X-Cookie: visible'"));
+        assert!(redacted.contains("https://example.test && echo done"));
+        assert!(!redacted.contains("session=secret"));
+        assert!(!redacted.contains("tail=secret-two"));
+        assert!(!redacted.contains("access=secret-three"));
     }
 
     #[test]

--- a/src/utils/redact.rs
+++ b/src/utils/redact.rs
@@ -34,15 +34,16 @@ static COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     )
     .unwrap()
 });
-const CURL_HEADER_OPTION_PATTERN: &str =
+const HEADER_OPTION_PATTERN: &str =
     r"(?:-[A-Za-z]*?H[ \t]*(?:\\\r?\n[ \t]*)*|(?i:--header)(?:[ \t]+|=[ \t]*)(?:\\\r?\n[ \t]*)*)";
 const CURL_COOKIE_OPTION_PATTERN: &str =
     r"(?:-[A-Za-z]*?b[ \t]*(?:\\\r?\n[ \t]*)*|(?i:--cookie)(?:[ \t]+|=[ \t]*)(?:\\\r?\n[ \t]*)*)";
+const SHELL_WORD_SUFFIX_PATTERN: &str = r#"(?:\\(?:\r?\n[ \t]*|[^\r\n])|[^ \t\r\n;&|()<>'"$\\]|'(?:[^'\r\n]*)'|"(?:\\.|[^"\\\r\n])*"|\$'(?:\\.|[^'\\\r\n])*')*"#;
 
 static SINGLE_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(
-        r"(?m)((?:^|[ \t;&|()<>])(?:{})?'(?i:set-cookie|cookie)[ \t]*:[ \t]*)[^'\r\n]*('?)",
-        CURL_HEADER_OPTION_PATTERN
+        r"(?m)((?:^|[ \t;&|()<>])(?:{})?'(?i:set-cookie|cookie)[ \t]*:[ \t]*)[^'\r\n]*('?){}",
+        HEADER_OPTION_PATTERN, SHELL_WORD_SUFFIX_PATTERN
     ))
     .unwrap()
 });
@@ -51,36 +52,33 @@ static ANSI_C_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     // escaped quote inside the header value. Keep this grammar separate from
     // ordinary single quotes, where backslashes have no escape semantics.
     Regex::new(&format!(
-        r"(?m)((?:^|[ \t;&|()<>])(?:{})?\$'(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^'\\\r\n])*('?)",
-        CURL_HEADER_OPTION_PATTERN
+        r"(?m)((?:^|[ \t;&|()<>])(?:{})?\$'(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^'\\\r\n])*('?){}",
+        HEADER_OPTION_PATTERN, SHELL_WORD_SUFFIX_PATTERN
     ))
     .unwrap()
 });
 static DOUBLE_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(
-        r#"(?m)((?:^|[ \t;&|()<>])(?:{})?"(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^"\\\r\n])*("?)"#,
-        CURL_HEADER_OPTION_PATTERN
+        r#"(?m)((?:^|[ \t;&|()<>])(?:{})?"(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^"\\\r\n])*("?){}"#,
+        HEADER_OPTION_PATTERN, SHELL_WORD_SUFFIX_PATTERN
     ))
     .unwrap()
 });
-static CURL_UNQUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
-    // curl accepts an attached short-option argument (`-HCookie:value`). Keep
-    // this command-token rule separate from COOKIE_HEADER_RE: a real header
-    // value extends to end-of-line and may obs-fold, while an unquoted shell
-    // argument ends at whitespace, quote, or a shell control operator. Curl
-    // permits boolean short options before the value-taking H (`-sH...`) and
-    // the equivalent `--header=...` spelling. The lazy cluster prefix stops at
-    // the first H, whose remaining token bytes are the header argument.
+static COMMAND_UNQUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    // curl accepts attached/clustered -H arguments and curl/wget share the
+    // long --header spelling. Keep this shell-word grammar separate from
+    // COOKIE_HEADER_RE: a real header extends to end-of-line and may obs-fold,
+    // while an unquoted command argument ends at an unescaped shell boundary.
     Regex::new(&format!(
         r#"(?m)((?:^|[ \t;&|()<>]){}(?i:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\[^\r\n]|[^ \t\r\n;&|()<>'"$\\])(?:\\(?:\r?\n[ \t]*|[^\r\n])|[^ \t\r\n;&|()<>'"$\\])*"#,
-        CURL_HEADER_OPTION_PATTERN
+        HEADER_OPTION_PATTERN
     ))
     .unwrap()
 });
 static SHELL_COOKIE_HEADER_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(
         r#"(?m)(?:^|[ \t;&|()<>]){}(?:\$?'|")?(?i:set-cookie|cookie)[ \t]*:"#,
-        CURL_HEADER_OPTION_PATTERN
+        HEADER_OPTION_PATTERN
     ))
     .unwrap()
 });
@@ -103,22 +101,22 @@ static CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
 });
 static SINGLE_QUOTED_CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(
-        r"(?m)((?:^|[ \t;&|()<>]){}')[^'\r\n]*('?)",
-        CURL_COOKIE_OPTION_PATTERN
+        r"(?m)((?:^|[ \t;&|()<>]){}')[^'\r\n]*('?){}",
+        CURL_COOKIE_OPTION_PATTERN, SHELL_WORD_SUFFIX_PATTERN
     ))
     .unwrap()
 });
 static ANSI_C_QUOTED_CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(
-        r"(?m)((?:^|[ \t;&|()<>]){}\$')(?:\\.|[^'\\\r\n])*('?)",
-        CURL_COOKIE_OPTION_PATTERN
+        r"(?m)((?:^|[ \t;&|()<>]){}\$')(?:\\.|[^'\\\r\n])*('?){}",
+        CURL_COOKIE_OPTION_PATTERN, SHELL_WORD_SUFFIX_PATTERN
     ))
     .unwrap()
 });
 static DOUBLE_QUOTED_CURL_COOKIE_OPTION_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(
-        r#"(?m)((?:^|[ \t;&|()<>]){}")(?:\\.|[^"\\\r\n])*("?)"#,
-        CURL_COOKIE_OPTION_PATTERN
+        r#"(?m)((?:^|[ \t;&|()<>]){}")(?:\\.|[^"\\\r\n])*("?){}"#,
+        CURL_COOKIE_OPTION_PATTERN, SHELL_WORD_SUFFIX_PATTERN
     ))
     .unwrap()
 });
@@ -130,7 +128,7 @@ static SENSITIVE_HEADER_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
     // `X-Cookie` remains distinct from a sensitive header name.
     Regex::new(&format!(
         r#"(?m)(?:^|[^!#$%&*+.^_`|~a-z0-9\-])(?:(?i:authorization|set-cookie|cookie)[ \t]*:|{}(?:\$?'|")?(?i:set-cookie|cookie)[ \t]*:)"#,
-        CURL_HEADER_OPTION_PATTERN
+        HEADER_OPTION_PATTERN
     ))
     .unwrap()
 });
@@ -354,7 +352,7 @@ pub(crate) fn redact_cookie_headers(input: &str, marker: &str) -> String {
     let redacted = replace_quoted_header_value(input, &ANSI_C_QUOTED_COOKIE_HEADER_RE, marker);
     let redacted = replace_quoted_header_value(&redacted, &SINGLE_QUOTED_COOKIE_HEADER_RE, marker);
     let redacted = replace_quoted_header_value(&redacted, &DOUBLE_QUOTED_COOKIE_HEADER_RE, marker);
-    let redacted = replace_header_value(&redacted, &CURL_UNQUOTED_COOKIE_HEADER_RE, marker);
+    let redacted = replace_header_value(&redacted, &COMMAND_UNQUOTED_COOKIE_HEADER_RE, marker);
     let redacted = redact_curl_cookie_options(&redacted, marker);
     replace_generic_cookie_headers(&redacted, marker)
 }
@@ -364,11 +362,18 @@ pub(crate) fn contains_sensitive_header_prefix(input: &str) -> bool {
         || (CURL_COMMAND_RE.is_match(input) && CURL_COOKIE_OPTION_PREFIX_RE.is_match(input))
 }
 
+fn is_cookie_header_name(name: &str) -> bool {
+    let name = name.trim();
+    name.eq_ignore_ascii_case("cookie") || name.eq_ignore_ascii_case("set-cookie")
+}
+
 /// Serialize a JSON value compactly after redacting Cookie-bearing strings.
 ///
 /// Redacting before serialization avoids JSON quote/escape boundaries blocking
-/// the text matcher. Writing directly to the output also avoids cloning the
-/// complete `Value`, and sanitizes object keys without key-collision loss.
+/// the text matcher. Cookie/Set-Cookie map values are opaque credentials even
+/// when the value itself lacks a header prefix. Writing directly to the output
+/// also avoids cloning the complete Value, and sanitizes object keys without
+/// key-collision loss.
 pub(crate) fn serialize_json_with_redacted_cookie_headers(
     value: &serde_json::Value,
     marker: &str,
@@ -409,7 +414,14 @@ pub(crate) fn serialize_json_with_redacted_cookie_headers(
                             .expect("serializing a JSON object key cannot fail"),
                     );
                     output.push(':');
-                    push_value(output, value, marker);
+                    if is_cookie_header_name(key) {
+                        output.push_str(
+                            &serde_json::to_string(marker)
+                                .expect("serializing a JSON marker cannot fail"),
+                        );
+                    } else {
+                        push_value(output, value, marker);
+                    }
                 }
                 output.push('}');
             }
@@ -618,6 +630,31 @@ mod tests {
     }
 
     #[test]
+    fn adjacent_shell_word_fragments_are_consumed_with_quoted_cookie_values() {
+        let redacted = redact_sensitive_headers(
+            r#"curl -H 'Cookie: 'session=adjacent-one https://one.test
+curl --header="Set-Cookie: "access=adjacent-two https://two.test
+curl -H $'Cookie: 'session=adjacent-three https://three.test
+curl --cookie 'session='adjacent-four https://four.test"#,
+            "***",
+        );
+
+        assert!(redacted.contains("-H 'Cookie: ***'"));
+        assert!(redacted.contains("--header=\"Set-Cookie: ***\""));
+        assert!(redacted.contains("-H $'Cookie: ***'"));
+        assert!(redacted.contains("--cookie '***'"));
+        for url in [
+            "https://one.test",
+            "https://two.test",
+            "https://three.test",
+            "https://four.test",
+        ] {
+            assert!(redacted.contains(url), "missing URL ({url}): {redacted}");
+        }
+        assert!(!redacted.contains("adjacent-"), "got: {redacted}");
+    }
+
+    #[test]
     fn ansi_c_quoted_cookie_headers_preserve_delimiters_and_following_command() {
         let redacted = redact_sensitive_headers(
             r#"curl -H $'Cookie: session=secret\'tail=secret-two' -H$'Set-Cookie: access=secret-three' -H $'X-Cookie: visible' https://example.test && echo done"#,
@@ -753,6 +790,20 @@ mod tests {
     }
 
     #[test]
+    fn wget_header_equals_arguments_share_cookie_redaction() {
+        let redacted = redact_sensitive_headers(
+            "wget --header=Cookie:session=wget-one --header='Set-Cookie: access=wget-two' https://example.test",
+            "***",
+        );
+
+        assert!(redacted.contains("--header=Cookie:***"));
+        assert!(redacted.contains("--header='Set-Cookie: ***'"));
+        assert!(redacted.contains("https://example.test"));
+        assert!(!redacted.contains("wget-one"));
+        assert!(!redacted.contains("wget-two"));
+    }
+
+    #[test]
     fn compact_json_serialization_redacts_nested_cookie_strings_and_keys() {
         let value = serde_json::json!({
             "headers": "Cookie: json-secret",
@@ -779,6 +830,27 @@ mod tests {
                 "JSON cookie leak ({secret}): {serialized}"
             );
         }
+    }
+
+    #[test]
+    fn compact_json_serialization_redacts_values_owned_by_cookie_header_keys() {
+        let value = serde_json::json!({
+            "headers": {
+                "Cookie": "session=json-map-one",
+                "Set-Cookie": ["access=json-map-two"],
+                "cookie": {"nested": "json-map-three"},
+                "X-Cookie": "visible"
+            }
+        });
+
+        let serialized = serialize_json_with_redacted_cookie_headers(&value, "***");
+        let reparsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(reparsed["headers"]["Cookie"], "***");
+        assert_eq!(reparsed["headers"]["Set-Cookie"], "***");
+        assert_eq!(reparsed["headers"]["cookie"], "***");
+        assert_eq!(reparsed["headers"]["X-Cookie"], "visible");
+        assert!(!serialized.contains("json-map-"), "got: {serialized}");
     }
 
     #[test]

--- a/src/utils/redact.rs
+++ b/src/utils/redact.rs
@@ -33,6 +33,17 @@ static COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     )
     .unwrap()
 });
+static CURL_ATTACHED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    // curl accepts an attached short-option argument (`-HCookie:value`). Keep
+    // this command-token rule separate from COOKIE_HEADER_RE: a real header
+    // value extends to end-of-line and may obs-fold, while an unquoted shell
+    // argument ends at whitespace or a shell control operator. The same RFC
+    // `tchar` boundary prevents suffix matches in tokens such as `X-HCookie`.
+    Regex::new(
+        r"(?im)((?:^|[^!#$%&'*+.^_`|~a-z0-9\-\r\n])-H(?:set-cookie|cookie)[ \t]*:[ \t]*)[^ \t\r\n;&|()<>]+",
+    )
+    .unwrap()
+});
 // Capture group 1 = key (+ optional surrounding `"`/`'` quote) + `=`/`:`
 // separator; group 2 = the value, EITHER a quoted string (whole body incl.
 // inner spaces, escape-aware so a `\"` inside cannot end the match early and
@@ -162,7 +173,8 @@ pub(crate) fn redact_sensitive_headers(input: &str, marker: &str) -> String {
 /// Compact command renderers use their own token-aware Authorization display
 /// rules, but still share this stricter whole-cookie contract.
 pub(crate) fn redact_cookie_headers(input: &str, marker: &str) -> String {
-    replace_header_value(input, &COOKIE_HEADER_RE, marker)
+    let redacted = replace_header_value(input, &CURL_ATTACHED_COOKIE_HEADER_RE, marker);
+    replace_header_value(&redacted, &COOKIE_HEADER_RE, marker)
 }
 
 pub(crate) fn redact_known_secrets(input: &str) -> String {
@@ -328,6 +340,21 @@ mod tests {
             redacted,
             "X-Cookie: visible-one\nCookieJar: visible-two\nX-Set-Cookie: visible-three"
         );
+    }
+
+    #[test]
+    fn attached_curl_header_option_redacts_cookie_without_matching_distinct_names() {
+        let redacted = redact_sensitive_headers(
+            "curl -HCookie:session=secret -HSet-Cookie:access=secret-two -HX-Cookie:visible-one -HCookieJar:visible-two",
+            "***",
+        );
+
+        assert!(redacted.contains("-HCookie:***"));
+        assert!(redacted.contains("-HSet-Cookie:***"));
+        assert!(redacted.contains("-HX-Cookie:visible-one"));
+        assert!(redacted.contains("-HCookieJar:visible-two"));
+        assert!(!redacted.contains("session=secret"));
+        assert!(!redacted.contains("access=secret-two"));
     }
 
     #[test]

--- a/src/utils/redact.rs
+++ b/src/utils/redact.rs
@@ -25,11 +25,24 @@ static COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     // Match the same RFC 7230 obs-fold shapes as AUTH_HEADER_RE while leaving
     // an ordinary unindented following line untouched.
     // The leading boundary rejects every RFC `tchar`, preventing a suffix
-    // match inside distinct names such as `X-Cookie` or `CookieJar`. It is part
-    // of capture 1 so quotes/spacing that introduce an embedded header survive
-    // the replacement. Multiline mode lets `^` recognize each header line.
+    // match inside distinct names such as `X-Cookie` or `CookieJar`. Quoted
+    // header arguments are handled by quote-aware rules below so the closing
+    // delimiter and following shell command are not consumed as header value.
+    // Multiline mode lets `^` recognize each header line.
     Regex::new(
-        r"(?im)((?:^|[^!#$%&'*+.^_`|~a-z0-9\-\r\n])(?:set-cookie|cookie)[ \t]*:[ \t]*)(?:[^\r\n]+(?:\r?\n[ \t]+[^\r\n]+)*|(?:\r?\n[ \t]+[^\r\n]+)+)",
+        r#"(?im)((?:^|[^"!#$%&'*+.^_`|~a-z0-9\-\r\n])(?:set-cookie|cookie)[ \t]*:[ \t]*)(?:[^\r\n]+(?:\r?\n[ \t]+[^\r\n]+)*|(?:\r?\n[ \t]+[^\r\n]+)+)"#,
+    )
+    .unwrap()
+});
+static SINGLE_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?im)((?:^|[ \t;&|()<>])(?:-H[ \t]*)?'(?:set-cookie|cookie)[ \t]*:[ \t]*)[^'\r\n]*('?)",
+    )
+    .unwrap()
+});
+static DOUBLE_QUOTED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?im)((?:^|[ \t;&|()<>])(?:-H[ \t]*)?"(?:set-cookie|cookie)[ \t]*:[ \t]*)(?:\\.|[^"\\\r\n])*("?)"#,
     )
     .unwrap()
 });
@@ -37,10 +50,22 @@ static CURL_ATTACHED_COOKIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     // curl accepts an attached short-option argument (`-HCookie:value`). Keep
     // this command-token rule separate from COOKIE_HEADER_RE: a real header
     // value extends to end-of-line and may obs-fold, while an unquoted shell
-    // argument ends at whitespace or a shell control operator. The same RFC
-    // `tchar` boundary prevents suffix matches in tokens such as `X-HCookie`.
+    // argument ends at whitespace, quote, or a shell control operator. Requiring
+    // a shell-token boundary before `-H` prevents suffix matches in tokens such
+    // as `X-HCookie`; quoted values use the dedicated rules above.
     Regex::new(
-        r"(?im)((?:^|[^!#$%&'*+.^_`|~a-z0-9\-\r\n])-H(?:set-cookie|cookie)[ \t]*:[ \t]*)[^ \t\r\n;&|()<>]+",
+        r#"(?im)((?:^|[ \t;&|()<>])-H(?:set-cookie|cookie)[ \t]*:[ \t]*)[^ \t\r\n;&|()<>'"]+"#,
+    )
+    .unwrap()
+});
+static SENSITIVE_HEADER_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
+    // Prefix-only detector for a relay tail that begins mid-line. It never
+    // materializes the matched value; callers use it only to decide whether an
+    // already-bounded partial line must be dropped. Quotes are accepted as
+    // shell delimiters, and curl's `-H` form is explicit so `X-Cookie` remains
+    // distinct from a sensitive header name.
+    Regex::new(
+        r#"(?im)(?:^|[^!#$%&*+.^_`|~a-z0-9\-])(?:(?:authorization|set-cookie|cookie)[ \t]*:|-H[ \t]*['"]?(?:set-cookie|cookie)[ \t]*:)"#,
     )
     .unwrap()
 });
@@ -156,6 +181,16 @@ fn replace_header_value(input: &str, regex: &Regex, marker: &str) -> String {
         .into_owned()
 }
 
+fn replace_quoted_header_value(input: &str, regex: &Regex, marker: &str) -> String {
+    regex
+        .replace_all(input, |captures: &regex::Captures<'_>| {
+            let prefix = captures.get(1).map(|m| m.as_str()).unwrap_or_default();
+            let closing_quote = captures.get(2).map(|m| m.as_str()).unwrap_or_default();
+            format!("{prefix}{marker}{closing_quote}")
+        })
+        .into_owned()
+}
+
 /// Redact sensitive HTTP header values while preserving useful header context.
 ///
 /// Authorization keeps a recognized authentication scheme (for example,
@@ -173,8 +208,14 @@ pub(crate) fn redact_sensitive_headers(input: &str, marker: &str) -> String {
 /// Compact command renderers use their own token-aware Authorization display
 /// rules, but still share this stricter whole-cookie contract.
 pub(crate) fn redact_cookie_headers(input: &str, marker: &str) -> String {
-    let redacted = replace_header_value(input, &CURL_ATTACHED_COOKIE_HEADER_RE, marker);
+    let redacted = replace_quoted_header_value(input, &SINGLE_QUOTED_COOKIE_HEADER_RE, marker);
+    let redacted = replace_quoted_header_value(&redacted, &DOUBLE_QUOTED_COOKIE_HEADER_RE, marker);
+    let redacted = replace_header_value(&redacted, &CURL_ATTACHED_COOKIE_HEADER_RE, marker);
     replace_header_value(&redacted, &COOKIE_HEADER_RE, marker)
+}
+
+pub(crate) fn contains_sensitive_header_prefix(input: &str) -> bool {
+    SENSITIVE_HEADER_PREFIX_RE.is_match(input)
 }
 
 pub(crate) fn redact_known_secrets(input: &str) -> String {
@@ -227,8 +268,8 @@ pub(crate) fn redact_known_secrets(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        dsn_password, mask_dsn_password, redact_known_secrets, redact_sensitive_headers,
-        register_known_secret, register_secret_or_dsn,
+        contains_sensitive_header_prefix, dsn_password, mask_dsn_password, redact_known_secrets,
+        redact_sensitive_headers, register_known_secret, register_secret_or_dsn,
     };
 
     fn redact_known_secret(input: &str) -> String {
@@ -355,6 +396,32 @@ mod tests {
         assert!(redacted.contains("-HCookieJar:visible-two"));
         assert!(!redacted.contains("session=secret"));
         assert!(!redacted.contains("access=secret-two"));
+    }
+
+    #[test]
+    fn quoted_cookie_header_arguments_preserve_delimiters_and_following_command() {
+        let redacted = redact_sensitive_headers(
+            "curl -H 'Cookie: session=secret one' -H\"Set-Cookie: access=secret-two\" https://example.test && echo done; printf 'X-Cookie: visible'",
+            "***",
+        );
+
+        assert!(redacted.contains("-H 'Cookie: ***'"));
+        assert!(redacted.contains("-H\"Set-Cookie: ***\""));
+        assert!(redacted.contains("https://example.test && echo done"));
+        assert!(redacted.contains("'X-Cookie: visible'"));
+        assert!(!redacted.contains("session=secret"));
+        assert!(!redacted.contains("access=secret-two"));
+    }
+
+    #[test]
+    fn sensitive_header_prefix_detector_distinguishes_suffix_names() {
+        assert!(contains_sensitive_header_prefix("Cookie: partial"));
+        assert!(contains_sensitive_header_prefix("curl -H'Cookie: partial"));
+        assert!(contains_sensitive_header_prefix(
+            "Authorization: Bearer partial"
+        ));
+        assert!(!contains_sensitive_header_prefix("X-Cookie: visible"));
+        assert!(!contains_sensitive_header_prefix("CookieJar: visible"));
     }
 
     #[test]


### PR DESCRIPTION
## 목표

Cookie/Set-Cookie 비밀값이 로그·최근 출력·Discord placeholder·tool error edge 등 어느 출력 경계를 지나더라도 header와 curl cookie 값 전체가 일관되게 마스킹되며, 대용량 오류에서도 메모리 사용이 입력 크기에 비례하지 않도록 합니다.

## 쉬운 설명

Cookie: session=secret이 줄바꿈·일반/ANSI-C 따옴표·curl header/cookie 옵션·compact JSON·긴 오류 축약 경계에 걸려도 비밀을 남기지 않습니다. 100MB 오류나 긴 비ASCII 문자열이 와도 panic 없이, 최대 2KiB edge와 UTF-8 경계에 맞춘 제한된 header 문맥만 검사합니다.

## 개선되는 것

### Fix 1 — 공통 민감 header redactor

- 출력 표면별 marker를 받는 utils::redact 공통 계약을 추가했습니다.
- Authorization은 진단에 필요한 scheme만 보존하고 Cookie/Set-Cookie는 값 전체를 마스킹합니다.
- RFC header-token 경계를 지켜 X-Cookie, CookieJar, X-Set-Cookie를 과잉 마스킹하지 않습니다.

### Fix 2 — obs-fold를 line selection 전에 마스킹

- 최근 agent output 전체를 먼저 sanitize한 뒤 tail line을 선택합니다.
- header 이름이 tail 밖에 있고 continuation만 안쪽에 남는 경우도 노출되지 않습니다.

### Fix 3 — quoted/attached curl header 지원

- -HCookie:value, -H 'Cookie: value', -H'Cookie: value', double-quoted Set-Cookie를 처리합니다.
- closing quote와 뒤의 URL/command는 보존하고 distinct header 이름은 그대로 둡니다.

### Fix 4 — 모든 command alias와 description 보호

- Bash, bash, command_execution, exec, exec_command, run_cmd, shell_command가 한 formatter를 공유합니다.
- command/cmd와 description을 truncation·Markdown wrapping 전에 각각 마스킹합니다.
- unknown/MCP compact JSON fallback도 redaction 후 truncate하도록 방어 경계를 통일했습니다.

### Fix 5 — 대용량 오류의 bounded edge redaction

- 2KiB 이하 line-heavy 오류는 한 번만 sanitize해 겹치는 head/tail 중복을 피합니다.
- 큰 오류는 1KiB head와 1KiB tail만 materialize합니다.
- tail이 line 중간에서 시작하면 최대 64KiB borrowed prefix만 검사하고, 민감 header/obs-fold 문맥을 증명할 수 없으면 첫 partial line을 fail-closed로 숨깁니다.

### Fix 6 — 소비 표면별 회귀 테스트

- 대소문자·탭·folded header·quoted/attached curl·alias·description·1,024-byte boundary·1MB급 single-line·UTF-8 tail을 검증합니다.
- ANSI-C quoted Cookie와 긴 비ASCII 단일 line의 context-window 경계도 직접 재현합니다.

### Fix 7 — ANSI-C quote와 UTF-8 context 경계 보강

- Bash ANSI-C quoted Cookie를 일반 single quote와 분리된 escape-aware 규칙으로 처리합니다.
- X-Cookie 같은 별도 이름과 closing quote·후속 command는 그대로 보존합니다.
- 64KiB borrowed context도 기존 UTF-8 tail helper로 경계를 맞춰 multibyte code point 중간 slice panic을 제거했습니다.

### Fix 8 — curl 전체 옵션 문법과 JSON 경계 보강

- clustered -sH, long --header, --header= 형태의 Cookie/Set-Cookie 값을 일반·single·double·ANSI-C quoting에서 처리합니다.
- curl --cookie, --cookie=, -b, clustered -sb 값을 마스킹하되 --cookie-jar, -c, 비-curl -b는 보존합니다.
- unknown/MCP fallback은 JSON을 compact serialize하기 전에 중첩 문자열과 object key를 재귀적으로 sanitize합니다.
- 전체 Value clone 없이 직접 serialize해 key 충돌에 의한 데이터 손실도 피합니다.

### Fix 9 — shell continuation·mixed line·Monitor 직접 소비 경계

- curl header/cookie option grammar를 공용 pattern으로 모아 short cluster·long option·backslash-newline 처리가 detector와 redactor 사이에서 어긋나지 않게 했습니다.
- curl 논리 명령을 continuation 단위로 모아 --cookie 또는 -b의 값이 다음 물리 line에 와도 quote와 CRLF를 보존하며 마스킹합니다.
- generic Cookie pass는 shell option이 있는 line 전체가 아니라 이미 처리된 option/header prefix만 보호해 같은 line의 독립 Cookie도 계속 검사합니다.
- escaped shell word 전체를 소비해 Cookie:\ session=secret의 뒷부분이 남지 않게 했습니다.
- Monitor는 표시 라벨을 유지하면서 공용 command formatter를 재사용해 description/command를 Markdown delimiter 전에 sanitize합니다.

### Fix 10 — JSON header map·인접 shell fragment·wget 경계

- compact JSON serializer가 case-insensitive Cookie/Set-Cookie object key를 인식하고, scalar/object는 opaque marker로 치환하며 반복 header array는 arity를 보존한 marker 배열로 직렬화합니다.
- quoted header/cookie 값 뒤 같은 shell word에 붙은 unquoted·single·double·ANSI-C fragment를 공용 suffix grammar로 함께 소비합니다.
- curl 전용이던 header option grammar 이름과 책임을 curl/wget 공용 command header 계약으로 정리했습니다.
- wget --header=Cookie:...와 quoted Set-Cookie equals 형태를 직접 회귀 테스트로 고정했습니다.

### Fix 11 — contextual header array·unquoted continuation·multiline quote

- compact JSON serializer가 `["Cookie", "session=secret"]` 같은 header pair/argv-style 배열에서 바로 앞 원소의 header 이름을 문맥으로 인식해 bare value도 마스킹합니다.
- `Cookie:\` 뒤 줄연결로 시작하거나 `Cookie:'session=secret'`처럼 첫 fragment가 quoted인 unquoted header word도 끝까지 소비합니다.
- single/double/ANSI-C quoted Cookie header가 실제 newline을 포함해도 closing quote와 후속 URL은 보존하고 전체 값만 마스킹합니다.
- unquoted·single·double·ANSI-C·backslash-newline을 하나의 재사용 가능한 shell-word fragment 문법으로 통합해 header/cookie option 규칙의 확장 지점을 단일화했습니다.
### Fix 12 — 최신 upstream test inventory gate 동기화

- PR base 이후 upstream `main`에 합쳐진 test-target integrity gate(#5130)를 branch에 merge해 GitHub merge ref와 동일한 검사 경로를 로컬에서 재현했습니다.
- 이번 3개 회귀 테스트의 cfg별 static identity 증가를 공식 `--print-lib-inventory-digest` 경로로 검토하고 digest/count pin을 `3928…458a` / `7,443`으로 갱신했습니다.
- POSIX 경로 의미가 필요한 검사기 unit tests는 WSL/Linux에서 34/34 통과했고, static inventory는 pinned count 대비 delta 0을 확인했습니다.
## Before → After

| 누출/성능 경계 | Before | After |
|---|---|---|
| Cookie: first second | first token이 scheme처럼 남을 수 있음 | 값 전체 마스킹 |
| folded continuation | 물리 line별 처리 시 continuation 노출 | 전체 buffer 선마스킹 |
| quoted/clustered curl header | shell 옵션 문법에 따라 matcher 우회 | short cluster·long option·quote-aware redaction |
| curl --cookie / -b | literal header가 없어 값 노출 | curl command line에서 cookie data 전체 마스킹 |
| curl option 줄연결 | continuation 자체만 값으로 오인 | 다음 line의 실제 값까지 quote/CRLF 보존 마스킹 |
| 일반 Cookie + curl header 혼합 line | option 보호 때문에 일반 Cookie 검사 skip | option prefix만 보호하고 나머지 span 계속 검사 |
| Monitor raw command | Markdown backtick이 matcher 경계를 차단 | field를 formatter 진입 직후 sanitize |
| compact JSON | quote/escape 경계에서 matcher 우회 | 중첩 string/key를 serialize 전에 마스킹 |
| JSON header map | Cookie key와 bare value의 관계 소실 | key가 소유한 값은 opaque 처리하고 반복 배열 arity 보존 |
| JSON header pair/argv 배열 | 각 원소를 독립 직렬화해 bare value 노출 | 직전 Cookie/Set-Cookie 이름 문맥으로 다음 값을 마스킹 |
| unquoted Cookie 줄연결/quoted fragment | 콜론 뒤 첫 byte 조건에서 matcher 우회 | 공용 shell-word fragment 전체를 소비 |
| multiline quoted Cookie header | 첫 물리 line만 마스킹하고 다음 quoted line 노출 | closing quote까지 하나의 shell word로 마스킹 |
| quoted+unquoted shell word | 첫 closing quote 뒤 secret fragment 잔존 | 같은 shell word의 모든 fragment 소비 |
| wget --header= | equals 경계로 generic matcher 우회 가능 | 공용 command header grammar로 마스킹 |
| Bash alias/description | fallback JSON 또는 raw description 노출 | 공통 command formatter |
| 1,024-byte edge | header와 값이 갈라져 tail 누출 | bounded context + partial-line fail-closed |
| 100MB error | 전체 payload 복사·다중 regex scan | 최대 2KiB materialize + 64KiB context |
| 긴 비ASCII line | byte subtraction이 code point 중간 slice 가능 | UTF-8-aware context window |
| 최신 base의 test inventory gate | 신규 회귀 테스트 identity와 pin 불일치 | 공식 digest/count 재산출로 delta 0 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| 일반 비접힘 다음 줄 | Cookie match가 소비하지 않음 | 유용한 로그 보존 |
| X-Cookie/CookieJar | token 경계 불일치 | 과잉 마스킹 방지 |
| --cookie-jar, -c, 비-curl -b | cookie-data 규칙 제외 | 일반 옵션 의미 보존 |
| backslash-newline 뒤 quoted cookie 값 | 논리 명령 단위로 인식 | 줄 구조·closing quote·후속 URL 보존 |
| 한 line의 일반 Cookie와 curl option | 두 redaction 책임을 span으로 분리 | 둘 다 마스킹, option/URL 문맥 보존 |
| curl Cookie 옵션 뒤 URL/다른 header | 값만 마스킹 | shell delimiter와 진단 문맥 보존 |
| JSON object key 두 개가 sanitize 후 같아짐 | clone/map 치환 없이 순서대로 직접 serialize | 값 유실 없음 |
| Cookie/Set-Cookie map 값이 array/object | 반복 array는 arity만 보존하고 각 원소를 marker로 치환, object는 opaque 처리 | 구조적 진단성 유지 + 중첩 credential 누출 없음 |
| contextual header pair와 X-Cookie pair 혼합 | exact header 이름의 바로 다음 값만 민감 문맥 적용 | Cookie 값은 마스킹하고 distinct header 값은 보존 |
| quoted header 내부 실제 newline | quote-aware matcher가 closing quote까지 소비 | 후속 URL/command 보존 + continuation 누출 없음 |
| quoted header 뒤 fragment와 후속 URL | 같은 word만 제거하고 whitespace에서 종료 | quote·URL 문맥 보존 |
| 매우 긴 민감 single line | head 마스킹 + tail partial line 숨김 | 비밀 조각 없음 |
| HTTP request/cookie 저장 | 관련 경로 미변경 | 런타임 인증 의미 유지 |

## 해결한 내용

- 공통 Cookie 계약을 tracing·agent recent output·Discord 출력·recovery audit·OpenCode tail에 연결했습니다.
- 리뷰의 obs-fold tail, oversized split, attached/quoted/ANSI-C/clustered/long/escaped curl·wget header, adjacent shell fragment, curl cookie-data continuation, mixed line, JSON escape/header-map/contextual pair, unquoted continuation, multiline quote, Monitor raw field 경계를 모두 반영했습니다.
- 대용량 출력은 bounded projection을 유지하고 compact JSON은 clone 없는 재귀 serializer로 분리했습니다.
- 최신 upstream test-target integrity gate를 branch에서 재현하고, 새 테스트 identity를 공식 digest/count pin에 반영했습니다.
- 출력 surface별 임시 정규식을 추가하지 않고 redactor와 command 분류 책임을 재사용 가능한 모듈에 유지했습니다.

## 포트 메모

- fork의 관련 구현 kunkunGames/AgentDesk#1429 방향을 최신 upstream에서 재검토했습니다.
- Authorization optional-scheme 규칙을 Cookie에 재사용하지 않고 전체 값·quote·alias·메모리·JSON 경계를 보강했습니다.
- 열린 upstream PR에서 같은 redaction 경로의 중복 후보는 없습니다.

## 검증

- [x] in-crate utils::redact::tests — 35/35 성공
- [x] tool-output projection — 9/9 성공
- [x] unknown/MCP compact JSON consumer 2/2(중첩 string + header map/pair), command curl option consumer 1/1, Monitor consumer 1/1 성공
- [x] cargo check --all-targets — 종료 코드 0, 저장소 기존 경고만 존재
- [x] test-lane coverage — 885개 모듈 / 6,049개 테스트, 기존 661개 baseline 증가 0, curated invocation 93개
- [x] cargo fmt --all -- --check 및 git diff --check
- [x] test-target integrity — static digest/count 일치(7,443, delta 0), WSL/Linux 검사기 tests 34/34 성공
- [ ] GitHub Actions — head 0337c4d74 실행 중
- [x] Dashboard·API schema·HTTP cookie 저장/파싱 동작 변경 없음
