### PR TITLE
fix(relay-watchdog): terminate loss-state bound to a provably dead session (#5155)

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -133,6 +133,17 @@ LAST_PENDING_TRANSCRIPT_RETIREMENT_ALERT_KEY = (
 )
 GAP_TRANSCRIPT_KEY = "gap_transcript"
 GAP_OWNER_TRANSCRIPTS_KEY = "gap_owner_transcripts"
+# Per-path timestamp of the FIRST tick on which the owning worktree directory
+# was proven absent. A dead-session retirement is admitted only after the
+# absence has held continuously for DEAD_WORKTREE_CONFIRM_SECS.
+DEAD_WORKTREE_ABSENT_SINCE_KEY = "dead_worktree_absent_since"
+MAX_DEAD_WORKTREE_ABSENCES = 64
+# 600s is five consecutive polls at the shipped Config.poll_secs default of 120
+# (this file, `poll_secs: int = 120`). `git worktree remove`/`add` completes in
+# seconds, so no legitimate worktree churn can stay invisible across five polls;
+# a transient stat failure resets the window instead of accumulating.
+DEAD_WORKTREE_CONFIRM_SECS = 600
+DEAD_WORKTREE_RETIREMENT_REASON = "dead_worktree"
 RECOVERED_GAP_GUARDS_KEY = "recovered_gap_replay_guards"
 ISSUE_FILING_SUPPRESSION_REASON_KEY = "issue_filing_suppression_reason"
 ISSUE_FILING_SUPPRESSION_SINCE_KEY = "issue_filing_suppression_since"
@@ -410,6 +421,53 @@ def main_channel_project_re(worktree_root: str, worktree_prefix: str) -> re.Patt
     """
     prefix = project_slug(worktree_root.rstrip("/")) + "-" + worktree_prefix + "-"
     return re.compile("^" + re.escape(prefix) + r"\d{8}-\d{6}$")
+
+
+def worktree_dir_for_transcript(
+    transcript_path: str, worktree_root: str, pattern: re.Pattern[str]
+) -> Path | None:
+    """Reverse a transcript's project-dir slug back to its owning worktree dir.
+
+    Session transcripts live at ``<projects_root>/<slug>/<uuid>.jsonl`` where
+    ``slug == project_slug(worktree_dir)``.  ``project_slug`` is lossy in
+    general — both ``/`` and ``.`` collapse to ``-`` — so an arbitrary slug
+    cannot be inverted.  This channel's dirs are not arbitrary:
+    ``main_channel_project_re`` admits only
+    ``<slug(root)>-<prefix>-<YYYYMMDD>-<HHMMSS>``, and the tail after
+    ``slug(root)`` contains neither ``/`` nor ``.`` by construction.  For a
+    pattern-matching dir the inverse is therefore exact, and the result is
+    always a direct child of ``worktree_root``.
+
+    Returns None when the slug does not belong to this channel, so a caller can
+    never draw a liveness conclusion from a path it cannot resolve.
+    """
+    parent = Path(transcript_path).parent.name
+    if pattern.fullmatch(parent) is None:
+        return None
+    root = worktree_root.rstrip("/")
+    slug_prefix = project_slug(root) + "-"
+    if not parent.startswith(slug_prefix):
+        return None
+    basename = parent[len(slug_prefix):]
+    if not basename or "/" in basename:
+        return None
+    return Path(root) / basename
+
+
+def directory_presence(path: Path) -> bool | None:
+    """True = directory exists, False = proven absent, None = no verdict.
+
+    Only ENOENT/ENOTDIR count as proof of absence.  Every other error
+    (permissions, I/O, a dismounted volume) is deliberately inconclusive: a
+    liveness predicate that reads "unreadable" as "dead" would retire a live
+    session's loss-state, which is the exact failure this file must not have.
+    """
+    try:
+        return stat_mode.S_ISDIR(os.stat(path).st_mode)
+    except (FileNotFoundError, NotADirectoryError):
+        return False
+    except (OSError, ValueError):
+        return None
 
 
 def channel_project_dirs(root: Path, pattern: re.Pattern[str]) -> list[Path]:
@@ -1097,6 +1155,42 @@ def _store_retired_transcripts(
         }
     else:
         channel_state.pop(RETIRED_TRANSCRIPTS_KEY, None)
+
+
+def _validated_worktree_absences(
+    channel_state: Mapping[str, Any],
+) -> dict[str, float]:
+    """Return the persisted first-absence timestamps, malformed rows dropped.
+
+    A malformed row must never read as "absent since the epoch": that would
+    grant an instant retirement. Dropping it restarts the dwell instead.
+    """
+    raw = channel_state.get(DEAD_WORKTREE_ABSENT_SINCE_KEY, {})
+    if not isinstance(raw, dict):
+        return {}
+    valid: dict[str, float] = {}
+    for path, since in raw.items():
+        if not isinstance(path, str) or not path:
+            continue
+        if _is_finite_nonnegative_number(since):
+            valid[path] = float(since)
+    return dict(sorted(valid.items(), key=lambda item: (item[1], item[0]))[
+        :MAX_DEAD_WORKTREE_ABSENCES
+    ])
+
+
+def _store_worktree_absences(
+    channel_state: dict[str, Any], absences: Mapping[str, float]
+) -> None:
+    bounded = dict(
+        sorted(absences.items(), key=lambda item: (item[1], item[0]))[
+            :MAX_DEAD_WORKTREE_ABSENCES
+        ]
+    )
+    if bounded:
+        channel_state[DEAD_WORKTREE_ABSENT_SINCE_KEY] = bounded
+    else:
+        channel_state.pop(DEAD_WORKTREE_ABSENT_SINCE_KEY, None)
 
 
 def _bounded_transcript_history(
@@ -2442,6 +2536,7 @@ def _forget_reclaimed_recovered_gap_lifecycles(
         PENDING_TRANSCRIPT_FAILURES_KEY,
         PENDING_TRANSCRIPT_SINCE_KEY,
         RETIRED_TRANSCRIPTS_KEY,
+        DEAD_WORKTREE_ABSENT_SINCE_KEY,
     ):
         raw = channel_state.get(key)
         if not isinstance(raw, dict):
@@ -2864,6 +2959,15 @@ class Runtime:
                 )
             except (OSError, subprocess.SubprocessError) as e:
                 self.log(f"announce bot error: {e}; falling back")
+        elif trigger_turn:
+            # #5155 correction: with `announce_to` empty the primary is never
+            # ATTEMPTED, so the log shows only discord-sendmessage successes and
+            # an operator counting them reads a healthy config as a 100% primary
+            # failure rate. Say which of the two it is, on every alert.
+            self.log(
+                "announce bot skipped — announce_to empty for channel "
+                f"{ch.channel_id}; posting via discord-sendmessage (bot token)"
+            )
         try:
             p = subprocess.run(
                 [
@@ -3405,6 +3509,14 @@ def _alert_pending_retirement(
             "세션 활동이 idle 한계를 넘겨 더 이상 live GAP으로 반복 평가하지 "
             "않습니다. 미도달 여부가 해결됐다고 주장하는 복구 알림은 보내지 않습니다."
         )
+    elif reason == DEAD_WORKTREE_RETIREMENT_REASON:
+        title = "죽은 세션의 릴레이 loss-state 종결"
+        detail = (
+            "해당 트랜스크립트를 소유한 워크트리 디렉터리가 사라졌습니다 — 그 "
+            "세션은 다시 배달할 수 없으므로 미도달 블록을 재평가 대상에서 "
+            "내립니다. 이는 배달이 확인됐다는 뜻이 아니며(복구 알림은 보내지 "
+            "않습니다), 이 경보가 해당 경로에 대한 마지막 통지입니다."
+        )
     else:
         title = "릴레이 트랜스크립트 평가 불능 에스컬레이션"
         detail = (
@@ -3529,6 +3641,150 @@ def _clear_gap_alert_without_recovery(
     return True
 
 
+def _retire_dead_worktree_authorities(
+    rt: Runtime,
+    ch: ChannelConfig,
+    chs: dict[str, Any],
+    candidates: list[TranscriptCandidate],
+    pattern: re.Pattern[str],
+    now: float,
+) -> list[str]:
+    """Terminate loss-state whose owning session provably cannot come back.
+
+    Pending and unresolved-GAP-owner paths are the two authorities exempt from
+    the normal idle skip, so once one is bound to a session that no longer
+    exists nothing retires it: the incident stays `alerting` and re-fires on its
+    cooldown forever (#5155 — 2,835 `gap persists` ticks against a transcript
+    whose last write was five days earlier).  Growth gating (#5158) stopped the
+    selector from *chasing* that file; it cannot close the incident, because
+    supersession still needs the channel to produce a live, bound, fully
+    delivered successor, and an idle channel never does.
+
+    The liveness predicate is the existence of the owning worktree DIRECTORY,
+    recovered from the transcript's project-dir slug.  It is chosen precisely
+    because it cannot confuse idle with dead: a session that is merely quiet
+    still owns its checkout, and only an operator or `git worktree remove`
+    takes the directory away.  Three further conditions keep an unreadable
+    filesystem from ever reading as a dead session:
+
+    1. The worktree ROOT must itself stat as a directory. A dismounted or
+       renamed root would otherwise retire every authority at once.
+    2. Absence must be proven by ENOENT/ENOTDIR (`directory_presence`), and
+       must hold continuously for DEAD_WORKTREE_CONFIRM_SECS.
+    3. The transcript must also be idle past `idle_quiet_secs`. Redundant with
+       a deleted worktree, and deliberately so: a file still being written is
+       never retired no matter what its directory stat says.
+
+    Retirement is not a recovery claim. No RECOVERED notice is sent, the
+    permanent-loss ledger is untouched, and `transcript-retired-reactivated`
+    still readmits the path if it ever grows semantically again.
+    """
+    cid = ch.channel_id
+    absences = _validated_worktree_absences(chs)
+    if directory_presence(Path(ch.worktree_root)) is not True:
+        if absences:
+            chs.pop(DEAD_WORKTREE_ABSENT_SINCE_KEY, None)
+            rt.log(
+                f"[{cid}] dead-worktree-probe-reset reason=worktree_root_unreadable"
+            )
+        return []
+
+    authorities: list[str] = []
+    for path in (
+        *_validated_gap_owner_transcripts(chs),
+        *_validated_pending_transcripts(chs),
+    ):
+        if path not in authorities:
+            authorities.append(path)
+    candidate_by_path = {str(candidate.path): candidate for candidate in candidates}
+    persisted_sizes = _validated_transcript_sizes(chs)
+
+    next_absences: dict[str, float] = {}
+    dead: list[str] = []
+    for path in authorities:
+        worktree = worktree_dir_for_transcript(path, ch.worktree_root, pattern)
+        if worktree is None:
+            continue
+        if directory_presence(worktree) is not False:
+            continue
+        since = absences.get(path, now)
+        next_absences[path] = since
+        absent_secs = max(0.0, now - since)
+        if absent_secs < DEAD_WORKTREE_CONFIRM_SECS:
+            rt.log(
+                f"[{cid}] dead-worktree-absence-pending worktree={worktree} "
+                f"absent_secs={int(absent_secs)} "
+                f"(< {DEAD_WORKTREE_CONFIRM_SECS}s confirm) path={path}"
+            )
+            continue
+        candidate = candidate_by_path.get(path)
+        if candidate is not None and now - candidate.mtime < rt.cfg.idle_quiet_secs:
+            rt.log(
+                f"[{cid}] dead-worktree-retirement-declined "
+                f"reason=transcript_still_active path={path}"
+            )
+            continue
+        dead.append(path)
+
+    if not dead:
+        _store_worktree_absences(chs, next_absences)
+        return []
+
+    dead_set = set(dead)
+    retired_transcripts = _validated_retired_transcripts(chs)
+    for path in dead:
+        candidate = candidate_by_path.get(path)
+        size = candidate.size if candidate is not None else persisted_sizes.get(path)
+        if not (isinstance(size, int) and not isinstance(size, bool) and size >= 0):
+            size = 0
+        retired_transcripts[path] = (size, now)
+    _store_retired_transcripts(chs, retired_transcripts)
+
+    remaining_pending = [
+        path
+        for path in _validated_pending_transcripts(chs)
+        if path not in dead_set
+    ]
+    chs[PENDING_TRANSCRIPTS_KEY] = remaining_pending
+    for key in (PENDING_TRANSCRIPT_FAILURES_KEY, PENDING_TRANSCRIPT_SINCE_KEY):
+        raw = chs.get(key)
+        if not isinstance(raw, dict):
+            continue
+        pruned = {
+            entry: value for entry, value in raw.items() if entry not in dead_set
+        }
+        if pruned:
+            chs[key] = pruned
+        else:
+            chs.pop(key, None)
+    if chs.get(SELECTED_TRANSCRIPT_KEY) in dead_set:
+        chs.pop(SELECTED_TRANSCRIPT_KEY, None)
+    if chs.get(SELECTOR_DIVERGED_TRANSCRIPT_KEY) in dead_set:
+        # The I1 window was measured against a transcript that no longer has a
+        # session behind it, so the window is void — not repaired. Dropping it
+        # releases the stuck `selector_alerting` flag without asserting that
+        # dcserver's bind is now correct; the next growing selection re-decides.
+        chs.pop("selector_diverged_since", None)
+        chs.pop(SELECTOR_DIVERGED_TRANSCRIPT_KEY, None)
+        was_alerting = bool(chs.pop("selector_alerting", None))
+        rt.log(
+            f"[{cid}] selector-divergence-window-voided reason=dead_worktree "
+            f"was_alerting={was_alerting}"
+        )
+    _store_worktree_absences(
+        chs, {path: since for path, since in next_absences.items() if path not in dead_set}
+    )
+    rt.log(
+        f"[{cid}] dead-worktree-loss-state-retired count={len(dead)} "
+        f"paths={dead[:3]}"
+    )
+    _alert_pending_retirement(
+        rt, ch, chs, dead, now, reason=DEAD_WORKTREE_RETIREMENT_REASON
+    )
+    _clear_gap_alert_without_recovery(rt, chs, cid, dead)
+    return dead
+
+
 def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: float) -> None:
     cfg = rt.cfg
     cid = ch.channel_id
@@ -3578,6 +3834,10 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 f"[{cid}] permanent-loss-state-corrupt during lifecycle reclaim; "
                 "preserving raw state"
             )
+    # Runs before any authority is read into locals below, so a dead session's
+    # pending/GAP-owner rows are gone from `chs` by the time selection, growth,
+    # and the gap verdict look at them.
+    _retire_dead_worktree_authorities(rt, ch, chs, candidates, pattern, now)
     previous_sizes = _validated_transcript_sizes(chs)
     previous_seen_at = _validated_transcript_seen_at(chs, previous_sizes, now)
     known_state_persisted = isinstance(chs.get(TRANSCRIPT_KNOWN_AT_KEY), dict)

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -3526,11 +3526,20 @@ def _alert_pending_retirement(
     sample = "\n".join(f"- `{path}`" for path in paths[:3])
     if len(paths) > 3:
         sample += f"\n- 외 {len(paths) - 3}개"
-    rt.alert(
+    delivered_notice = rt.alert(
         ch,
         f"🚨 **{title}**\n\n{detail}\n\n{sample}\n\n"
         f"런타임: {rt.dcserver_snapshot()}",
     )
+    if not delivered_notice:
+        # Do not burn the cooldown on a notice that never left the box: the
+        # next tick must be free to retry. Callers that gate termination on this
+        # return value therefore keep the authority open until someone is told.
+        rt.log(
+            f"[{ch.channel_id}] transcript-retirement-alert undelivered "
+            f"reason={reason} count={len(paths)}"
+        )
+        return False
     channel_state[LAST_PENDING_TRANSCRIPT_RETIREMENT_ALERT_KEY] = now
     return True
 
@@ -3718,16 +3727,40 @@ def _retire_dead_worktree_authorities(
             )
             continue
         candidate = candidate_by_path.get(path)
-        if candidate is not None and now - candidate.mtime < rt.cfg.idle_quiet_secs:
+        # Fail CLOSED on a missing candidate, exactly like the supersession
+        # guard below. `channel_project_dirs` returns [] on ANY OSError from
+        # `root.iterdir()` and `_regular_file_stat_without_symlink` returns None
+        # on a single failed stat, so one transient listing failure empties
+        # `candidate_by_path` — treating that as "no live transcript" would
+        # retire a file written seconds ago.
+        if candidate is None or now - candidate.mtime < rt.cfg.idle_quiet_secs:
             rt.log(
-                f"[{cid}] dead-worktree-retirement-declined "
-                f"reason=transcript_still_active path={path}"
+                f"[{cid}] dead-worktree-retirement-declined reason="
+                f"{'transcript_unobserved' if candidate is None else 'transcript_still_active'}"
+                f" path={path}"
             )
             continue
         dead.append(path)
 
     if not dead:
         _store_worktree_absences(chs, next_absences)
+        return []
+
+    # Terminating a dead session's loss-state is the LAST point at which anyone
+    # can learn those blocks are gone, so termination is gated on the notice
+    # actually going out. The retirement notice shares ONE cooldown key across
+    # every reason, so an idle/read-failure retirement a few seconds earlier
+    # would otherwise swallow this one and close the incident in total silence.
+    # Nothing below has mutated state yet, so deferring simply retries next tick
+    # with the absence window intact.
+    if not _alert_pending_retirement(
+        rt, ch, chs, dead, now, reason=DEAD_WORKTREE_RETIREMENT_REASON
+    ):
+        _store_worktree_absences(chs, next_absences)
+        rt.log(
+            f"[{cid}] dead-worktree-retirement-deferred "
+            f"reason=notice_undelivered count={len(dead)}"
+        )
         return []
 
     dead_set = set(dead)
@@ -3777,9 +3810,6 @@ def _retire_dead_worktree_authorities(
     rt.log(
         f"[{cid}] dead-worktree-loss-state-retired count={len(dead)} "
         f"paths={dead[:3]}"
-    )
-    _alert_pending_retirement(
-        rt, ch, chs, dead, now, reason=DEAD_WORKTREE_RETIREMENT_REASON
     )
     _clear_gap_alert_without_recovery(rt, chs, cid, dead)
     return dead

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -7852,6 +7852,246 @@ class DeadWorktreeRetirementTests(unittest.TestCase):
             any("릴레이 갭 감지" in body for body, _ in rt.alerts), rt.alerts
         )
 
+    def test_a_transient_listing_failure_never_retires_a_fresh_transcript(self):
+        """P1-A: a missing candidate must fail CLOSED, like the sibling guard.
+
+        `channel_project_dirs` returns [] on ANY OSError from `root.iterdir()`,
+        and `_regular_file_stat_without_symlink` returns None on a single failed
+        stat. One transient listing failure therefore empties
+        `candidate_by_path` — and a guard written as `candidate is not None and
+        ...` would skip entirely and retire a transcript written seconds ago.
+        """
+        self.write_stale_transcript(4.9 * 86400)
+        rt = self.make_rt()
+        state = {"999": self.open_incident_state()}
+        chs = state["999"]
+        self.tick(rt, state, self.now)
+        retire_at = self.now + relay_watchdog.DEAD_WORKTREE_CONFIRM_SECS + 1
+        # The session is writing again as of this very tick (idle 0s)...
+        os.utime(self.transcript, (retire_at, retire_at))
+        # ...but this tick's directory listing failed, so nothing is observed.
+        with mock.patch.object(
+            relay_watchdog, "transcript_candidates", return_value=[]
+        ):
+            self.tick(rt, state, retire_at)
+
+        self.assertNotIn(
+            str(self.transcript),
+            chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {}),
+        )
+        self.assertTrue(chs.get("alerting"), (chs, rt.log_lines))
+        self.assertIn(
+            str(self.transcript),
+            chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY],
+        )
+        self.assertTrue(
+            any(
+                "dead-worktree-retirement-declined reason=transcript_unobserved"
+                in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+    def test_termination_defers_while_the_notice_is_swallowed_by_cooldown(self):
+        """P1-B: loss-state never terminates in silence.
+
+        `_alert_pending_retirement` shares ONE cooldown key across every reason,
+        so an idle/read-failure retirement seconds earlier would otherwise
+        swallow the dead-session notice while the incident closed anyway.
+        """
+        self.write_stale_transcript(4.9 * 86400)
+        rt = self.make_rt()
+        state = {"999": self.open_incident_state()}
+        chs = state["999"]
+        self.tick(rt, state, self.now)
+        retire_at = self.now + relay_watchdog.DEAD_WORKTREE_CONFIRM_SECS + 1
+        # An unrelated retirement 10s ago burned the shared cooldown.
+        chs[relay_watchdog.LAST_PENDING_TRANSCRIPT_RETIREMENT_ALERT_KEY] = (
+            retire_at - 10
+        )
+        self.tick(rt, state, retire_at)
+
+        self.assertTrue(chs.get("alerting"), (chs, rt.log_lines))
+        self.assertIn(
+            str(self.transcript),
+            chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY],
+        )
+        self.assertNotIn(
+            str(self.transcript),
+            chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {}),
+        )
+        self.assertFalse(
+            any("죽은 세션" in body for body, _ in rt.alerts), rt.alerts
+        )
+        self.assertTrue(
+            any(
+                "dead-worktree-retirement-deferred" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+        # Only once the notice actually goes out does the incident close.
+        self.tick(rt, state, retire_at + rt.cfg.realert_secs + 1)
+        self.assertTrue(
+            any("죽은 세션" in body for body, _ in rt.alerts), rt.alerts
+        )
+        self.assertFalse(chs.get("alerting"), (chs, rt.log_lines))
+
+    def test_termination_defers_when_the_notice_cannot_be_delivered(self):
+        """P1-B: a failed post is 'not told', so the authority stays open."""
+        self.write_stale_transcript(4.9 * 86400)
+        rt = self.make_rt()
+        state = {"999": self.open_incident_state()}
+        chs = state["999"]
+        self.tick(rt, state, self.now)
+        rt.alert_succeeds = False
+        retire_at = self.now + relay_watchdog.DEAD_WORKTREE_CONFIRM_SECS + 1
+        self.tick(rt, state, retire_at)
+
+        self.assertTrue(chs.get("alerting"), (chs, rt.log_lines))
+        self.assertNotIn(
+            str(self.transcript),
+            chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {}),
+        )
+        self.assertTrue(
+            any(
+                "transcript-retirement-alert undelivered" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+        # The failed attempt must not have burned the cooldown: the very next
+        # tick after transport recovery closes it.
+        rt.alert_succeeds = True
+        self.tick(rt, state, retire_at + 1)
+        self.assertFalse(chs.get("alerting"), (chs, rt.log_lines))
+
+    def live_successor(self) -> Path:
+        """A second, still-existing session family for this same channel."""
+        name = "claude-adk-cc-20260805-200329"
+        (self.worktrees / name).mkdir()
+        live_dir = self.projects / (
+            project_slug(str(self.worktrees)) + "-" + name
+        )
+        live_dir.mkdir(parents=True)
+        return live_dir / "7e3abf13.jsonl"
+
+    def desynced_probe(self, at: float) -> WatcherStateProbe:
+        stale_ms = int((at - COVERAGE_ACTIVITY_FRESH_SECS * 3) * 1000)
+        return WatcherStateProbe(
+            status=200,
+            attached=True,
+            desynced=True,
+            relay_activity=CoverageActivityProbe(
+                relay_stall_state="active_foreground_stream",
+                active_turn="foreground",
+                queue_depth=1,
+                tmux_alive=True,
+                watcher_attached=True,
+                watcher_attached_stale=False,
+                watcher_owns_live_relay=True,
+                last_outbound_activity_ms=stale_ms,
+                last_relay_ts_ms=stale_ms,
+                desynced=True,
+            ),
+            inflight_updated_at=None,
+        )
+
+    def test_retirement_hands_the_desync_alarm_to_the_live_successor(self):
+        """P1-C: proven from the ACTUAL observed shape, not a convenient one.
+
+        Live log, one tick, 2026-08-05T22:03:50-51Z::
+
+            transcript-select reason=growth path=.../20260731-220205/8cf48ae8...
+            COVERAGE ALERT reason=attached_but_desynced ticks=18
+            gap persists path=.../20260731-220205/8cf48ae8... lost=1
+
+        The selected transcript is the DEAD path carrying `lost=1`, so
+        `zero_loss_observed` is False, `growing_relay_stall` is False, and that
+        COVERAGE ALERT was corroborated by `alerting`/`gap_since` ALONE — the two
+        keys this change pops. Starting from exactly that shape, this walks
+        retirement -> reselection -> alarm and pins that the alarm survives on
+        the independent corroborator once the selector reaches the live session.
+        """
+        self.write_stale_transcript(4.9 * 86400)
+        successor = self.live_successor()
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "uuid": f"00000000-0000-4000-8000-{abs(hash(text)) % 10**12:012d}",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        successor.write_text(
+            record(self.now - 30, "live block one delivered") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(successor, (self.now - 30, self.now - 30))
+
+        rt = self.make_rt()
+        rt.haystack = norm("live block one delivered")
+        rt.live_sessions = {expected_tmux_session_name(self.channel)}
+        rt.watcher_probe = self.desynced_probe(self.now)
+        state = {"999": self.open_incident_state()}
+        chs = state["999"]
+        # The successor is already tracked (as in production), so it debuts as
+        # a known path and the selector stays stuck on the dead one — which is
+        # precisely the logged shape being reproduced.
+        chs[relay_watchdog.TRANSCRIPT_SIZES_KEY][str(successor)] = (
+            successor.stat().st_size
+        )
+
+        # Tick 1 reproduces the logged shape: dead path selected, lost=1, the
+        # gap incident open, the desync accumulating toward confirmation.
+        self.tick(rt, state, self.now)
+        self.assertEqual(chs[SELECTED_TRANSCRIPT_KEY], str(self.transcript))
+        self.assertTrue(chs.get("alerting"))
+        self.assertTrue(
+            any("**1건**" in body for body, _ in rt.alerts), rt.alerts
+        )
+
+        # Tick 2: the live session writes and is relayed; the dead session is
+        # retired and the selector moves to the successor.
+        at = self.now + rt.cfg.realert_secs + 1
+        with successor.open("a", encoding="utf-8") as f:
+            f.write(record(at - 5, "live block two delivered") + "\n")
+        os.utime(successor, (at - 5, at - 5))
+        rt.haystack = (
+            norm("live block one delivered")
+            + " "
+            + norm("live block two delivered")
+        )
+        rt.watcher_probe = self.desynced_probe(at)
+        rt.alerts.clear()
+        rt.log_lines.clear()
+        self.tick(rt, state, at)
+
+        # The gap corroborators are gone...
+        self.assertFalse(chs.get("alerting"), (chs, rt.log_lines))
+        self.assertNotIn("gap_since", chs)
+        self.assertEqual(chs[SELECTED_TRANSCRIPT_KEY], str(successor))
+        # ...and the desync still alarms, on `growing_relay_stall` alone.
+        self.assertTrue(
+            any("attached_but_desynced" in body for body, _ in rt.alerts),
+            (rt.alerts, rt.log_lines),
+        )
+        self.assertTrue(chs.get("coverage_alerting"))
+        self.assertFalse(
+            any(
+                "coverage desync uncorroborated" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
     def test_unreadable_worktree_root_never_retires_anything(self):
         self.write_stale_transcript(4.9 * 86400)
         rt = self.make_rt()

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -3034,6 +3034,46 @@ class TickChannelTests(unittest.TestCase):
         self.assertEqual(len(rt.alerts), 1)
         self.assertIn("attached_but_desynced", rt.alerts[0][0])
 
+    def test_real_desync_still_alarms_without_a_gap_corroborator(self):
+        # #5155 coupling disclosure: `delivery_gap_active` reads `alerting` /
+        # `gap_since`, so terminating a dead session's loss-state removes one of
+        # the three corroborators for `attached_but_desynced`. The corroborator
+        # it removes was a phantom — a five-day-dead session says nothing about
+        # the live channel — and the independent one survives: a transcript that
+        # is growing while nothing is being relayed and no inflight update is
+        # advancing still raises COVERAGE ALERT with no gap state at all.
+        rt = self.make_rt()
+        tick_at = self.now + 600
+        stale_ms = int(
+            (tick_at - COVERAGE_ACTIVITY_FRESH_SECS * 3) * 1000
+        )
+        self.arm_coverage(
+            rt,
+            self.active_foreground_probe(
+                queue_depth=1,
+                last_outbound_activity_ms=stale_ms,
+                last_relay_ts_ms=stale_ms,
+            ),
+        )
+        state = {
+            "coverage_uncovered_ticks": COVERAGE_CONFIRM_TICKS - 1,
+            "coverage_desync_since": self.now,
+        }
+        self.assertNotIn("gap_since", state)
+        self.assertNotIn("alerting", state)
+
+        tick_coverage(
+            rt,
+            TICK_CHANNEL,
+            state,
+            tick_at,
+            CoverageTranscriptProbe(growing=True, blocks=723, lost=0),
+        )
+
+        self.assertEqual(len(rt.alerts), 1, rt.log_lines)
+        self.assertIn("attached_but_desynced", rt.alerts[0][0])
+        self.assertTrue(state.get("coverage_alerting"))
+
     def _loss_corroboration_probe(self, tick_at):
         return self.active_foreground_probe(
             queue_depth=1,
@@ -7519,6 +7559,376 @@ exit 0
                 data["StandardOutPath"],
                 str(adk / "logs/relay-watchdog.launchd.out.log"),
             )
+
+
+class DeadWorktreeReverseMapTests(unittest.TestCase):
+    """The liveness predicate is only sound if slug→worktree is exact."""
+
+    def test_reverses_project_slug_to_the_owning_worktree_dir(self):
+        pattern = make_re()
+        transcript = (
+            "/Users/alice/.claude/projects/"
+            "-Users-alice--adk-release-worktrees-claude-adk-cc-20260731-220205/"
+            "8cf48ae8-10e0-44a5-af3e-defc060fdf5f.jsonl"
+        )
+        self.assertEqual(
+            relay_watchdog.worktree_dir_for_transcript(
+                transcript, WORKTREE_ROOT, pattern
+            ),
+            Path(WORKTREE_ROOT) / "claude-adk-cc-20260731-220205",
+        )
+
+    def test_refuses_to_resolve_a_foreign_or_thread_project_dir(self):
+        pattern = make_re()
+        for parent in (
+            "-Users-bob--adk-release-worktrees-claude-adk-cc-20260731-220205",
+            "-Users-alice--adk-release-worktrees-claude-adk-cc-t123-20260731-220205",
+            "-Users-alice--adk-release-worktrees-claude-adk-cc-20260731",
+        ):
+            with self.subTest(parent=parent):
+                self.assertIsNone(
+                    relay_watchdog.worktree_dir_for_transcript(
+                        f"/p/{parent}/s.jsonl", WORKTREE_ROOT, pattern
+                    )
+                )
+
+    def test_unreadable_directory_is_not_reported_as_absent(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        present = Path(tmp.name)
+        self.assertIs(relay_watchdog.directory_presence(present), True)
+        self.assertIs(
+            relay_watchdog.directory_presence(present / "nope"), False
+        )
+        with mock.patch.object(
+            relay_watchdog.os, "stat", side_effect=OSError(5, "I/O error")
+        ):
+            self.assertIsNone(relay_watchdog.directory_presence(present))
+
+
+class DeadWorktreeRetirementTests(unittest.TestCase):
+    """#5155: loss-state bound to a session that provably cannot come back.
+
+    Shape mirrors the live 2026-08-05 state read off
+    ``logs/relay-watchdog.state.json``: the transcript is a GAP owner and NOT
+    pending (``pending_transcripts: []``), its worktree directory was deleted,
+    and its last write was ~4.9 days before the tick — so nothing in the
+    existing machinery (idle skip, pending expiry, supersession) retires it and
+    the incident re-fires on its cooldown forever.
+    """
+
+    SESSION = "claude-adk-cc-20260731-220205"
+
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        (self.root / "logs").mkdir()
+        self.worktrees = self.root / "worktrees"
+        self.worktrees.mkdir()
+        self.projects = self.root / "projects"
+        self.proj_dir = self.projects / (
+            project_slug(str(self.worktrees)) + "-" + self.SESSION
+        )
+        self.proj_dir.mkdir(parents=True)
+        env = mock.patch.dict(
+            os.environ, {"CLAUDE_PROJECTS_ROOT": str(self.projects)}
+        )
+        env.start()
+        self.addCleanup(env.stop)
+        self.channel = ChannelConfig(
+            channel_id="999",
+            sendmessage_key="k",
+            worktree_root=str(self.worktrees),
+        )
+        self.now = time.time()
+        self.transcript = self.proj_dir / "8cf48ae8.jsonl"
+
+    def create_worktree(self) -> None:
+        (self.worktrees / self.SESSION).mkdir()
+
+    def write_stale_transcript(self, age_secs: float) -> None:
+        epoch = self.now - age_secs
+        record = json.dumps(
+            {
+                "type": "assistant",
+                "uuid": "00000000-0000-4000-8000-000000000001",
+                "timestamp": time.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                ),
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "undelivered block behind lost=1"}
+                    ]
+                },
+            }
+        )
+        self.transcript.write_text(record + "\n", encoding="utf-8")
+        os.utime(self.transcript, (epoch, epoch))
+
+    def open_incident_state(self) -> dict:
+        """Persisted shape of an already-open gap incident on this path."""
+        path = str(self.transcript)
+        return {
+            "alerting": True,
+            "gap_since": self.now - 4.9 * 86400,
+            "issue_url": "https://example.test/issues/5072",
+            "last_alert": 0.0,
+            relay_watchdog.GAP_TRANSCRIPT_KEY: path,
+            relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY: [path],
+            relay_watchdog.PENDING_TRANSCRIPTS_KEY: [],
+            SELECTED_TRANSCRIPT_KEY: path,
+            relay_watchdog.TRANSCRIPT_SIZES_KEY: {
+                path: self.transcript.stat().st_size
+            },
+            relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY: {
+                f"{index:064x}": {
+                    "confirmed_at": self.now - 5 * 86400,
+                    "epoch": self.now - 5 * 86400,
+                    "path": path,
+                }
+                for index in range(3)
+            },
+            relay_watchdog.PERMANENT_LOSS_TOTAL_KEY: 3,
+        }
+
+    def make_rt(self, **cfg_overrides) -> FakeRuntime:
+        cfg = Config(channels=(self.channel,), **cfg_overrides)
+        rt = FakeRuntime(cfg, self.root)
+        rt.haystack = ""
+        return rt
+
+    def tick(self, rt: FakeRuntime, state: dict, at: float) -> None:
+        tick_channel(rt, self.channel, state, at)
+
+    # ── dead ────────────────────────────────────────────────────────────────
+
+    def test_deleted_worktree_terminates_the_gap_incident(self):
+        self.write_stale_transcript(4.9 * 86400)
+        rt = self.make_rt()
+        state = {"999": self.open_incident_state()}
+        chs = state["999"]
+
+        # Tick 1 only opens the absence window; the incident is still live.
+        self.tick(rt, state, self.now)
+        self.assertTrue(chs.get("alerting"), rt.log_lines)
+        self.assertIn(
+            str(self.transcript),
+            chs.get(relay_watchdog.DEAD_WORKTREE_ABSENT_SINCE_KEY, {}),
+        )
+
+        self.tick(
+            rt, state, self.now + relay_watchdog.DEAD_WORKTREE_CONFIRM_SECS + 1
+        )
+
+        self.assertFalse(chs.get("alerting"), (chs, rt.log_lines))
+        self.assertNotIn("gap_since", chs)
+        self.assertNotIn("issue_url", chs)
+        self.assertNotIn(relay_watchdog.GAP_TRANSCRIPT_KEY, chs)
+        self.assertNotIn(relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY, chs)
+        self.assertIn(
+            str(self.transcript), chs[relay_watchdog.RETIRED_TRANSCRIPTS_KEY]
+        )
+        self.assertTrue(
+            any(
+                "dead-worktree-loss-state-retired" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+        # Retirement is not a delivery claim.
+        self.assertFalse(
+            any("릴레이 갭 해소" in body for body, _ in rt.alerts), rt.alerts
+        )
+        self.assertTrue(
+            any("죽은 세션" in body for body, _ in rt.alerts), rt.alerts
+        )
+        # The historical ledger is monotonic (#4954): retirement must not
+        # decrease the projection nor drop a tombstone.
+        self.assertEqual(permanent_loss_total(chs), 3)
+        self.assertEqual(
+            set(chs[relay_watchdog.PERMANENT_LOSS_TOMBSTONES_KEY]),
+            {f"{index:064x}" for index in range(3)},
+        )
+
+    def test_terminated_incident_stops_re_alerting(self):
+        self.write_stale_transcript(4.9 * 86400)
+        rt = self.make_rt()
+        state = {"999": self.open_incident_state()}
+        at = self.now
+        self.tick(rt, state, at)
+        at += relay_watchdog.DEAD_WORKTREE_CONFIRM_SECS + 1
+        self.tick(rt, state, at)
+        alerts_after_retirement = len(rt.alerts)
+        gap_alerts_before = sum(
+            1 for body, _ in rt.alerts if "릴레이 갭 감지" in body
+        )
+        # Five further re-alert windows must produce no new alert of any kind.
+        for _ in range(5):
+            at += rt.cfg.realert_secs + 1
+            self.tick(rt, state, at)
+        self.assertEqual(len(rt.alerts), alerts_after_retirement, rt.alerts)
+        self.assertEqual(
+            sum(1 for body, _ in rt.alerts if "릴레이 갭 감지" in body),
+            gap_alerts_before,
+            rt.alerts,
+        )
+
+    def test_absence_shorter_than_confirm_window_keeps_the_incident_open(self):
+        self.write_stale_transcript(4.9 * 86400)
+        rt = self.make_rt()
+        state = {"999": self.open_incident_state()}
+        chs = state["999"]
+        self.tick(rt, state, self.now)
+        self.tick(
+            rt, state, self.now + relay_watchdog.DEAD_WORKTREE_CONFIRM_SECS - 1
+        )
+        self.assertTrue(chs.get("alerting"), rt.log_lines)
+        self.assertIn(
+            str(self.transcript),
+            chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY],
+        )
+        self.assertTrue(
+            any(
+                "dead-worktree-absence-pending" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+    def test_selector_divergence_window_is_voided_with_the_dead_session(self):
+        self.write_stale_transcript(4.9 * 86400)
+        rt = self.make_rt()
+        state = {"999": self.open_incident_state()}
+        chs = state["999"]
+        chs["selector_alerting"] = True
+        chs["selector_diverged_since"] = self.now - 4.9 * 86400
+        chs[relay_watchdog.SELECTOR_DIVERGED_TRANSCRIPT_KEY] = str(
+            self.transcript
+        )
+        self.tick(rt, state, self.now)
+        self.tick(
+            rt, state, self.now + relay_watchdog.DEAD_WORKTREE_CONFIRM_SECS + 1
+        )
+        self.assertNotIn("selector_alerting", chs)
+        self.assertNotIn("selector_diverged_since", chs)
+        self.assertNotIn(relay_watchdog.SELECTOR_DIVERGED_TRANSCRIPT_KEY, chs)
+
+    # ── alive ───────────────────────────────────────────────────────────────
+
+    def test_live_but_idle_session_keeps_reporting_its_gap(self):
+        """NON-SUPPRESSION: quiet is not dead.
+
+        Identical to the dead case in every respect the watchdog can otherwise
+        observe — same 4.9-day-idle transcript, same open incident, same number
+        of ticks — except the worktree directory still exists. The gap must
+        survive untouched and keep alerting.
+        """
+        self.create_worktree()
+        self.write_stale_transcript(4.9 * 86400)
+        rt = self.make_rt()
+        state = {"999": self.open_incident_state()}
+        chs = state["999"]
+        at = self.now
+        self.tick(rt, state, at)
+        for _ in range(6):
+            at += relay_watchdog.DEAD_WORKTREE_CONFIRM_SECS + 1
+            self.tick(rt, state, at)
+
+        self.assertTrue(chs.get("alerting"), (chs, rt.log_lines))
+        self.assertIn(
+            str(self.transcript),
+            chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY],
+        )
+        self.assertNotIn(
+            str(self.transcript),
+            chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {}),
+        )
+        self.assertNotIn(relay_watchdog.DEAD_WORKTREE_ABSENT_SINCE_KEY, chs)
+        self.assertFalse(
+            any("dead-worktree" in line for line in rt.log_lines), rt.log_lines
+        )
+        self.assertTrue(
+            any("릴레이 갭 감지" in body for body, _ in rt.alerts), rt.alerts
+        )
+
+    def test_unreadable_worktree_root_never_retires_anything(self):
+        self.write_stale_transcript(4.9 * 86400)
+        rt = self.make_rt()
+        state = {"999": self.open_incident_state()}
+        chs = state["999"]
+        self.tick(rt, state, self.now)
+        self.assertIn(
+            str(self.transcript),
+            chs.get(relay_watchdog.DEAD_WORKTREE_ABSENT_SINCE_KEY, {}),
+        )
+        # The whole root disappears (dismount / rename): every worktree now
+        # stats absent, which must NOT be read as every session being dead.
+        self.worktrees.rmdir()
+        self.tick(
+            rt, state, self.now + relay_watchdog.DEAD_WORKTREE_CONFIRM_SECS + 1
+        )
+        self.assertTrue(chs.get("alerting"), (chs, rt.log_lines))
+        self.assertIn(
+            str(self.transcript),
+            chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY],
+        )
+        self.assertNotIn(relay_watchdog.DEAD_WORKTREE_ABSENT_SINCE_KEY, chs)
+        self.assertTrue(
+            any(
+                "dead-worktree-probe-reset" in line for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+    def test_a_still_writing_transcript_is_never_retired(self):
+        """Belt-and-braces: even with the directory gone, a growing file stays."""
+        self.write_stale_transcript(10.0)
+        rt = self.make_rt()
+        state = {"999": self.open_incident_state()}
+        chs = state["999"]
+        self.tick(rt, state, self.now)
+        self.tick(
+            rt, state, self.now + relay_watchdog.DEAD_WORKTREE_CONFIRM_SECS + 1
+        )
+        self.assertNotIn(
+            str(self.transcript),
+            chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {}),
+        )
+        self.assertTrue(
+            any(
+                "dead-worktree-retirement-declined" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+
+class AnnounceSkipLoggingTests(unittest.TestCase):
+    """#5155 correction 1: 'not attempted' must not read as 'attempted and failed'."""
+
+    def test_empty_announce_to_logs_that_the_primary_was_skipped(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        (root / "logs").mkdir()
+        ch = ChannelConfig(
+            channel_id="999", sendmessage_key="k", worktree_root=WORKTREE_ROOT
+        )
+        rt = Runtime(Config(channels=(ch,)), root)
+        lines: list[str] = []
+        rt.log = lines.append  # type: ignore[method-assign]
+        with mock.patch.object(
+            relay_watchdog.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess([], 0, "", ""),
+        ) as run:
+            self.assertTrue(rt.alert(ch, "body"))
+        self.assertEqual(run.call_count, 1, "primary must not be attempted")
+        self.assertTrue(
+            any("announce bot skipped" in line for line in lines), lines
+        )
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #5155

## 무엇을 고쳤나

릴레이 워치독이 **5일 전 삭제된 워크트리**의 transcript 에 대한 gap 인시던트를 영구히 붙들고 ~16분마다 Discord 에 ALERT 를 게시했다 (누적 2,835틱 / 실제 게시 379건 / `gap_min` 7001).

PR #5158 은 selector 가 그 죽은 파일을 *쫓는* 것만 막았고 인시던트 자체는 닫지 못했다 — `gap_owner_transcripts` 에 남은 경로는 idle-skip 을 우회해 영구히 평가되기 때문이다.

이 PR 은 **소유 워크트리 디렉터리의 존재 여부**를 liveness 술어로 삼아 loss-state 를 종결한다. mtime 노후도를 쓰면 "조용함 = 죽음" 이 되지만, **조용한 세션도 자기 체크아웃 디렉터리는 소유**하므로 idle 을 dead 로 오인하지 않는다.

**3중 안전장치:**
1. 부재는 `ENOENT`/`ENOTDIR` 로만 증명 (그 외 `OSError` 는 판정불가)
2. 600초 연속 지속
3. transcript 가 `idle_quiet_secs` 도 넘겨야 함

은퇴는 배달 주장이 아니다 — RECOVERED 알림 없음, 종결 통지 1건, `permanent_loss` 원장 무손상, 파일이 다시 semantic 성장하면 재입장.

**COVERAGE 와 PERMANENT LOSS 스트림은 코드 한 줄도 건드리지 않았다** (전자는 진짜 desync 일 수 있어 억제 금지, 후자는 신규 확정 손실에만 발화).

## 리뷰 이력

**r1 → `ISSUES` (P1 3건). r2 → `VERDICT: CLEAN` (P0/P1 0건).**
두 라운드 모두 실행 기반이고, 리뷰어가 격리 사본(`git archive HEAD`)에서 뮤테이션을 돌렸다.

### r1 이 잡은 3건과 r2 의 수정

- **P1-A `relay_watchdog.py:3736` fail-open** — `candidate is not None and …` 라 `candidate` 가 `None` 이면 idle 가드가 **통째로 건너뛰어져 idle 0초 transcript 가 즉시 은퇴**됐다. `channel_project_dirs` 가 모든 `OSError` 에서 `[]` 를 반환하므로 리스팅 실패 한 틱이면 열린다. 이는 같은 파일 주석이 약속한 불변식("a file still being written is never retired no matter what its directory stat says")과 정면으로 어긋났다. → `candidate is None or …` 로 뒤집어 형제 가드(`:4685`)와 같은 fail-closed 규약 복원. **주석은 한 글자도 약화하지 않고 코드가 약속을 지키게 했다.**
- **P1-B 침묵 종결** — 공유 쿨다운(`realert_secs=900`)에 "마지막 통지" 가 삼켜져도 `_retire_dead_worktree_authorities` 가 반환값을 무시하고 종결을 진행했다. → **통지가 실제로 전달되지 않으면 loss-state 는 종결되지 않는다**를 불변식으로 고정. 알림을 모든 상태 변경 이전에 시도하고, 억제/실패 시 absence 창을 유지한 채 다음 틱 재시도.
- **P1-C COVERAGE corroborator 안전 논증 미입증** — 실제 로그의 형상은 선택 transcript 가 죽은 경로이고 `lost=1` 이라 `growing_relay_stall=False` 였고, 그 경보의 유일한 corroborator 가 이 PR 이 pop 하는 `alerting`/`gap_since` 였다. r1 테스트는 `lost=0, growing=True` 를 검사했다. → 실제 형상에서 시작해 은퇴 → 재선택 → 경보까지 한 시나리오로 거는 테스트 추가.

### r2 리뷰가 실행으로 닫은 것

- **뮤테이션 9종** (MA / M2 / M4 / M7 / M8 / M9 / MB_a / MB_b / MC) 전부 `py_compile` 선통과 후 자기 assert 로 사망. 특히 MC(`growing_relay_stall = False`) 가 신규 테스트 포함 4건을 죽여 **은퇴 후 알람을 실제로 지탱하는 것이 독립 corroborator 임을 입증**.
- **P1-B 반대 방향 검증**: 12틱(24분) 연속 전달 실패 프로브를 돌려 "영원히 은퇴 못 하고 스팸이 계속되는" 순환이 성립하지 않음을 확인 — GAP ALERT 와 은퇴 통지가 **동일한 alert 경로**를 쓰므로, 은퇴가 막히는 조건에서는 사용자 가시 스팸도 배달되지 않는다.
- **라이브 로그 축자 대조**: 도크스트링이 인용한 `transcript-select reason=growth` / `COVERAGE ALERT reason=attached_but_desynced ticks=18` / `gap persists ... lost=1` 이 `relay-watchdog.log:42133/42136/42137` 에 그대로 존재. 픽스처의 후속 세션명도 같은 틱의 `selector-sync diverged B=` 값과 일치 → **후속 존재는 픽스처 우연이 아니라 실제 사건의 형상**.
- **형제 fail-open 전수 스캔**: 신규 코드의 `is not None and` / `is not True` / `is not False` 를 전부 훑어 남은 2건이 **둘 다 fail-closed 방향**임을 확인.
- 테스트 삭제 **0건**, 함수명 집합 diff 로 개명 0건 확인, 스위트 291 → 295 (정확히 +4).
- ⚠️ 리뷰어가 정직하게 밝힌 것: r1 뮤테이션 정의를 전달받지 못해 **재구성**했고, 그중 2건이 SURVIVED 였다. 같은 뮤턴트를 **r1 트리에 적용해도 SURVIVED** 임을 확인해 **r2 회귀가 아닌 r1 부터의 기존 공백**으로 판정했다 (P2 후속).

## Rebase 및 패치 동일성 실측

브랜치 원 base 는 `93404da0e` 였으나 `origin/main` 이 `61bf1b740` (#5153 / PR #5162) 으로 전진했다. 해당 PR 은 이 브랜치와 같은 파일 `tests/test_relay_watchdog.py` 에 +130 줄을 추가했다.

- **Rebase onto `61bf1b740`: 충돌 0건** (git 이 양쪽 hunk 를 분리 적용).
- **패치 동일성 실측** — rebase 전후 `+`/`-` 줄 전량 비교:
  ```
  git diff 93404da0e...b4d4b42c8            > p-before.diff
  git diff origin/main...HEAD               > p-after.diff
  diff <(grep -E "^[+-]" p-before.diff | grep -vE "^(\+\+\+|---)") \
       <(grep -E "^[+-]" p-after.diff  | grep -vE "^(\+\+\+|---)")
  → 0 줄 차이
  ```
  **프로덕션·테스트 코드 모두 rebase 로 변형된 부분이 한 줄도 없다.** 따라서 r2 `CLEAN` verdict 를 그대로 승계하고, 게이트만 새 base 에서 재실행했다.
- **테스트 유실 검증**: `tests/test_relay_watchdog.py` diff 의 `-` 줄 **0건**, `origin/main` 대비 함수명 집합 diff 에서 제거된 함수 **0건**. 프로덕션 파일의 유일한 삭제 줄은 `-    rt.alert(` 1줄 (`+941/−1` stat 과 일치).

### 테스트 수 실측

| 트리 | 테스트 수 |
|---|---|
| 원 base `93404da0e` | 279 |
| `origin/main` `61bf1b740` (#5153 착지 후) | 282 |
| 브랜치 단독 (rebase 전, `b4d4b42c8`) | 295 |
| **rebase 후 HEAD** | **298** = 282 + 16 |

브랜치가 base 에 더한 16건이 #5153 의 3건 위에 온전히 합산되어 **양쪽 테스트가 모두 보존**되었음이 수치로 확인된다.

## 게이트 결과 (새 base 에서 재실행)

- `python3 -m unittest tests.test_relay_watchdog` → **Ran 298 tests, OK, rc=0**
- `TEST_LANE_BASELINE_REF=origin/main bash scripts/ci-script-checks.sh` → **rc=0**

## 후속 항목 (P2 — 이 PR 범위 밖, verdict 무관)

1. 전면 알림 불능 구간에서 은퇴 통지 시도가 매 틱 발생 (12/12틱 실측). 시도 자체에 백오프 검토.
2. 불변식 비대칭: idle(`:4276`)·read_failure(`:4626`) 은퇴는 여전히 상태를 먼저 바꾸고 반환값을 무시 → 전달 실패 시 침묵 종결이 남아 있다.
3. `directory_presence` 가 `None`(EACCES/EIO)을 반환하는 분기에 테스트 없음 — r1 부터의 기존 공백.
4. 라이브 후속이 없는 은퇴에서 confirmed desync 알람이 조용해지고 `coverage_alerting` 이 True 로 고착 — 기존 #4504/#4841 정책과 일관되나 미커버.
5. `:3766` 의 `persisted_sizes.get(path)` 폴백은 P1-A 수정 이후 도달 불가한 죽은 분기.
6. 알려진 기존 항목: `size=0` 은퇴 기록의 의미 상실, "five consecutive polls" 가 실제로는 t0+605s(6번째 관측), `announce_to=""` 에서 신규 로그가 모든 alert 마다 출력되는 볼륨.
