### PR TITLE
fix(ci): re-pin lib-inventory identity after #5122-#5129 merges

### DIFF
--- a/scripts/check_test_target_integrity.py
+++ b/scripts/check_test_target_integrity.py
@@ -91,9 +91,9 @@ LIB_INVENTORY_KNOWN_CARGO_ONLY = frozenset({
 # Keep the count beside the digest so a failed check reports a signed count
 # delta even though the compact pin deliberately does not embed every identity.
 LIB_INVENTORY_STATIC_IDS_SHA256 = (
-    "3928ebd31e87a81bc24185a69926c6e91f1a544533a678972bb257b7d61a458a"
+    "29f684007e997f35fcbfbe7aa887b2c8b1d7c343cb3fe053e628709b81ea0240"
 )
-LIB_INVENTORY_STATIC_IDS_COUNT = 7443
+LIB_INVENTORY_STATIC_IDS_COUNT = 7450
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## 문제

`Main script checks` (test-target integrity gate) 가 `bba09527` 이후 main 에서 계속 실패 중입니다.

```
lib inventory identity: static=changed
  digest=29f684007e997f35fcbfbe7aa887b2c8b1d7c343cb3fe053e628709b81ea0240
  count=7450 pinned-count=7443 delta=+7
```

이 gate 는 PR 레인에서는 돌지 않고 main 레인에서만 도는 identity pin 이라, #5122·#5123·#5124·#5127·#5128·#5129 가 순차 머지되면서 drift 가 누적됐습니다. 여섯 PR 모두 테스트를 추가했지만 pin 을 갱신한 것은 #5128 뿐이고, 그 값(7410 → 7443)은 나머지 다섯 PR 이 머지되기 전 base 기준으로 계산된 값입니다.

## 검증 — 실제 삭제가 아니라 rename 임을 확인

`8ae099636`(마지막 green main) 과 `745b34204`(현재 main) 의 static test ID 집합을 직접 비교했습니다.

- 추가: **41개**
- 제거: **1개**
  - `services::agents::turn::tests::normalize_recent_output_masks_auth_headers_and_key_assignments`
  - 이것은 삭제가 아니라 **rename** 입니다. #5128 이 `..._masks_sensitive_headers_and_key_assignments` 로 이름을 바꾸고 Cookie/Set-Cookie assertion 을 추가했습니다.

즉 커버리지 손실 없음. 순수하게 drift 된 identity 상수를 사실대로 다시 pin 하는 변경이며, gate 를 약화시키는 변경이 아닙니다.

## 변경

`scripts/check_test_target_integrity.py` 의 pin 상수 2개:

| 상수 | Before | After |
|---|---|---|
| `LIB_INVENTORY_STATIC_IDS_SHA256` | `3928ebd3…d61a458a` | `29f68400…81ea0240` |
| `LIB_INVENTORY_STATIC_IDS_COUNT` | 7443 | 7450 |

## 재현 / 검증

```
python3 scripts/check_test_target_integrity.py --print-lib-inventory-digest
# before: current=7450 pinned=7443 delta=+7
# after:  current=7450 pinned=7450 delta=+0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)