### PR TITLE
fix(relay): keep settlement when the JSONL incarnation is unknown (#5154)

### DIFF
--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -2965,6 +2965,7 @@ services::discord::outbound::delivery_record::tests::long_chunk_full_commit_reco
 services::discord::outbound::delivery_record::tests::long_chunk_partial_or_err_never_records_anchor_3610c
 services::discord::outbound::delivery_record::tests::malformed_record_reads_none_conservative
 services::discord::outbound::delivery_record::tests::missing_record_reads_none_conservative
+services::discord::outbound::delivery_record::tests::not_delivered_never_settles_the_ledger_5154
 services::discord::outbound::delivery_record::tests::only_frontier_writer_advances_frontier
 services::discord::outbound::delivery_record::tests::ordered_jsonl_blocked_writer_revalidates_after_rotation_4911
 services::discord::outbound::delivery_record::tests::ordered_jsonl_commit_is_generation_scoped_and_monotonic
@@ -2993,6 +2994,8 @@ services::discord::outbound::delivery_record::tests::shadow_write_preserves_exis
 services::discord::outbound::delivery_record::tests::shadow_writes_frontier_and_reports_match
 services::discord::outbound::delivery_record::tests::should_shadow_mirror_requires_delivered_and_enabled
 services::discord::outbound::delivery_record::tests::sidecar_path_is_outside_inflight_scan_set
+services::discord::outbound::delivery_record::tests::unknown_generation_confirmed_delivery_settles_ledger_without_frontier_5154
+services::discord::outbound::delivery_record::tests::unknown_generation_without_pinned_inbound_id_settles_nothing_5154
 services::discord::outbound::delivery_record::tests::watcher_long_chunk_partial_or_unadvanced_never_records_3610d
 services::discord::outbound::delivery_record::tests::watcher_long_chunk_same_channel_anchor_pair_3610d
 services::discord::outbound::delivery_record::tests::watcher_owner_context_preserves_frontier_and_resolves_current_generation_3751

--- a/src/services/discord/outbound/delivery_record.rs
+++ b/src/services/discord/outbound/delivery_record.rs
@@ -2025,6 +2025,23 @@ pub(in crate::services::discord) fn shadow_mirror_delivered_frontier(
     );
 }
 
+/// The caller-PINNED half of the ledger-id safety rule: an id the caller bound to
+/// THIS delivery — either the watcher's delivery-lease authority or the explicit
+/// `ledger_user_msg_id` argument that every production terminal-delivery call site
+/// passes from its own turn/inflight snapshot. Unlike the receipt-qualified
+/// fresh-row fallback it needs neither an inflight re-read nor an authoritative
+/// JSONL generation, so it is the only ledger-id source usable on the
+/// unknown-generation path where no durable frontier is written (#5154).
+fn pinned_ledger_user_msg_id(
+    watcher_authority: Option<WatcherDeliveryRecordAuthority>,
+    ledger_user_msg_id: Option<u64>,
+) -> Option<u64> {
+    watcher_authority
+        .and_then(|authority| authority.ledger_user_msg_id)
+        .or(ledger_user_msg_id)
+        .filter(|user_msg_id| *user_msg_id != 0)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn shadow_mirror_delivered_frontier_inner(
     shared: &crate::services::discord::SharedData,
@@ -2052,12 +2069,47 @@ fn shadow_mirror_delivered_frontier_inner(
         return false;
     }
     if generation_mtime_ns == 0 || range.1 <= range.0 {
+        // #5154: the durable frontier is generation-scoped, so without an
+        // authoritative JSONL incarnation/range it MUST stay unwritten — that guard
+        // is unchanged and just as strict. But "this user message was answered" is
+        // NOT a fact about a JSONL incarnation, and the single early return that
+        // used to live here also skipped the completed-turn ledger append below.
+        // `catch_up/settled_ledger_consult.rs` treats that ledger as the ONLY
+        // settled-evidence source, so a confirmed, delivered turn was re-collected
+        // by catch-up and its prompt re-submitted verbatim. Settlement recording is
+        // therefore separated from frontier persistence.
+        //
+        // Only CALLER-PINNED ids are used here. The receipt-qualified fresh-row
+        // fallback further below is deliberately NOT reproduced: it is qualified by
+        // an exact receipt, which cannot be constructed without an authoritative
+        // generation, and an unqualified current row could let a delayed A settle a
+        // newer B.
+        //
+        // The #4081 delivered-content fingerprint is deliberately NOT recorded on
+        // this path. Its match predicate requires exact generation equality
+        // (`recent_content_fingerprint_matches`) against a reader-side FRESH marker
+        // read (`recent_delivered_content_matches` → `current_generation_mtime_ns`),
+        // so a fingerprint stored under the unknown-generation sentinel `0` becomes
+        // permanently unmatchable the moment the generation is re-established, while
+        // still consuming a slot in the bounded `recent_delivered_contents` ring. It
+        // would look like a duplicate defense without being one. Duplicate defense on
+        // this path stays with the ledger; the fingerprint is not restored here.
+        let settled_ledger_user_msg_id =
+            pinned_ledger_user_msg_id(watcher_authority, ledger_user_msg_id);
+        if let Some(user_msg_id) = settled_ledger_user_msg_id {
+            completed_turn_ledger::append_completed_turn(
+                provider,
+                terminal_anchor_channel_id.unwrap_or(channel_id),
+                user_msg_id,
+            );
+        }
         tracing::warn!(
             provider = provider.as_str(),
             channel_id,
             range = ?range,
             generation_mtime_ns,
-            "confirmed delivery lacks an authoritative JSONL incarnation/range; preserving prior durable frontier"
+            ?settled_ledger_user_msg_id,
+            "confirmed delivery lacks an authoritative JSONL incarnation/range; preserving prior durable frontier (completed-turn settlement still recorded when the caller pinned an inbound id)"
         );
         return false;
     }
@@ -2106,10 +2158,7 @@ fn shadow_mirror_delivered_frontier_inner(
     // A ledger id is safe only when the caller pinned it to this delivery or
     // the same fresh row produced the exact receipt above. Never guess from an
     // unqualified current row: a delayed A could otherwise settle newer B.
-    let safe_ledger_user_msg_id = watcher_authority
-        .and_then(|authority| authority.ledger_user_msg_id)
-        .or(ledger_user_msg_id)
-        .filter(|user_msg_id| *user_msg_id != 0)
+    let safe_ledger_user_msg_id = pinned_ledger_user_msg_id(watcher_authority, ledger_user_msg_id)
         .or_else(|| {
             receipt
                 .as_ref()
@@ -4563,6 +4612,166 @@ mod tests {
         assert!(
             x_settled.is_empty(),
             "no ledger entry may be written under the offset-authority channel X"
+        );
+    }
+
+    /// #5154 regression. A confirmed terminal delivery whose JSONL incarnation is
+    /// UNKNOWN (`generation_mtime_ns == 0`) must still leave settled evidence that
+    /// the user message was answered, while the generation-scoped durable frontier
+    /// stays unwritten.
+    ///
+    /// Production shape being reproduced: the turn-bridge funnel
+    /// (`shadow_mirror_delivered_frontier`) passes `watcher_authority = None`, so the
+    /// incarnation is read from `coord.confirmed_end_generation_mtime_ns`. A stale
+    /// tmux-watermark reset leaves that atomic at its initial `0` and the only
+    /// re-establishment site refuses to write a `0`, so confirmed deliveries kept
+    /// arriving with an unknown incarnation. The old single early return dropped the
+    /// completed-turn ledger append along with the frontier, and
+    /// `catch_up/settled_ledger_consult.rs` treats that ledger as the ONLY
+    /// settled-evidence source — so catch-up re-collected already-answered messages
+    /// and re-submitted their prompts verbatim.
+    ///
+    /// The `range`/`user_msg_id`/`channel_id` values below are the ones observed in
+    /// the reported incident (issue #5154 WARN line at 20:53:32.847Z, channel
+    /// 1479671298497183835, `range=(0, 42675) generation_mtime_ns=0`).
+    #[test]
+    fn unknown_generation_confirmed_delivery_settles_ledger_without_frontier_5154() {
+        let _root = IsolatedRoot::new();
+        let provider = ProviderKind::Claude;
+        let owner = ChannelId::new(1_479_671_298_497_183_835);
+        let delivery = ChannelId::new(1_479_671_298_497_183_835);
+        let tmux = "AgentDesk-claude-5154-unknown-incarnation";
+        let pinned_user_msg_id = 1_534_665_637_186_765_043_u64;
+
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let coord = shared.tmux_relay_coord(owner);
+        // The stale-watermark reset left the incarnation atomic at its initial `0`
+        // and no writer re-established it. Deliberately NOT stored: `0` IS the
+        // initial value, and the test must exercise exactly that state.
+        assert_eq!(
+            coord
+                .confirmed_end_generation_mtime_ns
+                .load(Ordering::Acquire),
+            0,
+            "precondition: the unknown-incarnation state under test"
+        );
+        coord.confirmed_end_offset.store(42_675, Ordering::Release);
+
+        // Confirmed delivery: `is_delivered == true`, range strictly growing
+        // (42675 > 0), incarnation unknown. Only the third condition is degenerate.
+        shadow_mirror_delivered_frontier(
+            &shared,
+            &provider,
+            owner,
+            Some(tmux),
+            (0, 42_675),
+            true,
+            Some(1_534_665_637_186_765_044),
+            Some(delivery.get()),
+            Some("confirmed terminal answer"),
+            Some(pinned_user_msg_id),
+        );
+
+        let record = read_record(&provider, owner.get());
+        // The frontier guard is UNCHANGED and just as strict: a frontier without an
+        // authoritative JSONL incarnation is meaningless and must never be durable.
+        assert!(
+            record
+                .as_ref()
+                .and_then(|record| record.delivered_frontier.as_ref())
+                .is_none(),
+            "#5154: an unknown JSONL incarnation must never produce a durable frontier"
+        );
+        // The #4081 content fingerprint is generation-scoped by its match predicate
+        // and is deliberately NOT recorded under the unknown-incarnation sentinel.
+        assert!(
+            record
+                .as_ref()
+                .map(|record| record.recent_delivered_contents.is_empty())
+                .unwrap_or(true),
+            "#5154: no fingerprint may be stored under the unknown-incarnation sentinel"
+        );
+
+        // MUTATION TARGET: "this user message was answered" is not a fact about a
+        // JSONL incarnation. Collapsing the settlement append back into the frontier
+        // guard's early return fails HERE, on this assertion.
+        assert!(
+            completed_turn_ledger::settled_user_msg_ids(&provider, delivery.get())
+                .contains(&pinned_user_msg_id),
+            "#5154 MUTATION: the answered user message must remain settled evidence \
+             even when the JSONL incarnation is unknown — otherwise catch-up \
+             re-collects it and re-submits the same turn_id verbatim"
+        );
+    }
+
+    /// #5154 companion: the settlement carve-out must NOT weaken the ledger-id
+    /// safety rule. With no caller-pinned inbound id there is nothing safe to
+    /// settle — the receipt-qualified fresh-row fallback cannot run without an
+    /// authoritative incarnation, and guessing from an unqualified current row
+    /// would let a delayed A settle a newer B. Nothing is written at all.
+    #[test]
+    fn unknown_generation_without_pinned_inbound_id_settles_nothing_5154() {
+        let _root = IsolatedRoot::new();
+        let provider = ProviderKind::Claude;
+        let owner = ChannelId::new(5_154_201);
+        let delivery = ChannelId::new(5_154_202);
+        let tmux = "AgentDesk-claude-5154-unpinned";
+
+        let shared = crate::services::discord::make_shared_data_for_tests();
+
+        shadow_mirror_delivered_frontier(
+            &shared,
+            &provider,
+            owner,
+            Some(tmux),
+            (0, 42_675),
+            true,
+            Some(5_154_203),
+            Some(delivery.get()),
+            Some("confirmed terminal answer"),
+            None, // caller pinned nothing
+        );
+
+        assert!(
+            completed_turn_ledger::settled_user_msg_ids(&provider, delivery.get()).is_empty(),
+            "#5154: an unpinned delivery must never invent a settled user_msg_id"
+        );
+        assert!(
+            read_record(&provider, owner.get())
+                .and_then(|record| record.delivered_frontier)
+                .is_none(),
+            "#5154: the frontier guard still holds"
+        );
+    }
+
+    /// #5154: `is_delivered == false` is still an absolute bar. The settlement
+    /// carve-out sits BELOW the `!is_delivered` return, so a non-delivered outcome
+    /// records nothing even with a pinned inbound id.
+    #[test]
+    fn not_delivered_never_settles_the_ledger_5154() {
+        let _root = IsolatedRoot::new();
+        let provider = ProviderKind::Claude;
+        let channel = ChannelId::new(5_154_301);
+        let pinned_user_msg_id = 5_154_300_u64;
+
+        let shared = crate::services::discord::make_shared_data_for_tests();
+
+        shadow_mirror_delivered_frontier(
+            &shared,
+            &provider,
+            channel,
+            Some("AgentDesk-claude-5154-not-delivered"),
+            (0, 42_675),
+            false, // NOT delivered
+            Some(5_154_302),
+            Some(channel.get()),
+            Some("undelivered body"),
+            Some(pinned_user_msg_id),
+        );
+
+        assert!(
+            completed_turn_ledger::settled_user_msg_ids(&provider, channel.get()).is_empty(),
+            "#5154: a non-delivered outcome must never produce settled evidence"
         );
     }
 


### PR DESCRIPTION
Closes #5154

## What broke

`shadow_mirror_delivered_frontier_inner`'s early return (`generation_mtime_ns == 0 || range.1 <= range.0`) skipped not only the durable frontier persist but also the content-fingerprint record **and the completed-turn ledger append**. So the fact "this user message was answered" was never recorded, and catch-up re-collected the same message, **re-submitting a prompt to the TUI under the same `turn_id`**.

Field measurement: the user sent 3 turns; 5 prompts were submitted to the TUI. The ledger and the delivery-record file froze at the same instant (5ms apart).

## The argument for the fix

**"This user message was answered" is not a fact about a JSONL incarnation.** The frontier guard is not relaxed by a single character — if the generation is unknown, nothing is still written durably. Only the ledger settlement is carved out and kept alive.

**Both disjuncts of the guard are covered** — a degenerate range is likewise a fact about JSONL space, not about settlement.

## Rebase / patch-identity measurement

The branch was cut at `93404da0e`; `origin/main` had advanced to `61bf1b740` (#5153 landed). Rebased onto current `origin/main`; **rebase applied cleanly with no conflict** — sibling PR #5163 (`fix-5159-turn-bot-identity`), which also touches `scripts/lib_test_inventory_manifest.txt`, has not landed yet, so no manifest conflict arose and no re-pin was needed.

Patch identity measured with the prescribed procedure:

```
diff <(grep -E "^[+-]" p-before-5154.diff | grep -vE "^(\+\+\+|---)") \
     <(grep -E "^[+-]" p-after-5154.diff  | grep -vE "^(\+\+\+|---)")
# => 0 differing lines (rc=0)
```

**0 differing lines.** The post-rebase patch is byte-identical to the reviewed patch, so the dual verdict below is carried over and only the gates were re-run on the new base.

Scope unchanged: 2 files, `+217/−5` (`delivery_record.rs` `+214/−5`, manifest `+3/−0`). **Manifest diff has zero `-` lines** — no entries dropped, no debt figure reduced.

## Gates re-run on the new base

| Gate | Result |
|---|---|
| `python3 scripts/check_test_target_integrity.py` | rc=0, `test-target integrity check passed` |
| `cargo fmt --check` | rc=0 |
| `cargo check --workspace --all-features --all-targets` | rc=0, 0 errors |
| `cargo test --lib services::discord::outbound` | rc=0, 195 passed / 0 failed |
| `cargo test --lib services::discord::turn_bridge` | rc=0, 370 passed / 0 failed |
| `cargo test --lib tmux_watcher` | rc=0, 314 passed / 0 failed |
| `cargo test --lib services::discord::catch_up` | rc=0, 68 passed / 0 failed |
| `cargo test --lib _5154` | rc=0, 3 passed / 0 failed |

## Review status

**dual review — both legs `VERDICT: CLEAN`, 0 P0/P1.**

**leg A (Opus — functional correctness, invariants, regressions, claim truthfulness)**, all 9 items executed:
- The `!is_delivered` absolute bar (`:2068-2070`) and the guard condition appear in the diff **as context lines only** = not one character changed.
- No false settlement via a degenerate range: `BridgeDeliveryLease::acquire` (`terminal_delivery.rs:635-641`) turns `end <= start` back into `NoRange`, and every record call sits inside `if let Some(lease)`.
- All 6 call sites subject to ledger settlement verified **pinned** by direct reading. The carve-out does not read the current row (`load_inflight_state` is **below** the carve-out at `:2124`), so the "a delayed A settles a newer B" hazard does not arise.
- The only thing written durably in the carve-out is **the completed-turn ledger sidecar** (no delivery-record write, no atomic store, no marker-file write).
- Full audit of the `−5` lines: the base text was pulled via `git show` and compared — the new helper body is **byte-identical** to the inline chain and the receipt-eligibility fallback is unchanged. **No guard removal disguised as a refactor.**
- Both mutations died rc=101 on their own asserts. Notably, **the mutation that neuters `!is_delivered` was caught only by the tests this PR adds** (none of the 88 pre-existing tests caught it) — a net coverage gain in the most dangerous direction.
- Regression sweep `outbound` 195 / `turn_bridge` 390 / `tmux_watcher` 8 / `catch_up` 30, all rc=0.

**leg B (codex — race, crash, authority counterexamples)**, 7 items executed:
- The ledger append is a temp file + `sync_all()` + atomic rename under flock, so it cannot tear on process death.
- The bridge/watcher epilogues can overlap, but **both take the same ledger flock** and only independent locks, so there is no lock-order inversion.
- Concretely constructed the interleaving where a delayed A settles a newer B and confirmed it **impossible** (the watcher side freezes the id into the lease key, and a newer snapshot is rejected by the range check and falls to id 0).
- A degenerate range means "delivered but no valid JSONL coordinate can be persisted", not "nothing was delivered" — traced `is_delivered` back to the actual send result to confirm.
- No authority expansion: nothing reaches beyond `!is_delivered`, send confirmation, and the caller's pinned identity.
- leg B's self-devised mutation was NOT RUN under sandbox and **the orchestrator closed it directly**: `pinned_ledger_user_msg_id(...)` → `None::<u64>` at `delivery_record.rs:2097`. Result rc=101, `87 passed; 1 failed`, with `unknown_generation_confirmed_delivery_settles_ledger_without_frontier_5154` dying on its own assert at `:4697`. Not a compile death (`Compiling agentdesk` present; the only `^error` line is `error: test failed`). Tree confirmed clean after revert.

## Follow-ups (P2, verdict-independent — tracked separately, deliberately NOT fixed here)

1. The fingerprint-not-recorded rationale comment (`:2088-2096`) does not hold in two states: under the accident state (marker read failure → the reader is also 0) a sentinel 0 fingerprint matches, and in the degenerate-range disjunct the generation is nonzero so the premise is void. Not a regression (base does not record either).
2. Deviation from the issue's acceptance criteria: fingerprint recording was not split out (documented intentional deviation), and acceptance criterion 4 (a 3-turn end-to-end test immediately after restart) is unimplementable at the unit level.
3. `unknown_generation_without_pinned_inbound_id_settles_nothing_5154` does not pin the "pinned-only" property itself (the fixture has no in-flight row, so it would pass even if the fallback were reintroduced).
4. No dedicated test nailing down the degenerate-range + send-confirmed case.
5. `atomic_write` does not fsync the parent directory after rename, so power-loss durability is weaker than process-crash atomicity.
6. Residual duplicate window: if the process dies after a successful send and the carve-out append but before `terminal_delivery_committed` is persisted, recovery does not consult the ledger and the answer can be relayed again (pre-existing, predates this diff).
