### PR TITLE
fix(gate): state the delivery-journal gate's real lexical scope

### DIFF
--- a/scripts/check_delivery_journal_raw_writer.py
+++ b/scripts/check_delivery_journal_raw_writer.py
@@ -26,7 +26,9 @@ FAMILY_REGISTRY = (
     ("pipe stream epoch", "src/services/discord/tmux_watcher/turn_stream_collector.rs", "collect_turn_stream_until_terminal"),
 )
 # Cheap lexical text match, not Rust parsing: each complete anchor file, including
-# tests, is scanned with only the suffix after // on that line removed.
+# tests, is scanned with only the suffix after // on that line removed. The scan
+# deliberately stays file-wide: lexical brace balancing cannot honestly bound a
+# Rust fn body when strings and macros may contain braces.
 # Strings, block comments (/* */ and /** */), raw strings, macros, and test-area
 # text count; line comments (including /// and //! doc comments) do not. The
 # result is a monotonic baseline signal, not proof of instrumentation.
@@ -96,7 +98,7 @@ def check(root: Path) -> tuple[bool, str]:
     if found != ALLOWLIST:
         return False, f"raw writer allowlist mismatch: expected={dict(ALLOWLIST)} actual={dict(found)} (scanned Rust files: {scanned_files})"
     uninstrumented = [name for name, instrumented in families if not instrumented]
-    summary = f"uninstrumented families: {len(uninstrumented)}/{len(families)} (lexical baseline signal; whole anchor file; only // suffix excluded; not proof; {', '.join(uninstrumented) or 'none'})"
+    summary = f"uninstrumented families: {len(uninstrumented)}/{len(families)} (lexical baseline signal; whole anchor file including tests; only // suffix excluded; not proof; {', '.join(uninstrumented) or 'none'})"
     if len(uninstrumented) > UNINSTRUMENTED_FAMILY_BASELINE:
         return False, f"{summary}; exceeds baseline {UNINSTRUMENTED_FAMILY_BASELINE}: {', '.join(uninstrumented)}"
     if len(uninstrumented) < UNINSTRUMENTED_FAMILY_BASELINE:

--- a/tests/test_delivery_journal_raw_writer.py
+++ b/tests/test_delivery_journal_raw_writer.py
@@ -104,10 +104,22 @@ class RawWriterAllowlistTests(unittest.TestCase):
         self.assertEqual(error, "")
         self.assertTrue(status[4][1], "raw-string marker intentionally pierces lexical scan")
 
+    def test_macro_facade_marker_is_known_lexical_match(self):
+        """Pin the declared behavior: facade-call text in a macro counts."""
+        root = self.fixture()
+        path = root / guard.FAMILY_REGISTRY[4][1]
+        path.write_text(path.read_text(encoding="utf-8") +
+                        "macro_rules! journal_probe { () => { self.journal.begin_fresh(); } }\n",
+                        encoding="utf-8")
+        status, error = guard.family_status(root)
+        self.assertEqual(error, "")
+        self.assertTrue(status[4][1], "macro facade-call text is a declared lexical match")
+
     def test_family_baseline_is_measured_and_named(self):
         ok, message = guard.check(self.fixture())
         self.assertTrue(ok, message)
         self.assertIn("uninstrumented families: 4/6", message)
+        self.assertIn("whole anchor file including tests", message)
         self.assertIn("watcher terminal family", message)
 
     def test_instrumentation_rule_is_mechanical(self):


### PR DESCRIPTION
EPIC #5071 slice **S1b**.

Refs #5140
Refs #5071

## What this changes

The delivery-journal gate decides "is this delivery family instrumented?" by lexically
scanning the **whole anchor file, including tests** — not the anchor `fn` body. That means
`uninstrumented families: 0/6` would **not** mean "every delivery path is instrumented",
and the S6 completion verdict could go false-green on it.

Bounding a Rust `fn` body lexically is not honest (strings and macros contain braces), so
per the issue's own acceptance criterion this takes the **documentation path**:

- states the real scope in the gate's summary output (`whole anchor file including tests`),
  so the emitted line can no longer be read as a proof of instrumentation;
- pins the previously-undeclared **macro** behavior with a test (facade-call text inside a
  `macro_rules!` block counts as a lexical match);
- asserts the new scope wording in the baseline test so the honesty statement is itself gated;
- restates the §Q4/§Q6 completion-window condition honestly.

`UNINSTRUMENTED_FAMILY_BASELINE` is **not** changed by this branch (it is `4`, from merged
#5157). No test is weakened or deleted.

### Why no design-doc file is in this diff
The §Q4/§Q6 restatement was applied to the campaign's canonical design doc, which lives
**outside** the repo (`scratchpad/` is git-excluded). That is intentional — a design-doc
file must **not** be added here.

## Verification (already run on this exact tree)

- **Adversarially counter-reviewed** at `aeceb70e7` → `VERDICT: CLEAN`, P0/P1 = 0. The
  reviewer independently ran mutation probes and showed the new macro test is
  **non-vacuous**: narrowing the scan to exclude `macro_rules!` lines makes the `assertTrue`
  fail. The two-way ratchet was re-proved.
- **Rebase preserved the reviewed patch exactly**: the `+`/`-` line sets before and after the
  rebase differ by **0 lines**. The single conflict (in `tests/test_delivery_journal_raw_writer.py`)
  was resolved by taking main's context (`4/6`, `watcher terminal family`,
  `UNINSTRUMENTED_FAMILY_BASELINE = 4` from #5157) and keeping this branch's one added
  assertion unchanged in place. The baseline value was not altered. The CLEAN verdict is
  therefore inherited.
- `python3 scripts/check_delivery_journal_raw_writer.py` → rc=0
  `OK: … uninstrumented families: 4/6 (lexical baseline signal; whole anchor file including tests; only // suffix excluded; not proof; …); scanned Rust files: 1315`
- `python3 -m unittest tests.test_delivery_journal_raw_writer` → rc=0, `Ran 21 tests` / `OK`
- Two-way ratchet re-proved on the new base: baseline+1 → rc=1 with the re-pin command
  printed; baseline-1 → rc=1 naming the families.
- `git status --porcelain` clean; `git ls-files scratchpad/` and `git ls-files .brief/` both empty.

Note: #5071 is the EPIC and must stay **open** — `Refs`, not a closing keyword. #5140 will be
closed manually after merge.
