### PR TITLE
fix(relay): size "fits one Discord message" in characters, not bytes

### DIFF
--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -4180,6 +4180,7 @@ services::discord::session_relay_sink::tests::inflight_sink_marker::commit_not_d
 services::discord::session_relay_sink::tests::inflight_sink_marker::commit_then_drop_releases_to_unleased
 services::discord::session_relay_sink::tests::inflight_sink_marker::drop_without_commit_releases_without_committing
 services::discord::session_relay_sink::tests::inflightless_ranged_frame_acquires_sink_lease_before_terminal_delivery_4277
+services::discord::session_relay_sink::tests::korean_answer_under_the_character_limit_stays_one_message
 services::discord::session_relay_sink::tests::lease_guard_drop_clears_own_lease_and_is_inert_for_foreign_owner
 services::discord::session_relay_sink::tests::lease_guard_drop_preserves_newer_turn_lease_no_clobber
 services::discord::session_relay_sink::tests::lease_guard_drop_preserves_newer_unassigned_lease_by_generation
@@ -4346,6 +4347,7 @@ services::discord::standby_relay::tests::extract_result_text_strips_tui_no_respo
 services::discord::standby_relay::tests::heartbeat_offset_rewinds_to_pending_result_until_delivery_commits
 services::discord::standby_relay::tests::inflight_signal_broadcast_delivers_to_subscriber
 services::discord::standby_relay::tests::inflight_signal_filter_matches_own_channel_only
+services::discord::standby_relay::tests::korean_answer_under_the_character_limit_stays_one_message
 services::discord::standby_relay::tests::placeholder_long_terminal_delivery_uses_ordered_new_chunks
 services::discord::standby_relay::tests::poll_scan_defers_fallback_until_completed_grace_expires
 services::discord::standby_relay::tests::poll_scan_prefers_result_before_completed_fallback
@@ -4681,6 +4683,7 @@ services::discord::tmux::tmux_watcher::session_bound_ack::tests::inflight_sink_m
 services::discord::tmux::tmux_watcher::session_bound_ack::tests::inflight_sink_marker_gate::leased_sink_fresh_waits_in_flight
 services::discord::tmux::tmux_watcher::session_bound_ack::tests::inflight_sink_marker_gate::reclaim_then_late_sink_commit_cannot_corrupt_lease
 services::discord::tmux::tmux_watcher::session_bound_ack::tests::inflight_sink_marker_gate::unleased_defers_to_reconciliation
+services::discord::tmux::tmux_watcher::session_bound_ack::tests::korean_answer_under_the_character_limit_stays_one_message
 services::discord::tmux::tmux_watcher::session_bound_ack::tests::not_attempted_sentinel::ack_wait_with_no_target_still_returns_missing_target
 services::discord::tmux::tmux_watcher::session_bound_ack::tests::not_attempted_sentinel::not_attempted_folds_identically_to_missing_target
 services::discord::tmux::tmux_watcher::session_bound_ack::tests::not_attempted_sentinel::not_attempted_is_distinct_from_missing_target
@@ -5419,6 +5422,7 @@ services::discord::turn_bridge::recovery_text::tests::voluntary_feedback_reminde
 services::discord::turn_bridge::recovery_text::tests::voluntary_feedback_reminder_stash_take_and_put_back_round_trips_pg
 services::discord::turn_bridge::response_delivery::headless_completion_footer_tests::headless_enqueue_success_registers_completion_footer_text
 services::discord::turn_bridge::response_delivery::streaming_edit_text_tests::empty_response_notice_is_delivery_only_not_history_payload
+services::discord::turn_bridge::response_delivery::tests::korean_answer_under_the_character_limit_stays_one_message
 services::discord::turn_bridge::response_delivery::tests::long_authoritative_done_after_rollover_replays_full_body
 services::discord::turn_bridge::response_delivery::tests::prompt_too_long_guidance_round_trips_folded_provider_detail
 services::discord::turn_bridge::response_delivery::tests::terminal_delivery_after_rollover_includes_authoritative_tail
@@ -5605,6 +5609,7 @@ services::discord::turn_bridge::terminal_delivery::tests::bridge_skip_save_is_id
 services::discord::turn_bridge::terminal_delivery::tests::empty_sink_commits_nonempty_response_that_was_already_fully_consumed
 services::discord::turn_bridge::terminal_delivery::tests::empty_sink_preserves_retry_unless_resume_retry_was_queued
 services::discord::turn_bridge::terminal_delivery::tests::final_completion_delivery_stays_blocked_until_terminal_message_commits
+services::discord::turn_bridge::terminal_delivery::tests::korean_answer_under_the_character_limit_stays_one_message
 services::discord::turn_bridge::terminal_delivery::tests::long_terminal_response_uses_new_chunk_messages
 services::discord::turn_bridge::terminal_delivery::tests::ordered_long_terminal_delivery_rolls_back_partial_chunks_before_retry
 services::discord::turn_bridge::terminal_delivery::tests::ordered_long_terminal_delivery_sends_all_chunks_and_deletes_placeholder

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -211,7 +211,8 @@ mod delivery;
 
 use self::delivery::send_channel_message_with_optional_reference;
 pub(super) use self::delivery::{
-    build_long_message_attachment, send_long_message_ctx, send_long_message_raw, split_message,
+    build_long_message_attachment, needs_multiple_messages, send_long_message_ctx,
+    send_long_message_raw, split_message,
 };
 #[allow(unused_imports)]
 pub(in crate::services::discord) use self::delivery::{

--- a/src/services/discord/formatting/delivery.rs
+++ b/src/services/discord/formatting/delivery.rs
@@ -9,7 +9,7 @@ pub(in crate::services::discord) async fn send_long_message_ctx(
     ctx: Context<'_>,
     text: &str,
 ) -> Result<(), Error> {
-    if char_count(text) <= DISCORD_MSG_LIMIT {
+    if !needs_multiple_messages(text) {
         tracing::debug!(
             target: "discord::chunker",
             path = "send_long_message_ctx",
@@ -47,7 +47,7 @@ pub(in crate::services::discord) async fn send_long_message_ctx(
 pub(in crate::services::discord) fn long_message_reply_builders(
     text: &str,
 ) -> Vec<poise::CreateReply> {
-    if char_count(text) <= DISCORD_MSG_LIMIT {
+    if !needs_multiple_messages(text) {
         return vec![poise::CreateReply::default().content(text.to_string())];
     }
 
@@ -123,7 +123,7 @@ pub(in crate::services::discord) async fn send_long_message_raw_with_reference_r
     reference: Option<(ChannelId, MessageId)>,
 ) -> Result<Vec<MessageId>, Error> {
     let payload_byte_len = text.len();
-    if char_count(text) <= DISCORD_MSG_LIMIT {
+    if !needs_multiple_messages(text) {
         tracing::debug!(
             target: "discord::chunker",
             path = "send_long_message_raw",
@@ -460,6 +460,24 @@ pub(in crate::services::discord) fn split_message(text: &str) -> Vec<String> {
     );
 
     chunks
+}
+
+/// Whether `text` exceeds what one Discord message can carry.
+///
+/// Discord's 2000 limit counts **characters**, so this must too. Callers used
+/// to compare `text.len()` — a **byte** count — against `DISCORD_MSG_LIMIT`.
+/// For ASCII the two agree, which is why the ASCII-only tests passed; for
+/// Korean (3 bytes per character in UTF-8) the byte comparison trips at roughly
+/// 667 characters, so a comfortably single-message answer was routed down the
+/// multi-chunk path and reached the channel split in two.
+///
+/// Deliberately not `split_message(text).len() > 1`: that chunker reserves a
+/// ~10-character margin for code-fence repair, so texts in the 1991..=2000
+/// range would be declared multi-message even though they fit one send. This
+/// predicate answers "does it fit at all"; [`split_message`] owns "how do I cut
+/// it once it doesn't".
+pub(in crate::services::discord) fn needs_multiple_messages(text: &str) -> bool {
+    char_count(text) > DISCORD_MSG_LIMIT
 }
 
 /// Build an `(inline_message, attachment)` pair for content that exceeds

--- a/src/services/discord/formatting/delivery.rs
+++ b/src/services/discord/formatting/delivery.rs
@@ -469,13 +469,74 @@ pub(in crate::services::discord) fn split_message(text: &str) -> Vec<String> {
 /// For ASCII the two agree, which is why the ASCII-only tests passed; for
 /// Korean (3 bytes per character in UTF-8) the byte comparison trips at roughly
 /// 667 characters, so a comfortably single-message answer was routed down the
-/// multi-chunk path and reached the channel split in two.
+/// multi-chunk path.
 ///
-/// Deliberately not `split_message(text).len() > 1`: that chunker reserves a
-/// ~10-character margin for code-fence repair, so texts in the 1991..=2000
-/// range would be declared multi-message even though they fit one send. This
-/// predicate answers "does it fit at all"; [`split_message`] owns "how do I cut
-/// it once it doesn't".
+/// Over most of the affected range the mis-route does NOT split the answer
+/// body: [`split_message`] already counts characters, so a 667..=1990-character
+/// body yields exactly one chunk either way. The ceiling is 1990, not 2000 —
+/// the chunker's `effective_limit` is `DISCORD_MSG_LIMIT - tag_overhead - 10`,
+/// and the 10 characters reserved for code-fence repair apply even to text with
+/// no fence. What this predicate actually selects is HOW the answer reaches the
+/// channel — edit the placeholder in place, or delete it and POST fresh
+/// messages. Taking the second branch for a single-message answer costs the
+/// answer its channel position, its reply anchor and its message id, and moves
+/// delivery-lease ownership.
+///
+/// In 1991..=2000 this predicate and [`split_message`] genuinely disagree: this
+/// returns `false` (one message) while the chunker, asked, cuts the text into
+/// two or more chunks. Whether that disagreement is observable depends on which
+/// branch a caller's `false` leads to, and the ten call sites split into three
+/// kinds:
+///
+/// * **Direct-POST callers** — `send_long_message_ctx` (:12),
+///   `long_message_reply_builders` (:50) and
+///   `send_long_message_raw_with_reference_returning_message_ids` (:126). Their
+///   `false` branch hands `text` to Discord whole and never calls the chunker,
+///   and Discord accepts all 2000 characters. Here the disagreement really is
+///   unreachable.
+/// * **Replace callers** — the per-surface predicates that wrap this one. Their
+///   `false` branch falls through to `replace_long_message_raw_with_outcome`
+///   (verified: `standby_relay.rs:854` reaching `:900`, and
+///   `session_relay_sink.rs:980` reaching `:1049`), and both wrappers funnel
+///   into `replace_long_message_raw_deferred_returning_receipt`, which calls
+///   `split_message(text)` **unconditionally** at
+///   `formatting/replace_long_message.rs:229` — this predicate's answer never
+///   reaches it. Here the disagreement IS reachable and IS observable: a
+///   1995-character body is edited into the placeholder as chunk 0 and the
+///   remainder is POSTed as a continuation, so the answer lands as two messages
+///   even though this predicate said one.
+/// * **Attachment-inline budget checks** — `build_attachment_inline` (:587,
+///   :601) asks only whether an already-composed inline notice fits, and picks
+///   between two candidate strings; no chunker is involved on either answer, so
+///   the disagreement cannot surface there either.
+///
+/// That is still not a correctness defect, but for a narrower reason than "it
+/// cannot happen". On the replace path the split neither truncates nor
+/// over-sends. No chunk can exceed the Discord limit: a chunk is at most
+/// `tag_overhead + effective_limit + 4` characters, and since `effective_limit`
+/// is `DISCORD_MSG_LIMIT - tag_overhead - 10`, that is at most 1994 — the
+/// 10-character reserve covers the 4-character closing code fence. Nothing is
+/// dropped: the chunker's loop consumes `remaining` until it is empty, and
+/// `replace_long_message.rs` emits chunk 0 as the edit and every later chunk as
+/// a continuation POST. The only character it removes is a single newline at a
+/// boundary that begins with one (`rest.strip_prefix('\n')`), consumed as the
+/// message separator; code-fence repair only ADDS characters. So the cost of
+/// the disagreement is one extra continuation message and a line break promoted
+/// to a message break — not lost content and not a rejected send.
+///
+/// Deliberately not `split_message(text).len() > 1`. The reason is NOT that the
+/// disagreement is unreachable — on the replace path it is not. It is that
+/// 1991..=2000-character texts genuinely DO fit one Discord message, and the
+/// chunker's 1990 ceiling is a code-fence repair margin rather than a Discord
+/// constraint. Adopting the chunker as the predicate would push those texts
+/// down the multi-message path on every surface, including the three
+/// direct-POST callers that deliver them as one message today, and would cost
+/// the replace callers the placeholder's channel position, reply anchor and
+/// message id for a limit Discord does not impose. This predicate answers "does
+/// it fit at all"; [`split_message`] owns "how do I cut it once it doesn't".
+/// The residual seam — a 10-character band in which the replace path cuts a
+/// body this predicate calls single-message — is known and bounded, and the
+/// #3089 A0 characterization tests pin the current answer.
 pub(in crate::services::discord) fn needs_multiple_messages(text: &str) -> bool {
     char_count(text) > DISCORD_MSG_LIMIT
 }
@@ -522,7 +583,12 @@ fn build_attachment_inline(text: &str, summary: Option<&str>) -> String {
 
     if let Some(summary) = trimmed_summary {
         let candidate = with_provenance(format!("{summary}{footer}"));
-        if char_count(&candidate) <= DISCORD_MSG_LIMIT {
+        // Same question, same definition: `!needs_multiple_messages(x)` is
+        // exactly `char_count(x) <= DISCORD_MSG_LIMIT`, which this used to
+        // open-code. Routed through the helper so "every surface that asks
+        // whether something fits one Discord message shares one definition"
+        // holds without an exception list.
+        if !needs_multiple_messages(&candidate) {
             return candidate;
         }
     }
@@ -536,7 +602,7 @@ fn build_attachment_inline(text: &str, summary: Option<&str>) -> String {
     // Discord limit, this attachment path has no second inline fallback and
     // the send will surface Discord's length rejection; keep this assertion so
     // that such a change is caught in debug/test builds rather than hidden.
-    debug_assert!(char_count(&fallback) <= DISCORD_MSG_LIMIT);
+    debug_assert!(!needs_multiple_messages(&fallback));
     fallback
 }
 

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -403,7 +403,7 @@ struct SinkPostHeartbeatGuard {
 impl toc::PostHeartbeatGuard for SinkPostHeartbeatGuard {}
 
 fn session_bound_should_send_new_chunks_for_placeholder(response_text: &str) -> bool {
-    response_text.len() > super::DISCORD_MSG_LIMIT
+    super::formatting::needs_multiple_messages(response_text)
 }
 
 /// Pick the one ordered coordinate used by every terminal sink path. Strict
@@ -1803,6 +1803,21 @@ mod tests {
         assert!(session_bound_should_send_new_chunks_for_placeholder(&body));
         assert!(!session_bound_should_send_new_chunks_for_placeholder(
             "[E2E:E15:BEGIN]\nE15-LINE-150\n[E2E:E15:END]"
+        ));
+    }
+
+    /// Twin of the standby-relay guard: a Korean answer that fits in one
+    /// Discord message must not be routed down the multi-chunk path just
+    /// because its UTF-8 byte length exceeds the character limit.
+    #[test]
+    fn korean_answer_under_the_character_limit_stays_one_message() {
+        let body = "한".repeat(900);
+        assert!(body.len() > super::super::DISCORD_MSG_LIMIT);
+        assert!(!session_bound_should_send_new_chunks_for_placeholder(&body));
+
+        let overflowing = "한".repeat(2100);
+        assert!(session_bound_should_send_new_chunks_for_placeholder(
+            &overflowing
         ));
     }
 

--- a/src/services/discord/standby_relay.rs
+++ b/src/services/discord/standby_relay.rs
@@ -1392,9 +1392,11 @@ mod tests {
     }
 
     /// Korean answers are ~3 bytes per character, so the old `text.len() >
-    /// DISCORD_MSG_LIMIT` byte check fired at ~667 characters and split a
-    /// single-message answer in two. The predicate must track `split_message`,
-    /// which counts characters.
+    /// DISCORD_MSG_LIMIT` byte check fired at ~667 characters and routed a
+    /// single-message answer down the delete-placeholder-and-POST-new-messages
+    /// path instead of the in-place edit. (It did not split the body:
+    /// `split_message` already counts characters and returns one chunk here.)
+    /// The predicate must track `split_message`, which counts characters.
     #[test]
     fn korean_answer_under_the_character_limit_stays_one_message() {
         let body = "한".repeat(900);

--- a/src/services/discord/standby_relay.rs
+++ b/src/services/discord/standby_relay.rs
@@ -530,7 +530,7 @@ fn standby_completed_drain_expired(
 }
 
 fn standby_should_send_new_chunks_for_placeholder(response_text: &str) -> bool {
-    response_text.len() > super::DISCORD_MSG_LIMIT
+    super::formatting::needs_multiple_messages(response_text)
 }
 
 fn standby_heartbeat_offset(
@@ -1389,6 +1389,20 @@ mod tests {
         assert!(!standby_should_send_new_chunks_for_placeholder(
             "[E2E:E15:BEGIN]\nE15-LINE-150\n[E2E:E15:END]"
         ));
+    }
+
+    /// Korean answers are ~3 bytes per character, so the old `text.len() >
+    /// DISCORD_MSG_LIMIT` byte check fired at ~667 characters and split a
+    /// single-message answer in two. The predicate must track `split_message`,
+    /// which counts characters.
+    #[test]
+    fn korean_answer_under_the_character_limit_stays_one_message() {
+        let body = "한".repeat(900);
+        assert!(body.len() > super::super::DISCORD_MSG_LIMIT);
+        assert!(!standby_should_send_new_chunks_for_placeholder(&body));
+
+        let overflowing = "한".repeat(2100);
+        assert!(standby_should_send_new_chunks_for_placeholder(&overflowing));
     }
 
     fn with_isolated_runtime_root<F: FnOnce()>(f: F) {

--- a/src/services/discord/tmux_watcher/session_bound_ack.rs
+++ b/src/services/discord/tmux_watcher/session_bound_ack.rs
@@ -421,7 +421,7 @@ pub(super) fn watcher_should_send_ordered_new_chunks_for_terminal_fallback(
     relay_text: &str,
 ) -> bool {
     session_bound_fallback_uses_full_body
-        && relay_text.len() > crate::services::discord::DISCORD_MSG_LIMIT
+        && crate::services::discord::formatting::needs_multiple_messages(relay_text)
 }
 
 /// #2840 (relay-stability P1): RAII guard for the cross-watcher emission slot

--- a/src/services/discord/tmux_watcher/session_bound_ack_tests.rs
+++ b/src/services/discord/tmux_watcher/session_bound_ack_tests.rs
@@ -723,3 +723,29 @@ mod inflight_sink_marker_gate {
         ));
     }
 }
+
+/// Korean is ~3 UTF-8 bytes per character, so the old `relay_text.len() >
+/// DISCORD_MSG_LIMIT` byte check in
+/// `watcher_should_send_ordered_new_chunks_for_terminal_fallback` fired at ~667
+/// characters and routed a single-message answer down the ordered-chunk
+/// fallback instead of the in-place edit. (It did not split the body:
+/// `split_message` already counts characters and returns one chunk here.)
+/// The predicate must count characters, like `split_message` does. (The
+/// `#3089` A0 characterization in
+/// `tmux_watcher/tests.rs` is ASCII-only, where the byte and character counts
+/// agree, so it cannot see this.)
+#[test]
+fn korean_answer_under_the_character_limit_stays_one_message() {
+    use super::watcher_should_send_ordered_new_chunks_for_terminal_fallback as should_send;
+
+    let body = "한".repeat(900);
+    assert!(
+        body.len() > crate::services::discord::DISCORD_MSG_LIMIT,
+        "2700 bytes, over the byte limit"
+    );
+    assert!(!should_send(true, &body));
+
+    let overflowing = "한".repeat(2100);
+    assert!(should_send(true, &overflowing));
+    assert!(!should_send(false, &overflowing));
+}

--- a/src/services/discord/tmux_watcher/tests.rs
+++ b/src/services/discord/tmux_watcher/tests.rs
@@ -5649,8 +5649,12 @@ mod watcher_short_replace_controller {
 }
 
 // #3089 A0 — characterization of the watcher terminal-fallback
-// should-send-new-chunks predicate (design §5 A0 item 1). Its gate is
-// `session_bound_fallback_uses_full_body && text.len() > DISCORD_MSG_LIMIT`.
+// should-send-new-chunks predicate (design §5 A0 item 1). Its gate is now
+// `session_bound_fallback_uses_full_body && needs_multiple_messages(text)`,
+// i.e. a CHARACTER count — it read `text.len() > DISCORD_MSG_LIMIT` (UTF-8
+// BYTES) until the byte/character fix, which tripped Korean bodies at ~667
+// characters. The assertions below still use an ASCII fixture, where the two
+// agree.
 // (The #2757 watcher edit-fail delete policy — the other watcher A0 datum —
 // is already pinned above by
 // `fallback_edit_failure_never_deletes_original_without_placeholder_probe`;

--- a/src/services/discord/turn_bridge/response_delivery.rs
+++ b/src/services/discord/turn_bridge/response_delivery.rs
@@ -85,7 +85,7 @@ pub(super) fn done_result_requires_full_terminal_replay(
 ) -> bool {
     response_sent_offset > 0
         && streamed_assistant_text_this_turn
-        && result.len() > super::super::DISCORD_MSG_LIMIT
+        && super::super::formatting::needs_multiple_messages(result)
         && !result.trim().is_empty()
         && full_response.trim() == result.trim()
 }
@@ -155,15 +155,47 @@ mod tests {
 
     #[test]
     fn long_authoritative_done_after_rollover_replays_full_body() {
-        let frozen_prefix = "probe 품질 ".repeat(220);
+        // The fixture is Korean, so it must clear the limit in CHARACTERS, not
+        // only in UTF-8 bytes: the old `repeat(220)` body was 2891 bytes but
+        // only 1991 characters — it fit one Discord message and passed this
+        // test purely on the byte comparison the predicate no longer makes.
+        let frozen_prefix = "probe 품질 ".repeat(240);
         let terminal_tail = "기준으로는 실패입니다";
         let terminal_body = format!("{frozen_prefix}{terminal_tail}");
         assert!(terminal_body.len() > DISCORD_MSG_LIMIT);
+        assert!(terminal_body.chars().count() > DISCORD_MSG_LIMIT);
 
         assert!(done_result_requires_full_terminal_replay(
             &terminal_body,
             &terminal_body,
             frozen_prefix.len(),
+            true,
+        ));
+    }
+
+    /// A Korean answer is ~3 UTF-8 bytes per character, so the old
+    /// `result.len() > DISCORD_MSG_LIMIT` byte check declared a comfortably
+    /// single-message body "long" at ~667 characters and reset the delivery
+    /// offset to replay the whole answer down the terminal-chunk path. (It did
+    /// not split the body: `split_message` already counts characters and
+    /// returns one chunk here.) The gate must count characters, like
+    /// `split_message` does.
+    #[test]
+    fn korean_answer_under_the_character_limit_stays_one_message() {
+        let body = "한".repeat(900);
+        assert!(
+            body.len() > DISCORD_MSG_LIMIT,
+            "2700 bytes, over the byte limit"
+        );
+        assert!(!done_result_requires_full_terminal_replay(
+            &body, &body, 900, true
+        ));
+
+        let overflowing = "한".repeat(2100);
+        assert!(done_result_requires_full_terminal_replay(
+            &overflowing,
+            &overflowing,
+            900,
             true,
         ));
     }

--- a/src/services/discord/turn_bridge/terminal_delivery.rs
+++ b/src/services/discord/turn_bridge/terminal_delivery.rs
@@ -50,7 +50,7 @@ pub(super) fn terminal_delivery_should_send_new_chunks(
     can_chain_locally: bool,
     formatted_response: &str,
 ) -> bool {
-    can_chain_locally && formatted_response.len() > super::super::DISCORD_MSG_LIMIT
+    can_chain_locally && super::super::formatting::needs_multiple_messages(formatted_response)
 }
 
 pub(super) fn record_stopped_turn_terminal_replace_delivery(
@@ -1146,6 +1146,30 @@ mod tests {
         assert!(!terminal_delivery_should_send_new_chunks(false, &body));
     }
 
+    /// Korean is ~3 UTF-8 bytes per character, so the old `formatted_response
+    /// .len() > DISCORD_MSG_LIMIT` byte check fired at ~667 characters and sent
+    /// a single-message answer down the multi-chunk path instead of the
+    /// in-place edit. (It did not split the body: `split_message` already
+    /// counts characters and returns one chunk here.) The predicate must count
+    /// characters, like `split_message` does. (The ASCII fixtures above cannot
+    /// see this: for ASCII the byte and character counts agree.)
+    #[test]
+    fn korean_answer_under_the_character_limit_stays_one_message() {
+        let body = "한".repeat(900);
+        assert!(
+            body.len() > crate::services::discord::DISCORD_MSG_LIMIT,
+            "2700 bytes, over the byte limit"
+        );
+        assert!(!terminal_delivery_should_send_new_chunks(true, &body));
+
+        let overflowing = "한".repeat(2100);
+        assert!(terminal_delivery_should_send_new_chunks(true, &overflowing));
+        assert!(!terminal_delivery_should_send_new_chunks(
+            false,
+            &overflowing
+        ));
+    }
+
     #[tokio::test]
     async fn ordered_long_terminal_delivery_sends_all_chunks_and_deletes_placeholder() {
         let body = format!(
@@ -1870,9 +1894,13 @@ mod tests {
     // #3089 A0 — characterization of the terminal-delivery
     // should-send-new-chunks predicate (design §5 A0 item 1, surface:
     // turn_bridge terminal delivery). `terminal_delivery_should_send_new_chunks
-    // (can_chain_locally, body)` is one of the FOUR per-surface `len > 2000`
-    // predicates the #3089 controller unifies; its gate is
-    // `can_chain_locally && body.len() > DISCORD_MSG_LIMIT`. Pinned inline in
+    // (can_chain_locally, body)` is one of the FOUR per-surface "does this fit
+    // one Discord message" predicates the #3089 controller unifies. Its gate is
+    // now `can_chain_locally && needs_multiple_messages(body)`, i.e. a CHARACTER
+    // count — it read `body.len() > DISCORD_MSG_LIMIT` (UTF-8 BYTES) until the
+    // byte/character fix, which tripped Korean bodies at ~667 characters. The
+    // assertions below still use an ASCII fixture, where the two agree. Pinned
+    // inline in
     // this `#[cfg(test)] mod tests` block => ZERO production LoC.
     mod a0_characterization_tests {
         use super::super::terminal_delivery_should_send_new_chunks as should_send;


### PR DESCRIPTION
## Summary

- Five predicates that answer **"does this finished answer fit in one Discord message?"** compared `text.len()` — a Rust **byte** count — against `DISCORD_MSG_LIMIT`, which is Discord's **character** limit. Korean is 3 bytes per UTF-8 character, so every one of them flipped at ~**667 characters** instead of 2000. Commit 1 (`6cd2df545`) converted two of them onto a single shared, character-counting `needs_multiple_messages` helper; commit 2 (`e843e2036`) converted the remaining three and folded the two already-correct open-coded `char_count(...) <= DISCORD_MSG_LIMIT` budget checks onto the same helper, so the question now has exactly one definition (10 call sites, counted).
- **This is not a body-splitting defect.** `split_message` has counted characters since #4214 — its single-chunk test is `remaining_chars <= effective_limit` — so a 667..=1990-character Korean body yields exactly **one** chunk down either branch. What these predicates select is the **delivery path**: *edit the existing placeholder in place* vs *delete the placeholder and POST fresh messages*. Sending a single-message Korean answer down the second branch costs it its channel position, its reply anchor and its message id, and moves delivery-lease ownership to the chunk path. No content is lost or truncated by this defect.
- Residual, honestly out of scope and left for its own change: the remaining byte comparisons against the constant are **budget arithmetic** in panel/label composition (`single_message_panel.rs:122`, `:310`, `tmux_placeholder_suppression/mod.rs:72`, `:80`, `:88`). Those truncate **content** (a Korean panel body is cut at ~630 characters) — a different defect class, tracked as **#5177**.
- The change also corrects a false claim carried in the previous commit message and copied into the `needs_multiple_messages` doc comment ("that disagreement is not reachable in the send path" — it *is* reachable on the replace path), plus three stale byte-wording comments. No production predicate, branch or constant changed as a result of those corrections.

### The three predicates converted in commit 2

| Predicate | Live callers |
|---|---|
| `terminal_delivery_should_send_new_chunks` (`turn_bridge/terminal_delivery.rs:53`) | `turn_bridge/terminal_outcome_delivery.rs:402`; `turn_bridge/terminal_controller_cutover.rs:72`, `:98` |
| `watcher_should_send_ordered_new_chunks_for_terminal_fallback` (`tmux_watcher/session_bound_ack.rs:424`) | `tmux_watcher/terminal_direct_fallback.rs:122`, `:181`; `tmux_watcher/terminal_send.rs:85` |
| `done_result_requires_full_terminal_replay` (`turn_bridge/response_delivery.rs:88`) | `turn_bridge/stream_loop/content_arms.rs:362` |

A full `rg DISCORD_MSG_LIMIT` sweep found **no fourth** production comparison asking "does this answer fit one Discord message" in bytes.

### Known residual seam (unchanged, deliberate)

In the 1991..=2000-character band the predicate and the chunker genuinely disagree: `effective_limit = DISCORD_MSG_LIMIT - tag_overhead - 10`, and that 10-character code-fence reserve applies even to fence-free text. The predicate is deliberately **not** `split_message(text).len() > 1` — those texts really do fit one Discord message, and adopting the chunker as the predicate would push them down the multi-message path on every surface, including the three direct-POST callers that deliver them as one message today. The #3089 A0 characterization rejects that form for the same reason. On the replace path the disagreement costs one extra continuation message and a line break promoted to a message break — no truncation, no over-limit chunk, no rejected send.

## Test plan

Regression tests pin the Korean case at the **predicate** level in each newly converted module — never on a message/chunk count, which stays 1 whether or not the defect is present and so proves nothing. Each uses the oracle established in commit 1: a body that **is** over the limit in bytes (`assert!(body.len() > DISCORD_MSG_LIMIT)`) must still make the predicate return `false`. 900 Korean characters (2700 bytes) stay single-message; 2100 do not.

- [x] `cargo check --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo doc --no-deps --lib` — 0 warnings
- [x] `scripts/ci-script-checks.sh` — pass
- [x] 6 module test suites — 269 passed, 0 failed
- [x] **Mutation M4 (predicate definition):** revert `needs_multiple_messages` in `formatting/delivery.rs:541` to `text.len() > DISCORD_MSG_LIMIT` (the original defect) → all **5** new tests **KILLED** by assertion, not by compile error:
  - `services::discord::session_relay_sink::tests::korean_answer_under_the_character_limit_stays_one_message`
  - `services::discord::standby_relay::tests::korean_answer_under_the_character_limit_stays_one_message`
  - `services::discord::tmux::tmux_watcher::session_bound_ack::tests::korean_answer_under_the_character_limit_stays_one_message`
  - `services::discord::turn_bridge::response_delivery::tests::korean_answer_under_the_character_limit_stays_one_message`
  - `services::discord::turn_bridge::terminal_delivery::tests::korean_answer_under_the_character_limit_stays_one_message`
- [x] **Mutations M1–M3 (call sites):** reverting each converted predicate individually is caught — `terminal_delivery.rs:53` by 4 tests, `session_bound_ack.rs:424` by 4, `response_delivery.rs:88` by 2. All assertion deaths.
- [x] `long_authoritative_done_after_rollover_replays_full_body` had a Korean fixture of 2891 bytes but only 1991 **characters** — it fit one Discord message and passed only because of the byte comparison. Its prefix grows from 220 to 240 repeats and a character-count precondition is asserted alongside the byte one. **No assertion was removed.**
- [x] `scripts/lib_test_inventory_manifest.txt` re-pinned for the five new tests: **+5 lines, −0**.
- [x] e2e observation on the deployed binary `9721fc70af9a` with the defect fully live: a 1409-character Korean answer relayed as a single message; a 2789-character one split at ~1990 characters (a byte-sized chunker would have cut it near 667) — confirming the chunker was never the defect.

## Queue Hygiene & Merge-Readiness checklist
- [x] **Duplicate PR guard:** checked open PRs; no overlapping change. Sibling relay branches under review (`fix-5169-ocx-gateway`, `fix-5170-transition-busy-spin`, `fix-5175-*`, `fix-5176-*`) touch disjoint files.
- [x] **No-change verification:** N/A — this PR modifies 10 files (+228/−17).
- [x] **Stale branch cleanup:** branch is cut fresh from `main` (`9721fc70a`); not a salvaged broad branch.
- [x] **Scratch file cleanup:** `git status` clean; no `.brief/`, `scratchpad/`, ad-hoc `.md`/`.sh`/`.sql` files included.

## Dashboard / UI checklist
N/A — no dashboard or UI surface is touched.

## Closes
Nothing. This branch is a campaign by-product with no dedicated issue.

Related (**not** closed by this PR):
- #5177 — completion-footer panel body trim is byte arithmetic (~630-character Korean cut). Explicitly declared out of scope above.
- #5173 — Discord's 2000 is UTF-16 code units, not Unicode scalars; this PR moves from bytes to scalars, which is correct for Korean (BMP, 1 code unit) but still over-counts astral characters such as emoji.

## WorkFingerprint

- **Agent:** Claude Opus 5 (1M context)
- **Boundary:** the "does this answer fit one Discord message" predicate only. No delivery mechanism, chunker, constant or control flow changed.
- **Primary files:** `src/services/discord/formatting/delivery.rs` (helper definition + doc), `turn_bridge/terminal_delivery.rs`, `turn_bridge/response_delivery.rs`, `tmux_watcher/session_bound_ack.rs`, `session_relay_sink.rs`, `standby_relay.rs`
- **Verification commands and results:** see Test plan — all green at `e843e2036`; mutation M4 re-confirmed KILLED at the final SHA (not inherited from the pre-amend SHA).
- **Skipped checks with reasons:** none skipped. `ci-script-checks.sh` requires `TEST_LANE_BASELINE_REF` to be injected locally (CI sets it at `.github/workflows/ci-pr.yml:969`); it was run with that env, not bypassed.
- **Risk:** Low. Each converted predicate becomes a delegation to an existing helper that is equal by definition on ASCII; the only behavioural change is on non-ASCII input, which is the defect being fixed. Two of the five conversions (`build_attachment_inline`) are literal no-ops.
- **Rollback notes:** revert the two commits; no migration, no config, no deployment step. The helper is `pub(in crate::services::discord)` with no external consumer.
- **Queue hygiene invariant:** one predicate, one definition — `needs_multiple_messages` now has 10 call sites and no open-coded sibling remains.
- **Related PRs/issues checked:** #4214 (chunker, already character-based), #3089 (A0 characterization, pinned and unmodified), #5173, #5177.
- **Why this is non-overlapping:** the byte→character conversion is confined to the five named predicates; the byte-based **budget/truncation** arithmetic in panel composition is untouched and reserved for #5177.
