### PR TITLE
fix(ci): repair the two stale #4270 queue_io oracles, serialize the #4893 capped-retry test, and wire queue_io into PR CI (#5181)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -789,13 +789,23 @@ jobs:
       # #5170: the transition-busy requeue oracles live in two modules that no
       # curated PR filter selected, so they would have been counted by the lib
       # inventory manifest and executed nowhere -- the #5046/#5041 defect. The
-      # queue_io oracle is named exactly on purpose: the surrounding
-      # `queue_io` module carries pre-existing #4270 failures that predate this
-      # lane, and a module-wide filter would import them.
+      # queue_io oracle was originally named exactly because the surrounding
+      # `queue_io` module carried pre-existing #4270 failures that predated that
+      # lane, and a module-wide filter would have imported them.
+      #
+      # #5181 removed that reason: the two #4270 pins were stale oracles calling
+      # the lease-less `mailbox_requeue_intervention_front` after #4811 made the
+      # promote-gate front-restore lease-AUTHORIZED, and the `_4893` capped-retry
+      # test released the shared test env lock while still depending on
+      # `AGENTDESK_ROOT_DIR`. With both fixed, the whole `queue_io` module is
+      # wired here so the next regression in it cannot merge unexecuted. The two
+      # named #5170 filters are kept deliberately: they pin the exact oracles
+      # that lane added, independent of how the module filter later evolves.
       - name: Transition-busy requeue spin regressions
         run: |
           env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::router::message_handler::intake_turn::race_loss:: -- --test-threads=1
           env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::queue_io::presleep_tests::race_loss_recheck_fences_on_transition_without_parking_a_waiter_5170 -- --exact --test-threads=1
+          env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::queue_io:: -- --test-threads=1
 
       - name: Stop PostgreSQL service
         if: always()

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -307,7 +307,10 @@ targets = {
     # operational-alert targets to the path-filtered required high-risk lane.
     # #5170 re-pins after wiring the transition-busy requeue oracles, which the
     # lib inventory manifest counted while no curated filter executed them.
-    "job_sha256" => "dc85115bd40b9f4ce8b1595d3568ae2a0996c78d7ca1e0fa4f03576ebeb6f1d9",
+    # #5181 re-pins after widening that lane from the two named #5170 oracles to
+    # the whole `services::discord::queue_io::` module, now that the module's
+    # pre-existing #4270/#4893 failures are fixed rather than filtered around.
+    "job_sha256" => "6bf1e4fea9bf977a711f462b6992ac27452faf2ffaf5fea36fd964aaa6354936",
     "require_debug_env" => false,
     "cargo_steps" => {
       "Observe curated lane selections" => {

--- a/scripts/test_lane_coverage_baseline.txt
+++ b/scripts/test_lane_coverage_baseline.txt
@@ -284,7 +284,6 @@ services::discord::prompt_builder::layer_rendering::workspace_aware_shared_rules
 services::discord::prompt_builder::memory_guidance::tests
 services::discord::prompt_builder::section_dedupe::tests
 services::discord::queue_exit_feedback_reconciler_tests
-services::discord::queue_io::presleep_tests
 services::discord::queue_overflow_dlq::tests
 services::discord::queue_reactions::tests
 services::discord::queued_dequeue_dispatch_guard_wiring_tests

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -1148,14 +1148,17 @@ mod presleep_tests {
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn capped_retry_is_parked_while_unrelated_backlog_progresses_and_backstop_disarms_4893() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
-        let tmp = tempfile::tempdir().expect("temp runtime root");
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", tmp.path()) };
+        // #5181: this test reads and writes `busy_followup_retry_store`, whose
+        // root is re-resolved from the process-global `AGENTDESK_ROOT_DIR` on
+        // EVERY call. Releasing the shared test env lock right after
+        // `make_shared_data_for_tests()` (as this test used to) left the rest of
+        // the body racing any sibling that repoints that variable at its own
+        // tempdir: the capped-retry records then become invisible, capped A is
+        // selected instead of parked, and this test fails ONLY under parallel
+        // execution. Hold the lock for the whole body via
+        // `scoped_runtime_root()`, like every other test in this module.
+        let _root = scoped_runtime_root();
         let shared = make_shared_data_for_tests();
-        drop(_lock);
 
         let provider = ProviderKind::Claude;
         let channel_id = ChannelId::new(4_893_310);
@@ -2362,11 +2365,18 @@ mod presleep_tests {
     }
 
     /// #4270 pin — sustained-busy convergence over the PRODUCTION defer
-    /// sequence (`take_next_soft` promote → `mailbox_requeue_intervention_front`
-    /// + slow-backstop arm, exactly what the `dispatch_queued_turn` promote gate
-    /// runs): repeated cycles converge to a SINGLE queue entry and a SINGLE
-    /// coalesced slow backstop (no accumulation / oscillation), and never fire a
-    /// fast kick.
+    /// sequence (`take_next_soft` promote → `mailbox_restore_dequeued_head`
+    /// with the promote's own dispatch lease + slow-backstop arm, exactly what
+    /// the `dispatch_queued_turn` promote gate runs — see
+    /// `router::intake_dispatch::queued`'s deferred-admission arm): repeated
+    /// cycles converge to a SINGLE queue entry and a SINGLE coalesced slow
+    /// backstop (no accumulation / oscillation), and never fire a fast kick.
+    ///
+    /// #5181/#4797 note: the front-restore is lease-AUTHORIZED. Since #4811 the
+    /// lease-less `mailbox_requeue_intervention_front` is refused with
+    /// `SourceIdPendingOrActive` once the promote has reserved
+    /// `pending_user_dispatch`, so threading the promote's lease through is what
+    /// makes the defer preserve the follow-up instead of dropping it.
     #[tokio::test(flavor = "current_thread")]
     async fn promote_defer_requeue_converges_no_oscillation_across_cycles_4270() {
         let _root = scoped_runtime_root();
@@ -2406,7 +2416,23 @@ mod presleep_tests {
             let intervention = taken
                 .intervention
                 .unwrap_or_else(|| panic!("cycle {cycle}: the follow-up must still be promotable"));
-            mailbox_requeue_intervention_front(&shared, &provider, channel_id, intervention).await;
+            let dispatch_lease = taken.dispatch_lease.unwrap_or_else(|| {
+                panic!("cycle {cycle}: the soft promote must hand back its dispatch lease")
+            });
+            let restored = mailbox_restore_dequeued_head(
+                &shared,
+                &provider,
+                channel_id,
+                intervention,
+                dispatch_lease,
+            )
+            .await;
+            assert!(
+                restored.enqueued,
+                "cycle {cycle}: the lease-authorized dequeued-head restore must preserve the \
+                 follow-up (refusal={:?})",
+                restored.refusal_reason
+            );
             arm_slow_idle_queue_backstop_if_queue_nonempty(
                 &shared,
                 &provider,
@@ -2559,7 +2585,23 @@ mod presleep_tests {
             .take_next_soft(queue_persistence_context(&shared, &provider, channel_id))
             .await;
         let intervention = taken.intervention.expect("promote once");
-        mailbox_requeue_intervention_front(&shared, &provider, channel_id, intervention).await;
+        let dispatch_lease = taken
+            .dispatch_lease
+            .expect("the soft promote must hand back its dispatch lease");
+        let restored = mailbox_restore_dequeued_head(
+            &shared,
+            &provider,
+            channel_id,
+            intervention,
+            dispatch_lease,
+        )
+        .await;
+        assert!(
+            restored.enqueued,
+            "the promote gate's lease-authorized restore must re-preserve the follow-up \
+             (refusal={:?})",
+            restored.refusal_reason
+        );
 
         // Watcher-idle drain: the TUI reached Idle, so the drain soft-takes and
         // claims. It must start exactly once and leave the queue empty.


### PR DESCRIPTION
Fixes #5181 (P1).

## 판정이 뒤집혔다 — 프로덕션이 아니라 테스트가 낡았다

이슈 R1 은 "테스트가 틀렸는지 프로덕션이 틀렸는지 판정하라"를 요구했다. 판정 결과는 **낡은 오라클**이다.

`origin/main` 의 `cargo test --lib queue_io` red 2건(`_4270` 계열)은 프로덕션 결함이 아니다. **`630178385`(#4811 / fix #4797, 2026-07-23)가 front-restore 를 lease-AUTHORIZED 로 바꾼 뒤 남은 낡은 오라클**이며, 그 뒤 약 2주간 red 였다.

**기전**: `turn_orchestrator/front_requeue.rs` 의 `requeue_intervention_front` 는 이제 incoming id 가 `pending_user_dispatch` 와 겹치면 `SourceIdPendingOrActive` 로 **거부**하고, `authorized_pending_restore`(promote 의 dispatch lease 제시)만 예외다. 프로덕션 promote 게이트는 전부 `mailbox_restore_dequeued_head`(lease 동반)로 이주했다 — 실제 게이트는 `router/intake_dispatch/queued.rs:99` 의 deferred-admission arm 이다. **이 두 테스트만 lease-less `mailbox_requeue_intervention_front` 를 계속 호출**해, promote 가 이미 `pending_user_dispatch` 를 예약한 뒤의 재삽입이 거부되어 큐 길이가 1 이 아니라 0 이 됐다.

방증: `tui_prompt_relay/bridge_gateway.rs:4` 에 `mailbox_requeue_intervention_front` 가 **unused import 로 남아 있다** — #4811 이 호출자를 옮기며 남긴 흔적이다. 이 PR 은 그 파일을 건드리지 않는다.

수정: 두 테스트를 프로덕션이 실제로 실행하는 시퀀스(`take_next_soft` 가 돌려준 dispatch lease 를 `mailbox_restore_dequeued_head` 에 태워 넘김)로 갱신하고, `restored.enqueued` 를 `refusal_reason` 과 함께 assert 한다. 테스트 삭제도 `#[ignore]` 도 없다.

## 병렬 flake `capped_retry_..._4893` (R2)

공유 상태는 static 이 아니라 **`AGENTDESK_ROOT_DIR` 프로세스 전역 env** 였다. `busy_followup_retry_store` 가 **매 호출마다** 그 env 에서 루트를 재해석하는데, 이 테스트는 `make_shared_data_for_tests()` 직후 공유 test env 락을 놓아버려서, 형제 테스트가 `scoped_runtime_root()` 로 그 변수를 자기 tempdir 로 바꾸면 capped 레코드가 보이지 않게 된다. capped A 가 park 되지 않고 선택되어 **병렬에서만** 실패한다.

**`--test-threads=1` 을 CI 에 박지 않았다.** 이슈가 최후수단이라고 명시한 대로다. 대신 모듈의 다른 25개 테스트가 이미 쓰는 방식 그대로 `scoped_runtime_root()` 로 본문 전체 동안 기존 테스트 전역 락을 유지해 직렬화했다.

## CI 배선 (R3)

`ci-pr.yml` high-risk-recovery 레인에 `services::discord::queue_io::` **1줄** 추가.

- `grep -c 'cargo test --lib' .github/workflows/ci-pr.yml`: `origin/main` **30** → 이 브랜치 **31**
- **#5170/#5180 이 넣은 2줄(`race_loss::`, `race_loss_recheck_..._5170`)은 그대로 보존**했다. 모듈 필터가 나중에 어떻게 바뀌든 그 레인이 핀한 오라클을 잃지 않기 위해서다.
- `--observe-selection` 실측: `selected=26` (0건 매치가 아님)

부수 변경 2건은 이 배선이 강제한 것이다:
- `scripts/check-ci-runner-hardening.sh` — job semantic hash 재핀
- `scripts/test_lane_coverage_baseline.txt` — `services::discord::queue_io::presleep_tests` 항목 제거 (**축소 방향**, 이제 CI 가 실제로 실행하므로 미커버 baseline 에서 빠진다)

## 뮤테이션 — 5건 중 4건 KILLED, 1건 부분 SURVIVED

| M | 좌표 | 결과 |
|---|---|---|
| M1 | `turn_orchestrator.rs:2792` `clear_pending_user_dispatch` 제거 | KILLED (양쪽 테스트) |
| M2 | `queue_io.rs:591-601` slow-backstop coalescing 해제 | KILLED |
| M3 | `front_requeue.rs:51` front insert 중복 | KILLED — 단 **`idle_drain` 은 SURVIVED** |
| M4 | `turn_orchestrator.rs:2464` `active_user_message_id = None` | KILLED |
| M5 | `turn_orchestrator.rs:2753` lease 인가 반전 | KILLED (양쪽) — **판정 근거** |

### M5 — 판정 전체의 근거 (최종 rebase SHA 에서 재실행, 승계 아님)

lease 인가를 반전(`Arc::ptr_eq` → `!Arc::ptr_eq`)하자 두 테스트가 **신규 assert 에서** 죽으며 `refusal=Some(SourceIdPendingOrActive)` 를 그대로 출력했다. 원래의 base-red 가 바로 그 거부였다는 **직접 증거**다. 컴파일 사망이 아니며, `git checkout --` 로 복구했고 커밋하지 않았다.

### ⚠️ M3 의 `idle_drain` SURVIVED — 숨기지 않고 보고한다

`front_requeue.rs:51` 의 front insert 를 중복시키는 뮤테이션에서 `promote_defer_requeue_converges_no_oscillation_across_cycles_4270` 는 죽었지만 **`idle_drain_after_promote_defer_dispatches_exactly_once_4270` 은 살아남았다.** 이 테스트는 promote-defer 를 1 사이클만 돌리고 그 뒤 drain 이 정확히 한 번 시작하는지를 보므로, 큐 길이의 중복 자체를 판별하지 못한다. 테스트를 고쳐 KILL 을 만들지 않고 그대로 남긴다.

오라클 자체가 죽어 있다는 뜻은 아니다: 같은 테스트가 **M1 / M4 / M5 에서는 자기 assert 로 죽는다.** 즉 lease 인가·pending-dispatch 정리·active-id 정리 계약은 이 테스트가 실제로 지키고 있고, 비어 있는 것은 "front 중복 삽입" 축 하나다.

## 검증 (전부 rebase 후 최종 SHA 에서 재실행)

| 게이트 | rc | passed |
|---|---|---|
| `cargo check --all-targets` | 0 | 경고 285 (전부 기존) |
| `cargo fmt --check` | 0 | — |
| `cargo test --lib queue_io -- --test-threads=1` | 0 | **26** |
| `cargo test --lib queue_io` 병렬 ×3 | 0/0/0 | **26/26/26** |
| `TEST_LANE_BASELINE_REF=origin/main ./scripts/ci-script-checks.sh` | 0 | — |
| `audit_maintainability.py --check` | 0 | — |
| 배선 필터 3종 (`race_loss::` / `_5170` / `queue_io::`) | 0/0/0 | 13 / 1 / **26** |

3,938개 병렬 실행에서 `queue_io` 실패 0건.

## 이 PR 소관이 아닌 기존 red

리포에는 이 브랜치와 무관한 **병렬 전용 실패 13건 + 진성 base-red 3건**이 있다 (`observability::emit::tests::every_emit_surface_records_one_recent_event` 등). **#5185** 소관이며, 이 PR 로 고치지 않는다.

## 범위 밖으로 남긴 것 (R4)

R4("CI 에서 한 번도 실행되지 않는 모듈 목록")는 이 PR 에서 닫지 않는다. `scripts/test_lane_coverage_baseline.txt` 가 이미 그 목록의 역할을 하고 있으며, 이 PR 은 거기서 **한 항목을 줄이는** 방향으로만 움직였다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
