### PR TITLE
fix(#5170): stop classifying SessionTransitionBusy as a race loss and stop the recheck from parking a transition waiter

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -786,6 +786,17 @@ jobs:
       - name: Local model durable queue wake regression
         run: env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::tui_prompt_relay::local_model_queue_wake_e2e -- --test-threads=1
 
+      # #5170: the transition-busy requeue oracles live in two modules that no
+      # curated PR filter selected, so they would have been counted by the lib
+      # inventory manifest and executed nowhere -- the #5046/#5041 defect. The
+      # queue_io oracle is named exactly on purpose: the surrounding
+      # `queue_io` module carries pre-existing #4270 failures that predate this
+      # lane, and a module-wide filter would import them.
+      - name: Transition-busy requeue spin regressions
+        run: |
+          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::router::message_handler::intake_turn::race_loss:: -- --test-threads=1
+          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::queue_io::presleep_tests::race_loss_recheck_fences_on_transition_without_parking_a_waiter_5170 -- --exact --test-threads=1
+
       - name: Stop PostgreSQL service
         if: always()
         run: ./scripts/ci/postgres-service.sh stop

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -718,6 +718,7 @@ src/
 │   │   │   │   │   ├── race_loss/
 │   │   │   │   │   │   ├── mailbox_reaction.rs
 │   │   │   │   │   │   ├── mailbox_reaction_tests.rs
+│   │   │   │   │   │   ├── queued_intake_cause.rs
 │   │   │   │   │   │   └── requeue_tests.rs
 │   │   │   │   │   ├── adk_thread.rs
 │   │   │   │   │   ├── claim_bootstrap.rs

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -305,7 +305,9 @@ targets = {
     "runs_on" => "ubuntu-latest",
     # #5034 re-pins after adding the attachment-delivery and catch-up
     # operational-alert targets to the path-filtered required high-risk lane.
-    "job_sha256" => "29c7a0c33753933e50c446f073da942bebd0c53881460260562cd9cabaef9c44",
+    # #5170 re-pins after wiring the transition-busy requeue oracles, which the
+    # lib inventory manifest counted while no curated filter executed them.
+    "job_sha256" => "dc85115bd40b9f4ce8b1595d3568ae2a0996c78d7ca1e0fa4f03576ebeb6f1d9",
     "require_debug_env" => false,
     "cargo_steps" => {
       "Observe curated lane selections" => {

--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -3506,7 +3506,7 @@ services::discord::queue_io::presleep_tests::lagged_completion_receiver_warns_an
 services::discord::queue_io::presleep_tests::marker_only_backlog_counts_as_backstop_work
 services::discord::queue_io::presleep_tests::normal_event_path_drains_before_backstop_records_zero_fires
 services::discord::queue_io::presleep_tests::promote_defer_requeue_converges_no_oscillation_across_cycles_4270
-services::discord::queue_io::presleep_tests::race_loss_recheck_waits_for_transition_before_kickoff_4794
+services::discord::queue_io::presleep_tests::race_loss_recheck_fences_on_transition_without_parking_a_waiter_5170
 services::discord::queue_io::presleep_tests::race_loss_requeue_does_not_rekick_until_holding_turn_completes_4078
 services::discord::queue_io::presleep_tests::race_loss_requeue_idle_recheck_kicks_after_missed_completion_4078
 services::discord::queue_io::presleep_tests::single_backstop_profile_is_the_only_slow_cycle
@@ -3950,7 +3950,9 @@ services::discord::router::message_handler::intake_turn::race_loss::mailbox_reac
 services::discord::router::message_handler::intake_turn::race_loss::mailbox_reaction_tests::standalone_without_start_attempt_adds_mailbox_once
 services::discord::router::message_handler::intake_turn::race_loss::race_loss_requeue_tests::busy_transition_is_durable_before_the_guard_is_released
 services::discord::router::message_handler::intake_turn::race_loss::race_loss_requeue_tests::persistence_failure_rolls_back_queue_and_clears_dispatch_reservation
+services::discord::router::message_handler::intake_turn::race_loss::race_loss_requeue_tests::race_loss_requeue_still_takes_the_immediate_idle_recheck_5170
 services::discord::router::message_handler::intake_turn::race_loss::race_loss_requeue_tests::race_loss_requeue_suppresses_post_enqueue_idle_kick_while_holder_active
+services::discord::router::message_handler::intake_turn::race_loss::race_loss_requeue_tests::transition_busy_requeue_replaces_the_immediate_rekick_with_the_slow_backstop_5170
 services::discord::router::message_handler::intake_turn::recovery_context_take_order_tests::discord_user_turn_keeps_user_and_streaming_placeholder_ids_separate
 services::discord::router::message_handler::intake_turn::recovery_context_take_order_tests::intake_real_turn_consumes_recovery_context_once_after_non_dispatch_guards
 services::discord::router::message_handler::intake_turn::recovery_context_take_order_tests::recovery_context_survives_intake_stale_dispatch_abort

--- a/scripts/test_lane_coverage_baseline.txt
+++ b/scripts/test_lane_coverage_baseline.txt
@@ -341,7 +341,6 @@ services::discord::router::message_handler::headless_turn::headless_hard_ceiling
 services::discord::router::message_handler::headless_turn::recovery_context_take_order_tests
 services::discord::router::message_handler::intake_turn::feedback_reminder_take_order_tests
 services::discord::router::message_handler::intake_turn::queue_pending_reaction_clear_tests
-services::discord::router::message_handler::intake_turn::race_loss::race_loss_requeue_tests
 services::discord::router::message_handler::intake_turn::recovery_context_take_order_tests
 services::discord::router::message_handler::intake_turn::tui_busy_pre_submit_queue_reaction_tests
 services::discord::router::message_handler::intake_turn::turn_start_dispatch_guard_preservation_tests

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -33,7 +33,7 @@ tokio::task_local! {
 }
 
 #[cfg(test)]
-type IdleQueueKickHookForTests = std::sync::Arc<
+pub(in crate::services::discord) type IdleQueueKickHookForTests = std::sync::Arc<
     dyn Fn(
             Arc<SharedData>,
             ProviderKind,
@@ -50,7 +50,7 @@ static IDLE_QUEUE_KICK_HOOK_FOR_TESTS: std::sync::Mutex<Option<IdleQueueKickHook
     std::sync::Mutex::new(None);
 
 #[cfg(test)]
-struct IdleQueueKickHookResetForTests;
+pub(in crate::services::discord) struct IdleQueueKickHookResetForTests;
 
 #[cfg(test)]
 impl Drop for IdleQueueKickHookResetForTests {
@@ -62,7 +62,7 @@ impl Drop for IdleQueueKickHookResetForTests {
 }
 
 #[cfg(test)]
-fn set_idle_queue_kick_hook_for_tests(
+pub(in crate::services::discord) fn set_idle_queue_kick_hook_for_tests(
     hook: IdleQueueKickHookForTests,
 ) -> IdleQueueKickHookResetForTests {
     *IDLE_QUEUE_KICK_HOOK_FOR_TESTS
@@ -140,12 +140,38 @@ pub(super) fn schedule_race_loss_requeue_post_enqueue_idle_recheck(
 ) {
     super::task_supervisor::spawn_observed("race_loss_requeue_idle_recheck", async move {
         // A race-loss recheck is an edge-trigger, not competing transition
-        // authority. Waiting here coalesces the one recheck behind the current
-        // transition instead of dequeue/requeue spinning while it is held.
-        let transition_guard = shared
-            .session_transition_lock(channel_id)
-            .lock_owned()
+        // authority — so it must not park in the transition lock's waiter queue.
+        //
+        // #5170 B: `tokio::sync::Mutex` hands a released permit straight to the
+        // head of its waiter queue and only returns it to the free-permit
+        // counter once that queue is empty, while `try_lock_owned()` consults
+        // the free-permit counter alone. One blocking waiter parked here
+        // therefore makes every non-blocking acquirer fail for as long as this
+        // task waits — including intake
+        // (`turn_start::try_intake_runtime_transition_after_redirect`) and the
+        // kickoff dequeue gate (`idle_queue_take_next_soft_if_ready`). #4794's
+        // `lock_owned().await` was meant to coalesce this recheck behind the
+        // live transition; instead it starved the very kickoff it was about to
+        // perform, and each starved intake requeued and spawned another waiter
+        // here. Not owning the transition means not owning an edge: defer to
+        // the slow fail-open backstop, the same treatment the finalize epilogue
+        // transition fence already gives a transition-owned channel.
+        let Ok(transition_guard) = shared.session_transition_lock(channel_id).try_lock_owned()
+        else {
+            tracing::debug!(
+                provider = provider.as_str(),
+                channel_id = channel_id.get(),
+                "Deferred drain: session transition owns channel; race-loss requeue recheck defers to the slow backstop"
+            );
+            arm_slow_idle_queue_backstop_if_queue_nonempty(
+                &shared,
+                &provider,
+                channel_id,
+                "race_loss_requeue_transition_busy",
+            )
             .await;
+            return;
+        };
 
         let snapshot = super::mailbox_snapshot(&shared, channel_id).await;
         if !race_loss_requeue_snapshot_has_idle_kickable_backlog(
@@ -1865,8 +1891,16 @@ mod presleep_tests {
         );
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn race_loss_recheck_waits_for_transition_before_kickoff_4794() {
+    /// #4794 fenced the recheck's kickoff behind the session transition; #5170
+    /// keeps that fence but replaces the blocking wait that implemented it. The
+    /// two properties #4794 actually protected — no kickoff seam while the
+    /// transition is held, and an untouched queue head — are asserted below
+    /// verbatim. What changes is the mechanism (`try_lock_owned` + slow
+    /// backstop instead of `lock_owned().await`) and therefore the release
+    /// behaviour: the recheck no longer parks a waiter that would intercept the
+    /// released permit ahead of every `try_lock_owned()` acquirer.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn race_loss_recheck_fences_on_transition_without_parking_a_waiter_5170() {
         let tmp = tempfile::tempdir().expect("temp runtime root");
         let _env = crate::config::set_agentdesk_root_for_test(tmp.path());
 
@@ -1898,7 +1932,7 @@ mod presleep_tests {
                     if channel != channel_id {
                         return None;
                     }
-                    assert_eq!(reason, "race_loss_requeue_idle_recheck");
+                    assert_eq!(reason, "race_loss_requeue_transition_busy");
                     hook_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                     let taken = super::super::mailbox_take_next_automatic_intervention(
                         &shared, &provider, channel,
@@ -1929,15 +1963,56 @@ mod presleep_tests {
                 .first()
                 .map(|item| item.message_id),
             Some(queued_msg),
-            "waiting recheck must leave the queued head untouched"
+            "fenced recheck must leave the queued head untouched"
+        );
+        // #5170: the recheck must not have parked a blocking waiter. Releasing
+        // a `tokio::sync::Mutex` assigns the permit to the head of the waiter
+        // queue inside `drop` itself, and returns it to the free-permit counter
+        // only when that queue is empty — so this `try_lock_owned()`, taken
+        // before any scheduling point, observes the handoff deterministically.
+        // It is the exact acquisition shape intake and the kickoff dequeue gate
+        // both use.
+        drop(transition_guard);
+        let reacquired = shared.session_transition_lock(channel_id).try_lock_owned();
+        assert!(
+            reacquired.is_ok(),
+            "a released transition must be reacquirable by a non-blocking acquirer; a parked recheck waiter would have intercepted the permit"
+        );
+        drop(reacquired);
+
+        yield_backstop_tasks().await;
+        assert_eq!(
+            kick_calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "the fenced recheck owns no edge and must not resume a kickoff on release"
+        );
+        // Over-suppression guard: declining the transition must hand the
+        // channel to the slow fail-open net, not drop it.
+        assert!(
+            shared
+                .restart
+                .deferred_hook_channels
+                .contains_key(&channel_id),
+            "a transition-fenced recheck must arm the slow backstop so the backlog still has an owner"
         );
 
-        drop(transition_guard);
+        // The slow backstop is the only owner left, and it does drain.
+        tokio::time::advance(
+            DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY + std::time::Duration::from_secs(1),
+        )
+        .await;
         yield_backstop_tasks().await;
         assert_eq!(
             kick_calls.load(std::sync::atomic::Ordering::SeqCst),
             1,
-            "exactly one coalesced recheck runs after transition release"
+            "the slow backstop must drain the backlog the fenced recheck declined"
+        );
+        assert!(
+            mailbox_snapshot(&shared, channel_id)
+                .await
+                .intervention_queue
+                .is_empty(),
+            "the backstop kick must consume the queued head"
         );
     }
 

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -1319,6 +1319,7 @@ pub(super) async fn handle_text_message(
             &dispatch_id_for_thread,
             turn_start_attempt,
             preserve_on_cancel,
+            race_loss::QueuedIntakeCause::RaceLoss,
         )
         .await;
     }

--- a/src/services/discord/router/message_handler/intake_turn/race_loss.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss.rs
@@ -2,6 +2,36 @@ use super::*;
 
 pub(in crate::services::discord::router::message_handler) mod mailbox_reaction;
 
+/// #5170: why this intake is being handed back to the durable queue.
+///
+/// The two causes look identical downstream (same `Intervention`, same durable
+/// enqueue) but they carry opposite information about *who else is running*:
+///
+/// * [`Self::RaceLoss`] — the mailbox start-turn claim was taken by another
+///   turn. There is a live opponent that owns the completion wake edge, and the
+///   post-enqueue recheck exists only to cover the case where that opponent had
+///   already finished before our enqueue became visible.
+/// * [`Self::SessionTransitionBusy`] — nobody claimed the mailbox. The
+///   per-channel session transition lock merely happened to be held at the
+///   instant intake tried to take it. Treating that as a lost race is what
+///   armed an immediate re-kick, whose own transition wait then guaranteed the
+///   next intake would fail the same way (#5170).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord::router::message_handler) enum QueuedIntakeCause {
+    RaceLoss,
+    SessionTransitionBusy,
+}
+
+impl QueuedIntakeCause {
+    /// A real race loss owns an edge-trigger recheck (the opponent may already
+    /// be gone). A transition-busy requeue owns no edge at all — the transition
+    /// holder is still mid-flight — so it hands the channel to the slow
+    /// fail-open backstop instead of re-kicking into the same busy lock.
+    fn wants_immediate_idle_recheck(self) -> bool {
+        matches!(self, Self::RaceLoss)
+    }
+}
+
 fn race_loss_persistence_failure(
     channel_id: ChannelId,
     persistence_error: Option<&str>,
@@ -22,6 +52,7 @@ async fn enqueue_race_loss_requeued_intervention(
     channel_id: ChannelId,
     user_msg_id: MessageId,
     intervention: Intervention,
+    cause: QueuedIntakeCause,
 ) -> crate::services::discord::MailboxEnqueueOutcome {
     let outcome = crate::services::discord::queue_io::with_post_enqueue_idle_queue_kick_suppressed(
         crate::services::discord::mailbox_enqueue_intervention(
@@ -66,11 +97,35 @@ async fn enqueue_race_loss_requeued_intervention(
         }
     }
     if outcome.enqueued && outcome.persistence_error.is_none() {
-        crate::services::discord::queue_io::schedule_race_loss_requeue_post_enqueue_idle_recheck(
-            shared.clone(),
-            provider.clone(),
-            channel_id,
-        );
+        if cause.wants_immediate_idle_recheck() {
+            crate::services::discord::queue_io::schedule_race_loss_requeue_post_enqueue_idle_recheck(
+                shared.clone(),
+                provider.clone(),
+                channel_id,
+            );
+        } else {
+            // #5170 A — the durable enqueue above stays exactly where it is (it
+            // is what closes the process-crash loss window). Only the wake
+            // policy changes: an immediate re-kick here would re-enter intake
+            // while the transition it just failed to take is still held, and
+            // every such failure enqueued again. Arm the slow fail-open
+            // backstop so the channel still drains if no other edge arrives —
+            // the same treatment the finalize epilogue already gives a
+            // transition-owned channel.
+            tracing::debug!(
+                provider = provider.as_str(),
+                channel_id = channel_id.get(),
+                user_message_id = user_msg_id.get(),
+                "session-transition-busy intake queued durably; deferring the drain to the slow backstop instead of an immediate re-kick"
+            );
+            crate::services::discord::arm_slow_idle_queue_backstop_if_queue_nonempty(
+                shared,
+                provider,
+                channel_id,
+                "intake_session_transition_busy",
+            )
+            .await;
+        }
     }
     outcome
 }
@@ -102,6 +157,7 @@ pub(super) async fn handle_race_loss_enqueue(
     dispatch_id_for_thread: &Option<String>,
     turn_start_attempt: Option<crate::services::discord::turn_view_reconciler::TurnStartAttempt>,
     preserve_on_cancel: bool,
+    cause: QueuedIntakeCause,
 ) -> Result<(), Error> {
     let bot_owner_provider = crate::services::discord::resolve_discord_bot_provider(token);
     let want_queued_card = !turn_kind.is_background_trigger() && channel_id == original_channel_id;
@@ -161,6 +217,7 @@ pub(super) async fn handle_race_loss_enqueue(
             // reply to plain text.
             voice_announcement.clone(),
         ),
+        cause,
     )
     .await;
 
@@ -641,10 +698,19 @@ pub(super) async fn handle_race_loss_enqueue(
         .await;
     }
     let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!(
-        "  [{ts}] 🔀 RACE: message queued (another turn won), channel {}",
-        channel_id
-    );
+    // #5170: only the mailbox start-turn claim can be lost to "another turn".
+    // A transition-busy requeue has no winning opponent to name, and saying so
+    // sent operators looking for a competing turn that was never there.
+    match cause {
+        QueuedIntakeCause::RaceLoss => tracing::info!(
+            "  [{ts}] 🔀 RACE: message queued (another turn won), channel {}",
+            channel_id
+        ),
+        QueuedIntakeCause::SessionTransitionBusy => tracing::info!(
+            "  [{ts}] 🔀 QUEUE: message queued (session transition held at intake), channel {}",
+            channel_id
+        ),
+    }
     return Ok(());
 }
 

--- a/src/services/discord/router/message_handler/intake_turn/race_loss.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss.rs
@@ -1,36 +1,9 @@
 use super::*;
 
 pub(in crate::services::discord::router::message_handler) mod mailbox_reaction;
+mod queued_intake_cause;
 
-/// #5170: why this intake is being handed back to the durable queue.
-///
-/// The two causes look identical downstream (same `Intervention`, same durable
-/// enqueue) but they carry opposite information about *who else is running*:
-///
-/// * [`Self::RaceLoss`] — the mailbox start-turn claim was taken by another
-///   turn. There is a live opponent that owns the completion wake edge, and the
-///   post-enqueue recheck exists only to cover the case where that opponent had
-///   already finished before our enqueue became visible.
-/// * [`Self::SessionTransitionBusy`] — nobody claimed the mailbox. The
-///   per-channel session transition lock merely happened to be held at the
-///   instant intake tried to take it. Treating that as a lost race is what
-///   armed an immediate re-kick, whose own transition wait then guaranteed the
-///   next intake would fail the same way (#5170).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::services::discord::router::message_handler) enum QueuedIntakeCause {
-    RaceLoss,
-    SessionTransitionBusy,
-}
-
-impl QueuedIntakeCause {
-    /// A real race loss owns an edge-trigger recheck (the opponent may already
-    /// be gone). A transition-busy requeue owns no edge at all — the transition
-    /// holder is still mid-flight — so it hands the channel to the slow
-    /// fail-open backstop instead of re-kicking into the same busy lock.
-    fn wants_immediate_idle_recheck(self) -> bool {
-        matches!(self, Self::RaceLoss)
-    }
-}
+pub(in crate::services::discord::router::message_handler) use queued_intake_cause::QueuedIntakeCause;
 
 fn race_loss_persistence_failure(
     channel_id: ChannelId,

--- a/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction_tests.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction_tests.rs
@@ -277,6 +277,7 @@ async fn stale_start_attempt_repairs_mailbox_from_live_queue_truth() {
         channel_id,
         message_id,
         user_intervention(message_id.get()),
+        QueuedIntakeCause::RaceLoss,
     )
     .await;
     assert!(enqueue.enqueued);
@@ -360,6 +361,7 @@ async fn busy_tui_requeue_preserves_standalone_marker_after_matching_rollback() 
         channel_id,
         message_id,
         user_intervention(message_id.get()),
+        QueuedIntakeCause::RaceLoss,
     )
     .await;
     assert!(enqueue.enqueued, "busy TUI follow-up genuinely requeues M");
@@ -436,6 +438,7 @@ async fn recently_finalized_message_requeued_in_live_mailbox_repairs_mailbox_mar
         channel_id,
         message_id,
         user_intervention(message_id.get()),
+        QueuedIntakeCause::RaceLoss,
     )
     .await;
     assert!(

--- a/src/services/discord/router/message_handler/intake_turn/race_loss/queued_intake_cause.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss/queued_intake_cause.rs
@@ -1,0 +1,29 @@
+/// #5170: why this intake is being handed back to the durable queue.
+///
+/// The two causes look identical downstream (same `Intervention`, same durable
+/// enqueue) but they carry opposite information about *who else is running*:
+///
+/// * [`Self::RaceLoss`] — the mailbox start-turn claim was taken by another
+///   turn. There is a live opponent that owns the completion wake edge, and the
+///   post-enqueue recheck exists only to cover the case where that opponent had
+///   already finished before our enqueue became visible.
+/// * [`Self::SessionTransitionBusy`] — nobody claimed the mailbox. The
+///   per-channel session transition lock merely happened to be held at the
+///   instant intake tried to take it. Treating that as a lost race is what
+///   armed an immediate re-kick, whose own transition wait then guaranteed the
+///   next intake would fail the same way (#5170).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord::router::message_handler) enum QueuedIntakeCause {
+    RaceLoss,
+    SessionTransitionBusy,
+}
+
+impl QueuedIntakeCause {
+    /// A real race loss owns an edge-trigger recheck (the opponent may already
+    /// be gone). A transition-busy requeue owns no edge at all — the transition
+    /// holder is still mid-flight — so it hands the channel to the slow
+    /// fail-open backstop instead of re-kicking into the same busy lock.
+    pub(super) fn wants_immediate_idle_recheck(self) -> bool {
+        matches!(self, Self::RaceLoss)
+    }
+}

--- a/src/services/discord/router/message_handler/intake_turn/race_loss/requeue_tests.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss/requeue_tests.rs
@@ -61,6 +61,7 @@ async fn busy_transition_is_durable_before_the_guard_is_released() {
         channel_id,
         message_id,
         user_intervention(message_id.get(), "resume transition queue"),
+        QueuedIntakeCause::SessionTransitionBusy,
     )
     .await;
     assert!(outcome.enqueued);
@@ -127,6 +128,7 @@ async fn persistence_failure_rolls_back_queue_and_clears_dispatch_reservation() 
         channel_id,
         message_id,
         user_intervention(message_id.get(), "must roll back"),
+        QueuedIntakeCause::RaceLoss,
     )
     .await;
     assert!(outcome.persistence_error.is_some());
@@ -175,6 +177,7 @@ async fn race_loss_requeue_suppresses_post_enqueue_idle_kick_while_holder_active
         channel_id,
         MessageId::new(4_078_101),
         user_intervention(4_078_101, "race loss requeue"),
+        QueuedIntakeCause::RaceLoss,
     )
     .await;
     tokio::task::yield_now().await;
@@ -200,4 +203,132 @@ async fn race_loss_requeue_suppresses_post_enqueue_idle_kick_while_holder_active
     assert!(snapshot.cancel_token.is_some());
     assert_eq!(snapshot.active_user_message_id, Some(holder_msg));
     assert_eq!(snapshot.intervention_queue.len(), 1);
+}
+
+async fn yield_spawned_tasks() {
+    for _ in 0..6 {
+        tokio::task::yield_now().await;
+    }
+}
+
+type RecordedKicks = Arc<std::sync::Mutex<Vec<&'static str>>>;
+
+fn record_idle_queue_kicks(
+    channel_id: ChannelId,
+) -> (
+    RecordedKicks,
+    crate::services::discord::queue_io::IdleQueueKickHookResetForTests,
+) {
+    let kicks: RecordedKicks = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let recorded = kicks.clone();
+    let reset = crate::services::discord::queue_io::set_idle_queue_kick_hook_for_tests(Arc::new(
+        move |shared, provider, channel, reason| {
+            let recorded = recorded.clone();
+            Box::pin(async move {
+                if channel != channel_id {
+                    return None;
+                }
+                recorded.lock().expect("recorded kicks").push(reason);
+                let taken = crate::services::discord::mailbox_take_next_automatic_intervention(
+                    &shared, &provider, channel,
+                )
+                .await;
+                Some(crate::services::discord::IdleQueueKickoffChannelOutcome {
+                    started: taken.intervention.is_some(),
+                })
+            })
+        },
+    ));
+    (kicks, reset)
+}
+
+/// #5170 A, under-enforcement direction: a `SessionTransitionBusy` intake is
+/// not a lost race and must not re-arm the immediate edge-trigger recheck.
+/// That recheck was the engine of the observed spin — each rotation re-entered
+/// intake against a transition it could not take, which requeued and spawned
+/// the next rotation. The durable enqueue itself is unchanged (asserted here so
+/// the crash-loss window stays closed).
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn transition_busy_requeue_replaces_the_immediate_rekick_with_the_slow_backstop_5170() {
+    let tmp = tempfile::tempdir().expect("temp runtime root");
+    let _env = crate::config::set_agentdesk_root_for_test(tmp.path());
+
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    let provider = ProviderKind::Claude;
+    let channel_id = ChannelId::new(5_170_100);
+    let message_id = MessageId::new(5_170_101);
+    let (kicks, _hook) = record_idle_queue_kicks(channel_id);
+
+    let outcome = enqueue_race_loss_requeued_intervention(
+        &shared,
+        &provider,
+        channel_id,
+        message_id,
+        user_intervention(message_id.get(), "transition busy intake"),
+        QueuedIntakeCause::SessionTransitionBusy,
+    )
+    .await;
+    assert!(
+        outcome.enqueued && outcome.persistence_error.is_none(),
+        "the durable enqueue is unchanged by the cause tag"
+    );
+    yield_spawned_tasks().await;
+
+    // The channel is fully idle here: no holder, no transition guard. The
+    // race-loss cause would kick immediately (see the control test below); the
+    // transition-busy cause must not, because the transition it just failed to
+    // take is still in flight.
+    assert!(
+        kicks.lock().expect("recorded kicks").is_empty(),
+        "a transition-busy requeue must not re-kick into the transition it just lost"
+    );
+
+    // Over-suppression direction: the backlog must still have an owner.
+    tokio::time::advance(std::time::Duration::from_secs(61)).await;
+    yield_spawned_tasks().await;
+    assert_eq!(
+        kicks.lock().expect("recorded kicks").as_slice(),
+        ["intake_session_transition_busy"],
+        "the slow fail-open backstop must drain the backlog the requeue declined to kick"
+    );
+    assert!(
+        crate::services::discord::mailbox_snapshot(&shared, channel_id)
+            .await
+            .intervention_queue
+            .is_empty(),
+        "the backstop kick must consume the queued message"
+    );
+}
+
+/// Control for the test above: a genuine mailbox race loss keeps the immediate
+/// recheck, so the #5170 split narrows the edge-trigger to the cause that
+/// actually owns an edge rather than removing it.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn race_loss_requeue_still_takes_the_immediate_idle_recheck_5170() {
+    let tmp = tempfile::tempdir().expect("temp runtime root");
+    let _env = crate::config::set_agentdesk_root_for_test(tmp.path());
+
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    let provider = ProviderKind::Claude;
+    let channel_id = ChannelId::new(5_170_200);
+    let message_id = MessageId::new(5_170_201);
+    let (kicks, _hook) = record_idle_queue_kicks(channel_id);
+
+    let outcome = enqueue_race_loss_requeued_intervention(
+        &shared,
+        &provider,
+        channel_id,
+        message_id,
+        user_intervention(message_id.get(), "race loss requeue"),
+        QueuedIntakeCause::RaceLoss,
+    )
+    .await;
+    assert!(outcome.enqueued && outcome.persistence_error.is_none());
+    yield_spawned_tasks().await;
+
+    assert_eq!(
+        kicks.lock().expect("recorded kicks").as_slice(),
+        ["race_loss_requeue_idle_recheck"],
+        "a real race loss against an already-finished opponent keeps its immediate recheck"
+    );
 }

--- a/src/services/discord/router/message_handler/intake_turn/runtime_transition.rs
+++ b/src/services/discord/router/message_handler/intake_turn/runtime_transition.rs
@@ -35,6 +35,13 @@ pub(super) async fn acquire_after_redirect_or_requeue(
     // immediately and let the normal queued consumer retry after the transition.
     // This removes the process-crash loss window that existed while intake waited
     // up to three seconds with the event only on this task's stack.
+    //
+    // #5170: the enqueue is unchanged, but it is NOT a race loss. Nothing
+    // claimed the mailbox here — the transition lock was simply held at this
+    // instant — so the requeue is tagged `SessionTransitionBusy` and takes the
+    // backoff wake policy (slow fail-open backstop) rather than the race-loss
+    // edge-trigger recheck, whose own transition wait re-entered intake against
+    // a lock it had itself made unacquirable, requeueing on every rotation.
     match try_intake_runtime_transition_after_redirect(shared, channel_id, fallback_state).await {
         Ok(transition) => Ok(Some(transition)),
         Err(_) => {
@@ -62,6 +69,7 @@ pub(super) async fn acquire_after_redirect_or_requeue(
                 dispatch_id_for_thread,
                 turn_start_attempt,
                 preserve_on_cancel,
+                race_loss::QueuedIntakeCause::SessionTransitionBusy,
             )
             .await?;
             Ok(None)

--- a/src/services/discord/router/message_handler/intake_turn/runtime_transition.rs
+++ b/src/services/discord/router/message_handler/intake_turn/runtime_transition.rs
@@ -39,7 +39,7 @@ pub(super) async fn acquire_after_redirect_or_requeue(
     // #5170: the enqueue is unchanged, but it is NOT a race loss. Nothing
     // claimed the mailbox here — the transition lock was simply held at this
     // instant — so the requeue is tagged `SessionTransitionBusy` and takes the
-    // backoff wake policy (slow fail-open backstop) rather than the race-loss
+    // deferred wake policy (the fixed 60s fail-open backstop) rather than the race-loss
     // edge-trigger recheck, whose own transition wait re-entered intake against
     // a lock it had itself made unacquirable, requeueing on every rotation.
     match try_intake_runtime_transition_after_redirect(shared, channel_id, fallback_state).await {


### PR DESCRIPTION
Fixes #5170.

## Symptom

A queued user message could sit unexecuted for up to **38h** while the channel
rotated a requeue loop **1246 times** (⏳ reattach count). The message was never
lost — it was durably enqueued — it just never got an owner that could run it.

## Mechanism

Two acquirers of the same per-channel session transition lock disagreed about
blocking:

| acquirer | site | mode |
|---|---|---|
| intake | `router/turn_start.rs:577` | `try_lock_owned()` |
| race-loss recheck | `queue_io.rs:145` | `lock_owned().await` |

**tokio's Mutex is fair.** `try_acquire` reads only the free-permit counter,
while releasing a permit hands it *directly* to the head of the waiter queue and
only returns it to the free counter once that queue is empty. So **as long as a
single blocking waiter is parked, no `try_lock_owned()` acquirer can ever win.**

Each such loss surfaced as `SessionTransitionBusy`, was **misclassified as a lost
race**, requeued — and the requeue spawned *another* blocking waiter, which
guaranteed the next loss. That is the closed feedback loop.

## The fix removes the producer, not just the label

The amplifier of the original defect was *"try_lock fails → requeue → spawn a new
blocking waiter"*. This change removes that producer:

**B. `queue_io.rs:159` no longer parks a waiter.** `lock_owned().await` →
`try_lock_owned()`, and on loss it defers to the slow fail-open backstop instead
of queueing behind the live transition — mirroring the treatment the
finalize-epilogue transition fence already gives a transition-owned channel.
With no waiter producer left on this path, a released permit returns to the free
counter and `try_lock_owned()` acquirers can win again.

**A. `SessionTransitionBusy` is no longer a race loss.** The durable enqueue is
unchanged (it is what closes the process-crash loss window the old three-second
intake wait had), but the requeue is now tagged
`QueuedIntakeCause::SessionTransitionBusy` and takes the **deferred wake policy:
no immediate edge-triggered recheck, and the fixed 60s fail-open backstop armed
instead** (`queue_io.rs:24` `DEFERRED_IDLE_QUEUE_BACKSTOP_DELAY = from_secs(60)`
— this is a fixed delay, not exponential backoff), so the backlog still has an
owner.

Both arms arm through `arm_slow_idle_queue_backstop_if_queue_nonempty`, which
passes a synthetic `started: false`, so the `started: true` misreport in the
issue's item C cannot suppress them — C is not needed for this slice.

## Test posture

The #4794 test is kept and retargeted: the two properties it protected (no
kickoff seam while the transition is held, untouched queue head) are asserted
verbatim; only the release behaviour changes, and the new assertions pin both
directions — the recheck parks no waiter, and the slow backstop still drains the
backlog it declined.

Mutation-checked, all three **KILLED by their own asserts** (not by compile
death):

| # | mutation | killed by |
|---|---|---|
| M1 | `race_loss/queued_intake_cause.rs:27` → always `true` | `transition_busy_requeue_replaces_the_immediate_rekick_with_the_slow_backstop_5170` @ `requeue_tests.rs:281` |
| M2 | same coordinate → always `false` | `race_loss_requeue_still_takes_the_immediate_idle_recheck_5170` @ `:329` |
| M3 | `queue_io.rs:159` restored to `lock_owned().await` (the original defect) | `race_loss_recheck_fences_on_transition_without_parking_a_waiter_5170` @ `queue_io.rs:1962` |

## Gates run on the final tree

| gate | rc |
|---|---|
| `python3 scripts/audit_maintainability.py --check` | 1 → **0** (cap violation resolved by moving `QueuedIntakeCause` to a sibling module, not by raising the cap) |
| `cargo check --all-targets` | 0 |
| `cargo fmt --check` | 0 |
| `cargo test --lib race_loss` | 0 (17 passed) |
| `TEST_LANE_BASELINE_REF=origin/main ./scripts/ci-script-checks.sh` | 0 |

## Pre-existing failure, not a regression

`cargo test --lib queue_io` exits 101 **on this branch and identically on the
base commit** (`a1b4a9876`). Same two failures on both:

- `idle_drain_after_promote_defer_dispatches_exactly_once_4270`
- `promote_defer_requeue_converges_no_oscillation_across_cycles_4270`

(`capped_retry_..._4893` breaks only under parallel execution — mutual
interference; it passes with `--test-threads=1`.)

`race_loss_recheck_fences_on_transition_without_parking_a_waiter_5170` is **ok in
every run**. Out of scope for this PR; not fixed here.

## Scope note

`docs/generated/maintainability-audit.md` is intentionally **not** committed. Its
regeneration drift is identical on `origin/main` and confined to files this
branch does not touch (`inflight.rs`, `turn_finalizer.rs`, `routes/*`). The
`namespace_size_caps` section this PR affects is byte-identical (`0 hits`) before
and after.

## CI wiring (added after review)

The three oracles above were selected by **no curated PR lane**. `ci-pr.yml`
does not run a whole `cargo test --lib`; it runs 28 hand-picked filters, and
none matched `queue_io` or `race_loss`. `scripts/lib_test_inventory_manifest.txt`
counts tests via `--list`, so re-pinning it to 7509 turned a gate green while
the three mutation-killing asserts executed **nowhere** — the #5046 defect, with
the #5041 wiring gate blind to it.

They are now wired into the existing path-filtered required **high-risk-recovery**
lane, whose `src/services/discord/**` filter this branch already trips:

| filter | selected |
|---|---|
| `services::discord::router::message_handler::intake_turn::race_loss::` | 13 |
| `services::discord::queue_io::presleep_tests::race_loss_recheck_fences_on_transition_without_parking_a_waiter_5170 -- --exact` | 1 |

The `queue_io` oracle is named with `--exact` deliberately: a module-wide filter
would import the two pre-existing #4270 failures into this lane.

`check_test_target_integrity.py --observe-selection` independently reports
`selected=13` / `selected=1` and `nonzero=18` of 18 invocations, so neither
command is a zero-match false green.

Two gates moved in the tightening direction as a consequence:
- `check-ci-runner-hardening.sh` — high-risk-recovery whole-job semantic hash
  re-pinned (same as #5034/#5040 did when adding targets).
- `scripts/test_lane_coverage_baseline.txt` — `race_loss_requeue_tests` is now
  covered, so its baseline entry is removed. The baseline may only shrink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
