### PR TITLE
fix(deploy): judge the relay watchdog on its PID, not on bootstrap rc (#5153)

### DIFF
--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -3241,22 +3241,40 @@ PLIST_EOF
                 fi
                 rm -f "$WATCHDOG_PLIST_BEFORE" 2>/dev/null || true
                 xattr -d com.apple.quarantine "$WATCHDOG_PLIST_PATH" 2>/dev/null || true
-                _wd_loaded=0
-                if launchctl print "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" >/dev/null 2>&1; then
-                    _wd_loaded=1
+                # #5153: neither `launchctl print` nor a `bootstrap` return code
+                # proves a SPAWN — they prove the job is LOADED. A 2026-08-06
+                # deploy printed "✓ Relay watchdog armed" while `launchctl list`
+                # showed the PID column as '-' and `pgrep` found nothing: relay
+                # gap monitoring was absent and the deploy still reported success.
+                # Judge on the PID column instead. This helper is read-only — it
+                # only queries launchd and never bootouts/bootstraps, so it cannot
+                # perturb the unload sequence below (the #5152 lesson).
+                _wd_spawned_pid() {
+                    local pid=""
+                    pid=$(launchctl list 2>/dev/null \
+                      | awk -v label="$WATCHDOG_LABEL" '$3 == label { print $1; exit }') \
+                      || pid=""
+                    # The PID column is '-' when the job is loaded but not running.
+                    case "$pid" in
+                        ''|*[!0-9]*) return 1 ;;
+                    esac
+                    printf '%s' "$pid"
+                }
+                _wd_running=0
+                if _wd_spawned_pid >/dev/null; then
+                    _wd_running=1
                 fi
                 if [ "$WATCHDOG_SCRIPT_CHANGED" = "0" ] \
                   && [ "$WATCHDOG_PLIST_CHANGED" = "0" ] \
-                  && [ "$_wd_loaded" = "1" ]; then
+                  && [ "$_wd_running" = "1" ]; then
                     echo "✓ Relay watchdog retained ($WATCHDOG_LABEL; durable authority uninterrupted)"
                 else
                     # Restart only when deployment material changed or the job is absent.
                     # The watermark lives in the atomic state file, so replacement loads
                     # the same pre-restart transcript authority before its first tick.
                     # NOTE: This block implements the same bootout/poll/bootstrap pattern as
-                    # the PG tunnel sites. Currently runs=2 (healthy), i.e. measured as not
-                    # requiring an explicit kickstart (unlike PG tunnel #5151). Scope: excluded
-                    # from this PR; unification is a follow-up gated on measurement (#5151).
+                    # the PG tunnel sites, and since #5153 the same explicit kickstart and
+                    # spawn verification (#5151 mis-spawn reproduced here on 2026-08-06).
                     launchctl bootout "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" 2>/dev/null || true
                     _wd_bootout_polls=0
                     while launchctl print "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" >/dev/null 2>&1; do
@@ -3279,7 +3297,35 @@ PLIST_EOF
                         fi
                     done
                     if [ "$_wd_armed" = "1" ]; then
-                        echo "✓ Relay watchdog armed ($WATCHDOG_LABEL)"
+                        # #5151/#5153: bootstrap loads the plist but does not guarantee
+                        # that launchd spawns the process. Mirror the PG tunnel fix
+                        # (#5152) with an explicit kickstart, placed after the single
+                        # bootout above — a second bootout here would change that
+                        # unload sequence's meaning (the regression #5152 hit).
+                        # kickstart's own rc is NOT the verdict; the PID column is.
+                        launchctl kickstart -k "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" >/dev/null 2>&1 || true
+                        _wd_pid=""
+                        _wd_spawn_polls=0
+                        while :; do
+                            if _wd_pid=$(_wd_spawned_pid); then
+                                break
+                            fi
+                            _wd_pid=""
+                            # Same 12 x 0.5s budget as the bootout poll above.
+                            if [ "$_wd_spawn_polls" -ge 12 ]; then
+                                break
+                            fi
+                            sleep 0.5
+                            _wd_spawn_polls=$((_wd_spawn_polls + 1))
+                        done
+                        if [ -n "$_wd_pid" ]; then
+                            echo "✓ Relay watchdog armed ($WATCHDOG_LABEL; pid $_wd_pid)"
+                        else
+                            # Fail-open per this block's INVARIANT (we are past DEPLOY_OK),
+                            # but never green: withholding the ✓ is the whole point of #5153.
+                            echo "⚠ Relay watchdog bootstrapped but NOT spawned (launchctl list PID column is '-') — relay gaps will go unwatched"
+                            echo "  Recover: launchctl kickstart -k $LAUNCHD_DOMAIN/$WATCHDOG_LABEL"
+                        fi
                     else
                         echo "⚠ Relay watchdog bootstrap FAILED after 3 attempts — relay gaps will go unwatched"
                     fi

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -7340,9 +7340,29 @@ class DeploymentWiringTests(unittest.TestCase):
         )
         return "\n".join(lines[start : end + 2])
 
-    def _run_block(self, block: str, adk_rel: Path, home: Path):
+    def _run_block(
+        self,
+        block: str,
+        adk_rel: Path,
+        home: Path,
+        *,
+        fake_bin: Path | None = None,
+        spawns: bool = True,
+    ):
         import shlex
 
+        # Default (fake_bin=None) keeps the original contract: no fake on PATH,
+        # so the real launchctl is asked about a nonexistent domain.
+        fake_env = ""
+        if fake_bin is not None:
+            fake_env = (
+                f"PATH={shlex.quote(str(fake_bin))}:$PATH\n"
+                f"EVENT_LOG={shlex.quote(str(home / 'events.log'))}\n"
+                f"WD_LOADED={shlex.quote(str(home / 'wd.loaded'))}\n"
+                f"WD_PID={shlex.quote(str(home / 'wd.pid'))}\n"
+                f"WD_SPAWNS={int(spawns)}\n"
+                "export PATH EVENT_LOG WD_LOADED WD_PID WD_SPAWNS\n"
+            )
         script = (
             "set -euo pipefail\n"
             f"REPO={shlex.quote(str(REPO_ROOT))}\n"
@@ -7350,11 +7370,117 @@ class DeploymentWiringTests(unittest.TestCase):
             f"HOME={shlex.quote(str(home))}\n"
             # Nonexistent domain: bootstrap must fail (fail-open ⚠ path) rather
             # than loading a test plist into the developer's real launchd.
-            "LAUNCHD_DOMAIN=gui/999999\n" + block + "\necho HARNESS-END\n"
+            "LAUNCHD_DOMAIN=gui/999999\n" + fake_env + block + "\necho HARNESS-END\n"
         )
         return subprocess.run(
             ["bash", "-c", script], capture_output=True, text=True, timeout=60
         )
+
+    @staticmethod
+    def _fake_launchctl_bin(root: Path) -> Path:
+        """Fake launchd shaped after the fake-launchctl harness in
+        tests/test_pg_tunnel.py.
+
+        It reproduces the #5153 defect exactly: `bootstrap` returns 0 and
+        `print` reports the job as loaded, yet `launchctl list` shows '-' in the
+        PID column because nothing was spawned. WD_SPAWNS=1 makes `kickstart`
+        the thing that actually produces a PID — which is what the 2026-08-06
+        manual recovery observed on the live node.
+        """
+        fake_bin = root / "fake-bin"
+        fake_bin.mkdir(parents=True, exist_ok=True)
+        (fake_bin / "launchctl").write_text(
+            """#!/bin/sh
+printf 'launchctl %s\\n' "$*" >> "$EVENT_LOG"
+case "$1" in
+  print) [ -f "$WD_LOADED" ] && exit 0; exit 1 ;;
+  bootout) rm -f "$WD_LOADED" "$WD_PID"; exit 0 ;;
+  bootstrap) : > "$WD_LOADED"; exit 0 ;;
+  kickstart)
+    [ "${WD_SPAWNS:-0}" != 1 ] || printf '4242\\n' > "$WD_PID"
+    exit 0 ;;
+  list)
+    if [ -f "$WD_LOADED" ]; then
+      pid='-'
+      [ ! -f "$WD_PID" ] || IFS= read -r pid < "$WD_PID"
+      printf '%s\\t0\\tcom.agentdesk.relay-watchdog\\n' "$pid"
+    fi
+    exit 0 ;;
+esac
+exit 0
+""",
+            encoding="utf-8",
+        )
+        (fake_bin / "sleep").write_text(
+            "#!/bin/sh\nexec /bin/sleep 0.01\n", encoding="utf-8"
+        )
+        for name in ("launchctl", "sleep"):
+            (fake_bin / name).chmod(0o755)
+        return fake_bin
+
+    @staticmethod
+    def _watchdog_fixture(root: Path) -> tuple[Path, Path]:
+        adk = root / "adk"
+        for sub in ("bin", "config", "logs"):
+            (adk / sub).mkdir(parents=True)
+        (adk / "config" / "relay-watchdog.json").write_text("{}", encoding="utf-8")
+        home = root / "home"
+        (home / "Library").mkdir(parents=True)
+        return adk, home
+
+    # #5153: the deploy printed "✓ Relay watchdog armed" off the bootstrap
+    # return code while `launchctl list` showed '-' and relay gap monitoring was
+    # gone for about two minutes. The ✓ must follow the PID, not the rc.
+    def test_bootstrap_without_spawn_never_prints_armed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk, home = self._watchdog_fixture(Path(tmp))
+            fake_bin = self._fake_launchctl_bin(Path(tmp))
+            p = self._run_block(
+                self._watchdog_block(), adk, home, fake_bin=fake_bin, spawns=False
+            )
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("HARNESS-END", p.stdout, "fail-open must reach the end")
+            events = (home / "events.log").read_text(encoding="utf-8")
+            self.assertIn(
+                "launchctl kickstart -k gui/999999/com.agentdesk.relay-watchdog",
+                events,
+                "bootstrap must be followed by an explicit kickstart (#5152 shape)",
+            )
+            self.assertNotIn(
+                "✓ Relay watchdog armed",
+                p.stdout,
+                "a loaded-but-unspawned watchdog must never be reported armed",
+            )
+            self.assertIn("NOT spawned", p.stdout)
+
+    def test_spawned_watchdog_is_reported_armed_with_its_pid(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk, home = self._watchdog_fixture(Path(tmp))
+            fake_bin = self._fake_launchctl_bin(Path(tmp))
+            p = self._run_block(
+                self._watchdog_block(), adk, home, fake_bin=fake_bin, spawns=True
+            )
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("HARNESS-END", p.stdout, "fail-open must reach the end")
+            self.assertIn("✓ Relay watchdog armed", p.stdout)
+            self.assertIn("pid 4242", p.stdout)
+            self.assertNotIn("NOT spawned", p.stdout)
+
+    def test_retained_fast_path_requires_a_running_pid_not_just_a_loaded_job(self):
+        """`launchctl print` rc proves loaded, not running — same #5153 defect on
+        the sibling branch. An unspawned job must fall through to the restart
+        path instead of being silently retained."""
+        deploy = (REPO_ROOT / "scripts" / "deploy-release.sh").read_text(
+            encoding="utf-8"
+        )
+        block = deploy[deploy.index('WATCHDOG_LABEL="com.agentdesk.relay-watchdog"') :]
+        retained = block.index("durable authority uninterrupted")
+        self.assertNotIn(
+            'if launchctl print "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" >/dev/null 2>&1; then',
+            block[:retained],
+            "the retained fast path must judge on the PID column, not on print rc",
+        )
+        self.assertIn("_wd_spawned_pid", block[:retained])
 
     # r4 review (PR #4399): plist values were raw-interpolated into the XML
     # heredoc, so an operator path containing &, <, or > produced an invalid


### PR DESCRIPTION
Closes #5153

## What this fixes

`scripts/deploy-release.sh` judged the relay watchdog on the return code of `launchctl bootstrap`. **bootstrap only loads the job — it does not guarantee a spawn.** The consequence was reproduced in production: the deploy printed `✓ Relay watchdog armed` while `launchctl list` showed the PID column as `-` and no process existed. Relay gap monitoring was absent for roughly 2 minutes and the deploy still reported success.

The fix:

- Adds a **read-only** helper `_wd_spawned_pid()` that reads the PID column out of `launchctl list` and judges on a **real PID**. It only queries launchd — it never bootouts or bootstraps, so it cannot perturb the unload sequence (the #5152 lesson).
- Inlines `launchctl kickstart -k` after the existing single `bootout`/`bootstrap`, mirroring the PG tunnel fix. kickstart's own rc is *not* the verdict.
- Polls for the PID 12 × 0.5s and prints `✓ ... pid N` **only** when a real PID is present. Otherwise it emits an explicit `⚠ ... bootstrapped but NOT spawned` warning plus a recovery command — fail-open (we are past `DEPLOY_OK`) but never falsely green.
- Closes an unenumerated sibling defect in the same block: the *retained* fast path used the rc of `launchctl print` as evidence of "running". `print` also only proves *loaded*; it now uses the same PID-based predicate.

Scope: 2 files, +182/−10 (`scripts/deploy-release.sh`, `tests/test_relay_watchdog.py`).

## Review status

Opus fresh-session adversarial counter-review, 1 leg — **VERDICT: CLEAN** (0 P0, 0 P1).

**Why 1 leg was sufficient:** the diff is narrow (2 files, ±192 lines) and single-concern, and it does not touch hot files, the relay-state contract, migrations, delivery authority, or live turns. Additionally, GPT quota was 92% consumed (reset 08-08 13:02), so the remaining GPT leg is preserved for the relay authority lane (#5154, T1 S3). The review leg performed every execution lens directly.

**Closed by execution:**
- `tests/test_pg_tunnel.py` 55/55. `bootout` call count is 5 on both base and HEAD — counted directly, because this path has a scar from a past regression.
- `tests/test_relay_watchdog.py` 282/282.
- All 3 new tests fail with rc=1 on `origin/main`, i.e. the defect is reproduced.
- Mutations were first proven not to be syntax deaths (`bash -n` rc=0), then failed against their own assertions.
- 0 deleted or weakened assertions.

**Measured without touching any live job** (one-shot throwaway launchd jobs):
- bootstrapping an already-loaded job returns rc=5, so the "stale PID misread" path is unreachable.
- `kickstart -k` bypasses `ThrottleInterval` (=30) and spawned at t=0.03s → the 6s budget has ~200x headroom, so there is no false-failure risk on a healthy deploy.

**Follow-ups (P2, verdict-independent, deliberately NOT fixed here):** post-spawn crash survival is unverified; `launchctl list` is domain-unqualified (consistent on this node); the parsing idiom is duplicated with `scripts/_defaults.sh:1405`.
