### PR TITLE
fix(deploy): add explicit launchctl kickstart after bootstrap for PG tunnel spawn guarantee

### DIFF
--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1070,20 +1070,28 @@ _rollback_pg_tunnel_migration() {
                 echo "✗ Failed to restore PG tunnel launchd plist during rollback" >&2
                 restore_ok=0
             else
-                # Retry bootstrap with same pattern as migration
+                # Retry bootstrap and explicit kickstart (required for process spawn after restore)
                 _pg_rollback_armed=0
                 for _pg_retry in 1 2 3; do
                     if launchctl bootstrap "$domain" "$plist" 2>/dev/null; then
-                        _pg_rollback_armed=1
-                        break
+                        # Kickstart: bootstrap loads plist but doesn't guarantee spawn
+                        if launchctl kickstart -k "$domain/${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" 2>/dev/null; then
+                            _pg_rollback_armed=1
+                            break
+                        else
+                            echo "⚠ PG tunnel rollback kickstart failed on attempt $_pg_retry — retrying" >&2
+                            if [ "$_pg_retry" -lt 3 ]; then
+                                sleep 2
+                            fi
+                        fi
                     fi
-                    if [ "$_pg_retry" -lt 3 ]; then
+                    if [ "$_pg_retry" -lt 3 ] && [ "$_pg_rollback_armed" != "1" ]; then
                         echo "⚠ PG tunnel rollback bootstrap attempt $_pg_retry failed — retrying in 2s" >&2
                         sleep 2
                     fi
                 done
                 if [ "$_pg_rollback_armed" != "1" ]; then
-                    echo "✗ Failed to restart previous PG tunnel launchd job after 3 attempts" >&2
+                    echo "✗ Failed to restart previous PG tunnel launchd job (bootstrap or kickstart) after 3 attempts" >&2
                     restore_ok=0
                 fi
             fi
@@ -2132,6 +2140,8 @@ _migrate_pg_tunnel_before_release_stop() {
     install -m 0755 "$wrapper_source" "$PG_TUNNEL_BIN" || return 1
     _install_pg_tunnel_plist || return 1
     xattr -d com.apple.quarantine "$PG_TUNNEL_PLIST_PATH" 2>/dev/null || true
+    # Bootout before take-over-canonical: we must stop the running process before wrapper claims canonical
+    # (subsequent bootout in helper will be no-op; retained for robustness and clarity of intent)
     launchctl bootout "$PG_TUNNEL_LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL" 2>/dev/null || true
     if ! "$wrapper_source" --take-over-canonical; then
         echo "✗ Failed to synchronously take over the canonical PG tunnel"
@@ -2141,7 +2151,8 @@ _migrate_pg_tunnel_before_release_stop() {
         echo "✗ Canonical PG tunnel listener survived synchronous takeover"
         return 1
     fi
-    # Use common bootout/poll/bootstrap pattern (extracted to _launchctl_bootout_and_spawn)
+    # Use common bootout/poll/bootstrap/kickstart pattern (via _launchctl_bootout_and_spawn helper).
+    # Bootout above is intentional (prepare for wrapper takeover); helper's bootout will be no-op.
     if ! _launchctl_bootout_and_spawn "$PG_TUNNEL_LAUNCHD_DOMAIN" "$PG_TUNNEL_LABEL" "$PG_TUNNEL_PLIST_PATH" "PG tunnel"; then
         return 1
     fi

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -970,6 +970,16 @@ _rollback_pg_tunnel_migration() {
 
     echo "↩ Restoring previous PG tunnel state..." >&2
     launchctl bootout "$domain/${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" 2>/dev/null || true
+    # Poll for launchd unload completion before re-binding; bootout is asynchronous.
+    _pg_rollback_polls=0
+    while launchctl print "$domain/${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" >/dev/null 2>&1; do
+        if [ "$_pg_rollback_polls" -ge 12 ]; then
+            echo "⚠ PG tunnel still unloading ~6s after rollback bootout — retrying restore anyway" >&2
+            break
+        fi
+        sleep 0.5
+        _pg_rollback_polls=$((_pg_rollback_polls + 1))
+    done
     if ! _pg_wait_canonical_listener_absent; then
         echo "✗ New PG tunnel listener survived rollback bootout; refusing restore bind race" >&2
         _pg_report_rollback_recovery "$backup"
@@ -997,9 +1007,26 @@ _rollback_pg_tunnel_migration() {
 
     if [ "$restore_ok" = 1 ]; then
         if [ "${PG_TUNNEL_ROLLBACK_JOB_LOADED:-0}" = 1 ]; then
-            if [ ! -f "$plist" ] || ! launchctl bootstrap "$domain" "$plist" 2>/dev/null; then
-                echo "✗ Failed to restart previous PG tunnel launchd job" >&2
+            if [ ! -f "$plist" ]; then
+                echo "✗ Failed to restore PG tunnel launchd plist during rollback" >&2
                 restore_ok=0
+            else
+                # Retry bootstrap with same pattern as migration
+                _pg_rollback_armed=0
+                for _pg_retry in 1 2 3; do
+                    if launchctl bootstrap "$domain" "$plist" 2>/dev/null; then
+                        _pg_rollback_armed=1
+                        break
+                    fi
+                    if [ "$_pg_retry" -lt 3 ]; then
+                        echo "⚠ PG tunnel rollback bootstrap attempt $_pg_retry failed — retrying in 2s" >&2
+                        sleep 2
+                    fi
+                done
+                if [ "$_pg_rollback_armed" != "1" ]; then
+                    echo "✗ Failed to restart previous PG tunnel launchd job after 3 attempts" >&2
+                    restore_ok=0
+                fi
             fi
         elif [ "${PG_TUNNEL_ROLLBACK_MANUAL_KIND:-none}" != none ]; then
             if [ ! -x "${PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE:-}" ] \
@@ -2055,12 +2082,34 @@ _migrate_pg_tunnel_before_release_stop() {
         echo "✗ Canonical PG tunnel listener survived synchronous takeover"
         return 1
     fi
-    if ! launchctl bootstrap "$PG_TUNNEL_LAUNCHD_DOMAIN" "$PG_TUNNEL_PLIST_PATH"; then
-        echo "✗ PG tunnel bootstrap failed"
+    # Poll for launchd unload completion; bootout is asynchronous and race with
+    # bootstrap would fail. Same pattern as relay watchdog (#4726 fix).
+    _pg_bootout_polls=0
+    while launchctl print "$PG_TUNNEL_LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL" >/dev/null 2>&1; do
+        if [ "$_pg_bootout_polls" -ge 12 ]; then
+            echo "⚠ PG tunnel still unloading ~6s after bootout — bootstrapping anyway"
+            break
+        fi
+        sleep 0.5
+        _pg_bootout_polls=$((_pg_bootout_polls + 1))
+    done
+    _pg_armed=0
+    for _pg_attempt in 1 2 3; do
+        if launchctl bootstrap "$PG_TUNNEL_LAUNCHD_DOMAIN" "$PG_TUNNEL_PLIST_PATH"; then
+            _pg_armed=1
+            break
+        fi
+        if [ "$_pg_attempt" -lt 3 ]; then
+            echo "⚠ PG tunnel bootstrap attempt $_pg_attempt failed — retrying in 2s"
+            sleep 2
+        fi
+    done
+    if [ "$_pg_armed" != "1" ]; then
+        echo "✗ PG tunnel bootstrap failed after 3 attempts"
         return 1
     fi
     echo "▸ Proving canonical PostgreSQL tunnel readiness on :15432..."
-    if ! _pg_sql_probe 15432; then
+    if ! _pg_sql_probe 15432 12; then
         echo "✗ Canonical PostgreSQL tunnel SQL readiness failed"
         return 1
     fi

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -959,7 +959,8 @@ _launchctl_bootout_and_spawn() {
     # Safe launchd service restart: bootout → poll → bootstrap → kickstart → running.
     # Issue: bootstrap loads plist but may not spawn process (runs=0, state=not running).
     # Solution: explicit kickstart -k forces immediate spawn after successful bootstrap.
-    # Polling (below) is defensive for edge cases; primary issue on this node was misspawn, not race.
+    # Measured: bootstrap rc=0 → runs=0; kickstart → runs=1 → SQL-ready in 0.25s.
+    # Polling (below) is defensive for edge cases; primary issue was misspawn, not race.
     # ARGS: domain label plist_path service_name
     local domain="$1" label="$2" plist_path="$3" service_name="${4:-service}"
 
@@ -3318,9 +3319,32 @@ PLIST_EOF
                     # Restart only when deployment material changed or the job is absent.
                     # The watermark lives in the atomic state file, so replacement loads
                     # the same pre-restart transcript authority before its first tick.
-                    # Use common bootout/poll/bootstrap/kickstart pattern (same as PG tunnel #5151).
-                    # Both services require explicit kickstart after bootstrap to ensure process spawn.
-                    if _launchctl_bootout_and_spawn "$LAUNCHD_DOMAIN" "$WATCHDOG_LABEL" "$WATCHDOG_PLIST_PATH" "Relay watchdog"; then
+                    # NOTE: This block implements bootout/poll/bootstrap pattern similar to
+                    # _launchctl_bootout_and_spawn. Currently runs=2 (healthy). Measured as
+                    # not requiring kickstart (unlike PG tunnel #5151). Scope: exclude from
+                    # this PR; integration candidate with verification (#5151 follow-up).
+                    launchctl bootout "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" 2>/dev/null || true
+                    _wd_bootout_polls=0
+                    while launchctl print "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" >/dev/null 2>&1; do
+                        if [ "$_wd_bootout_polls" -ge 12 ]; then
+                            echo "⚠ Relay watchdog still unloading ~6s after bootout — bootstrapping anyway"
+                            break
+                        fi
+                        sleep 0.5
+                        _wd_bootout_polls=$((_wd_bootout_polls + 1))
+                    done
+                    _wd_armed=0
+                    for _wd_attempt in 1 2 3; do
+                        if launchctl bootstrap "$LAUNCHD_DOMAIN" "$WATCHDOG_PLIST_PATH"; then
+                            _wd_armed=1
+                            break
+                        fi
+                        if [ "$_wd_attempt" -lt 3 ]; then
+                            echo "⚠ Relay watchdog bootstrap attempt $_wd_attempt failed — retrying in 2s"
+                            sleep 2
+                        fi
+                    done
+                    if [ "$_wd_armed" = "1" ]; then
                         echo "✓ Relay watchdog armed ($WATCHDOG_LABEL)"
                     else
                         echo "⚠ Relay watchdog bootstrap FAILED after 3 attempts — relay gaps will go unwatched"

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -955,59 +955,6 @@ _pg_wait_canonical_listener_absent() {
     return 1
 }
 
-_launchctl_bootout_and_spawn() {
-    # Safe launchd service restart: bootout → poll → bootstrap → kickstart → running.
-    # Issue: bootstrap loads plist but may not spawn process (runs=0, state=not running).
-    # Solution: explicit kickstart -k forces immediate spawn after successful bootstrap.
-    # Measured: bootstrap rc=0 → runs=0; kickstart → runs=1 → SQL-ready in 0.25s.
-    # Polling (below) is defensive for edge cases; primary issue was misspawn, not race.
-    # ARGS: domain label plist_path service_name
-    local domain="$1" label="$2" plist_path="$3" service_name="${4:-service}"
-
-    launchctl bootout "$domain/$label" 2>/dev/null || true
-
-    # Poll for launchd unload completion (max 12 × 0.5s = 6s).
-    # Note: Observed on this node: polling yielded 0 rounds, bootstrap rc=0 but runs=0 (process not spawned).
-    # Root cause was launchd not executing the process despite successful plist bootstrap.
-    # Polling retained as defensive measure for potential race on other nodes/timings.
-    local polls=0
-    while launchctl print "$domain/$label" >/dev/null 2>&1; do
-        if [ "$polls" -ge 12 ]; then
-            echo "⚠ $service_name still loading ~6s after bootout — proceeding with bootstrap" >&2
-            break
-        fi
-        sleep 0.5
-        polls=$((polls + 1))
-    done
-
-    # Bootstrap with retry (max 3 attempts, 2s between retries)
-    local loaded=0 attempt
-    for attempt in 1 2 3; do
-        if launchctl bootstrap "$domain" "$plist_path" 2>/dev/null; then
-            loaded=1
-            break
-        fi
-        if [ "$attempt" -lt 3 ]; then
-            echo "⚠ $service_name bootstrap attempt $attempt failed — retrying in 2s" >&2
-            sleep 2
-        fi
-    done
-
-    if [ "$loaded" != "1" ]; then
-        echo "✗ $service_name bootstrap failed after 3 attempts" >&2
-        return 1
-    fi
-
-    # Explicit kickstart: bootstrap loads plist but doesn't guarantee process spawn.
-    # Kickstart forces immediate spawn; required for consistent readiness after restart (#5151).
-    if ! launchctl kickstart -k "$domain/$label" 2>/dev/null; then
-        echo "⚠ $service_name kickstart failed — service may not spawn immediately" >&2
-        return 1
-    fi
-
-    return 0
-}
-
 _pg_report_rollback_recovery() {
     local backup=${1:-unknown}
     echo "⚠ PG tunnel rollback incomplete; recovery material retained at $backup" >&2
@@ -1027,18 +974,7 @@ _rollback_pg_tunnel_migration() {
     fi
 
     echo "↩ Restoring previous PG tunnel state..." >&2
-    # Use common bootout/poll/bootstrap pattern; we'll actually call restore below
-    # after file restoration, but the unload poll is the same.
     launchctl bootout "$domain/${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" 2>/dev/null || true
-    local rollback_polls=0
-    while launchctl print "$domain/${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" >/dev/null 2>&1; do
-        if [ "$rollback_polls" -ge 12 ]; then
-            echo "⚠ PG tunnel still unloading ~6s after rollback bootout — retrying restore anyway" >&2
-            break
-        fi
-        sleep 0.5
-        rollback_polls=$((rollback_polls + 1))
-    done
     if ! _pg_wait_canonical_listener_absent; then
         echo "✗ New PG tunnel listener survived rollback bootout; refusing restore bind race" >&2
         _pg_report_rollback_recovery "$backup"
@@ -1066,15 +1002,15 @@ _rollback_pg_tunnel_migration() {
 
     if [ "$restore_ok" = 1 ]; then
         if [ "${PG_TUNNEL_ROLLBACK_JOB_LOADED:-0}" = 1 ]; then
-            if [ ! -f "$plist" ]; then
-                echo "✗ Failed to restore PG tunnel launchd plist during rollback" >&2
+            # #5151: bootstrap only loads the plist; it does not guarantee that launchd
+            # spawns the process (observed rc=0 with runs=0 despite RunAtLoad/KeepAlive).
+            # The explicit kickstart is what actually brings the tunnel back, so rollback
+            # must treat a kickstart failure as a restore failure too.
+            if [ ! -f "$plist" ] \
+              || ! launchctl bootstrap "$domain" "$plist" 2>/dev/null \
+              || ! launchctl kickstart -k "$domain/${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" 2>/dev/null; then
+                echo "✗ Failed to restart previous PG tunnel launchd job" >&2
                 restore_ok=0
-            else
-                # Use common bootout/poll/bootstrap/kickstart helper (same as migration).
-                # Rollback context: prior state was captured; bootout in helper re-clears state before restore.
-                if ! _launchctl_bootout_and_spawn "$domain" "${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" "$plist" "PG tunnel rollback"; then
-                    restore_ok=0
-                fi
             fi
         elif [ "${PG_TUNNEL_ROLLBACK_MANUAL_KIND:-none}" != none ]; then
             if [ ! -x "${PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE:-}" ] \
@@ -2121,8 +2057,6 @@ _migrate_pg_tunnel_before_release_stop() {
     install -m 0755 "$wrapper_source" "$PG_TUNNEL_BIN" || return 1
     _install_pg_tunnel_plist || return 1
     xattr -d com.apple.quarantine "$PG_TUNNEL_PLIST_PATH" 2>/dev/null || true
-    # Bootout before take-over-canonical: we must stop the running process before wrapper claims canonical
-    # (subsequent bootout in helper will be no-op; retained for robustness and clarity of intent)
     launchctl bootout "$PG_TUNNEL_LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL" 2>/dev/null || true
     if ! "$wrapper_source" --take-over-canonical; then
         echo "✗ Failed to synchronously take over the canonical PG tunnel"
@@ -2132,9 +2066,17 @@ _migrate_pg_tunnel_before_release_stop() {
         echo "✗ Canonical PG tunnel listener survived synchronous takeover"
         return 1
     fi
-    # Use common bootout/poll/bootstrap/kickstart pattern (via _launchctl_bootout_and_spawn helper).
-    # Bootout above is intentional (prepare for wrapper takeover); helper's bootout will be no-op.
-    if ! _launchctl_bootout_and_spawn "$PG_TUNNEL_LAUNCHD_DOMAIN" "$PG_TUNNEL_LABEL" "$PG_TUNNEL_PLIST_PATH" "PG tunnel"; then
+    if ! launchctl bootstrap "$PG_TUNNEL_LAUNCHD_DOMAIN" "$PG_TUNNEL_PLIST_PATH"; then
+        echo "✗ PG tunnel bootstrap failed"
+        return 1
+    fi
+    # #5151: bootstrap loads the plist but does not guarantee that launchd spawns the
+    # process — measured rc=0 with runs=0 even though RunAtLoad=true and KeepAlive=true.
+    # The explicit kickstart is what actually starts it (runs 0→1, SQL-ready in 0.25s).
+    # Deliberately placed after the single bootout above: adding a second bootout here
+    # would re-stop the job the wrapper just claimed as canonical.
+    if ! launchctl kickstart -k "$PG_TUNNEL_LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL"; then
+        echo "✗ PG tunnel kickstart failed"
         return 1
     fi
     echo "▸ Proving canonical PostgreSQL tunnel readiness on :15432..."
@@ -3311,10 +3253,10 @@ PLIST_EOF
                     # Restart only when deployment material changed or the job is absent.
                     # The watermark lives in the atomic state file, so replacement loads
                     # the same pre-restart transcript authority before its first tick.
-                    # NOTE: This block implements bootout/poll/bootstrap pattern similar to
-                    # _launchctl_bootout_and_spawn. Currently runs=2 (healthy). Measured as
-                    # not requiring kickstart (unlike PG tunnel #5151). Scope: exclude from
-                    # this PR; integration candidate with verification (#5151 follow-up).
+                    # NOTE: This block implements the same bootout/poll/bootstrap pattern as
+                    # the PG tunnel sites. Currently runs=2 (healthy), i.e. measured as not
+                    # requiring an explicit kickstart (unlike PG tunnel #5151). Scope: excluded
+                    # from this PR; unification is a follow-up gated on measurement (#5151).
                     launchctl bootout "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" 2>/dev/null || true
                     _wd_bootout_polls=0
                     while launchctl print "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" >/dev/null 2>&1; do

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1070,28 +1070,9 @@ _rollback_pg_tunnel_migration() {
                 echo "✗ Failed to restore PG tunnel launchd plist during rollback" >&2
                 restore_ok=0
             else
-                # Retry bootstrap and explicit kickstart (required for process spawn after restore)
-                _pg_rollback_armed=0
-                for _pg_retry in 1 2 3; do
-                    if launchctl bootstrap "$domain" "$plist" 2>/dev/null; then
-                        # Kickstart: bootstrap loads plist but doesn't guarantee spawn
-                        if launchctl kickstart -k "$domain/${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" 2>/dev/null; then
-                            _pg_rollback_armed=1
-                            break
-                        else
-                            echo "⚠ PG tunnel rollback kickstart failed on attempt $_pg_retry — retrying" >&2
-                            if [ "$_pg_retry" -lt 3 ]; then
-                                sleep 2
-                            fi
-                        fi
-                    fi
-                    if [ "$_pg_retry" -lt 3 ] && [ "$_pg_rollback_armed" != "1" ]; then
-                        echo "⚠ PG tunnel rollback bootstrap attempt $_pg_retry failed — retrying in 2s" >&2
-                        sleep 2
-                    fi
-                done
-                if [ "$_pg_rollback_armed" != "1" ]; then
-                    echo "✗ Failed to restart previous PG tunnel launchd job (bootstrap or kickstart) after 3 attempts" >&2
+                # Use common bootout/poll/bootstrap/kickstart helper (same as migration).
+                # Rollback context: prior state was captured; bootout in helper re-clears state before restore.
+                if ! _launchctl_bootout_and_spawn "$domain" "${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" "$plist" "PG tunnel rollback"; then
                     restore_ok=0
                 fi
             fi

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -876,6 +876,11 @@ _rollback_release_binary() {
     echo "↩ Rolling back release binary to previous good version..."
     domain="$(_launchd_domain)" || domain="gui/$(id -u 2>/dev/null)"
     # Stop the crash-looping new process before swapping the binary back.
+    # NOTE: bootout is asynchronous; race with bootstrap below exists, same as #4726/#5151.
+    # Unlike PG tunnel (fail-closed, blocking), release rollback has tmux fallback (line 897)
+    # and health check (line 899). Rollback is best-effort, not fail-closed; if bootstrap
+    # fails, tmux fallback handles service restart. Scope: PG tunnel (#5151) only; release
+    # rollback follow-up deferred (#5151 comment).
     launchctl bootout "$domain/$plist" 2>/dev/null || true
     tmux kill-session -t "${AGENTDESK_RELEASE_TMUX_SESSION:-AgentDesk-dcserver-release-manual}" 2>/dev/null || true
     # The bad binary is never locked (uchg is deferred to the success path), so
@@ -950,6 +955,47 @@ _pg_wait_canonical_listener_absent() {
     return 1
 }
 
+_launchctl_bootout_and_bootstrap_retry() {
+    # Common pattern for safe launchd service restart after bootout.
+    # Bootout is asynchronous; immediately bootstrapping risks race conditions (#4726, #5151).
+    # This helper polls for unload completion, then retries bootstrap.
+    # ARGS: domain label plist_path service_name
+    local domain="$1" label="$2" plist_path="$3" service_name="${4:-service}"
+
+    launchctl bootout "$domain/$label" 2>/dev/null || true
+
+    # Poll for launchd unload completion (max 12 × 0.5s = 6s)
+    local polls=0
+    while launchctl print "$domain/$label" >/dev/null 2>&1; do
+        if [ "$polls" -ge 12 ]; then
+            echo "⚠ $service_name still unloading ~6s after bootout — bootstrapping anyway" >&2
+            break
+        fi
+        sleep 0.5
+        polls=$((polls + 1))
+    done
+
+    # Bootstrap with retry (max 3 attempts, 2s between retries)
+    local armed=0 attempt
+    for attempt in 1 2 3; do
+        if launchctl bootstrap "$domain" "$plist_path" 2>/dev/null; then
+            armed=1
+            break
+        fi
+        if [ "$attempt" -lt 3 ]; then
+            echo "⚠ $service_name bootstrap attempt $attempt failed — retrying in 2s" >&2
+            sleep 2
+        fi
+    done
+
+    if [ "$armed" = "1" ]; then
+        return 0
+    else
+        echo "✗ $service_name bootstrap failed after 3 attempts" >&2
+        return 1
+    fi
+}
+
 _pg_report_rollback_recovery() {
     local backup=${1:-unknown}
     echo "⚠ PG tunnel rollback incomplete; recovery material retained at $backup" >&2
@@ -969,16 +1015,17 @@ _rollback_pg_tunnel_migration() {
     fi
 
     echo "↩ Restoring previous PG tunnel state..." >&2
+    # Use common bootout/poll/bootstrap pattern; we'll actually call restore below
+    # after file restoration, but the unload poll is the same.
     launchctl bootout "$domain/${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" 2>/dev/null || true
-    # Poll for launchd unload completion before re-binding; bootout is asynchronous.
-    _pg_rollback_polls=0
+    local rollback_polls=0
     while launchctl print "$domain/${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" >/dev/null 2>&1; do
-        if [ "$_pg_rollback_polls" -ge 12 ]; then
+        if [ "$rollback_polls" -ge 12 ]; then
             echo "⚠ PG tunnel still unloading ~6s after rollback bootout — retrying restore anyway" >&2
             break
         fi
         sleep 0.5
-        _pg_rollback_polls=$((_pg_rollback_polls + 1))
+        rollback_polls=$((rollback_polls + 1))
     done
     if ! _pg_wait_canonical_listener_absent; then
         echo "✗ New PG tunnel listener survived rollback bootout; refusing restore bind race" >&2
@@ -2082,30 +2129,8 @@ _migrate_pg_tunnel_before_release_stop() {
         echo "✗ Canonical PG tunnel listener survived synchronous takeover"
         return 1
     fi
-    # Poll for launchd unload completion; bootout is asynchronous and race with
-    # bootstrap would fail. Same pattern as relay watchdog (#4726 fix).
-    _pg_bootout_polls=0
-    while launchctl print "$PG_TUNNEL_LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL" >/dev/null 2>&1; do
-        if [ "$_pg_bootout_polls" -ge 12 ]; then
-            echo "⚠ PG tunnel still unloading ~6s after bootout — bootstrapping anyway"
-            break
-        fi
-        sleep 0.5
-        _pg_bootout_polls=$((_pg_bootout_polls + 1))
-    done
-    _pg_armed=0
-    for _pg_attempt in 1 2 3; do
-        if launchctl bootstrap "$PG_TUNNEL_LAUNCHD_DOMAIN" "$PG_TUNNEL_PLIST_PATH"; then
-            _pg_armed=1
-            break
-        fi
-        if [ "$_pg_attempt" -lt 3 ]; then
-            echo "⚠ PG tunnel bootstrap attempt $_pg_attempt failed — retrying in 2s"
-            sleep 2
-        fi
-    done
-    if [ "$_pg_armed" != "1" ]; then
-        echo "✗ PG tunnel bootstrap failed after 3 attempts"
+    # Use common bootout/poll/bootstrap pattern (extracted to _launchctl_bootout_and_bootstrap_retry)
+    if ! _launchctl_bootout_and_bootstrap_retry "$PG_TUNNEL_LAUNCHD_DOMAIN" "$PG_TUNNEL_LABEL" "$PG_TUNNEL_PLIST_PATH" "PG tunnel"; then
         return 1
     fi
     echo "▸ Proving canonical PostgreSQL tunnel readiness on :15432..."
@@ -3282,6 +3307,11 @@ PLIST_EOF
                     # Restart only when deployment material changed or the job is absent.
                     # The watermark lives in the atomic state file, so replacement loads
                     # the same pre-restart transcript authority before its first tick.
+                    # NOTE: This code block (`:3305-3330`) implements the same bootout/poll/bootstrap
+                    # pattern as `_launchctl_bootout_and_bootstrap_retry` (line ~953). When extracting
+                    # the relay watchdog restart logic to use the common helper, preserve service-specific
+                    # error messages and reconcile any local variable naming (e.g. `_wd_*` → parameters).
+                    # Candidate for integration in next refactor (#5151 follow-up). #4726 #5151
                     launchctl bootout "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" 2>/dev/null || true
                     _wd_bootout_polls=0
                     while launchctl print "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" >/dev/null 2>&1; do

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -876,11 +876,11 @@ _rollback_release_binary() {
     echo "↩ Rolling back release binary to previous good version..."
     domain="$(_launchd_domain)" || domain="gui/$(id -u 2>/dev/null)"
     # Stop the crash-looping new process before swapping the binary back.
-    # NOTE: bootout is asynchronous; race with bootstrap below exists, same as #4726/#5151.
-    # Unlike PG tunnel (fail-closed, blocking), release rollback has tmux fallback (line 897)
-    # and health check (line 899). Rollback is best-effort, not fail-closed; if bootstrap
-    # fails, tmux fallback handles service restart. Scope: PG tunnel (#5151) only; release
-    # rollback follow-up deferred (#5151 comment).
+    # NOTE: bootstrap may not spawn process (runs=0) despite rc=0 (#5151 root cause).
+    # Release rollback has tmux fallback (line 897) + health check (line 899); if bootstrap
+    # succeeds but process doesn't spawn, tmux fallback will restart via SSH.
+    # Observed issue (#5151): explicit kickstart required after bootstrap. Scope: PG tunnel
+    # only for now; release rollback suitable for future unification if measured necessary.
     launchctl bootout "$domain/$plist" 2>/dev/null || true
     tmux kill-session -t "${AGENTDESK_RELEASE_TMUX_SESSION:-AgentDesk-dcserver-release-manual}" 2>/dev/null || true
     # The bad binary is never locked (uchg is deferred to the success path), so
@@ -955,20 +955,24 @@ _pg_wait_canonical_listener_absent() {
     return 1
 }
 
-_launchctl_bootout_and_bootstrap_retry() {
-    # Common pattern for safe launchd service restart after bootout.
-    # Bootout is asynchronous; immediately bootstrapping risks race conditions (#4726, #5151).
-    # This helper polls for unload completion, then retries bootstrap.
+_launchctl_bootout_and_spawn() {
+    # Safe launchd service restart: bootout → poll → bootstrap → kickstart → running.
+    # Issue: bootstrap loads plist but may not spawn process (runs=0, state=not running).
+    # Solution: explicit kickstart -k forces immediate spawn after successful bootstrap.
+    # Polling (below) is defensive for edge cases; primary issue on this node was misspawn, not race.
     # ARGS: domain label plist_path service_name
     local domain="$1" label="$2" plist_path="$3" service_name="${4:-service}"
 
     launchctl bootout "$domain/$label" 2>/dev/null || true
 
-    # Poll for launchd unload completion (max 12 × 0.5s = 6s)
+    # Poll for launchd unload completion (max 12 × 0.5s = 6s).
+    # Note: Observed on this node: polling yielded 0 rounds, bootstrap rc=0 but runs=0 (process not spawned).
+    # Root cause was launchd not executing the process despite successful plist bootstrap.
+    # Polling retained as defensive measure for potential race on other nodes/timings.
     local polls=0
     while launchctl print "$domain/$label" >/dev/null 2>&1; do
         if [ "$polls" -ge 12 ]; then
-            echo "⚠ $service_name still unloading ~6s after bootout — bootstrapping anyway" >&2
+            echo "⚠ $service_name still loading ~6s after bootout — proceeding with bootstrap" >&2
             break
         fi
         sleep 0.5
@@ -976,10 +980,10 @@ _launchctl_bootout_and_bootstrap_retry() {
     done
 
     # Bootstrap with retry (max 3 attempts, 2s between retries)
-    local armed=0 attempt
+    local loaded=0 attempt
     for attempt in 1 2 3; do
         if launchctl bootstrap "$domain" "$plist_path" 2>/dev/null; then
-            armed=1
+            loaded=1
             break
         fi
         if [ "$attempt" -lt 3 ]; then
@@ -988,12 +992,19 @@ _launchctl_bootout_and_bootstrap_retry() {
         fi
     done
 
-    if [ "$armed" = "1" ]; then
-        return 0
-    else
+    if [ "$loaded" != "1" ]; then
         echo "✗ $service_name bootstrap failed after 3 attempts" >&2
         return 1
     fi
+
+    # Explicit kickstart: bootstrap loads plist but doesn't guarantee process spawn.
+    # Kickstart forces immediate spawn; required for consistent readiness after restart (#5151).
+    if ! launchctl kickstart -k "$domain/$label" 2>/dev/null; then
+        echo "⚠ $service_name kickstart failed — service may not spawn immediately" >&2
+        return 1
+    fi
+
+    return 0
 }
 
 _pg_report_rollback_recovery() {
@@ -2129,8 +2140,8 @@ _migrate_pg_tunnel_before_release_stop() {
         echo "✗ Canonical PG tunnel listener survived synchronous takeover"
         return 1
     fi
-    # Use common bootout/poll/bootstrap pattern (extracted to _launchctl_bootout_and_bootstrap_retry)
-    if ! _launchctl_bootout_and_bootstrap_retry "$PG_TUNNEL_LAUNCHD_DOMAIN" "$PG_TUNNEL_LABEL" "$PG_TUNNEL_PLIST_PATH" "PG tunnel"; then
+    # Use common bootout/poll/bootstrap pattern (extracted to _launchctl_bootout_and_spawn)
+    if ! _launchctl_bootout_and_spawn "$PG_TUNNEL_LAUNCHD_DOMAIN" "$PG_TUNNEL_LABEL" "$PG_TUNNEL_PLIST_PATH" "PG tunnel"; then
         return 1
     fi
     echo "▸ Proving canonical PostgreSQL tunnel readiness on :15432..."
@@ -3307,33 +3318,9 @@ PLIST_EOF
                     # Restart only when deployment material changed or the job is absent.
                     # The watermark lives in the atomic state file, so replacement loads
                     # the same pre-restart transcript authority before its first tick.
-                    # NOTE: This code block (`:3305-3330`) implements the same bootout/poll/bootstrap
-                    # pattern as `_launchctl_bootout_and_bootstrap_retry` (line ~953). When extracting
-                    # the relay watchdog restart logic to use the common helper, preserve service-specific
-                    # error messages and reconcile any local variable naming (e.g. `_wd_*` → parameters).
-                    # Candidate for integration in next refactor (#5151 follow-up). #4726 #5151
-                    launchctl bootout "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" 2>/dev/null || true
-                    _wd_bootout_polls=0
-                    while launchctl print "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" >/dev/null 2>&1; do
-                        if [ "$_wd_bootout_polls" -ge 12 ]; then
-                            echo "⚠ Relay watchdog still unloading ~6s after bootout — bootstrapping anyway"
-                            break
-                        fi
-                        sleep 0.5
-                        _wd_bootout_polls=$((_wd_bootout_polls + 1))
-                    done
-                    _wd_armed=0
-                    for _wd_attempt in 1 2 3; do
-                        if launchctl bootstrap "$LAUNCHD_DOMAIN" "$WATCHDOG_PLIST_PATH"; then
-                            _wd_armed=1
-                            break
-                        fi
-                        if [ "$_wd_attempt" -lt 3 ]; then
-                            echo "⚠ Relay watchdog bootstrap attempt $_wd_attempt failed — retrying in 2s"
-                            sleep 2
-                        fi
-                    done
-                    if [ "$_wd_armed" = "1" ]; then
+                    # Use common bootout/poll/bootstrap/kickstart pattern (same as PG tunnel #5151).
+                    # Both services require explicit kickstart after bootstrap to ensure process spawn.
+                    if _launchctl_bootout_and_spawn "$LAUNCHD_DOMAIN" "$WATCHDOG_LABEL" "$WATCHDOG_PLIST_PATH" "Relay watchdog"; then
                         echo "✓ Relay watchdog armed ($WATCHDOG_LABEL)"
                     else
                         echo "⚠ Relay watchdog bootstrap FAILED after 3 attempts — relay gaps will go unwatched"


### PR DESCRIPTION
Closes #5151

## 요약

PG 터널 마이그레이션/롤백의 launchd 재시작 경로에 **명시적 `launchctl kickstart -k`** 를 추가한다. 이 결함 때문에 **모든 배포가 실패**하고 있었고, 실패한 배포가 **프로덕션 DB 경로(PG 터널)를 내려간 채로 남겼다.**

`scripts/deploy-release.sh` 1파일.

## 정정된 근본 원인

**`launchctl bootstrap` 은 plist 의 "로드"만 보장하고 "프로세스 스폰"을 보장하지 않는다.**

plist 에 `RunAtLoad=true` 와 `KeepAlive=true` 가 모두 설정되어 있음에도, `bootstrap` 이 `rc=0` 으로 성공한 직후 서비스는 `runs=0` (state = not running) 상태로 남는다. 프로세스가 뜨지 않으므로 뒤따르는 SQL readiness 프로브가 반드시 실패하고, 배포 전체가 중단된다.

해결책은 `bootstrap` 성공 이후 **명시적 `kickstart -k`** 로 즉시 스폰을 강제하는 것이다.

### 초기 가설은 실측으로 기각됐다

> [!IMPORTANT]
> 최초 가설 — "#4726 에서 고친 `bootout→bootstrap` **race** 가 형제 사이트에 미적용됐다" — 는 **실측으로 기각됐다.**
>
> - 언로드 폴링이 **0회**로 끝났다. 즉 `bootout` 직후 이미 언로드가 완료돼 있었고, 경합할 창(window)이 존재하지 않았다.
> - `bootstrap` 은 `rc=0` 으로 정상 반환했다. 즉 로드 실패도 아니었다.
>
> 경합도 로드 실패도 아니었고, **로드는 됐으나 스폰이 안 되는 것(misspawn)** 이 진짜 원인이다.
> 이 정정을 반영해 **#5151 본문은 2회 수정됐다.** (이슈 **제목**에는 아직 초기 가설 표현이 남아 있다.)

### 흥미로운 사실: 답은 이미 #4726 안에 있었다

#4726 **본문의 수동 복구 절차**는 다음과 같았다:

```
bootout → sleep 3 → bootstrap → kickstart
```

`kickstart` 가 이미 거기 적혀 있었다. 그런데 **#4726 의 코드 수정은 `kickstart` 를 빠뜨리고** `bootout → poll → bootstrap` 까지만 구현했다. 수동 절차가 동작했던 진짜 이유(`kickstart`)가 코드로 옮겨지지 않은 것이다. 이번 PR 이 그 누락을 메운다.

## 실측 증거

| 단계 | `runs` | 결과 |
|---|---|---|
| `bootstrap` (rc=0) | **0** | 로드만 됨, 미스폰 → SQL 프로브 실패 |
| `kickstart -k` | **1** | 스폰됨 → **SQL-ready 0.25초** |

## 왜 위험한 결함이었는가

단순한 "배포 실패"가 아니었다.

`_rollback_pg_tunnel_migration()` 의 복구 경로가 **동일한 `bootstrap`-만-호출 패턴**을 쓰고 있었다. 따라서:

1. migration 이 미스폰으로 실패한다
2. 롤백이 발동한다
3. **롤백도 똑같은 이유(미스폰)로 실패한다**
4. PG 터널이 **내려간 채로 남는다**

즉 **배포 실패가 프로덕션 DB 경로를 죽였다.** fail-safe 가 아니라 fail-deadly 다.
실제로 **배포 2차·3차 시도에서 이 상태를 관측**했고, 매번 **수동 `launchctl kickstart`** 로 복구해야 했다.

## 변경 내용

두 사이트에 `kickstart -k` 를 **인라인으로** 추가한다.

- **migration (`_migrate_pg_tunnel_before_release_stop`)** — 기존 `bootout` 1회와 게이트된 `launchctl bootstrap "$PG_TUNNEL_LAUNCHD_DOMAIN" "$PG_TUNNEL_PLIST_PATH"` 를 그대로 두고, 그 뒤에 `kickstart -k` 추가.
- **rollback (`_rollback_pg_tunnel_migration`)** — 기존 한 줄 조건과 `"Failed to restart previous PG tunnel launchd job"` 메시지를 그대로 두고 `kickstart -k` 를 조건에 추가. kickstart 실패도 restore 실패로 취급한다.
- migration 의 readiness 예산을 `_pg_sql_probe 15432` → `_pg_sql_probe 15432 12` 로 상향. **`kickstart -k` 는 kill 후 재스폰이므로 plist 의 `ThrottleInterval=10` 에 걸릴 수 있다.** 기본 5초로는 부족하다.

### 리뷰 중 발견해 되돌린 것 (중요)

초기 커밋은 공통 헬퍼 `_launchctl_bootout_and_spawn()` 로 두 사이트를 통합했다. 그 헬퍼는 **자체적으로 무조건 `bootout` 을 수행**했고, migration 경로에서는 그 결과 **`bootout` 이 2회** 발생했다 — 그것도 wrapper 가 `--take-over-canonical` 로 canonical `:15432` 를 **이미 점유한 뒤에**. "헬퍼의 bootout 은 no-op" 이라는 당시 주석은 **틀렸다.** 방금 인수인계받은 잡을 다시 내리는 동작이다.

`tests/test_pg_tunnel.py` 가 이걸 잡아냈다 (**7 failures + 1 error**, `origin/main` 에서는 55/55 green). 해당 하니스의 `launchctl` fake 는 **bootout 횟수를 단계 판별자로** 쓴다 — 2번째 bootout 이 "롤백 단계 진입" 표시다. 추가된 bootout 때문에 **canonical readiness 프로브가 rollback 프로브로 오분류**되어 `FAIL_CANONICAL` 주입이 발동하지 않았고, **실패해야 할 migration 이 성공으로 보고**됐다.

그래서 헬퍼를 폐기하고 위와 같이 인라인 최소 변경으로 되돌렸다. 덕분에 `bootout` 시퀀스와 게이트된 리터럴, 기존 에러 메시지 계약이 모두 `origin/main` 과 동일하게 유지된다.

## 범위 제한 (의도적)

- **relay-watchdog 사이트 (`:3253` 부근)** — 현재 **`runs=2` 로 정상 동작 중**이라 제외. 이 영역 **비주석 변경 0줄**(주석만 추가).
- **release binary rollback (`:876`)** — tmux fallback 이 있어 제외, 주석만 추가.

두 건 모두 후속 이슈에서 **실측 후** 판정한다.

## 남은 한계

> [!WARNING]
> 이 수정은 **이 노드에서의 실측**에 근거한다. 다른 노드에서 `launchctl print` 의 rc 의미나 스폰 타이밍이 다를 가능성은 **검증되지 않았다.**

## 검증

- `tests/test_pg_tunnel.py` — **55/55 통과** (수정 전 7 failures + 1 error)
- `origin/main` 기준선도 55/55 통과로 대조 확인 (회귀 여부 판별)
- `bash -n scripts/deploy-release.sh` → **rc=0**
- `shellcheck -S warning scripts/deploy-release.sh` → **rc=0, 경고 0건**
- `tests.test_relay_watchdog` 278/278, `test_toolchain_update` 35/35, `test_analyze_prs` 52/52, `test_portable_path_lint` 6/6, `test_install_bootstrap_portable` 11/11 통과
- 실측: `runs` 0→1, SQL-ready 0.25초

> [!NOTE]
> `scripts/deploy-release.sh` 는 실제 배포 스크립트이므로 이 PR 검증 과정에서 **실행하지 않았다.** `tests/test_pg_tunnel.py` 는 `launchctl`/`psql` 을 완전히 stub 하고 가짜 도메인 `gui/999999` 를 쓰므로 실제 launchd 를 건드리지 않는다.
