### PR TITLE
fix(ci): make test-target integrity gate claims truthful and repinnable (#5008)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -272,6 +272,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      # --verify-lib-inventory invokes `cargo test --lib -- --list`; keep the
+      # main-push aggregate job on the pinned Rust toolchain and shared cache.
+      - name: Install Rust toolchain for lib inventory
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94.1"
+
+      - name: Setup sccache for lib inventory
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Cache Cargo dependencies for lib inventory
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+          cache-bin: false
+          shared-key: cargo-dependencies-v2
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Setup Python for script checks
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -888,6 +888,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      # --verify-lib-inventory invokes `cargo test --lib -- --list`, so this
+      # required aggregate job must provision the same pinned toolchain and
+      # cache used by the other Rust lanes before running ci-script-checks.sh.
+      - name: Install Rust toolchain for lib inventory
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94.1"
+
+      - name: Setup sccache for lib inventory
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Cache Cargo dependencies for lib inventory
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+          cache-bin: false
+          shared-key: cargo-dependencies-v2
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Setup Python for script checks
         uses: actions/setup-python@v5
         with:

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -60,6 +60,26 @@
   path already implemented (e.g. Discord outbound v3). For pre-migration giant
   files (no canonical replacement yet), the column is `n/a`.
 
+### CI lib-test identity inventory pin
+
+The source-of-truth for the static lib-test identity pin is
+`scripts/check_test_target_integrity.py`. Adding, deleting, or renaming a Rust
+lib test requires a reviewable companion update:
+
+1. Run `python3 scripts/check_test_target_integrity.py
+   --print-lib-inventory-digest` (this is read-only and does not compile).
+2. Review the source diff and the command's digest/count output. Update
+   `LIB_INVENTORY_STATIC_IDS_SHA256` and, when the signed count delta is not
+   zero, `LIB_INVENTORY_STATIC_IDS_COUNT` in the same diff.
+3. Re-run `--verify-lib-inventory`; its failure output repeats the digest,
+   count delta, and the exact re-pin command.
+
+The pin is a source constant, not an external immutable manifest. A deletion
+or rename can therefore pass if the same unreviewed diff re-pins it; the gate's
+guarantee is review visibility of the 64-hex digest/count change, not an
+unforgeable deletion block. Keep the named platform/include exceptions in the
+same file synchronized when a test moves across those compilation boundaries.
+
 ## Surface Map (by feature)
 
 ### `provider_output_guard`

--- a/docs/ci/release-gates.md
+++ b/docs/ci/release-gates.md
@@ -43,6 +43,26 @@ Selection observer required gate가 red로 만드는 observer 사망은 **프로
 `targets`에 없는 신규 job 경계, job ID 인용이나 표현 변형으로 인한 추출량 붕괴,
 invocation 하한은 이 게이트가 보장하지 않는다.
 
+`scripts/ci-script-checks.sh`가 독립 실행하는
+`check_test_target_integrity.py --verify-lib-inventory` 검사는 Rust 소스에서
+정적으로 수집한 lib 테스트의 전체 이름 집합을 고정된 identity digest와 비교하고,
+같은 트리에서 `cargo test --lib -- --list`가 연 집합과의 차이가 명시된
+platform/include 차이인지 비교한다. 따라서 기존 테스트를 삭제하거나 이름만 바꾸면
+개수가 같아도 이 inventory 검사가 red가 된다.
+
+이 inventory 검사는 테스트 identity만 확인하며 다음을 보장하지 않는다.
+
+- 대상 테스트에 `#[ignore]`를 붙여 실행에서 제외하는 조작은 identity를 유지하므로
+  이 inventory 검사가 거부하지 않는다.
+- 컴파일되고 통과하지만 아무것도 검증하지 않는 빈 테스트 본문은 정적 identity
+  검사로 원리적으로 판별할 수 없다.
+- workflow의 실제 test step에 `if: false`를 넣고 해당 job의 semantic hash를
+  재핀해도 Rust test identity는 바뀌지 않는다. 이 inventory 검사는 그 step의
+  실행 여부를 검증하지 않는다.
+- path filter에 `!src/...` 부정 패턴을 넣어 변경을 lane 선택에서 제외해도 Rust test
+  identity는 바뀌지 않는다. 이 inventory 검사는 path-filter의 lane 선택 의미론을
+  검증하지 않는다.
+
 ### Gate ↔ 실제 커맨드
 
 | Gate | main 커맨드 | 재현 커맨드 (로컬) |

--- a/docs/ci/release-gates.md
+++ b/docs/ci/release-gates.md
@@ -47,8 +47,21 @@ invocation 하한은 이 게이트가 보장하지 않는다.
 `check_test_target_integrity.py --verify-lib-inventory` 검사는 Rust 소스에서
 정적으로 수집한 lib 테스트의 전체 이름 집합을 고정된 identity digest와 비교하고,
 같은 트리에서 `cargo test --lib -- --list`가 연 집합과의 차이가 명시된
-platform/include 차이인지 비교한다. 따라서 기존 테스트를 삭제하거나 이름만 바꾸면
-개수가 같아도 이 inventory 검사가 red가 된다.
+platform/include 차이인지 비교한다. 새 테스트를 추가하거나 기존 테스트를 삭제·이름
+변경하면 static identity digest가 달라지거나 저장된 개수 delta가 생겨 red가 된다.
+실패 출력에는 계산된 digest와 signed count delta가 함께 나오며, 다음 명령으로
+현재 값을 다시 계산할 수 있다:
+
+```sh
+python3 scripts/check_test_target_integrity.py --print-lib-inventory-digest
+```
+
+출력을 검토한 뒤 `scripts/check_test_target_integrity.py`의
+`LIB_INVENTORY_STATIC_IDS_SHA256`와 `LIB_INVENTORY_STATIC_IDS_COUNT`를 같은 diff에서
+수동으로 갱신한다. 이 pin은 리포 소스 안의 값이므로, 같은 PR에서 삭제·이름 변경을
+검토하지 않고 digest/count를 함께 재핀하면 통과할 수 있다. 즉 이 게이트가 제공하는
+것은 삭제·이름 변경 PR이 64-hex 상수와 count pin을 함께 건드려야 한다는 **리뷰
+가시성**이지, 외부 불변 원장에 의한 삭제 방지는 아니다.
 
 이 inventory 검사는 테스트 identity만 확인하며 다음을 보장하지 않는다.
 
@@ -62,6 +75,15 @@ platform/include 차이인지 비교한다. 따라서 기존 테스트를 삭제
 - path filter에 `!src/...` 부정 패턴을 넣어 변경을 lane 선택에서 제외해도 Rust test
   identity는 바뀌지 않는다. 이 inventory 검사는 path-filter의 lane 선택 의미론을
   검증하지 않는다.
+- static identity digest/count pin 자체는 같은 PR에서 갱신할 수 있으므로, 그 갱신을
+  동반한 삭제·이름 변경을 이 검사만으로 막는 것은 보장하지 않는다. 반드시 소스 diff와
+  새 digest/count를 함께 리뷰해야 한다.
+
+`--verify-lib-inventory`는 `cargo test --manifest-path Cargo.toml --lib -- --list`를
+실행하므로 전체 lib 크레이트 컴파일이 필요하다. 이를 호출하는 PR `Script checks`와
+main `Main script checks` job은 모두 Rust 1.94.1 toolchain, sccache, Cargo dependency
+cache를 먼저 설치한다. 이 wiring을 바꾸면 해당 workflow setup과 이 문서의 재현 명령을
+함께 검토한다.
 
 ### Gate ↔ 실제 커맨드
 

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -127,6 +127,51 @@ unless script_check_commands == ["./scripts/ci-script-checks.sh"]
   exit 1
 end
 
+# The aggregate job is intentionally excluded from the high-churn cargo-job
+# `targets` hash below, but its inventory verifier has a hard prerequisite:
+# cargo must be available before ci-script-checks.sh starts. Pin the setup shape
+# here so removing the toolchain/cache silently cannot recreate D2.
+script_steps = Array(script_checks_job["steps"])
+setup_specs = {
+  "Install Rust toolchain for lib inventory" => {
+    "uses" => "dtolnay/rust-toolchain@master",
+    "toolchain" => "1.94.1",
+  },
+  "Setup sccache for lib inventory" => {
+    "uses" => "mozilla-actions/sccache-action@v0.0.10",
+  },
+  "Cache Cargo dependencies for lib inventory" => {
+    "uses" => "Swatinem/rust-cache@v2",
+    "cache-targets" => false,
+    "cache-bin" => false,
+    "shared-key" => "cargo-dependencies-v2",
+  },
+}
+setup_specs.each do |name, spec|
+  matches = script_steps.select { |step| step.is_a?(Hash) && step["name"] == name }
+  unless matches.length == 1
+    warn "#{path}: Script checks must retain exactly one #{name.inspect} step"
+    exit 1
+  end
+  step = matches.fetch(0)
+  expected_uses = spec.fetch("uses")
+  unless step["uses"] == expected_uses
+    warn "#{path}: Script checks #{name.inspect} must use #{expected_uses}"
+    exit 1
+  end
+  if spec.key?("toolchain") && step.dig("with", "toolchain") != spec["toolchain"]
+    warn "#{path}: Script checks #{name.inspect} must pin Rust 1.94.1"
+    exit 1
+  end
+  spec.each do |key, expected|
+    next if key == "uses" || key == "toolchain"
+    unless step.dig("with", key) == expected
+      warn "#{path}: Script checks #{name.inspect} must retain #{key}=#{expected.inspect}"
+      exit 1
+    end
+  end
+end
+
 targets = {
   # The independent explicit step-inventory layer was removed. What remains
   # splits into two mechanisms of very different strength, and conflating them

--- a/scripts/check_test_target_integrity.py
+++ b/scripts/check_test_target_integrity.py
@@ -19,6 +19,7 @@ scripts/test_target_integrity_allowlist.txt (normalized command per line).
 from __future__ import annotations
 
 import argparse
+import hashlib
 import re
 import shlex
 import subprocess
@@ -47,6 +48,45 @@ JOB_HEADER = re.compile(r"^  ([A-Za-z0-9_-]+):(?:\s*#.*)?$")
 RECIPE_HEADER = re.compile(r"^([A-Za-z0-9_-]+):(?:\s.*)?$")
 EVIDENCE_LINE = re.compile(r"^selection-evidence: selected=(\d+) command=(.*)$")
 SUMMARY_KEYS = {"invocations", "nonzero", "findings", "extraction_errors", "execution_errors"}
+
+# The static parser intentionally sees platform-gated tests from every host.
+# libtest only lists tests compiled for the current host, and include!()-based
+# tests are outside this parser. These exact, named differences are reviewed
+# data; any drift on either side fails --verify-lib-inventory.
+LIB_INVENTORY_STATIC_ONLY_BASE = frozenset({
+    "cli::discord_thread_create::tests::thread_create_lock_cancel_child_process",
+    "cli::discord_thread_create::tests::windows_async_waiter_recovers_abandoned_owner",
+    "cli::discord_thread_create::tests::windows_cancelled_async_holder_releases_before_runtime_exit",
+    "cli::discord_thread_create::tests::windows_lock_uses_global_current_sid_named_mutex",
+    "cli::discord_thread_create_lock::windows::tests::wait_status_accepts_normal_and_abandoned_but_reports_errors",
+    "services::discord::placeholder_sweeper::abandon_guard::tests::claude_e_process_cleanup_is_fail_closed_without_unix_probe",
+})
+LIB_INVENTORY_STATIC_ONLY_BY_PLATFORM = {
+    "darwin": frozenset({
+        "services::process::simple_cancel_watcher_tests::linux_proc_stat_parser_handles_comm_with_spaces_and_parens",
+    }),
+    "linux": frozenset({
+        "cli::init::launchd_plist_tests::clamp_launchd_nofile_soft_limit_never_exceeds_host_hard_limit",
+        "cli::init::launchd_plist_tests::generate_launchd_plist_release_sets_clamped_soft_number_of_files_limit",
+        "cli::init::launchd_plist_tests::generate_launchd_plist_uses_requested_fresh_home_and_root_only",
+        "services::platform::binary_resolver::tests::codex_fallback_dirs_include_app_bundle_resources_on_macos",
+    }),
+}
+LIB_INVENTORY_KNOWN_CARGO_ONLY = frozenset({
+    "services::discord::tmux::restored_turn_injected_anchor_tests::task_notification_kind_restart_invariant_tests::task_notification_kind_restart_roundtrip_4253",
+    "services::discord::tmux::tmux_output_stream::tests::provider_output_guard_tests::invariant_4371_raw_claude_jsonl_reaches_last_mile_guard_without_leaking",
+    "services::discord::tmux::tmux_watcher::terminal_direct_fallback::tests::committed_cleanup_preserves_tracking_until_delete_commits_4508",
+    "services::discord::tmux::tmux_watcher::terminal_direct_fallback::tests::committed_edit_failure_cleanup_has_controller_legacy_parity_4508",
+    "services::discord::tmux::tmux_watcher::terminal_direct_fallback::tests::legacy_edit_failure_revalidation_precedes_fallback_post_4508",
+    "services::discord::tmux::tmux_watcher::terminal_direct_fallback::tests::recovered_task_response_identity_is_stable_without_inflight_or_context",
+    "services::discord::tmux::tmux_watcher::terminal_direct_fallback::tests::watcher_task_response_wiring_prepares_reference_before_send_and_marks_after_frontier",
+})
+# SHA-256 of UTF-8 "\n".join(sorted(static full test IDs)), without a trailing
+# newline. The identity is platform-independent because the parser includes
+# every cfg-gated source test; regenerate only after reviewing the named diff.
+LIB_INVENTORY_STATIC_IDS_SHA256 = (
+    "700edad866962420a94acb7b8c5471625d6aba6368d9ea81859c89b085b873b6"
+)
 
 
 @dataclass(frozen=True)
@@ -89,6 +129,200 @@ def discover_targets(repo_root: Path) -> dict[str, Path]:
     for auto_bin in sorted((repo_root / "src/bin").glob("*.rs")):
         targets.setdefault(f"bin:{auto_bin.stem}", auto_bin)
     return targets
+
+
+@dataclass(frozen=True)
+class RustToken:
+    value: str
+    line: int
+    kind: str = "punct"
+
+
+def _rust_tokens(text: str) -> list[RustToken]:
+    """Tokenize the Rust subset needed for attrs, items, and brace scopes."""
+    tokens: list[RustToken] = []
+    index = 0
+    line = 1
+    while index < len(text):
+        char = text[index]
+        if char.isspace():
+            line += char == "\n"
+            index += 1
+            continue
+        if text.startswith("//", index):
+            end = text.find("\n", index)
+            index = len(text) if end < 0 else end
+            continue
+        if text.startswith("/*", index):
+            depth = 1
+            index += 2
+            while index < len(text) and depth:
+                if text.startswith("/*", index):
+                    depth += 1
+                    index += 2
+                elif text.startswith("*/", index):
+                    depth -= 1
+                    index += 2
+                else:
+                    line += text[index] == "\n"
+                    index += 1
+            continue
+        raw = re.match(r'r(#{0,255})"', text[index:])
+        if raw:
+            marker = '"' + raw.group(1)
+            start_line = line
+            start = index + raw.end()
+            end = text.find(marker, start)
+            if end < 0:
+                end = len(text)
+                index = len(text)
+            else:
+                index = end + len(marker)
+            value = text[start:end]
+            line += value.count("\n")
+            tokens.append(RustToken(value, start_line, "string"))
+            continue
+        if char == '"':
+            start_line = line
+            index += 1
+            value = []
+            while index < len(text):
+                if text[index] == "\\" and index + 1 < len(text):
+                    value.extend(text[index:index + 2])
+                    line += text[index + 1] == "\n"
+                    index += 2
+                elif text[index] == '"':
+                    index += 1
+                    break
+                else:
+                    value.append(text[index])
+                    line += text[index] == "\n"
+                    index += 1
+            tokens.append(RustToken("".join(value), start_line, "string"))
+            continue
+        if char == "'":
+            literal = re.match(r"'(?:\\.|[^\\'\n])'", text[index:])
+            if literal:
+                index += literal.end()
+                continue
+        ident = re.match(r"[A-Za-z_][A-Za-z0-9_]*", text[index:])
+        if ident:
+            tokens.append(RustToken(ident.group(), line, "ident"))
+            index += ident.end()
+            continue
+        if char in "#[]{}();=:":
+            tokens.append(RustToken(char, line))
+        index += 1
+    return tokens
+
+
+@dataclass(frozen=True)
+class StaticTestInventory:
+    tests: dict[str, str]
+    module_errors: dict[str, str]
+
+
+def collect_static_tests(root: Path, repo_root: Path) -> StaticTestInventory:
+    """Collect full #[test]/#[tokio::test] identities without compiling."""
+    tests: dict[str, str] = {}
+    module_errors: dict[str, str] = {}
+    queue: list[tuple[Path, tuple[str, ...], Path]] = [(root, (), root.parent)]
+    seen: set[tuple[Path, tuple[str, ...]]] = set()
+    while queue:
+        source, outer, base_dir = queue.pop()
+        identity = (source.resolve(), outer)
+        if identity in seen or not source.is_file():
+            continue
+        seen.add(identity)
+        tokens = _rust_tokens(source.read_text("utf-8"))
+        scopes: list[tuple[int, str, Path]] = []
+        depth = 0
+        pending_path: str | None = None
+        pending_test = False
+        index = 0
+        while index < len(tokens):
+            token = tokens[index]
+            current_names = outer + tuple(scope[1] for scope in scopes)
+            current_dir = scopes[-1][2] if scopes else base_dir
+            if token.value == "#" and index + 1 < len(tokens) \
+                    and tokens[index + 1].value == "[":
+                end = index + 2
+                attr_depth = 1
+                while end < len(tokens) and attr_depth:
+                    attr_depth += tokens[end].value == "["
+                    attr_depth -= tokens[end].value == "]"
+                    end += 1
+                attr = tokens[index + 2:end - 1]
+                path_end = next((offset for offset, item in enumerate(attr)
+                                 if item.value in ("(", "=", "]")), len(attr))
+                attr_path = tuple(item.value for item in attr[:path_end]
+                                  if item.kind == "ident")
+                pending_test = pending_test or attr_path in {
+                    ("test",), ("tokio", "test"),
+                }
+                if attr_path == ("path",):
+                    string = next((item.value for item in attr
+                                   if item.kind == "string"), None)
+                    pending_path = string or pending_path
+                index = end
+                continue
+            if token.value == "fn" and token.kind == "ident" \
+                    and index + 1 < len(tokens):
+                name = tokens[index + 1]
+                if pending_test and name.kind == "ident":
+                    test_id = "::".join(current_names + (name.value,))
+                    tests[test_id] = f"{source.relative_to(repo_root)}:{token.line}"
+                pending_path = None
+                pending_test = False
+            elif token.value == "mod" and token.kind == "ident" \
+                    and index + 2 < len(tokens) \
+                    and tokens[index + 1].kind == "ident":
+                name = tokens[index + 1].value
+                cursor = index + 2
+                while cursor < len(tokens) and tokens[cursor].value not in (";", "{"):
+                    cursor += 1
+                if cursor < len(tokens):
+                    path_names = current_names + (name,)
+                    site = f"{source.relative_to(repo_root)}:{token.line}"
+                    if tokens[cursor].value == "{":
+                        depth += 1
+                        scopes.append((depth, name, current_dir / name))
+                        index = cursor + 1
+                        pending_path = None
+                        pending_test = False
+                        continue
+                    candidates = ((source.parent / pending_path,
+                                   current_dir / pending_path)
+                                  if pending_path else
+                                  (current_dir / f"{name}.rs",
+                                   current_dir / name / "mod.rs"))
+                    child = next((item for item in candidates if item.is_file()), None)
+                    if child:
+                        redirected = pending_path is not None
+                        child_dir = (child.parent
+                                     if redirected or child.name == "mod.rs"
+                                     else child.parent / child.stem)
+                        queue.append((child, path_names, child_dir))
+                    else:
+                        missing = ", ".join(
+                            str(item.relative_to(repo_root))
+                            if item.is_relative_to(repo_root) else str(item)
+                            for item in candidates
+                        )
+                        module_errors["::".join(path_names)] = f"{site} (missing {missing})"
+                    pending_path = None
+                    pending_test = False
+            if token.kind == "punct" and token.value == "{":
+                depth += 1
+            elif token.kind == "punct" and token.value == "}":
+                depth -= 1
+                while scopes and scopes[-1][0] > depth:
+                    scopes.pop()
+            elif token.kind == "punct" and token.value == ";":
+                pending_path = None
+                pending_test = False
+            index += 1
+    return StaticTestInventory(tests, module_errors)
 
 
 def collect_modules(root: Path, repo_root: Path) -> dict[str, str]:
@@ -329,6 +563,53 @@ def _test_ids(output: str) -> set[str]:
             if line.strip().endswith(": test")}
 
 
+@dataclass(frozen=True)
+class InventoryComparison:
+    static_only: frozenset[str]
+    cargo_only: frozenset[str]
+    static_ids: frozenset[str]
+    cargo_ids: frozenset[str]
+    module_errors: tuple[tuple[str, str], ...] = ()
+    execution_error: str | None = None
+
+
+def _identity_digest(test_ids: frozenset[str] | set[str]) -> str:
+    return hashlib.sha256("\n".join(sorted(test_ids)).encode()).hexdigest()
+
+
+def expected_lib_static_only(platform_name: str) -> frozenset[str] | None:
+    platform_only = LIB_INVENTORY_STATIC_ONLY_BY_PLATFORM.get(platform_name)
+    return None if platform_only is None else \
+        LIB_INVENTORY_STATIC_ONLY_BASE | platform_only
+
+
+def compare_lib_inventory(repo_root: Path, runner=None) -> InventoryComparison:
+    """Compare static full lib test IDs with compiled libtest `--list` IDs."""
+    inventory = collect_static_tests(discover_targets(repo_root)["lib"], repo_root)
+    static_ids = frozenset(inventory.tests)
+    module_errors = tuple(sorted(inventory.module_errors.items()))
+    runner = runner or subprocess.run
+    argv = ["cargo", "test", "--manifest-path", str(repo_root / "Cargo.toml"),
+            "--lib", "--", "--list"]
+    try:
+        proc = runner(argv, cwd=repo_root, capture_output=True, text=True)
+    except OSError as error:
+        return InventoryComparison(frozenset(), frozenset(), static_ids,
+                                   frozenset(), module_errors,
+                                   f"cargo could not start: {error}")
+    if proc.returncode:
+        detail = proc.stderr[-1000:].strip() or proc.stdout[-1000:].strip()
+        return InventoryComparison(
+            frozenset(), frozenset(), static_ids, frozenset(), module_errors,
+            f"cargo list failed (rc={proc.returncode}): {detail}",
+        )
+    cargo_ids = frozenset(_test_ids(proc.stdout))
+    return InventoryComparison(
+        static_ids - cargo_ids, cargo_ids - static_ids,
+        static_ids, cargo_ids, module_errors,
+    )
+
+
 def observe_curated(repo_root: Path, workflow: Path, jobs: set[str], runner=None
                     ) -> list[tuple[list[str], int, str | None]]:
     runner = runner or subprocess.run
@@ -473,6 +754,8 @@ def main(argv: list[str] | None = None) -> int:
                         help="exit 1 on violations (default: warn only)")
     parser.add_argument("--run-list-check", action="store_true",
                         help="also run `cargo test ... -- --list` (compiles)")
+    parser.add_argument("--verify-lib-inventory", action="store_true",
+                        help="compare static lib test IDs with compiled --list IDs")
     parser.add_argument("--observe-selection", action="store_true",
                         help="warn-only execution evidence for curated jobs")
     parser.add_argument("--verify-selection-evidence", type=Path,
@@ -493,6 +776,46 @@ def main(argv: list[str] | None = None) -> int:
         for error in errors:
             print(f"selection-evidence verifier: {error}", file=sys.stderr)
         return 1 if errors else 0
+    if args.verify_lib_inventory:
+        # Contract boundary for this specific inventory check: it compares test
+        # identities, not whether their bodies assert anything or whether a CI
+        # lane executes them. Consequently it does not reject (1) #[ignore],
+        # (2) an empty but compiling test body, (3) `if: false` on the workflow
+        # test step after that job's semantic hash is re-pinned, or (4) a
+        # negative path-filter pattern that prevents the lane from being chosen.
+        expected_static_only = expected_lib_static_only(sys.platform)
+        if expected_static_only is None:
+            print(f"lib inventory comparison: unsupported platform {sys.platform}",
+                  file=sys.stderr)
+            return 2
+        comparison = compare_lib_inventory(repo_root)
+        if comparison.execution_error:
+            print(f"lib inventory comparison: {comparison.execution_error}",
+                  file=sys.stderr)
+            return 2
+        for module, site in comparison.module_errors:
+            print(f"lib inventory module-resolution: {module} at {site}",
+                  file=sys.stderr)
+        for test_id in sorted(comparison.static_only):
+            print(f"lib inventory static-only: {test_id}", file=sys.stderr)
+        for test_id in sorted(comparison.cargo_only):
+            print(f"lib inventory cargo-only: {test_id}", file=sys.stderr)
+        static_identity_matches = (
+            _identity_digest(comparison.static_ids)
+            == LIB_INVENTORY_STATIC_IDS_SHA256
+        )
+        print("lib inventory comparison: "
+              f"static-only={len(comparison.static_only)} "
+              f"cargo-only={len(comparison.cargo_only)} "
+              f"module-errors={len(comparison.module_errors)}")
+        print("lib inventory identity: "
+              f"static={'match' if static_identity_matches else 'changed'}")
+        return 1 if (
+            comparison.static_only != expected_static_only
+            or comparison.cargo_only != LIB_INVENTORY_KNOWN_CARGO_ONLY
+            or comparison.module_errors
+            or not static_identity_matches
+        ) else 0
     if args.observe_selection:
         if len(workflows) != 1 or not args.job:
             parser.error("--observe-selection requires one --workflow and --job")

--- a/scripts/check_test_target_integrity.py
+++ b/scripts/check_test_target_integrity.py
@@ -14,6 +14,10 @@ fatal, and opt-in `--run-list-check` additionally runs
 `cargo test ... -- --list` (compiles) to flag lanes selecting 0 tests.
 Legitimately-empty lanes (platform `#[cfg]`) are excused via
 scripts/test_target_integrity_allowlist.txt (normalized command per line).
+
+`--print-lib-inventory-digest` is the read-only re-pin path: it computes the
+static digest/count without invoking cargo so a test diff can be reviewed before
+the two source pin constants are updated.
 """
 
 from __future__ import annotations
@@ -84,9 +88,12 @@ LIB_INVENTORY_KNOWN_CARGO_ONLY = frozenset({
 # SHA-256 of UTF-8 "\n".join(sorted(static full test IDs)), without a trailing
 # newline. The identity is platform-independent because the parser includes
 # every cfg-gated source test; regenerate only after reviewing the named diff.
+# Keep the count beside the digest so a failed check reports a signed count
+# delta even though the compact pin deliberately does not embed every identity.
 LIB_INVENTORY_STATIC_IDS_SHA256 = (
     "700edad866962420a94acb7b8c5471625d6aba6368d9ea81859c89b085b873b6"
 )
+LIB_INVENTORY_STATIC_IDS_COUNT = 7410
 
 
 @dataclass(frozen=True)
@@ -754,6 +761,14 @@ def main(argv: list[str] | None = None) -> int:
                         help="exit 1 on violations (default: warn only)")
     parser.add_argument("--run-list-check", action="store_true",
                         help="also run `cargo test ... -- --list` (compiles)")
+    parser.add_argument(
+        "--print-lib-inventory-digest",
+        action="store_true",
+        help=(
+            "print the current static lib-test digest and count without "
+            "running cargo (use to review and re-pin the source constant)"
+        ),
+    )
     parser.add_argument("--verify-lib-inventory", action="store_true",
                         help="compare static lib test IDs with compiled --list IDs")
     parser.add_argument("--observe-selection", action="store_true",
@@ -776,6 +791,27 @@ def main(argv: list[str] | None = None) -> int:
         for error in errors:
             print(f"selection-evidence verifier: {error}", file=sys.stderr)
         return 1 if errors else 0
+    if args.print_lib_inventory_digest:
+        target = discover_targets(repo_root).get("lib")
+        if target is None:
+            print("lib inventory digest: lib target not found", file=sys.stderr)
+            return 2
+        inventory = collect_static_tests(target, repo_root)
+        for module, site in sorted(inventory.module_errors.items()):
+            print(f"lib inventory module-resolution: {module} at {site}",
+                  file=sys.stderr)
+        static_ids = frozenset(inventory.tests)
+        digest = _identity_digest(static_ids)
+        delta = len(static_ids) - LIB_INVENTORY_STATIC_IDS_COUNT
+        print(f"lib inventory static digest: {digest}")
+        print("lib inventory static count: "
+              f"current={len(static_ids)} "
+              f"pinned={LIB_INVENTORY_STATIC_IDS_COUNT} "
+              f"delta={delta:+d}")
+        print("lib inventory re-pin: update "
+              "LIB_INVENTORY_STATIC_IDS_SHA256 (and COUNT when delta is "
+              "nonzero) after reviewing the test diff")
+        return 1 if inventory.module_errors else 0
     if args.verify_lib_inventory:
         # Contract boundary for this specific inventory check: it compares test
         # identities, not whether their bodies assert anything or whether a CI
@@ -800,22 +836,35 @@ def main(argv: list[str] | None = None) -> int:
             print(f"lib inventory static-only: {test_id}", file=sys.stderr)
         for test_id in sorted(comparison.cargo_only):
             print(f"lib inventory cargo-only: {test_id}", file=sys.stderr)
-        static_identity_matches = (
-            _identity_digest(comparison.static_ids)
-            == LIB_INVENTORY_STATIC_IDS_SHA256
+        static_digest = _identity_digest(comparison.static_ids)
+        static_identity_matches = static_digest == LIB_INVENTORY_STATIC_IDS_SHA256
+        static_count_delta = (
+            len(comparison.static_ids) - LIB_INVENTORY_STATIC_IDS_COUNT
         )
         print("lib inventory comparison: "
               f"static-only={len(comparison.static_only)} "
               f"cargo-only={len(comparison.cargo_only)} "
               f"module-errors={len(comparison.module_errors)}")
         print("lib inventory identity: "
-              f"static={'match' if static_identity_matches else 'changed'}")
-        return 1 if (
+              f"static={'match' if static_identity_matches else 'changed'} "
+              f"digest={static_digest} "
+              f"count={len(comparison.static_ids)} "
+              f"pinned-count={LIB_INVENTORY_STATIC_IDS_COUNT} "
+              f"delta={static_count_delta:+d}")
+        failed = (
             comparison.static_only != expected_static_only
             or comparison.cargo_only != LIB_INVENTORY_KNOWN_CARGO_ONLY
             or comparison.module_errors
+            or len(comparison.static_ids) != LIB_INVENTORY_STATIC_IDS_COUNT
             or not static_identity_matches
-        ) else 0
+        )
+        if failed:
+            print("lib inventory re-pin: run `python3 scripts/"
+                  "check_test_target_integrity.py "
+                  "--print-lib-inventory-digest`, review the reported "
+                  "count delta and source diff, then update the two pin "
+                  "constants")
+        return 1 if failed else 0
     if args.observe_selection:
         if len(workflows) != 1 or not args.job:
             parser.error("--observe-selection requires one --workflow and --job")

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -135,13 +135,14 @@ fi
 "$PYTHON" scripts/check_test_lane_coverage.py --baseline-ref "$TEST_LANE_BASELINE_REF"
 "$PYTHON" -m unittest tests.test_test_lane_coverage
 
-echo "=== Test-target integrity gate (#5003, warn-only rollout) ==="
+echo "=== Test-target integrity gate (#5003/#5008) ==="
 # cargo exits 0 on zero filter matches, so a curated lane with the wrong
 # --lib/--bin/--test flag can run 0 tests while its required check stays
 # green. Warn-only until the known offenders are repaired (separate slice);
 # flip to --enforce afterwards. The unittest run below is the gate's own
 # mutation proof (bad fixture must fail, fixed fixture must pass).
 "$PYTHON" scripts/check_test_target_integrity.py
+"$PYTHON" scripts/check_test_target_integrity.py --verify-lib-inventory
 "$PYTHON" -m unittest tests.test_check_test_target_integrity
 
 echo "=== PostgreSQL test-lane membership gate (#4979, enforced) ==="

--- a/tests/test_check_test_target_integrity.py
+++ b/tests/test_check_test_target_integrity.py
@@ -311,6 +311,8 @@ mod after_string_brace {
         ), mock.patch.object(
             integrity, "LIB_INVENTORY_STATIC_IDS_SHA256",
             integrity._identity_digest(pinned_ids),
+        ), mock.patch.object(
+            integrity, "LIB_INVENTORY_STATIC_IDS_COUNT", len(pinned_ids),
         ), contextlib.redirect_stdout(io.StringIO()):
             return integrity.main([
                 "--repo-root", str(REPO_ROOT), "--verify-lib-inventory",
@@ -335,6 +337,60 @@ mod after_string_brace {
         self.assertEqual(self._inventory_cli(
             self._comparison(renamed), baseline,
         ), 1, "same-count identity replacement must fail")
+
+    def test_print_flag_reports_digest_and_signed_count_delta(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._fixture(root)
+            output = io.StringIO()
+            with mock.patch.object(
+                integrity, "LIB_INVENTORY_STATIC_IDS_COUNT", 3,
+            ), contextlib.redirect_stdout(output):
+                rc = integrity.main([
+                    "--repo-root", str(root),
+                    "--print-lib-inventory-digest",
+                ])
+        self.assertEqual(rc, 0)
+        rendered = output.getvalue()
+        expected_ids = {
+            "nested::tests::plain_case",
+            "nested::tests::async_case",
+            "nested::after_string_brace::keeps_root_scope",
+        }
+        self.assertIn(
+            f"lib inventory static digest: {integrity._identity_digest(expected_ids)}",
+            rendered,
+        )
+        self.assertIn("lib inventory static count: current=3 pinned=3 delta=+0", rendered)
+        self.assertIn("LIB_INVENTORY_STATIC_IDS_SHA256", rendered)
+
+    def test_changed_pin_stays_red_and_reports_repin_command(self) -> None:
+        baseline = {"module::tests::kept", "module::tests::guard"}
+        added = baseline | {"module::tests::new_case"}
+        output = io.StringIO()
+        with mock.patch.object(
+            integrity, "compare_lib_inventory", return_value=self._comparison(added),
+        ), mock.patch.object(
+            integrity, "LIB_INVENTORY_STATIC_IDS_SHA256",
+            integrity._identity_digest(baseline),
+        ), mock.patch.object(
+            integrity, "LIB_INVENTORY_STATIC_IDS_COUNT", len(baseline),
+        ), contextlib.redirect_stdout(output):
+            rc = integrity.main([
+                "--repo-root", str(REPO_ROOT), "--verify-lib-inventory",
+            ])
+        self.assertEqual(rc, 1)
+        rendered = output.getvalue()
+        self.assertIn("static=changed", rendered)
+        self.assertIn(
+            f"digest={integrity._identity_digest(added)}", rendered,
+        )
+        self.assertIn("delta=+1", rendered)
+        self.assertIn(
+            "python3 scripts/check_test_target_integrity.py "
+            "--print-lib-inventory-digest",
+            rendered,
+        )
 
     def test_ci_script_runs_inventory_verifier_as_a_standalone_command(self) -> None:
         lines = (REPO_ROOT / "scripts/ci-script-checks.sh").read_text(

--- a/tests/test_check_test_target_integrity.py
+++ b/tests/test_check_test_target_integrity.py
@@ -250,6 +250,102 @@ class RunListCheckContract(unittest.TestCase):
         self.assertIn("rc=101", detail)
 
 
+class LibInventoryIdentityContract(unittest.TestCase):
+    def _fixture(self, root: Path) -> None:
+        (root / "src" / "nested").mkdir(parents=True)
+        (root / "Cargo.toml").write_text(
+            '[package]\nname = "fixture"\n\n[lib]\npath = "src/lib.rs"\n',
+            encoding="utf-8",
+        )
+        (root / "src" / "lib.rs").write_text(
+            'mod nested;\nconst FAKE: &str = "#[test] fn string_case() {}";\n',
+            encoding="utf-8",
+        )
+        (root / "src" / "nested" / "mod.rs").write_text(
+            """// #[test] fn comment_case() {}
+#[cfg(test)]
+mod tests {
+    const OPEN_BRACE: &str = "{";
+
+    #[test]
+    fn plain_case() {}
+
+    #[tokio::test]
+    async fn async_case() {}
+}
+
+#[cfg(test)]
+mod after_string_brace {
+    #[test]
+    fn keeps_root_scope() {}
+}
+""",
+            encoding="utf-8",
+        )
+
+    def test_static_inventory_collects_full_ids_not_comment_or_string(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._fixture(root)
+            inventory = integrity.collect_static_tests(root / "src/lib.rs", root)
+        self.assertEqual(set(inventory.tests), {
+            "nested::tests::plain_case",
+            "nested::tests::async_case",
+            "nested::after_string_brace::keeps_root_scope",
+        })
+        self.assertEqual(inventory.module_errors, {})
+
+    def _comparison(self, static_ids: set[str]):
+        expected = integrity.expected_lib_static_only(sys.platform)
+        assert expected is not None
+        return integrity.InventoryComparison(
+            expected,
+            integrity.LIB_INVENTORY_KNOWN_CARGO_ONLY,
+            frozenset(static_ids),
+            frozenset(),
+        )
+
+    def _inventory_cli(self, comparison, pinned_ids: set[str]) -> int:
+        with mock.patch.object(
+            integrity, "compare_lib_inventory", return_value=comparison,
+        ), mock.patch.object(
+            integrity, "LIB_INVENTORY_STATIC_IDS_SHA256",
+            integrity._identity_digest(pinned_ids),
+        ), contextlib.redirect_stdout(io.StringIO()):
+            return integrity.main([
+                "--repo-root", str(REPO_ROOT), "--verify-lib-inventory",
+            ])
+
+    def test_cli_accepts_exact_pinned_static_identity(self) -> None:
+        baseline = {"module::tests::kept", "module::tests::guard"}
+        self.assertEqual(self._inventory_cli(
+            self._comparison(baseline), baseline,
+        ), 0)
+
+    def test_cli_rejects_identity_deleted_from_static_and_cargo(self) -> None:
+        baseline = {"module::tests::kept", "module::tests::guard"}
+        deleted = {"module::tests::kept"}
+        self.assertEqual(self._inventory_cli(
+            self._comparison(deleted), baseline,
+        ), 1, "identity deletion must fail even when static/cargo drift sets match")
+
+    def test_cli_rejects_same_count_identity_rename(self) -> None:
+        baseline = {"module::tests::kept", "module::tests::guard"}
+        renamed = {"module::tests::kept", "module::tests::renamed_guard"}
+        self.assertEqual(self._inventory_cli(
+            self._comparison(renamed), baseline,
+        ), 1, "same-count identity replacement must fail")
+
+    def test_ci_script_runs_inventory_verifier_as_a_standalone_command(self) -> None:
+        lines = (REPO_ROOT / "scripts/ci-script-checks.sh").read_text(
+            "utf-8"
+        ).splitlines()
+        self.assertIn(
+            '"$PYTHON" scripts/check_test_target_integrity.py --verify-lib-inventory',
+            lines,
+        )
+
+
 class ExecutionEvidenceSummaryContract(unittest.TestCase):
     def _summary_fields(self, rendered: str) -> dict[str, int]:
         lines = [line for line in rendered.splitlines()


### PR DESCRIPTION
Closes #5008

## What this is

The test-target integrity gate declared guarantees it does not actually provide, and its
hardest failure mode (lib inventory digest drift) had no runnable repin path. This PR makes
the gate's claims truthful and makes its one genuinely blocking failure recoverable.

## r2 findings addressed

### D1 (P0) — lib inventory digest was a dead-end failure

`scripts/check_test_target_integrity.py` pins a digest over **every** lib test id. Adding a
single lib test therefore turns a required CI check red — but there was no repin command, no
actionable failure output, and no documented procedure. Contributors would hit a red required
check with nothing to act on.

- Added `--print-lib-inventory-digest`, a **read-only** repin path (computes and prints, writes nothing).
- Failure output now reports the digest delta, the count delta, and the exact repin command to run.
- Added `LIB_INVENTORY_STATIC_IDS_COUNT` as a companion pin so a count-only drift is caught
  independently of the digest.
- Added paired tests in `tests/test_check_test_target_integrity.py` covering the repin path and
  the failure-output contract.

### D2 (P1) — inventory verify called `cargo` in a job with no Rust toolchain

`--verify-lib-inventory` shells out to `cargo test --lib -- --list`, but the aggregate script-checks
job had no Rust setup step. The gate would have failed on `cargo: command not found` rather than on
a real drift.

- Added pinned Rust 1.94.1 + sccache + `Swatinem/rust-cache` to **both** the PR `Script checks` job
  (`.github/workflows/ci-pr.yml`) and the main-push `Main script checks` job (`.github/workflows/ci-main.yml`),
  matching the toolchain and `shared-key` used by the other Rust lanes.
- `scripts/check-ci-runner-hardening.sh` now structurally pins all three setup steps in both workflows,
  so silently dropping the toolchain cannot regress back in.

### D3/D4 (P1) — unconditional claims that were simply false

The docs claimed that deleting or renaming an existing test makes CI red, unconditionally.
That is not true: repinning the source pin **in the same PR** passes. The gate's real guarantee is
narrower.

- Corrected the claim to what actually holds: the gate guarantees **review visibility of a 64-hex pin change**,
  nothing more.
- Added explicit non-guarantee bullets to `docs/ci/release-gates.md` and
  `docs/agent-maintenance/change-surfaces.md` so the limits are stated rather than implied.

## Review status

Both legs of a dual review independently examined the **exact same head SHA** (`78b667d8a`) and returned
`VERDICT: CLEAN`.

- **Leg A** (static / claim-truthfulness lens): audited every remaining assertion in the touched docs and
  comments against what the gate code actually enforces, and confirmed no claim outruns the implementation.
- **Leg B** (execution lens): did not read-only review — it **ran** things. It exercised the D1 repin path
  end to end, attempted three separate bypasses of the repin path, mutated the D2 setup steps to confirm
  `check-ci-runner-hardening.sh` actually catches their removal, mutated the
  `not static_identity_matches` branch to confirm the failure path is reachable, and executed the full local
  gate suite rather than reasoning about it.

## Non-goal

This PR does **not** weaken any gate. Baseline/allowlist/hardening requirements, pin constants, and exact-match
strings are unchanged except where a repin is independently justified — weakening a gate would directly
contradict the point of this change.
