### PR TITLE
fix: keep bot watchdog alarms out of the intervention queue and preserve attachment provenance (#5034)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -766,11 +766,14 @@ jobs:
           cargo test --lib services::discord::terminal_ui_obligation::tests -- --test-threads=1
 
       # #5034: watchdog/operational alerts are notifications, not queued turns;
-      # run the sender-policy, outbox-delivery, watchdog, and intake-boundary
-      # regressions in the same path-filtered required lane as the production change.
+      # run the sender-policy, attachment-delivery, catch-up, outbox-delivery,
+      # watchdog, and intake-boundary regressions in the same path-filtered
+      # required lane as the production change.
       - name: Operational alert intake admission regressions
         run: |
           env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::dispatch_policy::allowed_turn_sender_tests -- --test-threads=1
+          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::formatting::delivery::attachment_delivery_tests -- --test-threads=1
+          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::catch_up::classification_order_tests::catch_up_human_visible_marker_recovers_and_strips_but_bot_marker_is_rejected -- --exact --test-threads=1
           env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::router::intake_gate::gate::tests -- --test-threads=1
           env -u AGENTDESK_ROOT_DIR cargo test --lib server::outbox_actionable_delivery::tests -- --test-threads=1
           env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::router::message_handler::watchdog::timeout_notice_tests -- --test-threads=1

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -92,6 +92,7 @@ jobs:
               - 'src/server/routes/auto_queue.rs'
               - 'src/server/routes/dispatched_sessions.rs'
               - 'src/server/routes/dispatches/**'
+              - 'src/server/outbox_actionable_delivery.rs'
               - 'src/server/routes/message_outbox.rs'
               - 'src/server/routes/scheduled_messages.rs'
               - 'src/server/worker_registry.rs'
@@ -765,12 +766,15 @@ jobs:
           cargo test --lib services::discord::terminal_ui_obligation::tests -- --test-threads=1
 
       # #5034: watchdog/operational alerts are notifications, not queued turns;
-      # run the sender-policy and single outer-admission-guard regressions in
-      # the same path-filtered required lane as the Discord production change.
+      # run the sender-policy, outbox-delivery, watchdog, and intake-boundary
+      # regressions in the same path-filtered required lane as the production change.
       - name: Operational alert intake admission regressions
         run: |
           env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::dispatch_policy::allowed_turn_sender_tests -- --test-threads=1
           env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::router::intake_gate::gate::tests -- --test-threads=1
+          env -u AGENTDESK_ROOT_DIR cargo test --lib server::outbox_actionable_delivery::tests -- --test-threads=1
+          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::router::message_handler::watchdog::timeout_notice_tests -- --test-threads=1
+          env -u AGENTDESK_ROOT_DIR cargo test --lib services::message_outbox::dedupe_key_tests -- --test-threads=1
           env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::router::intake_gate::live_intake_preserve_wiring_tests::one_admission_guard_precedes_all_soft_intervention_entrypoints -- --exact --test-threads=1
 
       # #5003: this production-path E2E previously ran only in main's broad

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -764,6 +764,15 @@ jobs:
           cargo test --lib services::discord::relay_recovery::tests -- --test-threads=1
           cargo test --lib services::discord::terminal_ui_obligation::tests -- --test-threads=1
 
+      # #5034: watchdog/operational alerts are notifications, not queued turns;
+      # run the sender-policy and single outer-admission-guard regressions in
+      # the same path-filtered required lane as the Discord production change.
+      - name: Operational alert intake admission regressions
+        run: |
+          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::dispatch_policy::allowed_turn_sender_tests -- --test-threads=1
+          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::router::intake_gate::gate::tests -- --test-threads=1
+          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::router::intake_gate::live_intake_preserve_wiring_tests::one_admission_guard_precedes_all_soft_intervention_entrypoints -- --exact --test-threads=1
+
       # #5003: this production-path E2E previously ran only in main's broad
       # non-PG lane, so test-only fixes could merge without executing it on PRs.
       - name: Local model durable queue wake regression

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -303,9 +303,9 @@ targets = {
     "needs" => "changes",
     "if" => "needs.changes.outputs.high_risk_recovery == 'true'",
     "runs_on" => "ubuntu-latest",
-    # #5034 re-pins after adding the outbox/watchdog operational-alert targets
-    # to the path-filtered required high-risk Discord lane.
-    "job_sha256" => "c92f3dd274cacae85f4251e683bb23bf46e822ca2ed7b37d95ff5ccc3a2ff609",
+    # #5034 re-pins after adding the attachment-delivery and catch-up
+    # operational-alert targets to the path-filtered required high-risk lane.
+    "job_sha256" => "29c7a0c33753933e50c446f073da942bebd0c53881460260562cd9cabaef9c44",
     "require_debug_env" => false,
     "cargo_steps" => {
       "Observe curated lane selections" => {

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -303,7 +303,9 @@ targets = {
     "needs" => "changes",
     "if" => "needs.changes.outputs.high_risk_recovery == 'true'",
     "runs_on" => "ubuntu-latest",
-    "job_sha256" => "9c3587d8664bdd63769c3306c016f241e851649a68a7c6a52b11e243c438df3d",
+    # #5034 re-pins after adding the path-filtered operational-alert admission
+    # regression step to the required high-risk Discord lane.
+    "job_sha256" => "214ab1a366a02fd2520aee9d001fd9f402bf685e487b2aaeb474650fbc316414",
     "require_debug_env" => false,
     "cargo_steps" => {
       "Observe curated lane selections" => {

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -303,9 +303,9 @@ targets = {
     "needs" => "changes",
     "if" => "needs.changes.outputs.high_risk_recovery == 'true'",
     "runs_on" => "ubuntu-latest",
-    # #5034 re-pins after adding the path-filtered operational-alert admission
-    # regression step to the required high-risk Discord lane.
-    "job_sha256" => "214ab1a366a02fd2520aee9d001fd9f402bf685e487b2aaeb474650fbc316414",
+    # #5034 re-pins after adding the outbox/watchdog operational-alert targets
+    # to the path-filtered required high-risk Discord lane.
+    "job_sha256" => "c92f3dd274cacae85f4251e683bb23bf46e822ca2ed7b37d95ff5ccc3a2ff609",
     "require_debug_env" => false,
     "cargo_steps" => {
       "Observe curated lane selections" => {

--- a/scripts/check_test_target_integrity.py
+++ b/scripts/check_test_target_integrity.py
@@ -91,9 +91,9 @@ LIB_INVENTORY_KNOWN_CARGO_ONLY = frozenset({
 # Keep the count beside the digest so a failed check reports a signed count
 # delta even though the compact pin deliberately does not embed every identity.
 LIB_INVENTORY_STATIC_IDS_SHA256 = (
-    "29f684007e997f35fcbfbe7aa887b2c8b1d7c343cb3fe053e628709b81ea0240"
+    "b7d4b719ea8c5f3c5af36daeb11bc41d9b0b976fc4fbbda6aa3855f1ef62cc11"
 )
-LIB_INVENTORY_STATIC_IDS_COUNT = 7450
+LIB_INVENTORY_STATIC_IDS_COUNT = 7459
 
 
 @dataclass(frozen=True)

--- a/scripts/test_lane_coverage_baseline.txt
+++ b/scripts/test_lane_coverage_baseline.txt
@@ -86,7 +86,6 @@ server::maintenance::registry_membership_tests
 server::maintenance::storage_jobs::tests
 server::message_outbox_retry_tests
 server::multinode_regression::tests
-server::outbox_actionable_delivery::tests
 server::policy_tick_schedule_tests
 server::rate_limit_header_tests
 server::routes::agents::tmux_relay_adoption_state_tests
@@ -355,7 +354,6 @@ services::discord::router::message_handler::voice_announcement_route::voice_rout
 services::discord::router::message_handler::voice_announcement_scope::tests
 services::discord::router::message_handler::watchdog::cold_start_retry_tests
 services::discord::router::message_handler::watchdog::relay_state_contract_refs
-services::discord::router::message_handler::watchdog::timeout_notice_tests
 services::discord::router::response_format::tests
 services::discord::runtime_bootstrap::bootstrap_tests
 services::discord::runtime_bootstrap::framework_setup::slash_command_registration_tests
@@ -553,7 +551,6 @@ services::memory::memento::tool_feedback_trigger_type_tests
 services::memory::memento::workspace_scope_tests
 services::memory::memento_instructions_cache::tests
 services::memory::memento_throttle::forget_ratio_tests
-services::message_outbox::dedupe_key_tests
 services::message_outbox::stop_turn_notify_removal_tests
 services::message_outbox_circuit_authority_tests
 services::message_outbox_recovery_tests

--- a/scripts/test_lane_coverage_baseline.txt
+++ b/scripts/test_lane_coverage_baseline.txt
@@ -218,7 +218,6 @@ services::discord::commands::tui_passthrough::tests
 services::discord::commands::voice::auto_join_tests
 services::discord::compact_turn_authority::tests
 services::discord::completion_footer_metadata::tests
-services::discord::dispatch_policy::allowed_turn_sender_tests
 services::discord::dispatch_policy::dispatch_turn_gate_tests
 services::discord::followup_retry_requeue_tests
 services::discord::footer_view_reconciler::tests
@@ -330,7 +329,6 @@ services::discord::router::dispatch_trigger::tests
 services::discord::router::intake_dispatch::notice::tests
 services::discord::router::intake_dispatch::tests
 services::discord::router::intake_gate::busy_duplicate_notice::tests
-services::discord::router::intake_gate::gate::tests
 services::discord::router::intake_gate::live_intake_preserve_wiring_tests
 services::discord::router::intake_gate::queue_effects::channel_queued_placeholder_pure_tests
 services::discord::router::intake_gate::queue_effects::duplicate_repair_interleaving_tests

--- a/src/server/outbox_actionable_delivery.rs
+++ b/src/server/outbox_actionable_delivery.rs
@@ -1,11 +1,12 @@
 //! Delivery policy for actionable operational outbox alerts (#4449).
 //!
 //! The durable row keeps its existing channel target and dedupe identity.  An
-//! announce-bot post is the primary delivery because messages in the configured
-//! operations channel are ingested by its resident AgentDesk role.  If that bot
-//! cannot deliver, retry once with the notify bot so the human-visible alert
-//! survives an announce credential/runtime failure.  Informational rows never
-//! enter this fallback path.
+//! announce-bot post is the primary delivery so the configured operations
+//! channel receives the notice through its resident role. Non-turn provenance
+//! keeps the notice out of intervention intake. If that bot cannot deliver,
+//! retry once with the notify bot so the human-visible alert survives an
+//! announce credential/runtime failure. Informational rows never enter this
+//! fallback path.
 
 use sqlx::PgPool;
 
@@ -23,6 +24,14 @@ fn should_fallback_to_notify(
         && crate::services::message_outbox::is_actionable_ops_alert(source, reason_code)
 }
 
+fn delivery_content(content: &str, source: &str, reason_code: Option<&str>) -> String {
+    if crate::services::message_outbox::is_non_turn_operational_alert(source, reason_code) {
+        crate::services::discord::dispatch_policy::prepend_operational_alert_origin(content)
+    } else {
+        content.to_string()
+    }
+}
+
 async fn deliver_with_bot(
     registry: &HealthRegistry,
     pg_pool: &PgPool,
@@ -30,11 +39,12 @@ async fn deliver_with_bot(
     bot: &str,
 ) -> (&'static str, String) {
     let (correlation_id, semantic_event_id) = row.delivery_ids();
+    let content = delivery_content(&row.content, &row.source, row.reason_code.as_deref());
     crate::services::discord::health::send_message_with_backends_and_delivery_options(
         registry,
         Some(pg_pool),
         &row.target,
-        &row.content,
+        &content,
         &row.source,
         bot,
         None,
@@ -90,7 +100,7 @@ pub(super) async fn deliver(
 
 #[cfg(test)]
 mod tests {
-    use super::should_fallback_to_notify;
+    use super::{delivery_content, should_fallback_to_notify};
 
     #[test]
     fn notify_fallback_requires_a_failed_actionable_announce_delivery() {
@@ -118,5 +128,19 @@ mod tests {
             "auto-queue-monitor",
             Some("auto_queue.monitor_recovery"),
         ));
+    }
+
+    #[test]
+    fn operational_alert_delivery_adds_non_turn_provenance() {
+        let marked = delivery_content(
+            "watchdog alert",
+            "dispatch_watchdog",
+            Some("dispatch_stuck"),
+        );
+        assert!(crate::services::discord::dispatch_policy::has_non_turn_provenance(&marked));
+        assert_eq!(
+            delivery_content("handoff", "lifecycle_notifier", Some("runtime_started")),
+            "handoff"
+        );
     }
 }

--- a/src/services/discord/catch_up.rs
+++ b/src/services/discord/catch_up.rs
@@ -55,6 +55,15 @@ fn catch_up_source_generation(
     }
 }
 
+fn catch_up_intervention_text(text: &str, author_is_bot: bool) -> String {
+    if author_is_bot {
+        return text.to_string();
+    }
+    let (without_operational_alert_origin, _) =
+        super::dispatch_policy::strip_operational_alert_origin(text);
+    without_operational_alert_origin.trim().to_string()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::services) struct CatchUpRetryState {
     checkpoint: u64,
@@ -1187,6 +1196,7 @@ async fn run_catch_up_sweep<A: CatchUpDiscordApi + ?Sized>(deps: CatchUpDeps<'_,
 
         for msg in &messages {
             let text = msg.content.trim().to_string();
+            let intervention_text = catch_up_intervention_text(&text, msg.author.bot);
             let msg_ts = msg.id.created_at();
             let age_reference = catch_up_message_age_reference_time(
                 chrono::Utc::now(),
@@ -1200,7 +1210,7 @@ async fn run_catch_up_sweep<A: CatchUpDiscordApi + ?Sized>(deps: CatchUpDeps<'_,
                 author_is_bot: msg.author.bot,
                 is_processable_kind: router::should_process_turn_message(msg.kind),
                 age_secs,
-                trimmed_text: text.clone(),
+                trimmed_text: intervention_text.clone(),
             };
             let outcome = match classify_catch_up_message_with_utility_resolution(
                 &view,
@@ -1313,7 +1323,7 @@ async fn run_catch_up_sweep<A: CatchUpDiscordApi + ?Sized>(deps: CatchUpDeps<'_,
                     source_message_ids: vec![msg.id],
                     source_message_queued_generations: vec![source_generation],
                     source_text_segments: Vec::new(),
-                    text: text.clone(),
+                    text: intervention_text.clone(),
                     mode: InterventionMode::Soft,
                     created_at: catch_up_intervention_created_at(
                         scan_wall_time,
@@ -1323,9 +1333,9 @@ async fn run_catch_up_sweep<A: CatchUpDiscordApi + ?Sized>(deps: CatchUpDeps<'_,
                     reply_context: None,
                     has_reply_boundary: msg.message_reference.is_some(),
                     merge_consecutive: !msg.author.bot
-                        && !text.starts_with('!')
-                        && !text.starts_with('/')
-                        && !text.starts_with("DISPATCH:"),
+                        && !intervention_text.starts_with('!')
+                        && !intervention_text.starts_with('/')
+                        && !intervention_text.starts_with("DISPATCH:"),
                     pending_uploads: Vec::new(),
                     voice_announcement: None,
                 },
@@ -1565,6 +1575,7 @@ async fn run_catch_up_sweep<A: CatchUpDiscordApi + ?Sized>(deps: CatchUpDeps<'_,
                 continue;
             }
             let text = msg.content.trim();
+            let intervention_text = catch_up_intervention_text(text, msg.author.bot);
             if text.is_empty() {
                 stats.skipped += 1;
                 continue;
@@ -1599,7 +1610,7 @@ async fn run_catch_up_sweep<A: CatchUpDiscordApi + ?Sized>(deps: CatchUpDeps<'_,
                 author_is_bot: msg.author.bot,
                 is_processable_kind: true,
                 age_secs: msg_age.num_seconds(),
-                trimmed_text: text.to_string(),
+                trimmed_text: intervention_text.clone(),
             };
             let author_is_authorized = {
                 let settings = shared.settings.read().await;
@@ -1690,7 +1701,7 @@ async fn run_catch_up_sweep<A: CatchUpDiscordApi + ?Sized>(deps: CatchUpDeps<'_,
                     source_message_ids: vec![msg.id],
                     source_message_queued_generations: vec![source_generation],
                     source_text_segments: Vec::new(),
-                    text: text.to_string(),
+                    text: intervention_text.clone(),
                     mode: InterventionMode::Soft,
                     created_at: catch_up_intervention_created_at(
                         scan_wall_time,
@@ -1700,9 +1711,9 @@ async fn run_catch_up_sweep<A: CatchUpDiscordApi + ?Sized>(deps: CatchUpDeps<'_,
                     reply_context: None,
                     has_reply_boundary: msg.message_reference.is_some(),
                     merge_consecutive: !msg.author.bot
-                        && !text.starts_with('!')
-                        && !text.starts_with('/')
-                        && !text.starts_with("DISPATCH:"),
+                        && !intervention_text.starts_with('!')
+                        && !intervention_text.starts_with('/')
+                        && !intervention_text.starts_with("DISPATCH:"),
                     pending_uploads: Vec::new(),
                     voice_announcement: None,
                 },

--- a/src/services/discord/catch_up/classification_order_tests.rs
+++ b/src/services/discord/catch_up/classification_order_tests.rs
@@ -16,9 +16,9 @@ use super::{
     CATCH_UP_RETRY_DEFERRED_REARM_LIMIT, CatchUpClassification, CatchUpClassificationDecision,
     CatchUpDeps, CatchUpDiscordApi, CatchUpMessageView, CatchUpTooOldOutboxRequest, ChannelId,
     MessageId, ProviderKind, RuntimeChannelBindingStatus, advance_catch_up_settled_frontier,
-    catch_up_source_generation, catch_up_too_old_drop, catch_up_too_old_notice,
-    classify_catch_up_message, classify_catch_up_message_with_utility_resolution,
-    run_catch_up_sweep,
+    catch_up_intervention_text, catch_up_source_generation, catch_up_too_old_drop,
+    catch_up_too_old_notice, classify_catch_up_message,
+    classify_catch_up_message_with_utility_resolution, run_catch_up_sweep,
 };
 use crate::services::discord::health::UtilityBotUserIdResolution;
 use crate::services::turn_orchestrator::{
@@ -308,6 +308,52 @@ fn notify_identity_is_terminal_before_age_even_when_discord_bot_flag_is_false() 
             "false-flag {label} identity must retain fresh eligible-trigger semantics"
         );
     }
+}
+
+#[test]
+fn catch_up_human_visible_marker_recovers_and_strips_but_bot_marker_is_rejected() {
+    let visible_marker = "[origin=operational_alert]please resume my work";
+    let human = view(HUMAN_ID, false, 60, visible_marker);
+    let bot = view(ANNOUNCE_BOT_ID, true, 60, visible_marker);
+
+    assert_eq!(
+        classify_catch_up_message(
+            &human,
+            Some(CURRENT_BOT_ID),
+            &HashSet::new(),
+            &HashSet::new(),
+            300,
+            &[ANNOUNCE_BOT_ID],
+            Some(ANNOUNCE_BOT_ID),
+            Some(NOTIFY_BOT_ID),
+        ),
+        CatchUpClassification::Recover,
+        "a human's visible provenance literal must not discard catch-up input"
+    );
+    assert_eq!(
+        catch_up_intervention_text(visible_marker, false),
+        "please resume my work",
+        "catch-up must strip the visible provenance literal before enqueueing human text"
+    );
+    assert_eq!(
+        catch_up_intervention_text(visible_marker, true),
+        visible_marker,
+        "bot text must retain its marker until the sender policy rejects it"
+    );
+    assert_eq!(
+        classify_catch_up_message(
+            &bot,
+            Some(CURRENT_BOT_ID),
+            &HashSet::new(),
+            &HashSet::new(),
+            300,
+            &[ANNOUNCE_BOT_ID],
+            Some(ANNOUNCE_BOT_ID),
+            Some(NOTIFY_BOT_ID),
+        ),
+        CatchUpClassification::NotAllowed,
+        "the same marker must continue to reject an announce-bot sender"
+    );
 }
 
 #[test]

--- a/src/services/discord/dispatch_policy.rs
+++ b/src/services/discord/dispatch_policy.rs
@@ -205,6 +205,66 @@ pub(in crate::services::discord) async fn stale_dispatch_turn_for_queued_interve
     filter_queued_dispatch_exit(intervention.preserve_on_cancel(), stale)
 }
 
+pub(in crate::services::discord) fn is_allowed_turn_sender(
+    allowed_bot_ids: &[u64],
+    announce_bot_id: Option<u64>,
+    author_id: u64,
+    author_is_bot: bool,
+    text: &str,
+) -> bool {
+    if announce_bot_id.is_some_and(|id| id == author_id) {
+        if has_operational_alert_provenance(text) {
+            return false;
+        }
+        // #3576 (restores the announce branch removed by #3478): the
+        // `announce` bot is the authoritative trigger source. Its live
+        // traffic — dispatch envelopes, PM-triage / deadlock / escalation
+        // cards, and agent-to-agent `/api/discord/send` messages — must
+        // start turns WITHOUT requiring the `DISPATCH:` / monitor-origin
+        // marker that gates other allowed bots. Explicit non-turn provenance
+        // suppresses only this bot branch; human messages are evaluated by the
+        // final branch below and are not rejected for carrying the literal.
+        //
+        // The lone exception is the legacy issue-announcement / completion
+        // card (📋/✅) shape: issue cards now route through notify-bot
+        // (#1448 follow-up, and #3478 removed the announce-token fallback
+        // in `issue_announcements.rs`), so announce never authors them in
+        // live traffic. This guard remains a conservative safety net for
+        // catch-up replays of pre-cutover announce-authored cards so they
+        // don't spawn spurious turns.
+        return !is_legacy_announce_issue_card(text);
+    }
+    if allowed_bot_ids.contains(&author_id) {
+        if has_operational_alert_provenance(text) {
+            return false;
+        }
+        return should_process_allowed_bot_turn_text(text);
+    }
+    !author_is_bot
+}
+
+/// Conservative guard (#3576) that suppresses announce-authored issue
+/// announcement / completion cards from triggering turns. Live issue cards
+/// route through notify-bot, which never reaches the announce branch above;
+/// this only catches catch-up replays of pre-cutover announce-authored cards.
+fn is_legacy_announce_issue_card(text: &str) -> bool {
+    let head = text.trim_start();
+    if head.starts_with("📋 **새 이슈 #") {
+        return true;
+    }
+    if let Some(rest) = head.strip_prefix("✅ **#") {
+        let digits_end = rest
+            .char_indices()
+            .find(|(_, ch)| !ch.is_ascii_digit())
+            .map(|(idx, _)| idx)
+            .unwrap_or(rest.len());
+        if digits_end > 0 && rest[digits_end..].starts_with(" 완료** —") {
+            return true;
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod dispatch_turn_gate_tests {
     use super::{
@@ -396,6 +456,25 @@ mod allowed_turn_sender_tests {
             "spam",
         ));
     }
+
+    #[test]
+    fn human_visible_operational_marker_is_allowed_but_bot_marker_is_rejected() {
+        let visible_marker = "[origin=operational_alert]please resume my work";
+        assert!(is_allowed_turn_sender(
+            &[ANNOUNCE_ID],
+            Some(ANNOUNCE_ID),
+            HUMAN_ID,
+            false,
+            visible_marker,
+        ));
+        assert!(!is_allowed_turn_sender(
+            &[ANNOUNCE_ID],
+            Some(ANNOUNCE_ID),
+            ANNOUNCE_ID,
+            true,
+            visible_marker,
+        ));
+    }
 }
 
 pub(in crate::services::discord) async fn resolve_announce_bot_user_id(
@@ -418,62 +497,6 @@ pub(in crate::services::discord) async fn resolve_notify_bot_user_id(
     registry
         .utility_bot_user_id(super::bot_role::UtilityBotRole::Notify)
         .await
-}
-
-pub(in crate::services::discord) fn is_allowed_turn_sender(
-    allowed_bot_ids: &[u64],
-    announce_bot_id: Option<u64>,
-    author_id: u64,
-    author_is_bot: bool,
-    text: &str,
-) -> bool {
-    if has_operational_alert_provenance(text) {
-        return false;
-    }
-    if announce_bot_id.is_some_and(|id| id == author_id) {
-        // #3576 (restores the announce branch removed by #3478): the
-        // `announce` bot is the authoritative trigger source. Its live
-        // traffic — dispatch envelopes, PM-triage / deadlock / escalation
-        // cards, and agent-to-agent `/api/discord/send` messages — must
-        // start turns WITHOUT requiring the `DISPATCH:` / monitor-origin
-        // marker that gates other allowed bots. Explicit non-turn provenance
-        // remains a global suppression gate for every sender.
-        //
-        // The lone exception is the legacy issue-announcement / completion
-        // card (📋/✅) shape: issue cards now route through notify-bot
-        // (#1448 follow-up, and #3478 removed the announce-token fallback
-        // in `issue_announcements.rs`), so announce never authors them in
-        // live traffic. This guard remains a conservative safety net for
-        // catch-up replays of pre-cutover announce-authored cards so they
-        // don't spawn spurious turns.
-        return !is_legacy_announce_issue_card(text);
-    }
-    if allowed_bot_ids.contains(&author_id) {
-        return should_process_allowed_bot_turn_text(text);
-    }
-    !author_is_bot
-}
-
-/// Conservative guard (#3576) that suppresses announce-authored issue
-/// announcement / completion cards from triggering turns. Live issue cards
-/// route through notify-bot, which never reaches the announce branch above;
-/// this only catches catch-up replays of pre-cutover announce-authored cards.
-fn is_legacy_announce_issue_card(text: &str) -> bool {
-    let head = text.trim_start();
-    if head.starts_with("📋 **새 이슈 #") {
-        return true;
-    }
-    if let Some(rest) = head.strip_prefix("✅ **#") {
-        let digits_end = rest
-            .char_indices()
-            .find(|(_, ch)| !ch.is_ascii_digit())
-            .map(|(idx, _)| idx)
-            .unwrap_or(rest.len());
-        if digits_end > 0 && rest[digits_end..].starts_with(" 완료** —") {
-            return true;
-        }
-    }
-    false
 }
 
 pub(in crate::services::discord) fn should_phase2_recover_message(

--- a/src/services/discord/dispatch_policy.rs
+++ b/src/services/discord/dispatch_policy.rs
@@ -7,11 +7,30 @@ use super::SharedData;
 use super::parse_dispatch_id;
 
 const MONITOR_AUTO_TURN_ORIGIN_LITERAL: &str = "[origin=monitor_auto_turn]";
+const OPERATIONAL_ALERT_ORIGIN_LITERAL: &str = "[origin=operational_alert]";
 
 fn hidden_monitor_auto_turn_origin_marker() -> &'static str {
     static MARKER: OnceLock<String> = OnceLock::new();
     MARKER.get_or_init(|| {
         MONITOR_AUTO_TURN_ORIGIN_LITERAL
+            .bytes()
+            .flat_map(|byte| {
+                (0..8).rev().map(move |shift| {
+                    if (byte >> shift) & 1 == 1 {
+                        '\u{200C}'
+                    } else {
+                        '\u{200B}'
+                    }
+                })
+            })
+            .collect()
+    })
+}
+
+fn hidden_operational_alert_origin_marker() -> &'static str {
+    static MARKER: OnceLock<String> = OnceLock::new();
+    MARKER.get_or_init(|| {
+        OPERATIONAL_ALERT_ORIGIN_LITERAL
             .bytes()
             .flat_map(|byte| {
                 (0..8).rev().map(move |shift| {
@@ -35,6 +54,21 @@ pub(in crate::services::discord) fn prepend_monitor_auto_turn_origin(text: &str)
     }
 }
 
+/// Prefix an operational alert with a provenance marker removed at intake.
+/// The marker is invisible in Discord while remaining stable in message text.
+pub(crate) fn prepend_operational_alert_origin(text: &str) -> String {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        String::new()
+    } else if trimmed.starts_with(hidden_operational_alert_origin_marker())
+        || trimmed.starts_with(OPERATIONAL_ALERT_ORIGIN_LITERAL)
+    {
+        trimmed.to_string()
+    } else {
+        format!("{}{}", hidden_operational_alert_origin_marker(), trimmed)
+    }
+}
+
 pub(in crate::services::discord) fn strip_monitor_auto_turn_origin<'a>(
     text: &'a str,
 ) -> (Cow<'a, str>, bool) {
@@ -47,6 +81,28 @@ pub(in crate::services::discord) fn strip_monitor_auto_turn_origin<'a>(
     }
 
     (Cow::Borrowed(text), false)
+}
+
+pub(crate) fn strip_operational_alert_origin<'a>(text: &'a str) -> (Cow<'a, str>, bool) {
+    if let Some(rest) = text.strip_prefix(hidden_operational_alert_origin_marker()) {
+        return (Cow::Borrowed(rest), true);
+    }
+
+    if let Some(rest) = text.strip_prefix(OPERATIONAL_ALERT_ORIGIN_LITERAL) {
+        return (Cow::Owned(rest.trim_start().to_string()), true);
+    }
+
+    (Cow::Borrowed(text), false)
+}
+
+pub(crate) fn has_non_turn_provenance(text: &str) -> bool {
+    let (without_alert, has_operational_alert) = strip_operational_alert_origin(text);
+    let (_, has_monitor_origin) = strip_monitor_auto_turn_origin(without_alert.as_ref());
+    has_operational_alert || has_monitor_origin
+}
+
+fn has_operational_alert_provenance(text: &str) -> bool {
+    strip_operational_alert_origin(text).1
 }
 
 pub(super) fn should_process_allowed_bot_turn_text(text: &str) -> bool {
@@ -234,7 +290,9 @@ mod dispatch_turn_gate_tests {
 
 #[cfg(test)]
 mod allowed_turn_sender_tests {
-    use super::is_allowed_turn_sender;
+    use super::{
+        has_non_turn_provenance, is_allowed_turn_sender, prepend_operational_alert_origin,
+    };
 
     const ANNOUNCE_ID: u64 = 1001;
     const OTHER_BOT_ID: u64 = 2002;
@@ -261,6 +319,21 @@ mod allowed_turn_sender_tests {
             ANNOUNCE_ID,
             true,
             "DISPATCH:1f3c2b1a-0000-4000-8000-000000000000\n── implementation dispatch ──",
+        ));
+    }
+
+    #[test]
+    fn announce_authored_operational_alert_does_not_trigger() {
+        let marked = prepend_operational_alert_origin(
+            "DISPATCH:1f3c2b1a-0000-4000-8000-000000000000\nwatchdog alert",
+        );
+        assert!(has_non_turn_provenance(&marked));
+        assert!(!is_allowed_turn_sender(
+            &[ANNOUNCE_ID],
+            Some(ANNOUNCE_ID),
+            ANNOUNCE_ID,
+            true,
+            &marked,
         ));
     }
 
@@ -354,14 +427,17 @@ pub(in crate::services::discord) fn is_allowed_turn_sender(
     author_is_bot: bool,
     text: &str,
 ) -> bool {
+    if has_operational_alert_provenance(text) {
+        return false;
+    }
     if announce_bot_id.is_some_and(|id| id == author_id) {
         // #3576 (restores the announce branch removed by #3478): the
         // `announce` bot is the authoritative trigger source. Its live
         // traffic — dispatch envelopes, PM-triage / deadlock / escalation
         // cards, and agent-to-agent `/api/discord/send` messages — must
         // start turns WITHOUT requiring the `DISPATCH:` / monitor-origin
-        // marker that gates other allowed bots. The `should_process_*`
-        // marker gate (#706 security) only applies to non-announce bots.
+        // marker that gates other allowed bots. Explicit non-turn provenance
+        // remains a global suppression gate for every sender.
         //
         // The lone exception is the legacy issue-announcement / completion
         // card (📋/✅) shape: issue cards now route through notify-bot

--- a/src/services/discord/formatting/delivery.rs
+++ b/src/services/discord/formatting/delivery.rs
@@ -468,19 +468,74 @@ pub(in crate::services::discord) fn build_long_message_attachment(
 
 fn build_attachment_inline(text: &str, summary: Option<&str>) -> String {
     let footer = format!("\n\n{ATTACHMENT_FOOTER_PREFIX} ({} bytes)", text.len());
+    let has_operational_alert_origin =
+        crate::services::discord::dispatch_policy::strip_operational_alert_origin(text).1;
     let trimmed_summary = summary.and_then(|s| {
         let t = s.trim();
         (!t.is_empty()).then_some(t)
     });
 
+    // Re-apply provenance before checking the limit. The hidden marker uses one
+    // Unicode scalar per bit: `[origin=operational_alert]` is 26 UTF-8 bytes,
+    // so the current marker contributes 208 characters. A summary that fits
+    // without the marker must therefore be allowed to fall back to the short
+    // generic notice instead of producing an over-limit inline message.
+    let with_provenance = |inline: String| {
+        if has_operational_alert_origin {
+            crate::services::discord::dispatch_policy::prepend_operational_alert_origin(&inline)
+        } else {
+            inline
+        }
+    };
+
     if let Some(summary) = trimmed_summary {
-        if char_count(summary) + char_count(&footer) <= DISCORD_MSG_LIMIT {
-            return format!("{summary}{footer}");
+        let candidate = with_provenance(format!("{summary}{footer}"));
+        if char_count(&candidate) <= DISCORD_MSG_LIMIT {
+            return candidate;
         }
     }
 
-    format!(
+    let fallback = with_provenance(format!(
         "📎 내용이 길어 전문을 파일로 첨부했습니다. ({} bytes)",
         text.len()
-    )
+    ));
+    // The fixed fallback is currently well below the remaining budget after
+    // the 208-character marker. If either wording or marker grows past the
+    // Discord limit, this attachment path has no second inline fallback and
+    // the send will surface Discord's length rejection; keep this assertion so
+    // that such a change is caught in debug/test builds rather than hidden.
+    debug_assert!(char_count(&fallback) <= DISCORD_MSG_LIMIT);
+    fallback
+}
+
+#[cfg(test)]
+mod attachment_delivery_tests {
+    use super::build_long_message_attachment;
+    use crate::services::discord::DISCORD_MSG_LIMIT;
+    use crate::services::discord::dispatch_policy::{
+        has_non_turn_provenance, is_allowed_turn_sender, prepend_operational_alert_origin,
+    };
+
+    const ANNOUNCE_ID: u64 = 1_001;
+
+    #[test]
+    fn oversize_operational_alert_attachment_inline_remains_non_turn() {
+        let operational_alert = prepend_operational_alert_origin(&format!(
+            "DISPATCH:operational alert\n{}",
+            "x".repeat(DISCORD_MSG_LIMIT)
+        ));
+        assert!(operational_alert.chars().count() > DISCORD_MSG_LIMIT);
+
+        let (inline, _attachment) = build_long_message_attachment(&operational_alert, None);
+
+        assert!(has_non_turn_provenance(&inline));
+        assert!(!is_allowed_turn_sender(
+            &[ANNOUNCE_ID],
+            Some(ANNOUNCE_ID),
+            ANNOUNCE_ID,
+            true,
+            &inline,
+        ));
+        assert!(inline.chars().count() <= DISCORD_MSG_LIMIT);
+    }
 }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -14,7 +14,7 @@ mod delivery_lease_cell;
 mod delivery_lease_key;
 mod destructive_cancel_gate;
 mod discord_io;
-mod dispatch_policy;
+pub(crate) mod dispatch_policy;
 pub(crate) mod e2e_control;
 mod footer_view_reconciler;
 pub(crate) mod formatting;

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -13,14 +13,13 @@ mod queue_effects;
 mod stale_turn;
 
 pub(in crate::services::discord) use gate::should_process_turn_message;
-#[cfg(test)]
-pub(super) use queue_effects::queue_pending_reaction_for;
 
 use gate::{
     bot_author_allowed_for_live_intake, live_sender_excluded_from_human_preservation,
-    should_merge_consecutive_messages, should_skip_for_missing_required_mention,
-    should_skip_human_slash_message, should_skip_self_authored_turn_message,
-    should_start_attachment_only_turn, strip_leading_bot_mention,
+    should_admit_turn_message, should_merge_consecutive_messages,
+    should_skip_for_missing_required_mention, should_skip_human_slash_message,
+    should_skip_self_authored_turn_message, should_start_attachment_only_turn,
+    strip_leading_bot_mention,
 };
 pub(in crate::services::discord::router) use queue_effects::should_schedule_post_enqueue_idle_drain;
 use queue_effects::{IntakeGateQueueEffects, render_visible_queued_ack};
@@ -701,8 +700,12 @@ pub(in crate::services::discord) async fn handle_event(
             }
 
             let raw_text = new_message.content.trim();
+            let (without_operational_alert_origin, _has_operational_alert_origin) =
+                super::super::dispatch_policy::strip_operational_alert_origin(raw_text);
             let (sanitized_text, has_monitor_auto_turn_origin) =
-                super::super::strip_monitor_auto_turn_origin(raw_text);
+                super::super::strip_monitor_auto_turn_origin(
+                    without_operational_alert_origin.as_ref(),
+                );
             let text = sanitized_text.trim();
 
             let is_allowed_bot_sender = bot_author_allowed_for_live_intake(
@@ -711,7 +714,7 @@ pub(in crate::services::discord) async fn handle_event(
                 user_id.get(),
             );
             if is_allowed_bot_sender
-                && !super::super::is_allowed_turn_sender(
+                && !should_admit_turn_message(
                     &settings_snapshot.allowed_bot_ids,
                     announce_bot_id,
                     user_id.get(),
@@ -1665,6 +1668,9 @@ pub(in crate::services::discord) async fn handle_event(
 }
 
 #[cfg(test)]
+pub(super) use queue_effects::queue_pending_reaction_for;
+
+#[cfg(test)]
 mod reply_context_tests {
     use super::gate::{should_start_attachment_only_turn, strip_leading_bot_mention};
     use super::{AttachmentReplyItem, format_attachment_reply_context};
@@ -1762,6 +1768,29 @@ mod live_intake_preserve_wiring_tests {
                 "origin: super::IntakeOrigin::LiveMessage,\n                    preserve_on_cancel,"
             ),
             "live IntakeSubmission must reuse the precomputed preservation value"
+        );
+    }
+
+    #[test]
+    fn one_admission_guard_precedes_all_soft_intervention_entrypoints() {
+        let module_src = include_str!("intake_gate.rs");
+        let production_end = module_src
+            .find("#[cfg(test)]\nmod reply_context_tests")
+            .expect("production intake gate ends before unit tests");
+        let production = &module_src[..production_end];
+        let guard = "if is_allowed_bot_sender\n                && !should_admit_turn_message(";
+        let guard_pos = production
+            .find(guard)
+            .expect("all intake queue branches share the outer admission guard");
+        let first_queue_entry = production
+            .find("SoftInterventionSpec {")
+            .expect("intake gate has a soft intervention queue entrypoint");
+
+        assert!(guard_pos < first_queue_entry);
+        assert_eq!(
+            production.matches("is_allowed_turn_sender(").count(),
+            0,
+            "queue branches must not make sender decisions independently"
         );
     }
 }

--- a/src/services/discord/router/intake_gate/gate.rs
+++ b/src/services/discord/router/intake_gate/gate.rs
@@ -55,9 +55,11 @@ pub(in crate::services::discord) fn bot_author_allowed_for_live_intake(
     allowed_bot_ids.contains(&author_id) || announce_bot_id.is_some_and(|id| id == author_id)
 }
 
-/// Single intake admission predicate shared by every queue branch below the
-/// live message gate. Operational alerts are notifications, not turn input,
-/// even when an announce bot authors them with a dispatch-looking body.
+/// Apply the sender policy at the live-intake queue boundary and reject
+/// non-turn provenance before any queue branch. `is_allowed_turn_sender`
+/// already rejects operational-alert provenance; the additional effective
+/// suppression here is monitor-origin text, while the combined check keeps the
+/// alert rejection explicit at this outer boundary.
 pub(super) fn should_admit_turn_message(
     allowed_bot_ids: &[u64],
     announce_bot_id: Option<u64>,

--- a/src/services/discord/router/intake_gate/gate.rs
+++ b/src/services/discord/router/intake_gate/gate.rs
@@ -55,6 +55,25 @@ pub(in crate::services::discord) fn bot_author_allowed_for_live_intake(
     allowed_bot_ids.contains(&author_id) || announce_bot_id.is_some_and(|id| id == author_id)
 }
 
+/// Single intake admission predicate shared by every queue branch below the
+/// live message gate. Operational alerts are notifications, not turn input,
+/// even when an announce bot authors them with a dispatch-looking body.
+pub(super) fn should_admit_turn_message(
+    allowed_bot_ids: &[u64],
+    announce_bot_id: Option<u64>,
+    author_id: u64,
+    author_is_bot: bool,
+    text: &str,
+) -> bool {
+    crate::services::discord::dispatch_policy::is_allowed_turn_sender(
+        allowed_bot_ids,
+        announce_bot_id,
+        author_id,
+        author_is_bot,
+        text,
+    ) && !crate::services::discord::dispatch_policy::has_non_turn_provenance(text)
+}
+
 pub(super) fn live_sender_excluded_from_human_preservation(
     allowed_bot_ids: &[u64],
     author_id: u64,
@@ -150,6 +169,27 @@ mod tests {
             automation_id,
             UtilityBotUserIdResolution::Unconfigured,
             UtilityBotUserIdResolution::Unconfigured,
+        ));
+    }
+
+    #[test]
+    fn operational_alert_is_not_admitted_but_announce_handoff_is() {
+        let marked = crate::services::discord::dispatch_policy::prepend_operational_alert_origin(
+            "DISPATCH:watchdog alert",
+        );
+        assert!(!should_admit_turn_message(
+            &[1001],
+            Some(1001),
+            1001,
+            true,
+            &marked,
+        ));
+        assert!(should_admit_turn_message(
+            &[1001],
+            Some(1001),
+            1001,
+            true,
+            "DISPATCH:real handoff",
         ));
     }
 }

--- a/src/services/discord/router/message_handler/watchdog.rs
+++ b/src/services/discord/router/message_handler/watchdog.rs
@@ -5,16 +5,6 @@ pub(super) const WATCHDOG_DEADLOCK_PREALERT_BOT: &str =
     crate::services::discord::bot_role::UtilityBotRole::Announce.alias();
 pub(super) const WATCHDOG_TIMEOUT_REASON: &str = "watchdog timeout";
 pub(super) const WATCHDOG_TIMEOUT_CANCEL_SOURCE: &str = "watchdog_timeout";
-#[cfg(not(test))]
-const PAUSED_WATCHER_COLD_START_RETRY_ATTEMPTS: u32 = 180;
-#[cfg(test)]
-const PAUSED_WATCHER_COLD_START_RETRY_ATTEMPTS: u32 = 20;
-#[cfg(not(test))]
-const PAUSED_WATCHER_COLD_START_RETRY_DELAY: std::time::Duration =
-    std::time::Duration::from_secs(1);
-#[cfg(test)]
-const PAUSED_WATCHER_COLD_START_RETRY_DELAY: std::time::Duration =
-    std::time::Duration::from_millis(10);
 
 pub(super) fn parse_watchdog_alert_channel_id(raw: &str) -> Option<serenity::ChannelId> {
     let trimmed = raw.trim();
@@ -136,6 +126,10 @@ pub(super) fn build_watchdog_timeout_notice_message(elapsed_mins: i64, has_queue
     }
 }
 
+fn mark_watchdog_alert_message(message: String) -> String {
+    super::super::super::dispatch_policy::prepend_operational_alert_origin(&message)
+}
+
 pub(super) async fn send_watchdog_timeout_notice(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
@@ -147,7 +141,10 @@ pub(super) async fn send_watchdog_timeout_notice(
         super::super::super::mailbox_has_pending_soft_queue(shared, provider, channel_id)
             .await
             .has_pending;
-    let message = build_watchdog_timeout_notice_message(elapsed_mins, has_queued);
+    let message = mark_watchdog_alert_message(build_watchdog_timeout_notice_message(
+        elapsed_mins,
+        has_queued,
+    ));
     if let Err(error) = channel_id.say(http, message).await {
         let ts = chrono::Local::now().format("%H:%M:%S");
         tracing::warn!(
@@ -451,7 +448,7 @@ pub(super) async fn maybe_send_watchdog_deadlock_prealert(
         }
     };
     let inflight = super::super::super::inflight::load_inflight_state(provider, channel_id.get());
-    let message = build_watchdog_deadlock_prealert_message(
+    let message = mark_watchdog_alert_message(build_watchdog_deadlock_prealert_message(
         provider,
         channel_id,
         now_ms,
@@ -459,7 +456,7 @@ pub(super) async fn maybe_send_watchdog_deadlock_prealert(
         turn_started_ms,
         max_deadline_ms,
         inflight.as_ref(),
-    );
+    ));
     match alert_channel_id.say(&*alert_http, message).await {
         Ok(_) => {
             let ts = chrono::Local::now().format("%H:%M:%S");
@@ -610,6 +607,17 @@ impl PendingPausedWatcherAttachKey {
 static PENDING_PAUSED_WATCHER_ATTACHES: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashSet<PendingPausedWatcherAttachKey>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+
+#[cfg(not(test))]
+const PAUSED_WATCHER_COLD_START_RETRY_ATTEMPTS: u32 = 180;
+#[cfg(test)]
+const PAUSED_WATCHER_COLD_START_RETRY_ATTEMPTS: u32 = 20;
+#[cfg(not(test))]
+const PAUSED_WATCHER_COLD_START_RETRY_DELAY: std::time::Duration =
+    std::time::Duration::from_secs(1);
+#[cfg(test)]
+const PAUSED_WATCHER_COLD_START_RETRY_DELAY: std::time::Duration =
+    std::time::Duration::from_millis(10);
 
 #[cfg(test)]
 static TEST_PAUSED_WATCHER_TMUX_LIVE_OVERRIDE: std::sync::OnceLock<
@@ -1036,6 +1044,22 @@ mod timeout_notice_tests {
             build_watchdog_timeout_notice_message(17, true),
             "⚠️ 턴이 17분 타임아웃으로 자동 중단되었습니다. 대기 중인 메시지로 다음 턴을 시작합니다."
         );
+    }
+
+    #[test]
+    fn watchdog_alert_messages_carry_non_turn_provenance() {
+        let timeout = mark_watchdog_alert_message(build_watchdog_timeout_notice_message(17, false));
+        let prealert = mark_watchdog_alert_message(build_watchdog_deadlock_prealert_message(
+            &ProviderKind::Claude,
+            serenity::ChannelId::new(42),
+            1_000,
+            61_000,
+            0,
+            120_000,
+            None,
+        ));
+        assert!(crate::services::discord::dispatch_policy::has_non_turn_provenance(&timeout));
+        assert!(crate::services::discord::dispatch_policy::has_non_turn_provenance(&prealert));
     }
 
     #[test]

--- a/src/services/message_outbox.rs
+++ b/src/services/message_outbox.rs
@@ -10,10 +10,9 @@ use crate::services::{
 pub(crate) const LIFECYCLE_NOTIFY_DEDUPE_TTL_SECS: i64 = 5 * 60;
 pub(crate) const LIFECYCLE_NOTIFIER_SOURCE: &str = "lifecycle_notifier";
 /// Actionable operational alerts are delivered by the announce bot first so
-/// the channel's resident AgentDesk role receives a real intake turn.  The
-/// outbox worker falls back to the notify bot only when that primary delivery
-/// fails, preserving human visibility without turning informational notices
-/// into agent work (#4449).
+/// the channel's resident AgentDesk role receives a human-visible notice. The
+/// delivery path stamps non-turn provenance; the outbox worker falls back to
+/// the notify bot only when that primary delivery fails (#4449).
 pub(crate) const ACTIONABLE_OPS_ALERT_BOT: &str = UtilityBotRole::Announce.alias();
 
 pub(crate) fn is_actionable_ops_alert(source: &str, reason_code: Option<&str>) -> bool {
@@ -30,6 +29,24 @@ pub(crate) fn is_actionable_ops_alert(source: &str, reason_code: Option<&str>) -
             | ("auto-queue-monitor", Some("auto_queue.monitor_stuck"))
             | ("auto-queue-monitor", Some("auto_queue.monitor_anomaly"))
     )
+}
+
+/// Operational outbox alerts are human-visible notifications, not turn input.
+/// Keep this classification separate from `is_actionable_ops_alert`: some
+/// notify-only alerts still need the same intake provenance if their bot is
+/// later configured as an allowed sender.
+pub(crate) fn is_non_turn_operational_alert(source: &str, reason_code: Option<&str>) -> bool {
+    is_actionable_ops_alert(source, reason_code)
+        || matches!(
+            (source, reason_code),
+            ("auto-queue-monitor", Some("auto_queue.monitor_review_long"))
+        )
+        || matches!(
+            source,
+            "stall_watchdog" | "quality_regression_alerter" | "queue_overflow_notice"
+        )
+        || (source == "auto-queue-monitor"
+            && reason_code.is_some_and(|reason| reason.starts_with("auto_queue.monitor_")))
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -189,7 +206,10 @@ pub(crate) fn dedupe_key_for_message_for_test(
 
 #[cfg(test)]
 mod dedupe_key_tests {
-    use super::{dedupe_key_for_message, delivery_bot_for_target_session, is_actionable_ops_alert};
+    use super::{
+        dedupe_key_for_message, delivery_bot_for_target_session, is_actionable_ops_alert,
+        is_non_turn_operational_alert,
+    };
 
     #[test]
     fn actionable_ops_alert_registry_is_exact_and_excludes_recovery_noise() {
@@ -227,6 +247,30 @@ mod dedupe_key_tests {
         assert!(!is_actionable_ops_alert(
             "wrong-source",
             Some("dispatch_stuck")
+        ));
+    }
+
+    #[test]
+    fn operational_alert_registry_includes_notify_only_alerts() {
+        for (source, reason) in [
+            ("auto-queue-monitor", "auto_queue.monitor_review_long"),
+            ("stall_watchdog", "stall_watchdog_suspected_stall"),
+            ("quality_regression_alerter", "agent_quality.regression"),
+            ("queue_overflow_notice", "queue_overflow.evict"),
+            (
+                "stall_watchdog",
+                "relay_reattach_circuit_open:discord:channel-42",
+            ),
+            ("auto-queue-monitor", "auto_queue.monitor_recovery"),
+        ] {
+            assert!(
+                is_non_turn_operational_alert(source, Some(reason)),
+                "missing non-turn provenance registration for {source}/{reason}"
+            );
+        }
+        assert!(!is_non_turn_operational_alert(
+            "lifecycle_notifier",
+            Some("runtime_started")
         ));
     }
 

--- a/src/services/message_outbox.rs
+++ b/src/services/message_outbox.rs
@@ -38,10 +38,6 @@ pub(crate) fn is_actionable_ops_alert(source: &str, reason_code: Option<&str>) -
 pub(crate) fn is_non_turn_operational_alert(source: &str, reason_code: Option<&str>) -> bool {
     is_actionable_ops_alert(source, reason_code)
         || matches!(
-            (source, reason_code),
-            ("auto-queue-monitor", Some("auto_queue.monitor_review_long"))
-        )
-        || matches!(
             source,
             "stall_watchdog" | "quality_regression_alerter" | "queue_overflow_notice"
         )


### PR DESCRIPTION
Closes #5034

## 문제

봇 워치독/운영 알람이 사용자 개입 큐(intervention queue)에 턴으로 적재되어 큐 용량(27/30)을 잠식하고,
그 과정에서 큐 카드와 첨부(attachment) provenance 가 훼손된다.

## 해결

운영 알람을 "알림"으로 분류해 턴 인테이크 경계에서 거부하고, catch-up/첨부 경로 전반에서
alert provenance 를 보존한다. 관련 회귀 테스트를 프로덕션 변경과 동일한 path-filtered required
레인에 바인딩했다.

## 리뷰 상태 — 듀얼 적대 리뷰 2 leg 모두 로직 CLEAN

- leg A / leg B **양쪽 모두 로직 CLEAN** verdict.
- leg B 의 유일한 P1 이었던 "lib inventory pin 미갱신" 은 이미 해소됨.
- 남은 지적은 P2 2건뿐이며, 이 캠페인 규칙상 verdict 는 P0/P1 유무로만 결정되므로 **P2 는 머지를 막지 않는다**.

### leg B 가 닫은 것

- attachment provenance 유실이 **debug/release 양쪽 production-path probe** 에서 닫힘.
- 사람이 볼 수 있는(human-visible) marker 는 live/catch-up 에서 허용·제거되지만,
  **announce-bot marker 는 live/catch-up/restore 전부에서 계속 거부**된다.
- 뮤테이션 3건 전부 자기 assert 에서 FAILED (테스트가 실제로 대상을 잡고 있음을 증명).
- 삭제된 110줄 전수 심사 통과.

## rebase — 패치 동일성 실측으로 verdict 승계

base 를 `8da7a24ce` → `216b78cba`(최신 origin/main) 로 rebase 했다. 충돌은 **0건**.

rebase 전후의 패치 본문을 실측 비교했다:

```
diff <(grep -E "^[+-]" before.diff | grep -vE "^(\+\+\+|---)") \
     <(grep -E "^[+-]" after.diff  | grep -vE "^(\+\+\+|---)")
```

결과 **차이 0줄 — 바이트 동일**. 즉 로직 패치가 전혀 변하지 않았으므로 기존 듀얼 리뷰 verdict 를 그대로 승계한다.
(직전 `8ae099636` → `8da7a24ce` rebase 때는 차이가 5줄이었고 전부 pin 상수 2개였다. 이번엔 그마저도 0.)

`.github/workflows/ci-pr.yml` 에서 #5125/#5126 이 `dashboard:` path filter 에 추가한 4줄
(`.nvmrc`, `scripts/check-dashboard-install-state.mjs`, `scripts/check-dashboard-toolchain.sh`,
`scripts/install-dashboard-dependencies.sh`)과 이 브랜치가 추가하는 16줄은 서로 다른 블록이라
**양쪽 추가가 모두 보존**되었다.

### pin 재확인

`#5125`/`#5126` 이 `src/**.rs` 를 건드리지 않아 lib 테스트 delta 가 0 이다. 추정하지 않고 관측했다:

```
lib inventory identity: static=match digest=b7d4b719ea8c5f3c5af36daeb11bc41d9b0b976fc4fbbda6aa3855f1ef62cc11 count=7459 pinned-count=7459 delta=+0
```

기존 pin(7459)이 새 base 에서도 유효하므로 pin 변경 없음.

## 크기

14 파일 `+495/-112` — 상한 20파일 / ±800줄 **이내**.

## 로컬 게이트 (전부 새 base 에서 재실행)

| 게이트 | rc |
|---|---|
| `cargo fmt --all --check` | 0 |
| `cargo check --workspace --all-targets` | 0 (error 0건) |
| `python3 scripts/generate_inventory_docs.py` | 0 (all unchanged) |
| `python3 scripts/check_agent_maintenance_docs.py` | 0 |
| `bash scripts/ci-script-checks.sh` | 0 |
| `bash scripts/check-ci-runner-hardening.sh` | 0 |
| `python3 scripts/check_test_target_integrity.py --verify-lib-inventory` | 0 (delta=+0) |
| `bash scripts/run_relay_authority_mutations.sh` | 0 |

레드라인 뮤테이션 게이트 원문:

```
MUTATION_SUMMARY killed=4 survived=0 minimum=4 status=PASS
```

## 미해결 P2

리뷰에서 P2 로 판정된 2건은 머지를 막지 않으며 **별도 후속 이슈**로 분리했다:

1. 리뷰가 확인한 **비보장(non-guarantee) 선언 4건이 리포에 존재하지 않는다** — 리뷰 보고서에만 있고
   코드/문서에 선언이 없어 다음 사람이 게이트가 그것까지 막는다고 오해할 수 있다.
2. `src/services/discord/router/intake_gate/gate.rs` 의 주석과 테스트 이름이 **실제 보장보다 넓게 주장**한다.
