### PR TITLE
cleanup(#5187): remove the path-A dead-code residue #5168 left behind

### DIFF
--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -453,7 +453,6 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
         }
     };
     let memory_scope_channel_id = resolved_role_binding.memory_channel_id(channel_id);
-    let memory_channel_id = memory_scope_channel_id.get();
     let inherited_memory_channel_name = resolved_role_binding.memory_channel_name(None);
     let role_binding = resolved_role_binding.role_binding.take();
     let provider = role_binding

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -453,7 +453,6 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
         }
     };
     let memory_scope_channel_id = resolved_role_binding.memory_channel_id(channel_id);
-    let inherited_memory_channel_name = resolved_role_binding.memory_channel_name(None);
     let role_binding = resolved_role_binding.role_binding.take();
     let provider = role_binding
         .as_ref()

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -922,7 +922,6 @@ pub(super) async fn handle_text_message(
             .map(|resolved| resolved.role_binding.clone());
     }
     let memory_scope_channel_id = resolved_role_binding.memory_channel_id(channel_id);
-    let memory_channel_name = resolved_role_binding.memory_channel_name(None);
     let role_binding = resolved_role_binding.role_binding;
 
     // For cross-channel dispatch reuse, override the provider so the turn

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -922,7 +922,6 @@ pub(super) async fn handle_text_message(
             .map(|resolved| resolved.role_binding.clone());
     }
     let memory_scope_channel_id = resolved_role_binding.memory_channel_id(channel_id);
-    let memory_channel_id = memory_scope_channel_id.get();
     let memory_channel_name = resolved_role_binding.memory_channel_name(None);
     let role_binding = resolved_role_binding.role_binding;
 

--- a/src/services/discord/router/message_handler/provider_isolation.rs
+++ b/src/services/discord/router/message_handler/provider_isolation.rs
@@ -30,13 +30,6 @@ impl ResolvedThreadRoleBinding {
             .map(|(parent_id, _)| *parent_id)
             .unwrap_or(channel_id)
     }
-
-    pub(super) fn memory_channel_name(&self, channel_name: Option<&str>) -> Option<String> {
-        self.inherited_parent
-            .as_ref()
-            .and_then(|(_, parent_name)| parent_name.clone())
-            .or_else(|| channel_name.map(String::from))
-    }
 }
 fn inheritable_thread_parent(
     thread_parent: Option<&(ChannelId, Option<String>)>,
@@ -854,7 +847,6 @@ mod thread_role_inheritance_tests {
             workspace.to_str()
         );
         assert_eq!(resolved.memory_channel_id(child), parent.0);
-        assert_eq!(resolved.memory_channel_name(None), parent.1);
         let memory = settings::ResolvedMemorySettings {
             backend: settings::MemoryBackendKind::Memento,
             ..Default::default()
@@ -907,10 +899,6 @@ mod thread_role_inheritance_tests {
         assert!(resolved.role_binding.is_none());
         assert!(resolve_thread_workspace(child, Some("thread"), Some(&parent)).is_none());
         assert_eq!(resolved.memory_channel_id(child), child);
-        assert_eq!(
-            resolved.memory_channel_name(Some("t")).as_deref(),
-            Some("t")
-        );
     }
 
     #[test]

--- a/src/services/memory/memento.rs
+++ b/src/services/memory/memento.rs
@@ -1572,8 +1572,9 @@ fn split_static_slice_sections(text: &str) -> (String, Vec<String>) {
 }
 
 /// Heuristic: a "new section" header line is either the bracketed banner
-/// (`[External Recall]`, `[External Recall — Identity Lite]`) or one of the
-/// known `<label>: ` colon-terminated headers emitted by the formatter.
+/// (`[External Recall]`, the only banner still emitted — see
+/// [`format_context_payload_for_external_recall`]) or one of the known
+/// `<label>: ` colon-terminated headers emitted by the formatter.
 fn line_starts_new_section(line: &str) -> bool {
     if line.starts_with('[') && line.ends_with(']') {
         return true;

--- a/src/services/memory/memento.rs
+++ b/src/services/memory/memento.rs
@@ -28,9 +28,7 @@ const MAX_WORKING_MEMORY_LINES: usize = 6;
 const MAX_MEMORY_LINES: usize = 6;
 const MAX_SKIP_LINES: usize = 4;
 const MEMENTO_CONTEXT_FULL_TOKEN_BUDGET: u64 = 1_000;
-const MEMENTO_CONTEXT_IDENTITY_TOKEN_BUDGET: u64 = 450;
 const MEMENTO_CONTEXT_FULL_TYPES: &[&str] = &["preference", "error", "procedure", "decision"];
-const MEMENTO_CONTEXT_IDENTITY_TYPES: &[&str] = &["preference", "procedure"];
 const MAX_CAPTURE_TURN_CHARS: usize = 2_000;
 const MEMENTO_MODEL_OUTPUT_MAX_BYTES: usize = 16 * 1024;
 
@@ -374,42 +372,24 @@ impl MementoBackend {
         args.insert("agentId".to_string(), json!(agent_id));
         args.insert("sessionId".to_string(), json!(request.session_id));
         args.insert("structured".to_string(), json!(true));
-        let (token_budget, types) = match request.mode {
-            RecallMode::Full => (
-                MEMENTO_CONTEXT_FULL_TOKEN_BUDGET,
-                MEMENTO_CONTEXT_FULL_TYPES,
-            ),
-            RecallMode::IdentityOnly => (
-                MEMENTO_CONTEXT_IDENTITY_TOKEN_BUDGET,
-                MEMENTO_CONTEXT_IDENTITY_TYPES,
-            ),
-        };
-        args.insert("tokenBudget".to_string(), json!(token_budget));
-        args.insert("types".to_string(), json!(types));
+        args.insert(
+            "tokenBudget".to_string(),
+            json!(MEMENTO_CONTEXT_FULL_TOKEN_BUDGET),
+        );
+        args.insert("types".to_string(), json!(MEMENTO_CONTEXT_FULL_TYPES));
         if !workspace.trim().is_empty() {
             args.insert("workspace".to_string(), json!(workspace));
         }
         let result = self
             .call_tool(config, "context", Value::Object(args))
             .await?;
-        // #1083: Different formatter per mode — `Full` keeps every section,
-        // `IdentityOnly` strips down to the identity + current session lines.
-        let external_recall = match request.mode {
-            RecallMode::Full => {
-                // #2660 — collapse repeat emissions of the static slice
-                // (Ranked context / Core memory / Anchored fallback) within
-                // the per-(workspace, agent, session, mode) TTL.
-                let rendered = format_context_payload_for_external_recall(&result.payload);
-                let slice_key = build_static_slice_cache_key(
-                    workspace,
-                    &agent_id,
-                    &request.session_id,
-                    request.mode,
-                );
-                elide_static_slice_if_recent(rendered, &slice_key)
-            }
-            RecallMode::IdentityOnly => format_context_payload_for_identity_only(&result.payload),
-        };
+        // #2660 — collapse repeat emissions of the static slice
+        // (Ranked context / Core memory / Anchored fallback) within
+        // the per-(workspace, agent, session, mode) TTL.
+        let rendered = format_context_payload_for_external_recall(&result.payload);
+        let slice_key =
+            build_static_slice_cache_key(workspace, &agent_id, &request.session_id, request.mode);
+        let external_recall = elide_static_slice_if_recent(rendered, &slice_key);
         Ok(ContextFetchResult {
             external_recall,
             token_usage: result.token_usage,
@@ -754,7 +734,6 @@ fn build_static_slice_cache_key(
 ) -> String {
     let mode = match mode {
         RecallMode::Full => "full",
-        RecallMode::IdentityOnly => "identity_only",
     };
     [workspace.trim(), agent_id.trim(), session_id.trim(), mode].join("\u{1f}")
 }
@@ -774,7 +753,6 @@ fn build_recall_dedup_key(
     };
     let mode = match mode {
         RecallMode::Full => "full",
-        RecallMode::IdentityOnly => "identity_only",
     };
     [
         workspace.trim(),
@@ -1312,55 +1290,6 @@ fn format_skip_line(item: &Map<String, Value>) -> Option<(String, String)> {
     }
 
     Some((skip_item, line))
-}
-
-/// #1083: Identity-only memento payload — emitted on default session-start
-/// turns when no recall trigger fires. Only the `identity` and the active
-/// `current_session` lines are kept so the model still knows who it is talking
-/// to without paying the full context cost.
-fn format_context_payload_for_identity_only(payload: &Value) -> Option<String> {
-    let mut sections = vec!["[External Recall — Identity Lite]".to_string()];
-
-    if let Some(hint) = search_event_feedback_hint(payload) {
-        sections.push(hint);
-    }
-
-    if let Some(identity) = payload
-        .get("identity")
-        .and_then(Value::as_str)
-        .map(normalize_whitespace)
-        .filter(|value| !value.is_empty())
-    {
-        sections.push(format!("Identity from Memento:\n{identity}"));
-    }
-
-    let working_session_lines = payload
-        .get("working")
-        .and_then(Value::as_object)
-        .and_then(|working| working.get("current_session"))
-        .and_then(Value::as_array)
-        .map(|items| {
-            dedup_lines(
-                items
-                    .iter()
-                    .filter_map(Value::as_object)
-                    .filter_map(|item| format_core_memory_line("session", item)),
-                MAX_WORKING_MEMORY_LINES,
-            )
-        })
-        .unwrap_or_default();
-    if !working_session_lines.is_empty() {
-        sections.push(format!(
-            "Current session context from Memento:\n- {}",
-            working_session_lines.join("\n- ")
-        ));
-    }
-
-    if sections.len() == 1 {
-        None
-    } else {
-        Some(sections.join("\n"))
-    }
 }
 
 fn format_context_payload_for_external_recall(payload: &Value) -> Option<String> {
@@ -2057,9 +1986,6 @@ mod static_slice_cache_tests {
         let key_a = build_static_slice_cache_key("ws", "agent", "sess", RecallMode::Full);
         let key_b = build_static_slice_cache_key("ws", "agent", "sess", RecallMode::Full);
         assert_eq!(key_a, key_b);
-        let key_other_mode =
-            build_static_slice_cache_key("ws", "agent", "sess", RecallMode::IdentityOnly);
-        assert_ne!(key_a, key_other_mode);
         let key_other_session =
             build_static_slice_cache_key("ws", "agent", "other-sess", RecallMode::Full);
         assert_ne!(key_a, key_other_session);

--- a/src/services/memory/mod.rs
+++ b/src/services/memory/mod.rs
@@ -46,21 +46,12 @@ impl TokenUsage {
 }
 
 /// Controls how much memento payload the backend should fetch and emit.
-///
-/// #1083: Memento recall throttling — by default a turn no longer auto-injects
-/// the full memento `context` payload. The first turn of a fresh session
-/// requests `IdentityOnly` (lightweight identity + working session) while
-/// trigger-based turns request `Full`.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) enum RecallMode {
     /// Full memento context payload — identity, working memory, ranked
-    /// memories, anchors, etc. Reserved for trigger-driven turns.
+    /// memories, anchors, etc.
     #[default]
     Full,
-    /// Lightweight identity-only payload. Used on default session-start turns
-    /// so the model still knows who it is talking to without paying the full
-    /// context cost.
-    IdentityOnly,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Closes #5187

## 핵심

`#5168`(memento 경로 A 제거)이 남긴 dead-code 찌꺼기를 걷어낸다. **순수 삭제 커밋**: 5파일 `+16/−114` (순 −98).

dead-code 경고를 **distinct `(code, file, message)` 기준**으로:

```
base 503154edd : 282 distinct
this HEAD      : 277 distinct
delta          :  −5 distinct, 신규 추가 0
```

이슈가 열거한 5건이 **정체성 기준으로 하나씩 전부 소멸**한다.

- `intake_turn.rs` `unused variable: memory_channel_id`
- `intake_turn.rs` `unused variable: memory_channel_name`
- `headless_turn.rs` `unused variable: memory_channel_id`
- `headless_turn.rs` `unused variable: inherited_memory_channel_name`
- `mod.rs` `variant IdentityOnly is never constructed`

## ⚠️ 두 가지 수치, 그리고 왜 다른가

| 기준 | base | HEAD | delta |
|---|---|---|---|
| **emission** (rustc 가 뱉은 줄 수) | 390 | 381 | **−9** |
| **distinct `(code, file, message)`** | 282 | 277 | **−5** |

**왜 다른가:** `cargo check --all-targets` 는 `lib` 과 `lib-test` 두 타깃을 각각 컴파일하고, 같은 `unused_variables` 진단을 **타깃마다 한 번씩 방출**한다. 그래서 지역변수 경고 1건이 emission 으로는 2로 세어진다.

**이 착시가 r1 실패를 가렸다.** r1 시점에 emission 은 −5 로 "줄었다"고 보였지만 distinct 로 재면 −3 이었고, 이슈가 지목한 경고 2건이 그대로 남아 있었다. emission 은 판별력이 없다. distinct 가 판별 기준이다. (`line` 은 키에서 의도적으로 제외했다 — diff 의 줄 밀림이 "삭제 + 추가"로 읽히는 것을 막기 위해서다.)

## 삭제 근거 — 미배선이 아니라 찌꺼기

이슈 요구 1번("삭제인지 미배선인지 판정하라")에 대한 답이다. 코드로 재확인했다.

- `ResolvedThreadRoleBinding::memory_channel_name` 은 side-effect 없는 getter 였다 — 상속 부모 이름을 clone 하거나 인자로 폴백. 호출 제거로 사라지는 것은 `Option<String>` clone 하나뿐이다.
- 살아있는 scope 경로는 스레드 상속을 **부모 id** 로만 나른다. 이름으로 나르지 않는다: `intake_turn.rs`/`headless_turn.rs` → `prompt_builder/mod.rs` → `memory_guidance.rs` 의 `resolve_memento_workspace(role_id, channel_id.get(), None)`, 이 래퍼가 `channel_name: None` 을 하드코딩한 뒤 `resolve_memento_workspace_for_channel` 로 간다.
- **`RecallRequest.channel_name` 에는 살아있는 프로덕션 생산자가 없다**: 살아남은 유일한 프로덕션 `RecallRequest` 생성자(`meeting_orchestrator/rounds.rs:372`)가 `channel_name: None` 을 하드코딩하고, `CaptureRequest` 에는 채널 이름 필드 자체가 없다.
- **범위를 명시한다:** `ReflectRequest.channel_name`(`src/services/memory/mod.rs:117`)은 **살아있다** — `turn_bridge/memory_lifecycle.rs:514` 에서 채워지고 `memento.rs:1799` 에서 소비된다. 이 변경과 무관하며 손대지 않았다.

두 호출부가 사라지면서 `memory_channel_name` 은 non-test 호출자가 0이 되어 함께 삭제했고, 그것만 실습하던 assertion 2개도 같이 지웠다. `let` 바인딩 2줄만 지우는 중간 상태를 실제로 컴파일해 보면 `unused_variables` 2건이 `method ... is never used` 1건으로 바뀔 뿐이다 — 이를 `#[allow(dead_code)]` 로 덮는 것은 정리가 아니라 은폐라서 하지 않았다. `memory_channel_id` 와 상속 assertion 은 그대로 두었으므로 스레드 상속 커버리지는 불변(7 passed).

`RecallMode::IdentityOnly` 는 이슈 요구 2번대로 제거했고, 그 producer 였던 `format_context_payload_for_identity_only` 와 `[External Recall — Identity Lite]` 배너도 함께 사라진다. 그 배너를 인용하던 `line_starts_new_section` 의 낡은 doc comment 도 갱신했다 — 이제 `[External Recall]` 이 유일한 배너다.

이슈 요구 3번("net-negative 로 끝내라") 충족: **−98줄**.

## 뮤테이션을 돌리지 않은 이유

**순수 삭제 커밋이라 억지 뮤테이션은 공허하다.** 삭제분에는 뮤테이트할 로직이 없고, 삭제된 코드에 뮤테이션을 걸어 봐야 "없는 것이 없다"만 확인된다. 대신 세 가지로 대체했다.

1. **삭제 안전성 전수 재확인** — 위 근거 전부를 코드에서 직접 확인했다(전언 신뢰 금지).
2. **두-줄-only 중간 컴파일로 신규 경고 실측 반증** — `let` 2줄만 지운 상태를 실제로 빌드해서, 추측이 아니라 컴파일러 출력으로 "새 경고가 생긴다"를 확인하고 그래서 accessor 까지 지우는 것으로 결론냈다.
3. **distinct 측정으로 판별력 확보** — emission 기준의 착시를 제거했다.

그리고 **리뷰어가 독립적으로 재현해 수치가 자릿수까지 일치**했고, **남은 커버리지에 뮤테이션을 걸어 2/2 KILLED** 를 확인했다.

## 리뷰

2라운드 적대 리뷰.

- **r1: `ISSUES`** — 이슈가 열거한 경고 5건 중 2건(`intake_turn.rs` `memory_channel_name`, `headless_turn.rs` `inherited_memory_channel_name`)이 잔존. emission −5 가 distinct −3 을 가린 것이 원인.
- **r2: `VERDICT: CLEAN`**

## 후속 (이번 PR 범위 밖, 별도 이슈로 등록)

리뷰가 P2 로 남긴 2건. 아래 후속 이슈 참조.

1. `inherited_parent` 의 이름 성분이 write-only 가 됐다 — 필드 자체는 읽히므로 `dead_code` 가 안 뜬다.
2. `RecallMode` 단일-variant 잔재 정리 — 캐시 키에 항상 상수 `"full"` 이 들어간다.
