### PR TITLE
fix(relay-watchdog): stop a replay floor from faking growth on a dead transcript (#5072)

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -3775,6 +3775,16 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         prior_size = guard[0] if guard is not None else previous_sizes.get(path)
         if prior_size is None or candidate.size <= prior_size:
             continue
+        observed_before = previous_sizes.get(path)
+        if observed_before is not None and candidate.size <= observed_before:
+            # Selection asks "which transcript is being written to *now*". A
+            # guard floor is a delivery watermark, not a growth observation:
+            # undelivered content parked above the floor must never make a
+            # transcript that has not changed since the last tick look like it
+            # is growing. Leaving this ungated pinned the selector to a
+            # worktree dead for days and held the I1 alert open against a
+            # healthy relay (#5072).
+            continue
         read_result = read_candidate(candidate)
         if (
             read_result.error is None

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -2525,6 +2525,91 @@ class TickChannelTests(unittest.TestCase):
             )
         )
 
+    def test_unchanged_transcript_above_replay_floor_is_not_growth(self):
+        # Live #5072 recurrence: a dead transcript whose replay floor sits below
+        # its own semantic end re-reported "growth" on every tick, pinning the
+        # selector to a worktree that had not been written to in days and
+        # holding the I1 selector-sync alert open against a healthy relay.
+        dead = self.proj_dir / "dead.jsonl"
+        live_dir = self.projects / (
+            "-Users-alice--adk-release-worktrees-claude-adk-cc-20260710-140500"
+        )
+        live_dir.mkdir()
+        live = live_dir / "live.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        # The trailing block is undelivered, so the gap-recovery re-arm at the
+        # end of the tick is refused (fresh_undelivered > 0) — the production
+        # shape in which the floor never advances on its own.
+        dead.write_text(
+            "".join(
+                record(self.now - 5000 - index, f"dead block {index}") + "\n"
+                for index in range(7)
+            )
+            + record(self.now - 200, "dead block 7") + "\n",
+            encoding="utf-8",
+        )
+        live.write_text(record(self.now - 30, "live block landed") + "\n", "utf-8")
+        os.utime(dead, (self.now - 4000, self.now - 4000))
+        os.utime(live, (self.now, self.now))
+
+        dead_size = dead.stat().st_size
+        rt = self.make_rt()
+        rt.haystack = norm(
+            " ".join(f"dead block {index}" for index in range(7))
+            + " live block landed"
+        )
+        # Guard armed at a recovery point below the transcript's semantic end:
+        # exactly the production shape (floor 4025250 vs file 4070983).
+        state: dict = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(dead),
+                relay_watchdog.TRANSCRIPT_SIZES_KEY: {str(dead): dead_size},
+                relay_watchdog.RECOVERED_GAP_GUARDS_KEY: {
+                    str(dead): {
+                        "size": dead_size - 100,
+                        "confirmed_at": self.now - 4500,
+                        "last_seen_at": self.now - 10,
+                        "absent_since": None,
+                    }
+                },
+            }
+        }
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertFalse(
+            any(
+                f"transcript-select reason=growth path={dead}" in line
+                for line in rt.log_lines
+            ),
+            "an unchanged transcript must not report growth off its replay floor",
+        )
+
+        rt.log_lines.clear()
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        self.assertFalse(
+            any(
+                f"transcript-select reason=growth path={dead}" in line
+                for line in rt.log_lines
+            ),
+            "the false growth signal must not return on later ticks either",
+        )
+        self.assertEqual(
+            state["999"][relay_watchdog.RECOVERED_GAP_GUARDS_KEY][str(dead)]["size"],
+            dead_size - 100,
+            "the replay floor must stay below the undelivered block (#4435)",
+        )
+
     def test_timestamped_assistant_growth_can_switch_selection(self):
         prior = self.proj_dir / "prior.jsonl"
         current_dir = self.projects / (


### PR DESCRIPTION
## 문제

트랜스크립트 선택(selector)의 성장 판정이 prior size를 `recovered_gap_replay_guards`(복구 replay floor)에서 가져왔다. 그 floor는 **배달 워터마크이지 성장 관측치가 아니다.** floor 위에 미배달 블록이 한 번 쌓이면 매 틱마다 파일을 다시 읽어 floor를 넘는 semantic 내용을 발견하고 `transcript-select reason=growth`를 보고한다. floor는 #4435 불변식상 전진할 수 없으므로 이 신호는 영구히 반복된다.

## 실측 (channel 1479671298497183835)

- `recovered_gap_replay_guards[...].size = 4025250`, 실제 파일 크기 `4070983` — 45,733 bytes 고정 격차
- 해당 트랜스크립트(`...20260731-220205/8cf48ae8...`)는 2026-08-01 09:56 이후 미변경 — 5일간 죽은 워크트리
- 그럼에도 2분마다 `transcript-select reason=growth`

결과: selector가 죽은 워크트리에 고정되고 dcserver가 바인딩한 live 트랜스크립트와 어긋나, **I1 셀렉터 동기화 알림과 #5072 gap 인시던트가 5일째(gap_min=6984) 열린 채 유지**되었다. 정작 릴레이 자체는 무손실이었다 — `frames_received: 100, frames_delivered: 100, dropped_frames: 0, sink_errors: 0`.

## 수정

growth 신호를 "직전 틱 대비 파일이 실제로 커졌는가"로 게이팅한다. floor 자체는 건드리지 않으므로 **#4435 불변식(replay floor는 미배달 내용을 넘어 전진하지 않는다)은 그대로 유지**된다.

초기 시도는 semantic growth 분기에서 floor를 전진시키는 방향이었으나, 기존 `test_invariant_4435_simultaneous_guard_growth_checks_every_growing_path`가 이를 잡아냈다. 그 불변식이 옳으므로 게이팅 방식으로 전환했다.

## 검증

- 회귀 테스트 `test_unchanged_transcript_above_replay_floor_is_not_growth` 추가 — 프로덕션 형태 재현(floor가 파일 semantic end보다 아래 + 미배달 블록이 그 위에 있어 gap 복구 re-arm이 거부되는 상태)
- 수정을 stash하면 FAIL, 복원하면 PASS 확인 (가짜 통과 아님)
- `python3 -m unittest tests.test_relay_watchdog` → 279/279 OK
- `scripts/ci-script-checks.sh` 관련 구간 통과

## 범위 밖 (별건)

`ci-script-checks.sh`의 lib inventory pin이 **clean HEAD에서도 이미 실패**한다 (`count=7475` vs `pinned-count=7474`, delta=+1). 직전 커밋 `88b4016d9`가 테스트를 추가하고 pin을 갱신하지 않은 것으로, 본 변경과 무관함을 stash 후 재실행으로 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
