### PR TITLE
fix(relay-watchdog): stop a replay floor from faking growth on a dead transcript (#5072)

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -3775,6 +3775,16 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         prior_size = guard[0] if guard is not None else previous_sizes.get(path)
         if prior_size is None or candidate.size <= prior_size:
             continue
+        observed_before = previous_sizes.get(path)
+        if observed_before is not None and candidate.size <= observed_before:
+            # Selection asks "which transcript is being written to *now*". A
+            # guard floor is a delivery watermark, not a growth observation:
+            # undelivered content parked above the floor must never make a
+            # transcript that has not changed since the last tick look like it
+            # is growing. Leaving this ungated pinned the selector to a
+            # worktree dead for days and held the I1 alert open against a
+            # healthy relay (#5072).
+            continue
         read_result = read_candidate(candidate)
         if (
             read_result.error is None

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -1844,14 +1844,11 @@ fn execute_streaming_local_tui_tmux(
     }
     crate::services::platform::tmux::set_option(tmux_session_name, "remain-on-exit", "on");
 
-    // #3087: stamp a per-spawn nonce on the Claude-TUI DIRECT spawn path too.
-    // Without it this path produces no `.spawn_nonce`, so the status-panel
-    // instance key is `None` and the new-session boundary cannot be detected.
-    if let Err(e) = crate::services::discord::write_spawn_nonce(tmux_session_name) {
-        debug_log(&format!(
-            "failed to write spawn nonce for {tmux_session_name} (claude-tui): {e}"
-        ));
-    }
+    // Stamp `.generation` + `.spawn_nonce` on the Claude-TUI DIRECT spawn path
+    // too. #3087 originally added only the nonce here, which left this path
+    // with no `.generation` at all — see `write_session_spawn_markers` for why
+    // that silently froze the durable relay frontier.
+    crate::services::discord::write_session_spawn_markers("claude-tui", tmux_session_name);
 
     let _ = sender.send(StreamMessage::Init {
         session_id: resolved_session_id.clone(),
@@ -2886,23 +2883,10 @@ fn execute_streaming_local_tmux(
     // Keep tmux session alive after process exits for post-mortem analysis
     crate::services::platform::tmux::set_option(tmux_session_name, "remain-on-exit", "on");
 
-    // Stamp generation marker so post-restart watcher restore can detect old sessions
-    let gen_marker_path =
-        crate::services::tmux_common::session_temp_path(tmux_session_name, "generation");
-    let current_gen = crate::services::discord::runtime_store::process_generation();
-    let _ = std::fs::write(&gen_marker_path, current_gen.to_string());
-
-    // #3087: stamp a per-spawn nonce in a SEPARATE marker. The status-panel
-    // session-instance key reads this nonce (unique per spawn) instead of the
-    // `.generation` mtime, so a missing/duplicate mtime can never collapse two
-    // distinct spawns into one instance key. Write errors are logged (not
-    // silently swallowed) since a missing nonce degrades the panel-reset
-    // boundary to best-effort.
-    if let Err(e) = crate::services::discord::write_spawn_nonce(tmux_session_name) {
-        debug_log(&format!(
-            "failed to write spawn nonce for {tmux_session_name}: {e}"
-        ));
-    }
+    // Stamp `.generation` (post-restart watcher restore detects old sessions by
+    // its content, wrapper identity by its mtime) + `.spawn_nonce` (status-panel
+    // instance key).
+    crate::services::discord::write_session_spawn_markers("claude-streaming", tmux_session_name);
 
     emit_fresh_session_watcher_handoff(&sender, output_path, input_fifo_path, tmux_session_name);
     log_producer_exit(

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -1903,12 +1903,10 @@ fn execute_streaming_local_tui_tmux(
 
     crate::services::platform::tmux::set_option(tmux_session_name, "remain-on-exit", "on");
 
-    // #3087: stamp a per-spawn nonce on the Codex-TUI DIRECT spawn path too.
-    // Without it this path produces no `.spawn_nonce`, so the status-panel
-    // instance key is `None` and the new-session boundary cannot be detected.
-    if let Err(e) = crate::services::discord::write_spawn_nonce(tmux_session_name) {
-        tracing::warn!("failed to write spawn nonce for {tmux_session_name} (codex-tui): {e}");
-    }
+    // Stamp `.generation` + `.spawn_nonce` on the Codex-TUI DIRECT spawn path
+    // too. #3087 originally added only the nonce here, leaving this path with no
+    // `.generation` — see `write_session_spawn_markers` for the frontier impact.
+    crate::services::discord::write_session_spawn_markers("codex-tui", tmux_session_name);
 
     wire_cancel_token_to_tmux_session(cancel_token.as_ref(), tmux_session_name);
 
@@ -2418,18 +2416,10 @@ fn execute_streaming_local_tmux(
     // Keep tmux session alive after process exits for post-mortem analysis
     crate::services::platform::tmux::set_option(tmux_session_name, "remain-on-exit", "on");
 
-    // Stamp generation marker so post-restart watcher restore can detect old sessions
-    let gen_marker_path =
-        crate::services::tmux_common::session_temp_path(tmux_session_name, "generation");
-    let current_gen = crate::services::discord::runtime_store::process_generation();
-    let _ = std::fs::write(&gen_marker_path, current_gen.to_string());
-
-    // #3087: stamp a per-spawn nonce in a SEPARATE marker (see claude.rs). The
-    // status-panel session-instance key reads this unique nonce instead of the
-    // `.generation` mtime, eliminating mtime missing/duplicate collisions.
-    if let Err(e) = crate::services::discord::write_spawn_nonce(tmux_session_name) {
-        tracing::warn!("failed to write spawn nonce for {tmux_session_name}: {e}");
-    }
+    // Stamp `.generation` (post-restart watcher restore detects old sessions by
+    // its content, wrapper identity by its mtime) + `.spawn_nonce` (status-panel
+    // instance key).
+    crate::services::discord::write_session_spawn_markers("codex-streaming", tmux_session_name);
 
     if let Some(ref token) = cancel_token {
         token.bind_unmanaged_session_name(tmux_session_name);

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -128,7 +128,7 @@ pub(crate) fn claim_cross_channel_tmux_watcher_for_high_risk_test(
 mod turn_completion_events;
 pub(in crate::services::discord) mod turn_end_wip_warning;
 #[cfg(unix)]
-pub(crate) use tmux::write_spawn_nonce;
+pub(crate) use tmux::write_session_spawn_markers;
 #[cfg(unix)]
 mod tmux_error_detect;
 #[cfg(unix)]

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -1428,15 +1428,16 @@ fn status_panel_resets_on_two_distinct_nonces_without_provider_id() {
     }
 }
 
-/// #3087 P2-2 — a TUI-direct spawn path (Claude-TUI / Codex-TUI) now stamps a
-/// `.spawn_nonce` via `write_spawn_nonce`, exactly like the main provider spawn
-/// sites. This drives the panel through the REAL filesystem chain those paths
-/// use at runtime: each TUI-direct spawn writes a fresh nonce, the panel derives
-/// its instance key from `session_panel_instance_key` (which reads that nonce),
-/// and a second TUI-direct spawn mints a DISTINCT nonce → distinct instance key
-/// → reset — even with no provider-session signal at all.
-// Exercises `write_spawn_nonce` / `session_panel_instance_key`, which live in
-// the unix-only `tmux` module (tmux/TUI-direct paths are unix-only).
+/// #3087 P2-2 — a TUI-direct spawn path (Claude-TUI / Codex-TUI) stamps its
+/// per-spawn markers through `write_session_spawn_markers`, the same funnel the
+/// main provider spawn sites use. This drives the panel through the REAL
+/// filesystem chain those paths use at runtime: each TUI-direct spawn writes a
+/// fresh nonce, the panel derives its instance key from
+/// `session_panel_instance_key` (which reads that nonce), and a second
+/// TUI-direct spawn mints a DISTINCT nonce → distinct instance key → reset —
+/// even with no provider-session signal at all.
+// Exercises `write_session_spawn_markers` / `session_panel_instance_key`, which
+// live in the unix-only `tmux` module (tmux/TUI-direct paths are unix-only).
 #[cfg(unix)]
 #[test]
 fn status_panel_resets_across_two_tui_direct_spawns_via_stamped_nonce() {
@@ -1466,9 +1467,9 @@ fn status_panel_resets_across_two_tui_direct_spawns_via_stamped_nonce() {
         std::fs::create_dir_all(parent).expect("runtime dir");
     }
 
-    // TUI-direct spawn #1 stamps a nonce (the exact call the Claude/Codex
+    // TUI-direct spawn #1 stamps its markers (the exact call the Claude/Codex
     // TUI-direct paths now make right after `create_session`).
-    crate::services::discord::write_spawn_nonce(&tmux_name).expect("tui spawn 1 nonce");
+    crate::services::discord::write_session_spawn_markers("claude-tui", &tmux_name);
     let key1 = crate::services::discord::tmux::session_panel_instance_key(&tmux_name)
         .expect("tui spawn 1 must produce an instance key");
     assert!(events.set_session_panel_lifecycle_event(
@@ -1486,7 +1487,7 @@ fn status_panel_resets_across_two_tui_direct_spawns_via_stamped_nonce() {
     );
 
     // TUI-direct spawn #2 (same tmux name) mints a DISTINCT nonce → distinct key.
-    crate::services::discord::write_spawn_nonce(&tmux_name).expect("tui spawn 2 nonce");
+    crate::services::discord::write_session_spawn_markers("claude-tui", &tmux_name);
     let key2 = crate::services::discord::tmux::session_panel_instance_key(&tmux_name)
         .expect("tui spawn 2 must produce an instance key");
     assert_ne!(

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -61,7 +61,7 @@ pub(super) use self::tmux_session_files::read_generation_file_mtime_ns;
 pub(in crate::services::discord) use self::tmux_session_files::reset_relay_watermark_on_generation_change;
 pub(in crate::services::discord) use self::tmux_session_files::reset_stale_relay_watermark_if_output_regressed;
 pub(super) use self::tmux_session_files::session_panel_instance_key;
-pub(crate) use self::tmux_session_files::write_spawn_nonce;
+pub(crate) use self::tmux_session_files::write_session_spawn_markers;
 use self::tmux_session_files::{
     preserve_mtime_after_write, reset_stale_local_relay_offset_if_output_regressed,
     sweep_orphan_session_files,

--- a/src/services/discord/tmux_session_files.rs
+++ b/src/services/discord/tmux_session_files.rs
@@ -9,17 +9,19 @@ use super::SharedData;
 /// migration window). All of those conditions are treated by callers as
 /// "fresh wrapper".
 ///
-/// `.generation` is written exactly once per spawn by `claude.rs` after
-/// `tmux::create_session` and never touched by the live wrapper, so its
+/// `.generation` is written exactly once per spawn by
+/// `write_session_spawn_markers` after `tmux::create_session` and never touched
+/// by the live wrapper, so its
 /// mtime uniquely identifies the wrapper instance even when jsonl
 /// rotation changes the jsonl inode (#1270). NOTE: this mtime signal is the
 /// #1270 wrapper-identity consumer ONLY. The status-panel session-instance
 /// key (#3087) no longer reads this mtime — it reads the dedicated
 /// `.spawn_nonce` marker content instead (see `session_panel_instance_key`).
 pub(in crate::services::discord) fn read_generation_file_mtime_ns(tmux_session_name: &str) -> i64 {
-    let Some(path) =
-        crate::services::tmux_common::resolve_session_temp_path(tmux_session_name, "generation")
-    else {
+    let Some(path) = crate::services::tmux_common::resolve_session_temp_path(
+        tmux_session_name,
+        GENERATION_SUFFIX,
+    ) else {
         return 0;
     };
     let Ok(meta) = std::fs::metadata(&path) else {
@@ -42,10 +44,15 @@ pub(in crate::services::discord) fn read_generation_file_mtime_ns(tmux_session_n
 /// own file so neither of those `.generation` consumers is perturbed.
 const SPAWN_NONCE_SUFFIX: &str = "spawn_nonce";
 
+/// The per-spawn marker-file suffix whose mtime is the #1270 wrapper-identity
+/// signal and whose CONTENT is the runtime generation number read by the
+/// adoption path (`watchers::lifecycle`).
+const GENERATION_SUFFIX: &str = "generation";
+
 /// Write a fresh, globally-unique per-spawn nonce to the `.spawn_nonce` marker.
 ///
-/// Called once at each provider spawn site (claude/codex/qwen) right after
-/// `tmux::create_session` stamps `.generation`. The nonce is the stability key
+/// Called once per spawn by `write_session_spawn_markers`, right after it
+/// stamps `.generation`. The nonce is the stability key
 /// the status panel uses to detect a genuine new-session boundary (#3087): it
 /// is guaranteed unique per spawn (a v4 UUID — no reliance on filesystem mtime
 /// resolution or `fsync` ordering), invariant across every status tick and
@@ -66,7 +73,7 @@ const SPAWN_NONCE_SUFFIX: &str = "spawn_nonce";
 /// than reading the PRIOR spawn's stale nonce (which would wrongly SUPPRESS the
 /// reset on a genuinely new session). "Absent → None key" is always preferred
 /// over "stale → colliding key".
-pub(crate) fn write_spawn_nonce(tmux_session_name: &str) -> std::io::Result<String> {
+fn write_spawn_nonce(tmux_session_name: &str) -> std::io::Result<String> {
     let nonce = uuid::Uuid::new_v4().simple().to_string();
     let path =
         crate::services::tmux_common::session_temp_path(tmux_session_name, SPAWN_NONCE_SUFFIX);
@@ -88,6 +95,50 @@ pub(crate) fn write_spawn_nonce(tmux_session_name: &str) -> std::io::Result<Stri
         return Err(e);
     }
     Ok(nonce)
+}
+
+/// Stamp BOTH per-spawn markers every provider spawn site owes the relay:
+/// `.generation` (runtime generation content + wrapper-identity mtime) and
+/// `.spawn_nonce` (status-panel instance key). Call this once per spawn right
+/// after `tmux::create_session`, on EVERY path — headless/streaming and
+/// TUI-direct alike.
+///
+/// This exists as one funnel because the pair used to be copy-pasted across
+/// five spawn sites, and #3087 only added `.spawn_nonce` to the two TUI-direct
+/// copies. Those two paths then produced NO `.generation` at all, which made
+/// `read_generation_file_mtime_ns` return 0 for the whole session and silently
+/// disabled the durable relay frontier: `advance_tmux_relay_confirmed_end`
+/// never paired an mtime with the offset, so
+/// `shadow_mirror_delivered_frontier_inner` refused every confirmed delivery
+/// ("lacks an authoritative JSONL incarnation/range") and the frontier never
+/// advanced — turns were delivered but never committed, and recovery redrive
+/// saw zero progress. One funnel means the next marker added here reaches all
+/// providers and both spawn shapes at once.
+///
+/// Both writes are best-effort but LOUD: a missing marker degrades relay
+/// durability rather than failing the spawn, so failures are logged with the
+/// spawn label instead of being swallowed by `let _ =`.
+pub(crate) fn write_session_spawn_markers(spawn_label: &str, tmux_session_name: &str) {
+    let generation_path =
+        crate::services::tmux_common::session_temp_path(tmux_session_name, GENERATION_SUFFIX);
+    let current_gen = crate::services::discord::runtime_store::process_generation();
+    if let Err(e) = std::fs::write(&generation_path, current_gen.to_string()) {
+        tracing::warn!(
+            spawn_label,
+            tmux_session_name,
+            path = %generation_path,
+            error = %e,
+            "failed to stamp .generation marker; durable relay frontier will not advance for this session"
+        );
+    }
+    if let Err(e) = write_spawn_nonce(tmux_session_name) {
+        tracing::warn!(
+            spawn_label,
+            tmux_session_name,
+            error = %e,
+            "failed to stamp .spawn_nonce marker; status-panel instance key degrades to None"
+        );
+    }
 }
 
 /// Read the per-spawn nonce from the `.spawn_nonce` marker CONTENT. Returns
@@ -575,5 +626,46 @@ mod tests {
         );
         // No committed delivery yet (offset 0) → None even if generations match.
         assert_eq!(committed_frontier_for_same_generation(0, 42, 42), None);
+    }
+
+    /// Every spawn path must leave `read_generation_file_mtime_ns` non-zero.
+    ///
+    /// Regression guard for the TUI-direct frontier freeze: those spawn sites
+    /// stamped only `.spawn_nonce`, so `read_generation_file_mtime_ns` returned
+    /// 0 for the session's whole lifetime. A 0 mtime makes
+    /// `advance_tmux_relay_confirmed_end` skip pairing the mtime with the
+    /// offset, which makes `shadow_mirror_delivered_frontier_inner` reject every
+    /// confirmed delivery — turns are delivered but the durable frontier never
+    /// advances. Asserting the funnel's post-condition catches a regression at
+    /// the marker layer instead of at a lost user response.
+    #[cfg(unix)]
+    #[test]
+    fn spawn_markers_make_generation_mtime_readable() {
+        let _lock = match crate::config::shared_test_env_lock().lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", tmp.path()) };
+
+        let tmux_name = format!("AgentDesk-claude-tui-spawn-markers-{}", std::process::id());
+        assert_eq!(
+            read_generation_file_mtime_ns(&tmux_name),
+            0,
+            "no marker stamped yet → the wrapper-identity mtime must be unknown"
+        );
+
+        write_session_spawn_markers("test-tui", &tmux_name);
+
+        assert_ne!(
+            read_generation_file_mtime_ns(&tmux_name),
+            0,
+            "a stamped spawn must expose a non-zero .generation mtime, or the \
+             durable relay frontier can never advance for the session"
+        );
+        assert!(
+            read_spawn_nonce(&tmux_name).is_some(),
+            "the same funnel must also stamp the status-panel instance nonce"
+        );
     }
 }

--- a/src/services/qwen.rs
+++ b/src/services/qwen.rs
@@ -1384,17 +1384,10 @@ fn execute_streaming_local_tmux(
 
     crate::services::platform::tmux::set_option(tmux_session_name, "remain-on-exit", "on");
 
-    let gen_marker_path =
-        crate::services::tmux_common::session_temp_path(tmux_session_name, "generation");
-    let current_gen = crate::services::discord::runtime_store::process_generation();
-    let _ = std::fs::write(&gen_marker_path, current_gen.to_string());
-
-    // #3087: stamp a per-spawn nonce in a SEPARATE marker (see claude.rs). The
-    // status-panel session-instance key reads this unique nonce instead of the
-    // `.generation` mtime, eliminating mtime missing/duplicate collisions.
-    if let Err(e) = crate::services::discord::write_spawn_nonce(tmux_session_name) {
-        tracing::warn!("failed to write spawn nonce for {tmux_session_name}: {e}");
-    }
+    // Stamp `.generation` (post-restart watcher restore detects old sessions by
+    // its content, wrapper identity by its mtime) + `.spawn_nonce` (status-panel
+    // instance key).
+    crate::services::discord::write_session_spawn_markers("qwen", tmux_session_name);
 
     if let Some(ref token) = cancel_token {
         token.bind_unmanaged_session_name(tmux_session_name);

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -2525,6 +2525,91 @@ class TickChannelTests(unittest.TestCase):
             )
         )
 
+    def test_unchanged_transcript_above_replay_floor_is_not_growth(self):
+        # Live #5072 recurrence: a dead transcript whose replay floor sits below
+        # its own semantic end re-reported "growth" on every tick, pinning the
+        # selector to a worktree that had not been written to in days and
+        # holding the I1 selector-sync alert open against a healthy relay.
+        dead = self.proj_dir / "dead.jsonl"
+        live_dir = self.projects / (
+            "-Users-alice--adk-release-worktrees-claude-adk-cc-20260710-140500"
+        )
+        live_dir.mkdir()
+        live = live_dir / "live.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        # The trailing block is undelivered, so the gap-recovery re-arm at the
+        # end of the tick is refused (fresh_undelivered > 0) — the production
+        # shape in which the floor never advances on its own.
+        dead.write_text(
+            "".join(
+                record(self.now - 5000 - index, f"dead block {index}") + "\n"
+                for index in range(7)
+            )
+            + record(self.now - 200, "dead block 7") + "\n",
+            encoding="utf-8",
+        )
+        live.write_text(record(self.now - 30, "live block landed") + "\n", "utf-8")
+        os.utime(dead, (self.now - 4000, self.now - 4000))
+        os.utime(live, (self.now, self.now))
+
+        dead_size = dead.stat().st_size
+        rt = self.make_rt()
+        rt.haystack = norm(
+            " ".join(f"dead block {index}" for index in range(7))
+            + " live block landed"
+        )
+        # Guard armed at a recovery point below the transcript's semantic end:
+        # exactly the production shape (floor 4025250 vs file 4070983).
+        state: dict = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(dead),
+                relay_watchdog.TRANSCRIPT_SIZES_KEY: {str(dead): dead_size},
+                relay_watchdog.RECOVERED_GAP_GUARDS_KEY: {
+                    str(dead): {
+                        "size": dead_size - 100,
+                        "confirmed_at": self.now - 4500,
+                        "last_seen_at": self.now - 10,
+                        "absent_since": None,
+                    }
+                },
+            }
+        }
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertFalse(
+            any(
+                f"transcript-select reason=growth path={dead}" in line
+                for line in rt.log_lines
+            ),
+            "an unchanged transcript must not report growth off its replay floor",
+        )
+
+        rt.log_lines.clear()
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        self.assertFalse(
+            any(
+                f"transcript-select reason=growth path={dead}" in line
+                for line in rt.log_lines
+            ),
+            "the false growth signal must not return on later ticks either",
+        )
+        self.assertEqual(
+            state["999"][relay_watchdog.RECOVERED_GAP_GUARDS_KEY][str(dead)]["size"],
+            dead_size - 100,
+            "the replay floor must stay below the undelivered block (#4435)",
+        )
+
     def test_timestamped_assistant_growth_can_switch_selection(self):
         prior = self.proj_dir / "prior.jsonl"
         current_dir = self.projects / (


### PR DESCRIPTION
## 문제

트랜스크립트 선택(selector)의 성장 판정이 prior size를 `recovered_gap_replay_guards`(복구 replay floor)에서 가져왔다. 그 floor는 **배달 워터마크이지 성장 관측치가 아니다.** floor 위에 미배달 블록이 한 번 쌓이면 매 틱마다 파일을 다시 읽어 floor를 넘는 semantic 내용을 발견하고 `transcript-select reason=growth`를 보고한다. floor는 #4435 불변식상 전진할 수 없으므로 이 신호는 영구히 반복된다.

## 실측 (channel 1479671298497183835)

- `recovered_gap_replay_guards[...].size = 4025250`, 실제 파일 크기 `4070983` — 45,733 bytes 고정 격차
- 해당 트랜스크립트(`...20260731-220205/8cf48ae8...`)는 2026-08-01 09:56 이후 미변경 — 5일간 죽은 워크트리
- 그럼에도 2분마다 `transcript-select reason=growth`

결과: selector가 죽은 워크트리에 고정되고 dcserver가 바인딩한 live 트랜스크립트와 어긋나, **I1 셀렉터 동기화 알림과 #5072 gap 인시던트가 5일째(gap_min=6984) 열린 채 유지**되었다. 정작 릴레이 자체는 무손실이었다 — `frames_received: 100, frames_delivered: 100, dropped_frames: 0, sink_errors: 0`.

## 수정

growth 신호를 "직전 틱 대비 파일이 실제로 커졌는가"로 게이팅한다. floor 자체는 건드리지 않으므로 **#4435 불변식(replay floor는 미배달 내용을 넘어 전진하지 않는다)은 그대로 유지**된다.

초기 시도는 semantic growth 분기에서 floor를 전진시키는 방향이었으나, 기존 `test_invariant_4435_simultaneous_guard_growth_checks_every_growing_path`가 이를 잡아냈다. 그 불변식이 옳으므로 게이팅 방식으로 전환했다.

## 검증

- 회귀 테스트 `test_unchanged_transcript_above_replay_floor_is_not_growth` 추가 — 프로덕션 형태 재현(floor가 파일 semantic end보다 아래 + 미배달 블록이 그 위에 있어 gap 복구 re-arm이 거부되는 상태)
- 수정을 stash하면 FAIL, 복원하면 PASS 확인 (가짜 통과 아님)
- `python3 -m unittest tests.test_relay_watchdog` → 279/279 OK
- `scripts/ci-script-checks.sh` 관련 구간 통과

## 범위 밖 (별건)

`ci-script-checks.sh`의 lib inventory pin이 **clean HEAD에서도 이미 실패**한다 (`count=7475` vs `pinned-count=7474`, delta=+1). 직전 커밋 `88b4016d9`가 테스트를 추가하고 pin을 갱신하지 않은 것으로, 본 변경과 무관함을 stash 후 재실행으로 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)