### PR TITLE
fix(#5189): give every deploy exit a terminal marker, and print it last

### DIFF
--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -105,6 +105,9 @@ echo "=== Inflight blind-save ratchet guard (#4259) ==="
 # #4511 post-deploy smoke WARN post-restart scoping
 bash tests/test_deploy_smoke_warn_scope_4511.sh
 
+echo "=== Cluster deploy peer verdict + terminal marker contract (#5189) ==="
+bash tests/test_cluster_deploy_peer_verdict_5189.sh
+
 echo "=== CI runner hardening guard ==="
 ./scripts/check-ci-runner-hardening.sh
 "$PYTHON" -m unittest tests.test_discord_thread_create_ci_wiring

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -741,6 +741,22 @@ _assert_release_binary_runtime_surface() {
     rm -f "$surface_dump"
 }
 
+_emit_terminal_deploy_marker() {
+    # EVERY deploy run must end its transcript on exactly one machine-greppable
+    # terminal line. Success is printed by the main body (`═══ Deploy Complete ═══`);
+    # this is its failure counterpart.
+    #
+    # #5189: this echo used to live inside _finalize_detached_helper, i.e. behind
+    # `DEPLOY_DETACHED_CHILD = 1` AND a non-empty report channel. An ssh-driven
+    # cluster peer leg satisfies neither, so a peer that refused promotion ended its
+    # transcript with NO terminal marker at all — leaving any log-based verdict with
+    # nothing to match and the operator with nothing to grep. The marker is the
+    # contract; the Discord notification below is the optional extra.
+    local status="${1:-0}"
+    [ "$status" -ne 0 ] || return 0
+    echo "═══ DEPLOY FAILED (exit=${status}) ═══"
+}
+
 _finalize_detached_helper() {
     local status="${1:-0}"
     [ "$DEPLOY_DETACHED_CHILD" = "1" ] || return 0
@@ -750,10 +766,6 @@ _finalize_detached_helper() {
     if [ "$status" -eq 0 ]; then
         content="✅ release deploy complete"
     else
-        # Emit a deterministic failure marker into the helper log so an operator
-        # tailing the log can poll for a single regex covering both outcomes
-        # (success: `═══ Deploy Complete ═══`, failure: this line).
-        echo "═══ DEPLOY FAILED (exit=${status}) ═══"
         content="❌ release deploy failed (exit ${status})
 log: ${DEPLOY_LOG_PATH:-n/a}"
         local summary
@@ -1089,6 +1101,7 @@ _cleanup_on_exit() {
     if [ -n "${DEPLOY_MKDIR_LOCK_DIR:-}" ] && [ -d "$DEPLOY_MKDIR_LOCK_DIR" ]; then
         rm -rf "$DEPLOY_MKDIR_LOCK_DIR" 2>/dev/null || true
     fi
+    _emit_terminal_deploy_marker "$status"
     _finalize_detached_helper "$status"
 }
 
@@ -1379,9 +1392,14 @@ EOF
     echo "    Poll the helper log in this turn until one terminal line appears:"
     echo "      success: ═══ Deploy Complete ═══"
     echo "      failure: ═══ DEPLOY FAILED (exit=N) ═══"
+    echo "    With --all-nodes these are printed only AFTER every peer leg has finished,"
+    echo "    so the wait below covers the cluster verdict too (#5189)."
     echo ""
     echo "    One-shot wait command (polling loop — self-terminates after match):"
-    echo "      LOG=$log_path; until [ -f \"\$LOG\" ] && grep -qm1 -E '═══ Deploy Complete ═══|═══ DEPLOY FAILED' \"\$LOG\"; do sleep 3; done; grep -E '═══ Deploy Complete ═══|═══ DEPLOY FAILED' \"\$LOG\" | tail -1"
+    # `^`-anchored: `grep -qm1` stops at the FIRST match, so a line that merely quotes
+    # a marker (the per-peer ✓ lines do) would end the wait early and be reported as
+    # the verdict. Terminal markers are emitted at column 0 (#5189).
+    echo "      LOG=$log_path; until [ -f \"\$LOG\" ] && grep -qm1 -E '^═══ Deploy Complete ═══|^═══ DEPLOY FAILED' \"\$LOG\"; do sleep 3; done; grep -E '^═══ Deploy Complete ═══|^═══ DEPLOY FAILED' \"\$LOG\" | tail -1"
     echo ""
     echo "    ⚠ DO NOT use 'tail -F | grep -m1' — grep -m1 exits on match but tail -F stays alive"
     echo "      on inotify wait, leaving the bash task hung past helper completion."
@@ -3348,8 +3366,18 @@ fi
 
 _write_release_source_manifest
 
-echo "═══ Deploy Complete ═══"
-
+# #5189: the terminal marker is the LAST line this run prints, on every path.
+# It used to be echoed HERE, before the cluster stage, and the polling command this
+# script hands the operator (see _spawn_detached_helper) stops at the FIRST match —
+# `grep -qm1` — so it locked onto this line and reported "Deploy Complete" while
+# peers were still unjudged. That is #5189's own defect on a second path. The window
+# is seconds today and grows to the 10-25 minutes a peer leg takes once peers deploy
+# in the ssh foreground.
+# Ordering is the fix, not a smarter regex: while peers are being deployed this
+# transcript carries NO terminal marker, which is the truth — there is no verdict
+# yet. A refused peer exits non-zero and the EXIT trap prints DEPLOY FAILED instead.
 if [ "$DEPLOY_ALL_NODES" = "1" ]; then
     _deploy_to_all_peers "$@"
 fi
+
+echo "═══ Deploy Complete ═══"

--- a/tests/test_cluster_deploy_peer_verdict_5189.sh
+++ b/tests/test_cluster_deploy_peer_verdict_5189.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Regression test for #5189, part 1: EVERY deploy run must end its transcript on a
+# terminal marker, and that marker must be the LAST thing the run prints.
+#
+# What actually happened (from deploy-release.93281.log): a cluster peer refused
+# promotion at the restart persistence gate and ended its log with NO terminal
+# marker at all, because the `DEPLOY FAILED` echo was gated behind the
+# detached-helper branch. A peer leg is neither a detached child nor report-channel
+# bound, so nothing was printed and no log-based verdict had anything to match.
+#
+# The gate's refusal was CORRECT ("the in-flight delivery frontier is not durable").
+# The defect is that the refusal never reached the report. §1 pins the marker onto
+# every non-zero exit. §2 pins its POSITION: the script hands the operator a polling
+# command built on `grep -qm1`, so a success marker printed before the cluster stage
+# is read as the verdict for a deploy that has judged no peer at all.
+#
+# Later parts of this stack judge the peers themselves; this file is the contract
+# they report through.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Overridable so a mutation run can point the same assertions at a patched copy.
+DEPLOY_SH="${AGENTDESK_TEST_DEPLOY_SH:-$REPO_ROOT/scripts/deploy-release.sh}"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agentdesk-cluster-verdict-test.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+extract_function() {
+    local function_name="$1"
+    awk -v start="^${function_name}[(][)] [{]$" '
+        $0 ~ start { printing = 1 }
+        printing { print }
+        printing && /^}$/ { exit }
+    ' "$DEPLOY_SH"
+}
+
+# Exercise the production functions without executing the deploy script.
+eval "$(extract_function _emit_terminal_deploy_marker)"
+
+failures=0
+fail_test() {
+    printf 'FAIL: %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+# --- 1. every failing run must leave a terminal marker --------------------
+# The peer's log ended with no marker precisely because this echo was gated on
+# the detached-helper branch. A peer leg is neither detached-child nor
+# report-channel bound.
+DEPLOY_DETACHED_CHILD=0
+REPORT_CHANNEL_ID=""
+export DEPLOY_DETACHED_CHILD REPORT_CHANNEL_ID
+marker_out="$(_emit_terminal_deploy_marker 1)"
+case "$marker_out" in
+    *"DEPLOY FAILED (exit=1)"*) : ;;
+    *) fail_test "a non-zero exit must print a terminal DEPLOY FAILED marker even outside the detached helper; got '$marker_out'" ;;
+esac
+marker_out="$(_emit_terminal_deploy_marker 0)"
+if [ -n "$marker_out" ]; then
+    fail_test "a successful exit must not print a failure marker; got '$marker_out'"
+fi
+# The emitter is only half the contract — the EXIT path has to CALL it. Asserting the
+# function in isolation leaves "delete the call site" undetected, and that restores
+# the original defect exactly: a marker nothing invokes is a silent non-zero exit.
+cleanup_body="$(extract_function _cleanup_on_exit)"
+if [ -z "$cleanup_body" ]; then
+    fail_test "could not extract _cleanup_on_exit from $DEPLOY_SH"
+fi
+case "$cleanup_body" in
+    *_emit_terminal_deploy_marker*) : ;;
+    *) fail_test "_cleanup_on_exit must emit the terminal marker; a marker function nothing calls leaves every non-zero exit silent" ;;
+esac
+
+# --- 2. the terminal marker must be the LAST thing a run prints ----------
+# The script hands the operator a polling command built on `grep -qm1`, which stops
+# at the FIRST match. While the success marker was printed BEFORE the cluster stage,
+# that command locked onto it and reported success for a deploy that had not judged a
+# single peer — #5189's own defect on a second path. The window is seconds today and
+# grows to the 10-25 minutes a peer leg takes once peers deploy in the ssh foreground.
+marker_line="$(grep -n '^echo "═══ Deploy Complete ═══"$' "$DEPLOY_SH" | head -1 | cut -d: -f1)"
+cluster_line="$(grep -n '^    _deploy_to_all_peers "\$@"$' "$DEPLOY_SH" | head -1 | cut -d: -f1)"
+if [ -z "$marker_line" ] || [ -z "$cluster_line" ]; then
+    fail_test "could not locate the terminal marker echo and the cluster-deploy call in $DEPLOY_SH"
+elif [ "$marker_line" -lt "$cluster_line" ]; then
+    fail_test "the success marker (line $marker_line) is printed BEFORE the cluster stage (line $cluster_line) — the advised poll will report it as the verdict while peers are still being judged"
+fi
+
+# The behavioural half: run the polling command this script actually prints, against
+# a log that is still GROWING, and require it to wait for the cluster verdict.
+run_bounded() {
+    # (deadline_secs, out_path, command-string) -> rc, 124 on deadline.
+    local deadline="$1" out="$2" cmd="$3"
+    ( eval "$cmd" ) > "$out" 2>&1 &
+    local pid=$! waited=0
+    while kill -0 "$pid" 2>/dev/null; do
+        if [ "$waited" -ge "$deadline" ]; then
+            kill -9 "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+            return 124
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    wait "$pid" 2>/dev/null || return $?
+    return 0
+}
+
+poll_stmt="$(grep -F 'until [ -f ' "$DEPLOY_SH" | head -1)"
+if [ -z "$poll_stmt" ]; then
+    fail_test "could not find the one-shot wait command the script prints for the operator"
+else
+    log_path="$TMP_ROOT/helper-growing.log"
+    # shellcheck disable=SC2034  # log_path is expanded by the extracted echo statement
+    poll_cmd="$(eval "$poll_stmt" | sed -E 's/^[[:space:]]+//')"
+    # Pre-cluster output including a per-peer ✓ line, which really does quote the
+    # marker (PEER_DEPLOY_VERDICT carries it). An unanchored match takes it as the verdict.
+    {
+        printf '%s\n' '✓ Post-deploy functional smoke passed'
+        printf '%s\n' '═══ Cluster Deploy → Peers ═══'
+        printf '%s\n' '  ✓ mac-air — ═══ Deploy Complete ═══; repo_head 4ee96e55e'
+    } > "$log_path"
+    (
+        sleep 4
+        {
+            printf '%s\n' '✗ Cluster deploy: 1/2 peer(s) did not prove promotion: mac-mini'
+            printf '%s\n' '═══ DEPLOY FAILED (exit=1) ═══'
+        } >> "$log_path"
+    ) &
+    writer_pid=$!
+    poll_rc=0
+    run_bounded 40 "$TMP_ROOT/poll.out" "$poll_cmd" || poll_rc=$?
+    wait "$writer_pid" 2>/dev/null || true
+    if [ "$poll_rc" -eq 124 ]; then
+        fail_test "the advised polling command never terminated on a log that reached a terminal marker"
+    elif ! grep -q '═══ DEPLOY FAILED (exit=1) ═══' "$TMP_ROOT/poll.out"; then
+        fail_test "an operator polling exactly as instructed must be handed the cluster verdict; got: $(cat "$TMP_ROOT/poll.out")"
+    fi
+    if grep -q 'repo_head 4ee96e55e' "$TMP_ROOT/poll.out"; then
+        fail_test "the polling command matched a line that merely QUOTES the terminal marker — it must match terminal lines only"
+    fi
+fi
+
+if [ "$failures" -ne 0 ]; then
+    printf '%s\n' "test_cluster_deploy_peer_verdict_5189: $failures assertion(s) failed" >&2
+    exit 1
+fi
+
+printf '%s\n' "test_cluster_deploy_peer_verdict_5189: all assertions passed"

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -1050,9 +1050,15 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
     @staticmethod
     def _production_cleanup_handlers() -> str:
         deploy = DEPLOY.read_text(encoding="utf-8")
+        # _cleanup_on_exit calls _emit_terminal_deploy_marker (#5189: every deploy
+        # exit must leave a greppable terminal marker). Pull in the real definition
+        # instead of stubbing it, so this harness cannot silently drift from the
+        # production exit path it claims to exercise.
+        marker_start = deploy.index("_emit_terminal_deploy_marker() {")
+        marker_end = deploy.index("_finalize_detached_helper() {", marker_start)
         start = deploy.index("_cleanup_owned_pg_tunnel_preflight() {")
         end = deploy.index("_self_hosted_release_session() {", start)
-        return deploy[start:end]
+        return deploy[marker_start:marker_end] + deploy[start:end]
 
     def test_int_cleanup_reaps_probe_once_and_returns_130(self):
         status, events = self._run_signal_cleanup("INT")


### PR DESCRIPTION
Stack unit 1 for #5189, and the **only** unit landing — the remaining three units were withdrawn and their work is tracked in **#5209**. Base `ea284deda`. This unit addresses exactly one defect: **a non-zero deploy exit that reports nothing.**

### What was broken

A cluster peer refused promotion at the restart-persistence gate and ended its transcript with **no terminal marker at all**. The `DEPLOY FAILED` echo lived inside `_finalize_detached_helper`, i.e. behind `DEPLOY_DETACHED_CHILD = 1` **and** a non-empty report channel. An ssh-driven peer leg satisfies neither, so a correct refusal never reached the report and a log-based verdict had nothing to match.

### The fix, in two halves

- **Existence** — `_emit_terminal_deploy_marker` is called from `_cleanup_on_exit`, so every non-zero exit on every path prints exactly one greppable terminal line, detached helper or not.
- **Position** — the success marker moves *below* the cluster stage. The polling command this script hands the operator is built on `grep -qm1`, which stops at the **first** match, so a marker printed before the peers were judged was read as the verdict for a deploy that had judged nobody. That grep is now `^`-anchored, because the per-peer summary lines legitimately quote the marker text.

`tests/test_cluster_deploy_peer_verdict_5189.sh` is new and is wired into `scripts/ci-script-checks.sh` **in this same commit**, so it gates from its first landing. `tests/test_pg_tunnel.py`'s cleanup harness now pulls in the real `_emit_terminal_deploy_marker` instead of stubbing it, so the harness cannot drift from the exit path it claims to exercise. The five physical trap lines that test pins are deliberately untouched.

### Size

4 files, ±202 lines: `scripts/ci-script-checks.sh`, `scripts/deploy-release.sh`, `tests/test_cluster_deploy_peer_verdict_5189.sh`, `tests/test_pg_tunnel.py`. Zero `.rs` files.

## ⚠️ Merged with `--admin` — CI said nothing about this code

GitHub Actions was in a multi-hour **major outage**, so none of `main`'s **seven required contexts** ever produced a verdict on this commit. `--admin` bypasses **all seven**. **This must not be recorded as "checks passed."**

Substitute evidence is a 20-check local landing gate run against the exact landed SHA: **PASS=17 FAIL=0 SKIP=3**. Details in the pre-merge comment on this PR.

### Not recovered by that gate — stated plainly

| gap | why |
|---|---|
| **Linux target** | host is darwin/arm64; the repo's 34 `target_os = "linux"` cfg blocks are never compiled |
| **PostgreSQL** | no `docker` on the host; the CI `postgres:17` service cannot be started |
| **Parallel load** | 4-vCPU runner vs 14-core host; all 8 ledger flakes are `parallel-only` |
| **macOS fresh-user smoke** | `ci-macos-fresh-user-smoke.sh` not reproduced |
| **bash 5 syntax check** | **미실행** — this host has only bash 3.2.57 and no container runtime |
| **Real deploy** | **미실행 by policy** — no deploy run, no `launchctl`, no dcserver restart, no peer ssh |

A **full `main` CI run is owed the moment Actions recovers.**

### Local gate summary

| gate | rc | detail |
|---|---|---|
| `bash -n` (bash 3.2.57), 3 shell files | 0 | |
| `shellcheck -S warning`, 3 shell files | 0 | |
| `tests/test_cluster_deploy_peer_verdict_5189.sh` | 0 | **10 asserts**, 0 skipped |
| `python3 -m unittest tests.test_pg_tunnel` | 0 | **55 ran**, 5 pinned trap lines unchanged |
| `scripts/ci-script-checks.sh` | 0 | new suite runs twice inside it, both green |
| `scripts/audit_maintainability.py --check` | 0 | |

### Scope

This unit does **not** complete #5189. Remaining work — R3 (migration ordering vs. peer promotion), R6 (gate-failure diagnostics), R7 (provider disconnected) — is tracked in **#5209**. Two further follow-ups are filed for the peer-side forensic log loss + peer-leg wall-clock bound, and for two P3 defects in `deploy-release.sh`.

**#5189 and #5209 both stay OPEN.**

Refs #5189
