### PR TITLE
perf(auto-queue): batch slot session resets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -358,6 +358,8 @@ src/
 │   │   ├── patterns.rs
 │   │   └── storage.rs
 │   ├── auto_queue/
+│   │   ├── runtime/
+│   │   │   └── clear_slot_sessions_pg_tests.rs
 │   │   ├── activate_command.rs
 │   │   ├── activate_preflight.rs
 │   │   ├── activate_route.rs

--- a/scripts/pg_test_lane_manifest.txt
+++ b/scripts/pg_test_lane_manifest.txt
@@ -38,6 +38,7 @@ src/services/auto_queue/cancel_run.rs
 src/services/auto_queue/phase_gate.rs
 src/services/auto_queue/planning.rs
 src/services/auto_queue/route_generate.rs
+src/services/auto_queue/runtime/clear_slot_sessions_pg_tests.rs
 src/services/cluster/intake_preflight.rs
 src/services/cluster/intake_router_hook.rs
 src/services/cluster/intake_router_hook/owner_record.rs
@@ -112,6 +113,7 @@ services::auto_queue::route::activate_command::tests::side_path_hijack_pg_tests
 services::auto_queue::route::phase_gate::pg_tests
 services::auto_queue::route::planning::failed_entry_alert_tests
 services::auto_queue::route::route_generate::deploy_gate_request_rejection_tests::postgres_tests
+services::auto_queue::runtime::clear_slot_sessions_pg_tests::tests
 services::auto_queue::tests
 services::cluster::intake_preflight::tests
 services::cluster::intake_router_hook::owner_record::tests
@@ -390,6 +392,7 @@ services::auto_queue::route::phase_gate::pg_tests::cancelled_run_rejects_dispatc
 services::auto_queue::route::planning::failed_entry_alert_tests::failed_entry_transition_and_alert_share_commit_with_explicit_ttl_pg
 services::auto_queue::route::planning::failed_entry_alert_tests::production_failure_wrapper_preserves_restoring_slot_binding_pg
 services::auto_queue::route::route_generate::deploy_gate_request_rejection_tests::postgres_tests::unavailable_deploy_gate_creates_no_database_rows
+services::auto_queue::runtime::clear_slot_sessions_pg_tests::tests::clear_slot_sessions_pg_batches_unique_targets_and_preserves_ineligible_rows
 services::auto_queue::tests::auto_queue_status_query_uses_latest_review_clock_pg
 services::cluster::intake_preflight::tests::evaluation_does_not_mutate_production_handoff_state_pg
 services::cluster::intake_router_hook::owner_record::tests::acquire_covers_each_generation_rule

--- a/src/services/auto_queue/runtime.rs
+++ b/src/services/auto_queue/runtime.rs
@@ -9,6 +9,8 @@ use crate::db::auto_queue::slot_predicate::{
 use crate::services::discord::health::HealthRegistry;
 use crate::services::discord::session_identity::tmux_name_from_session_key;
 
+const SLOT_THREAD_RESET_SESSION_INFO: &str = "Slot thread reset";
+
 #[derive(Debug, Clone)]
 struct RuntimeSlotClearTarget {
     provider_name: String,
@@ -122,29 +124,34 @@ pub async fn clear_slot_sessions_pg(
     pool: &PgPool,
     thread_channel_ids: &[u64],
 ) -> Result<usize, String> {
-    let mut cleared_sessions = 0usize;
-    for thread_channel_id in thread_channel_ids {
-        let result = sqlx::query(
-            "UPDATE sessions
-             SET status = 'idle',
-                 active_dispatch_id = NULL,
-                 session_info = $1,
-                 claude_session_id = NULL,
-                 tokens = 0,
-                 last_heartbeat = NOW()
-             WHERE thread_channel_id = $2
-               AND status IN ('turn_active', 'awaiting_bg', 'awaiting_user', 'working', 'idle')",
-        )
-        .bind("Slot thread reset")
-        .bind(thread_channel_id.to_string())
-        .execute(pool)
-        .await
-        .map_err(|error| {
-            format!("clear postgres slot sessions for {thread_channel_id}: {error}")
-        })?;
-        cleared_sessions += result.rows_affected() as usize;
+    let mut thread_channel_ids = thread_channel_ids
+        .iter()
+        .map(u64::to_string)
+        .collect::<Vec<_>>();
+    thread_channel_ids.sort_unstable();
+    thread_channel_ids.dedup();
+    if thread_channel_ids.is_empty() {
+        return Ok(0);
     }
-    Ok(cleared_sessions)
+
+    let thread_count = thread_channel_ids.len();
+    sqlx::query(
+        "UPDATE sessions
+         SET status = 'idle',
+             active_dispatch_id = NULL,
+             session_info = $1,
+             claude_session_id = NULL,
+             tokens = 0,
+             last_heartbeat = NOW()
+         WHERE thread_channel_id = ANY($2::TEXT[])
+           AND status IN ('turn_active', 'awaiting_bg', 'awaiting_user', 'working', 'idle')",
+    )
+    .bind(SLOT_THREAD_RESET_SESSION_INFO)
+    .bind(&thread_channel_ids)
+    .execute(pool)
+    .await
+    .map(|result| result.rows_affected() as usize)
+    .map_err(|error| format!("clear postgres slot sessions for {thread_count} thread(s): {error}"))
 }
 
 pub async fn clear_slot_threads_for_slot_pg(
@@ -387,3 +394,7 @@ async fn filter_safe_slot_thread_reset_targets(
     }
     Ok(safe_to_reset)
 }
+
+#[cfg(test)]
+#[path = "runtime/clear_slot_sessions_pg_tests.rs"]
+mod clear_slot_sessions_pg_tests;

--- a/src/services/auto_queue/runtime/clear_slot_sessions_pg_tests.rs
+++ b/src/services/auto_queue/runtime/clear_slot_sessions_pg_tests.rs
@@ -1,0 +1,131 @@
+#[cfg(test)]
+mod tests {
+    use super::super::clear_slot_sessions_pg;
+    use crate::db::auto_queue::test_support::TestPostgresDb;
+
+    #[tokio::test]
+    async fn clear_slot_sessions_pg_batches_unique_targets_and_preserves_ineligible_rows() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        let target_thread_id = 7_001_u64;
+        let target_thread_id_text = target_thread_id.to_string();
+        let resettable_statuses = ["turn_active", "awaiting_bg", "awaiting_user", "idle"];
+
+        for (index, status) in resettable_statuses.iter().enumerate() {
+            sqlx::query(
+                "INSERT INTO sessions (
+                 session_key,
+                 provider,
+                 status,
+                 active_dispatch_id,
+                 session_info,
+                 tokens,
+                 thread_channel_id,
+                 claude_session_id
+             )
+             VALUES ($1, 'claude', $2, $3, 'before reset', 41, $4, $5)",
+            )
+            .bind(format!("clear-slot-batch-{index}"))
+            .bind(status)
+            .bind(format!("dispatch-{index}"))
+            .bind(&target_thread_id_text)
+            .bind(format!("claude-session-{index}"))
+            .execute(&pool)
+            .await
+            .expect("seed resettable slot session"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL fixture
+        }
+
+        sqlx::query(
+            "INSERT INTO sessions (
+             session_key, provider, status, active_dispatch_id, session_info, tokens,
+             thread_channel_id, claude_session_id
+         )
+         VALUES
+             ('clear-slot-disconnected', 'claude', 'disconnected', 'keep-dispatch',
+              'keep disconnected', 73, $1, 'keep-claude-session'),
+             ('clear-slot-unrelated', 'claude', 'turn_active', 'unrelated-dispatch',
+              'keep unrelated', 89, '7002', 'unrelated-claude-session')",
+        )
+        .bind(&target_thread_id_text)
+        .execute(&pool)
+        .await
+        .expect("seed preserved slot sessions"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL fixture
+
+        assert_eq!(
+            clear_slot_sessions_pg(&pool, &[])
+                .await
+                .expect("skip an empty slot-session batch"),
+            0
+        );
+        assert_eq!(
+            clear_slot_sessions_pg(&pool, &[target_thread_id, target_thread_id])
+                .await
+                .expect("clear a deduplicated slot-session batch"),
+            resettable_statuses.len()
+        );
+
+        let reset_rows: Vec<(String, Option<String>, Option<String>, i64, Option<String>)> =
+            sqlx::query_as(
+                "SELECT status, active_dispatch_id, session_info, tokens, claude_session_id
+         FROM sessions
+         WHERE thread_channel_id = $1
+           AND session_key LIKE 'clear-slot-batch-%'
+         ORDER BY session_key",
+            )
+            .bind(&target_thread_id_text)
+            .fetch_all(&pool)
+            .await
+            .expect("load reset slot sessions"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
+        assert_eq!(reset_rows.len(), resettable_statuses.len());
+        assert!(reset_rows.iter().all(|row| {
+            row == &(
+                "idle".to_string(),
+                None,
+                Some("Slot thread reset".to_string()),
+                0,
+                None,
+            )
+        }));
+
+        let preserved_rows: Vec<(
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            i64,
+            Option<String>,
+        )> = sqlx::query_as(
+            "SELECT session_key, status, active_dispatch_id, session_info, tokens, claude_session_id
+         FROM sessions
+         WHERE session_key IN ('clear-slot-disconnected', 'clear-slot-unrelated')
+         ORDER BY session_key",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("load preserved slot sessions"); // agentdesk-audit: allow-unwrap — test-only PostgreSQL assertion
+        assert_eq!(
+            preserved_rows,
+            vec![
+                (
+                    "clear-slot-disconnected".to_string(),
+                    "disconnected".to_string(),
+                    Some("keep-dispatch".to_string()),
+                    Some("keep disconnected".to_string()),
+                    73,
+                    Some("keep-claude-session".to_string()),
+                ),
+                (
+                    "clear-slot-unrelated".to_string(),
+                    "turn_active".to_string(),
+                    Some("unrelated-dispatch".to_string()),
+                    Some("keep unrelated".to_string()),
+                    89,
+                    Some("unrelated-claude-session".to_string()),
+                ),
+            ]
+        );
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+}


### PR DESCRIPTION
## 목표

슬롯 thread를 초기화할 때 thread 수만큼 PostgreSQL `UPDATE`를 반복하던 경로를 단일 batch query로 바꾸고, 중복·빈 입력·부분 적용 의미를 명시적으로 고정합니다.

## 쉬운 설명

한 슬롯에 여러 thread가 연결되어 있어도 데이터베이스에는 한 번만 초기화 요청을 보냅니다. 중복 thread ID는 한 번만 처리하고, 초기화 대상이 아닌 세션과 다른 thread의 세션은 그대로 유지합니다.

## 개선되는 것

### Fix 1 — N회 UPDATE를 단일 batch UPDATE로 축소

- `thread_channel_id = ANY($2::TEXT[])`로 모든 대상 thread를 한 statement에서 갱신합니다.
- `TEXT[]` 타입을 명시해 schema의 `thread_channel_id TEXT` 계약을 고정합니다.
- N개 thread 처리 시 DB round trip을 N회에서 1회로 줄이고 부분 적용 가능성을 제거합니다.

### Fix 2 — 입력과 반환값 계약 정규화

- ID를 문자열로 변환한 뒤 정렬·중복 제거합니다.
- 빈 입력은 SQL을 실행하지 않고 0을 반환합니다.
- 오류 문맥에는 전체 ID 목록 대신 정규화된 thread 수만 남겨 로그 크기를 제한합니다.

### Fix 3 — 실제 PostgreSQL 회귀 테스트

- 최신 schema의 초기화 가능 상태 `turn_active`, `awaiting_bg`, `awaiting_user`, `idle`을 한 번에 검증합니다.
- 중복 ID, 빈 입력, `disconnected`, 무관한 thread, 초기화 field와 반환 row 수를 함께 확인합니다.
- 독립 테스트 모듈을 PostgreSQL 권위 lane manifest에 등록했습니다.

### Fix 4 — 생성형 아키텍처 inventory 동기화

- 새 `runtime/clear_slot_sessions_pg_tests.rs` 모듈을 `ARCHITECTURE.md` 생성 결과에 반영했습니다.
- 최초 CI의 Script checks가 발견한 누락을 생성기 source-of-truth대로 수정하고 `--check`로 재검증했습니다.

## Before → After

| 시나리오 | Before | After |
|---|---|---|
| thread ID 3개 초기화 | UPDATE 최대 3회 | `ANY(TEXT[])` UPDATE 1회 |
| 같은 ID가 중복 입력 | row 재갱신·반환 수 중복 가능 | 한 번만 갱신·집계 |
| 두 번째 ID에서 SQL 실패 | 앞선 변경은 적용될 수 있음 | 단일 statement 전체 성공/실패 |
| 빈 목록 | 호출 경로에 의존 | query 없이 `Ok(0)` |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| 대상의 `disconnected`/`aborted` 세션 | status filter로 제외 | 비활성 세션 보존 |
| 목록에 없는 활성 세션 | `ANY(TEXT[])` 불일치 | 무관한 세션 보존 |
| 레거시 `working` row | 기존 허용 조건 유지 | 혼합 배포 호환성 유지 |
| 큰 ID 목록에서 오류 | ID 원문 없이 count만 기록 | 로그 폭증 방지 |

## 해결한 내용

- `src/services/auto_queue/runtime.rs`: ID 정규화, 빈 입력 guard, 단일 typed-array UPDATE, 제한된 오류 문맥을 적용했습니다.
- `src/services/auto_queue/runtime/clear_slot_sessions_pg_tests.rs`: 실제 최신 schema에서 batch 갱신과 보호 조건을 검증합니다.
- `scripts/pg_test_lane_manifest.txt`: 새 파일·모듈·테스트를 PG lane에 등록했습니다. baseline/allowlist는 변경하지 않았습니다.
- `ARCHITECTURE.md`: 생성형 모듈 tree를 동기화했습니다.

## 포트 메모

- fork의 병합된 `kunkunGames/AgentDesk#1425` 아이디어를 현재 upstream/main에서 재검토했습니다.
- 단순 `ANY` 전환에 더해 명시적 `TEXT[]`, 빈/중복 입력, 원자성, 제한된 오류 문맥, 최신 schema 회귀 테스트를 보강했습니다.
- 열린 upstream PR에서 동일 함수나 slot-session batch reset 중복 후보는 없습니다.

## 검증

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --all-targets` — 종료 코드 0, 저장소 기존 경고만 존재
- [x] PostgreSQL lane membership — 444개 테스트 / 72파일, rule4 신규 부채 0
- [x] test-lane coverage — 887개 모듈 / 6,024개 테스트, 기존 661개 baseline과 일치, curated invocation 93개
- [x] `python scripts/generate_inventory_docs.py --check`
- [x] `git diff --check`
- [x] 이전 head의 실제 PostgreSQL GitHub job 성공
- [x] GitHub Actions — head `5d38299f0` 15/15 완료(14 success + 1 expected skip), mergeability `CLEAN`
- [ ] 로컬 실제 PostgreSQL 실행 — PostgreSQL/Docker/Podman이 없어 원격 PostgreSQL job을 권위 gate로 사용