### PR TITLE
fix(#5190): stop an orphan transcript from pinning a channel in permanent relay GAP

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -978,6 +978,7 @@ def _orphan_authority_matured(
 def _channel_has_live_delivery(
     evaluated: list[tuple[TranscriptCandidate, Verdict]],
     fresh_undelivered_by_path: Mapping[str, int],
+    current_delivered_by_path: Mapping[str, float],
     exclude_path: str,
     now: float,
     gap_alert_secs: int,
@@ -986,10 +987,17 @@ def _channel_has_live_delivery(
 
     This is the whole safety hinge of the #5190 orphan handling, so it demands
     positive proof rather than the absence of a complaint: a sibling path with a
-    clean verdict, nothing fresh outstanding, and a delivery actually matched
-    inside the same window that would have declared a gap. When the relay is
-    genuinely down every transcript fails at least one of those, this returns
-    False, and the gap alert proceeds untouched.
+    clean verdict, nothing fresh outstanding, and a recent block of its own
+    matched in THIS tick's haystack.
+
+    That last clause is why `Verdict.delivered_ts` cannot be the evidence
+    (#5190 R4): it is `max(persisted watermark, current match)`, so an idle
+    transcript that delivered ten minutes ago and matches nothing now still
+    carried a fresh-looking timestamp — a stale watermark voting as if it were a
+    live delivery, for up to `gap_alert_secs`. `current_delivered_by_path`
+    carries only what this tick actually matched. When the relay is genuinely
+    down nothing matches, this returns False, and the gap alert proceeds
+    untouched.
     """
     for candidate, verdict in evaluated:
         path = str(candidate.path)
@@ -999,9 +1007,10 @@ def _channel_has_live_delivery(
             continue
         if fresh_undelivered_by_path.get(path, 0) > 0:
             continue
-        if gap_is_unobserved(verdict) or not verdict.delivered_ts:
+        matched_ts = current_delivered_by_path.get(path, 0.0)
+        if matched_ts <= 0.0:
             continue
-        if now - verdict.delivered_ts > gap_alert_secs:
+        if now - matched_ts > gap_alert_secs:
             continue
         return True
     return False
@@ -4587,6 +4596,10 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
 
     evaluated: list[tuple[TranscriptCandidate, Verdict]] = []
     fresh_undelivered_by_path: dict[str, int] = {}
+    # #5190 R4: the newest block epoch this tick actually matched in the
+    # haystack, per path. Distinct from `Verdict.delivered_ts`, which folds in
+    # the persisted watermark and so cannot answer "is it delivering NOW?".
+    current_delivered_by_path: dict[str, float] = {}
     suspected_permanent_losses = 0
     new_permanent_losses = 0
     raw_delivery_by_path = chs.get(LAST_ACTUAL_DELIVERY_BY_PATH_KEY, {})
@@ -4784,14 +4797,37 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             and not matched
         )
         fresh_undelivered_by_path[path] = fresh_undelivered
+        current_delivered_by_path[path] = max(
+            (
+                epoch
+                for (epoch, _), matched in zip(
+                    tombstone_update.active_blocks, active_matches
+                )
+                if matched
+            ),
+            default=0.0,
+        )
         # #5190: a stranded-orphan marker written on an earlier tick matures
         # into an abandonment once the window has elapsed and the file is still
         # frozen. Resurrection (semantic growth) voids it below, so a session
         # that starts writing again is never closed out behind its own back.
+        marker_matured = _orphan_authority_matured(chs, path, now)
+        # #5190 R3: elapsed time is not the finding — the finding is "these
+        # blocks cannot be recovered", and the confirmation window exists to let
+        # that be falsified. A stranded block that finally reached Discord
+        # during the window recovers the verdict, so retiring on the timer alone
+        # would announce "회수 불가" about blocks that had already arrived. The
+        # claim is re-checked against THIS tick's verdict before it is made.
         orphan_matured = (
-            path not in semantic_growth_paths
-            and _orphan_authority_matured(chs, path, now)
+            marker_matured
+            and path not in semantic_growth_paths
+            and verdict.state == STATE_GAP
         )
+        if marker_matured and not orphan_matured:
+            rt.log(
+                f"[{cid}] orphan-stranded-maturity-voided path={path} "
+                f"state={verdict.state} lost={verdict.lost}"
+            )
         if orphan_matured:
             orphan_retired_paths.append(path)
         if tombstone_update.newly_tombstoned:
@@ -5014,6 +5050,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         if path not in stranded_since and not _channel_has_live_delivery(
             evaluated,
             fresh_undelivered_by_path,
+            current_delivered_by_path,
             path,
             now,
             cfg.gap_alert_secs,
@@ -5306,26 +5343,60 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 else "이 세션에서 배달이 확인된 이력이 없습니다 "
                 "(경과 시간을 측정할 기준점 없음).\n"
             )
-            # #5190 R4/R5: the alerting transcript is not always the channel's
-            # active session, and the two cases call for different responses.
-            # Naming the file and narrowing the claim is the difference between
-            # "the relay is down right now" and "a past session left blocks
-            # behind".
-            orphan_gap = bool(selected_path) and verdict_path != selected_path
+            # #5190 R5: say only what this tick proved, one clause per piece of
+            # evidence. Non-selection alone does NOT make a transcript a past
+            # session — a concurrent one swapped in moments ago is also
+            # non-selected, and calling it "과거 세션" while its blocks are being
+            # lost right now is exactly backwards. It also proves nothing about
+            # the relay's health; that claim belongs to the delivering sibling,
+            # which is a separate check. A true enumeration beats a false
+            # universal.
+            not_selected = bool(selected_path) and verdict_path != selected_path
+            frozen_secs = max(0.0, now - verdict_candidate.mtime)
+            frozen_min = int(frozen_secs) // 60
+            orphan_gap = (
+                not_selected
+                and verdict_path not in semantic_growth_paths
+                and frozen_secs >= cfg.orphan_abandon_secs
+            )
+            delivering_elsewhere = _channel_has_live_delivery(
+                evaluated,
+                fresh_undelivered_by_path,
+                current_delivered_by_path,
+                verdict_path,
+                now,
+                cfg.gap_alert_secs,
+            )
             headline = (
                 "🚨 **릴레이 갭 감지 (out-of-band 워치독) — 고아 세션**"
                 if orphan_gap
                 else "🚨 **릴레이 갭 감지 (out-of-band 워치독)**"
             )
-            scope_line = (
-                f"대상 세션: `{Path(verdict_path).name}` — "
-                "**고아 세션(현재 활성 세션 아님)**. 현재 활성 세션은 "
-                f"`{Path(str(selected_path)).name}` 입니다. 즉 이 경보는 "
-                "\"지금 릴레이가 죽었다\"가 아니라 \"과거 세션에 미도달 블록이 "
-                "남아 있다\"는 뜻입니다.\n"
-                if orphan_gap
-                else f"대상 세션: `{Path(verdict_path).name}` (현재 활성 세션).\n"
-            )
+            if not not_selected:
+                scope_line = (
+                    f"대상 세션: `{Path(verdict_path).name}` (현재 활성 세션).\n"
+                )
+            else:
+                scope_line = (
+                    f"대상 세션: `{Path(verdict_path).name}` — 이 채널의 현재 "
+                    f"활성 세션(`{Path(str(selected_path)).name}`)이 아닙니다. "
+                    + (
+                        f"이 트랜스크립트는 **{frozen_min}분째 새 기록이 "
+                        "없습니다** (고아 세션으로 판정).\n"
+                        if orphan_gap
+                        else f"마지막 기록으로부터 {frozen_min}분 경과 — 아직 "
+                        "과거 세션이라고 단정할 수 없습니다 (판정 기준 "
+                        f"{cfg.orphan_abandon_secs // 60}분).\n"
+                    )
+                    + (
+                        "이 채널의 다른 세션은 이번 점검에서 실제로 배달이 "
+                        "확인됐습니다 — 릴레이 전체 장애가 아니라 이 "
+                        "트랜스크립트의 미도달 블록 문제입니다.\n"
+                        if delivering_elsewhere
+                        else "이 채널에서 지금 배달 중인 다른 세션은 확인되지 "
+                        "않았습니다 — 릴레이 장애 가능성이 남아 있습니다.\n"
+                    )
+                )
             rt.alert(
                 ch,
                 f"{headline}\n\n"

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -982,6 +982,7 @@ def _channel_has_live_delivery(
     exclude_path: str,
     now: float,
     gap_alert_secs: int,
+    newer_than: float = 0.0,
 ) -> bool:
     """Is some OTHER transcript on this channel demonstrably still delivering?
 
@@ -998,6 +999,22 @@ def _channel_has_live_delivery(
     carries only what this tick actually matched. When the relay is genuinely
     down nothing matches, this returns False, and the gap alert proceeds
     untouched.
+
+    KNOWN LIMIT of the `gap_alert_secs` bound (#5190 R3 P2-D). The timestamps in
+    `current_delivered_by_path` are block WRITE epochs, not delivery times. A
+    match proves the block was delivered somewhere in `[epoch, now]`, so the
+    bound really says "a delivery happened within the last `gap_alert_secs`" —
+    NOT "a delivery is happening now". An idle sibling whose last block was
+    written `gap_alert_secs - 1` ago and is still inside the bounded Discord
+    read window therefore keeps voting "alive" for that whole span, even if the
+    relay died immediately after. Nothing in the haystack carries a Discord
+    message timestamp, so this cannot be tightened here.
+
+    `newer_than` is how the caller closes that window when it matters: passing
+    the tick a finding was first made requires a match whose block was WRITTEN
+    after that moment, which no relay that was already dead could have produced.
+    It is a lower bound on the evidence, not a replacement for the freshness
+    bound above — both must hold.
     """
     for candidate, verdict in evaluated:
         path = str(candidate.path)
@@ -1009,6 +1026,8 @@ def _channel_has_live_delivery(
             continue
         matched_ts = current_delivered_by_path.get(path, 0.0)
         if matched_ts <= 0.0:
+            continue
+        if matched_ts <= newer_than:
             continue
         if now - matched_ts > gap_alert_secs:
             continue
@@ -3713,9 +3732,24 @@ def _alert_pending_retirement(
     now: float,
     *,
     reason: str,
-) -> bool:
+) -> str:
+    """Send a retirement notice; report WHY it did or did not go out.
+
+    #5190 R3 P2-E: this used to answer a bare bool, and every caller read the
+    False as "nobody could be told". Two very different things produce it. A
+    send failure means the notice never left the box. A cooldown hit means the
+    box is fine and something else — possibly an unrelated `idle` or
+    `read_failure` retirement on the SAME shared cooldown key — spoke within
+    `realert_secs`. Callers gate identically on both (neither is a notice about
+    THESE paths), but the log line must not call a cooldown an undelivered
+    message: that is a false statement about the relay's health, which is the
+    exact defect class this campaign keeps closing.
+
+    Returns one of: `"sent"`, `"cooldown"`, `"undelivered"`, `"empty"`. Only
+    `"sent"` means someone was told about `paths`.
+    """
     if not paths:
-        return False
+        return "empty"
     raw_last_alert = channel_state.get(
         LAST_PENDING_TRANSCRIPT_RETIREMENT_ALERT_KEY, 0.0
     )
@@ -3729,7 +3763,7 @@ def _alert_pending_retirement(
             f"[{ch.channel_id}] transcript-retirement-alert suppressed "
             f"reason={reason} count={len(paths)} cooldown"
         )
-        return False
+        return "cooldown"
     if reason == "idle":
         title = "릴레이 트랜스크립트 평가 권한 만료"
         detail = (
@@ -3776,9 +3810,9 @@ def _alert_pending_retirement(
             f"[{ch.channel_id}] transcript-retirement-alert undelivered "
             f"reason={reason} count={len(paths)}"
         )
-        return False
+        return "undelivered"
     channel_state[LAST_PENDING_TRANSCRIPT_RETIREMENT_ALERT_KEY] = now
-    return True
+    return "sent"
 
 
 def _reset_issue_filing_suppression(channel_state: dict[str, Any]) -> None:
@@ -3990,13 +4024,14 @@ def _retire_dead_worktree_authorities(
     # would otherwise swallow this one and close the incident in total silence.
     # Nothing below has mutated state yet, so deferring simply retries next tick
     # with the absence window intact.
-    if not _alert_pending_retirement(
+    dead_notice = _alert_pending_retirement(
         rt, ch, chs, dead, now, reason=DEAD_WORKTREE_RETIREMENT_REASON
-    ):
+    )
+    if dead_notice != "sent":
         _store_worktree_absences(chs, next_absences)
         rt.log(
             f"[{cid}] dead-worktree-retirement-deferred "
-            f"reason=notice_undelivered count={len(dead)}"
+            f"notice={dead_notice} count={len(dead)}"
         )
         return []
 
@@ -4510,9 +4545,23 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         rt.log(
             f"[{cid}] transcript-pending-expired count={len(expired_pending_paths)}"
         )
-        _alert_pending_retirement(
+        # #5190 R3 R7 — TWO CONVENTIONS NOW COEXIST IN THIS FILE, on purpose and
+        # under protest. This path retires FIRST and notifies second; the
+        # orphan-stranded and dead-worktree retirements below treat the notice
+        # AS the retirement and defer the whole thing when nobody was told.
+        # Aligning this one means deferring state that the block above has
+        # already mutated, which is a distinct change with its own regression
+        # surface and is tracked as a #5190 follow-up. What does not wait is
+        # saying so: an unannounced retirement is logged rather than dropped, so
+        # the divergence is visible in the record instead of being silent.
+        idle_notice = _alert_pending_retirement(
             rt, ch, chs, expired_pending_paths, now, reason="idle"
         )
+        if idle_notice != "sent":
+            rt.log(
+                f"[{cid}] transcript-pending-expired-unannounced "
+                f"notice={idle_notice} count={len(expired_pending_paths)}"
+            )
         _clear_gap_alert_without_recovery(
             rt, chs, cid, expired_pending_paths
         )
@@ -4905,7 +4954,9 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             f"[{cid}] transcript-pending-escalated "
             f"count={len(escalated_pending_paths)}"
         )
-        _alert_pending_retirement(
+        # Same divergence as the idle expiry above (#5190 R3 R7): retired first,
+        # announced second. Logged rather than silently dropped.
+        escalated_notice = _alert_pending_retirement(
             rt,
             ch,
             chs,
@@ -4913,6 +4964,11 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             now,
             reason="read_failure",
         )
+        if escalated_notice != "sent":
+            rt.log(
+                f"[{cid}] transcript-pending-escalated-unannounced "
+                f"notice={escalated_notice} count={len(escalated_pending_paths)}"
+            )
         _clear_gap_alert_without_recovery(
             rt, chs, cid, escalated_pending_paths
         )
@@ -5010,6 +5066,9 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     # last part, so nothing below can silence a real outage.
     stranded_since = _validated_orphan_stranded_since(chs)
     orphan_unattributable_paths: set[str] = set()
+    # Paths whose stranded finding is re-corroborated on THIS tick, and so the
+    # only ones a matured marker may actually close out (#5190 R3 P2-A).
+    orphan_corroborated_paths: set[str] = set()
     for candidate, verdict in evaluated:
         path = str(candidate.path)
         # The freeze floor is load-bearing, not cosmetic. Without it this same
@@ -5023,7 +5082,29 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         # strictly stronger bar: twice the freeze floor, a delivery frontier
         # that has itself gone a full freeze floor without advancing (it is not
         # simply lagging), and dcserver proving the channel has moved to another
-        # session. Every one of those is falsified by a live relay outage.
+        # session.
+        #
+        # #5190 R3 P2-B — what those three actually are. An earlier revision of
+        # this comment claimed "every one of those is falsified by a live relay
+        # outage". That was false, and false in the direction that flatters the
+        # code:
+        #   · the doubled freeze floor is a TIME FILTER. An outage neither
+        #     satisfies nor falsifies it; it only sets how long a corpse must
+        #     lie still before anyone may say so.
+        #   · the stale delivery frontier is an ANTI-LAGGING filter. An outage
+        #     does not falsify it — an outage SATISFIES it, because a frontier
+        #     that stops advancing is exactly what a stopped relay produces. It
+        #     argues FOR the marker during an outage, not against it.
+        #   · successor binding is evidence of SESSION ROTATION, not of
+        #     delivery. The watcher stays bound to the current session while the
+        #     relay is stone dead, so dcserver goes on answering yes.
+        # Exactly one check in this mechanism can tell a dead session from a
+        # dead relay: `_channel_has_live_delivery` — a SIBLING transcript
+        # matching a block of its own in THIS tick's haystack. It holds that
+        # line alone. Everything above only decides who is eligible to be asked;
+        # that one call is the only thing that answers, which is why it is
+        # re-run before any marker is allowed to close (#5190 R3 P2-A) and why
+        # its own freshness limits are documented rather than glossed.
         observed_history = not gap_is_unobserved(verdict)
         freeze_floor = cfg.orphan_abandon_secs * (
             ORPHAN_OBSERVED_FREEZE_MULTIPLIER if observed_history else 1
@@ -5047,18 +5128,27 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             if stranded_since.pop(path, None) is not None:
                 rt.log(f"[{cid}] orphan-stranded-marker-cleared path={path}")
             continue
-        if path not in stranded_since and not _channel_has_live_delivery(
-            evaluated,
-            fresh_undelivered_by_path,
-            current_delivered_by_path,
-            path,
-            now,
-            cfg.gap_alert_secs,
-        ):
-            # No corroborating delivery anywhere on the channel — this may well
-            # be a live outage. Leave it to the normal gap path.
-            continue
-        if path not in stranded_since:
+        # #5190 R3 P2-A: the marker records a finding made on ONE earlier tick,
+        # and `_orphan_authority_matured` only asks whether the clock has run
+        # out since. Everything that justified opening it has to still hold at
+        # the moment it is cashed in, or the retirement rests on evidence nobody
+        # re-read. Reaching this line already re-establishes ①③ and the freeze
+        # floor for this tick — `eligible` above is the very predicate that
+        # opened the marker — so what is left to re-prove is ④, which is also
+        # the only one of them a relay outage can falsify.
+        marker_since = stranded_since.get(path)
+        if marker_since is None:
+            if not _channel_has_live_delivery(
+                evaluated,
+                fresh_undelivered_by_path,
+                current_delivered_by_path,
+                path,
+                now,
+                cfg.gap_alert_secs,
+            ):
+                # No corroborating delivery anywhere on the channel — this may
+                # well be a live outage. Leave it to the normal gap path.
+                continue
             stranded_since[path] = now
             rt.log(
                 f"[{cid}] orphan-stranded-marker-opened path={path} "
@@ -5066,25 +5156,87 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 f"observed_history={observed_history} "
                 f"freeze_floor={int(freeze_floor)}s"
             )
+        elif _channel_has_live_delivery(
+            evaluated,
+            fresh_undelivered_by_path,
+            current_delivered_by_path,
+            path,
+            now,
+            cfg.gap_alert_secs,
+            newer_than=marker_since,
+        ):
+            # Corroboration strong enough to CLOSE on, which is a stricter thing
+            # than the corroboration that opened the marker: the sibling's block
+            # was WRITTEN after the finding was made, so no relay that had
+            # already died by then could have delivered it. This is what shuts
+            # the write-epoch window documented on `_channel_has_live_delivery`
+            # (#5190 R3 P2-D), where an idle sibling's one old-but-still-matched
+            # block could vote "alive" for a full `gap_alert_secs` — longer than
+            # the confirmation window it would have been carrying.
+            orphan_corroborated_paths.add(path)
         orphan_unattributable_paths.add(path)
-    if orphan_retired_paths and not _alert_pending_retirement(
-        rt,
-        ch,
-        chs,
-        orphan_retired_paths,
-        now,
-        reason=ORPHAN_STRANDED_RETIREMENT_REASON,
-    ):
-        # #5190 R1: the notice IS the retirement. Retiring anyway would drop the
-        # pending authority, clear the gap, and delete the only surviving record
-        # of these blocks with nobody ever told — an observation failure
-        # collapsed into a success. The marker survives untouched, so the next
-        # tick resumes from exactly here and the alert keeps firing meanwhile.
-        rt.log(
-            f"[{cid}] orphan-stranded-retirement-deferred "
-            f"count={len(orphan_retired_paths)} notice=undelivered"
+    if orphan_retired_paths:
+        # #5190 R3 P2-A: a matured marker is a claim, not a licence. Three
+        # shapes reach here with an expired timer and no corroboration this
+        # tick, and all three used to retire anyway:
+        #   (a) the channel stopped delivering after the marker was opened — a
+        #       live outage read as proof of abandonment, which is precisely the
+        #       inversion this whole mechanism is built to avoid;
+        #   (b) the orphan was PROMOTED to this channel's active session, so
+        #       retiring it drops the channel's gap ownership to zero and the
+        #       currently-running session loses its own loss record;
+        #   (c) the path went unevaluated for a tick and came back to find its
+        #       timer already run out, closing without ④ ever being asked.
+        # (a) and (c) fail the ④ re-check below; (b) never reaches it, because
+        # `eligible` above rejects a selected path and clears its marker.
+        unconfirmed = [
+            path
+            for path in orphan_retired_paths
+            if path not in orphan_corroborated_paths
+        ]
+        if unconfirmed:
+            # The marker itself survives: the finding may well still be true,
+            # and nothing about this tick disproves it. What it no longer does
+            # is close anything out on its own authority.
+            rt.log(
+                f"[{cid}] orphan-stranded-maturity-unconfirmed "
+                f"count={len(unconfirmed)} selected={selected_path} "
+                f"paths={','.join(sorted(unconfirmed))}"
+            )
+            orphan_retired_paths = [
+                path
+                for path in orphan_retired_paths
+                if path in orphan_corroborated_paths
+            ]
+    if orphan_retired_paths:
+        orphan_notice = _alert_pending_retirement(
+            rt,
+            ch,
+            chs,
+            orphan_retired_paths,
+            now,
+            reason=ORPHAN_STRANDED_RETIREMENT_REASON,
         )
-        orphan_retired_paths = []
+        if orphan_notice != "sent":
+            # #5190 R1: the notice IS the retirement. Retiring anyway would drop
+            # the pending authority, clear the gap, and delete the only
+            # surviving record of these blocks with nobody ever told — an
+            # observation failure collapsed into a success. The marker survives
+            # untouched, so the next tick resumes from exactly here and the
+            # alert keeps firing meanwhile.
+            #
+            # #5190 R3 P2-E: `notice=` reports WHICH of those happened.
+            # `undelivered` means the message never left the box; `cooldown`
+            # means it was suppressed by the retirement cooldown key that all
+            # reasons share, so an unrelated idle/read_failure/dead_worktree
+            # notice within `realert_secs` delays this one by up to that long.
+            # The old line said `notice=undelivered` for both, which made the
+            # log lie about the relay in the cooldown case.
+            rt.log(
+                f"[{cid}] orphan-stranded-retirement-deferred "
+                f"count={len(orphan_retired_paths)} notice={orphan_notice}"
+            )
+            orphan_retired_paths = []
     if orphan_retired_paths:
         retired_orphans = set(orphan_retired_paths)
         for path in orphan_retired_paths:
@@ -5351,7 +5503,17 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             # the relay's health; that claim belongs to the delivering sibling,
             # which is a separate check. A true enumeration beats a false
             # universal.
-            not_selected = bool(selected_path) and verdict_path != selected_path
+            # #5190 R3 P2-F: this is a THREE-state question, not two. There is a
+            # tick on which `selected_path` is None — reached whenever the
+            # selected transcript expires out of the pending set in this very
+            # pass, because `tr` is cleared there and `selected` is resolved
+            # from it immediately after, while a different path keeps its GAP
+            # ownership and stays the alert subject. Folding that case into the
+            # `not not_selected` arm rendered "대상 세션: X (현재 활성 세션)" on a
+            # channel with no active session at all — an unproven PRESENTNESS
+            # asserted, the exact mirror of the unproven pastness R5 removed.
+            selection_known = bool(selected_path)
+            not_selected = selection_known and verdict_path != selected_path
             frozen_secs = max(0.0, now - verdict_candidate.mtime)
             frozen_min = int(frozen_secs) // 60
             orphan_gap = (
@@ -5372,7 +5534,22 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 if orphan_gap
                 else "🚨 **릴레이 갭 감지 (out-of-band 워치독)**"
             )
-            if not not_selected:
+            if not selection_known:
+                scope_line = (
+                    f"대상 세션: `{Path(verdict_path).name}` — 이 채널에는 현재 "
+                    "활성 세션으로 판정된 트랜스크립트가 없습니다(이번 점검에서 "
+                    "선택 권한이 확정되지 않음). 따라서 이 경로가 활성 세션인지 "
+                    "과거 세션인지는 이번 점검으로 판정되지 않았습니다.\n"
+                    + (
+                        "이 채널의 다른 세션은 이번 점검에서 실제로 배달이 "
+                        "확인됐습니다 — 릴레이 전체 장애가 아니라 이 "
+                        "트랜스크립트의 미도달 블록 문제입니다.\n"
+                        if delivering_elsewhere
+                        else "이 채널에서 지금 배달 중인 다른 세션은 확인되지 "
+                        "않았습니다 — 릴레이 장애 가능성이 남아 있습니다.\n"
+                    )
+                )
+            elif not not_selected:
                 scope_line = (
                     f"대상 세션: `{Path(verdict_path).name}` (현재 활성 세션).\n"
                 )

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -156,6 +156,13 @@ ORPHAN_STRANDED_RETIREMENT_REASON = "orphan_stranded"
 # consecutive polls at the shipped poll_secs default, so one anomalous tick can
 # never retire anything.
 ORPHAN_STRANDED_CONFIRM_SECS = 600
+# An orphan WITH delivery history carries a real, measured gap, so silencing it
+# on the never-observed evidence bar would risk burying an outage this watchdog
+# exists to report (#5190 R2). It is admitted only on a strictly stronger bar:
+# this multiple of the freeze floor, plus a delivery frontier that has itself
+# been stale for a full freeze floor, plus dcserver independently confirming the
+# channel is now bound to a DIFFERENT session.
+ORPHAN_OBSERVED_FREEZE_MULTIPLIER = 2
 # `Verdict.gap_secs` when NO delivery was ever matched for a path. It is not a
 # duration and must never be rendered as one (#5190/#5052): "never observed"
 # and "infinitely stale" are different claims, and `float("inf")` collapsed
@@ -910,13 +917,52 @@ def _store_orphan_stranded_since(
         channel_state.pop(ORPHAN_STRANDED_SINCE_KEY, None)
 
 
+def _release_pending_authority(
+    channel_state: dict[str, Any],
+    remaining_pending: list[str],
+    pending_failures: dict[str, int],
+    pending_since: dict[str, float],
+    released: set[str],
+) -> tuple[list[str], dict[str, int], dict[str, float]]:
+    """Drop paths from every pending-authority map in one step (#5190).
+
+    The three maps are one fact recorded three ways, so releasing a path from
+    only some of them leaves a half-retired authority behind. Callers that must
+    release atomically with an external side effect (a retirement notice that
+    actually left the box) need a single call they can place after it.
+    """
+    remaining_pending = [
+        path for path in remaining_pending if path not in released
+    ]
+    pending_failures = {
+        path: failures
+        for path, failures in pending_failures.items()
+        if path not in released
+    }
+    pending_since = {
+        path: since
+        for path, since in pending_since.items()
+        if path not in released
+    }
+    channel_state[PENDING_TRANSCRIPTS_KEY] = remaining_pending
+    if pending_failures:
+        channel_state[PENDING_TRANSCRIPT_FAILURES_KEY] = pending_failures
+    else:
+        channel_state.pop(PENDING_TRANSCRIPT_FAILURES_KEY, None)
+    if pending_since:
+        channel_state[PENDING_TRANSCRIPT_SINCE_KEY] = pending_since
+    else:
+        channel_state.pop(PENDING_TRANSCRIPT_SINCE_KEY, None)
+    return remaining_pending, pending_failures, pending_since
+
+
 def _orphan_authority_matured(
     channel_state: Mapping[str, Any], path: str, now: float
 ) -> bool:
     """True once a stranded-orphan marker has held long enough to close out.
 
     The marker itself carries the evidence — it is only written on a tick where
-    the path was already frozen past `orphan_abandon_secs` AND the channel was
+    the path was already frozen past its freeze floor AND the channel was
     provably delivering on another transcript — so this only asks whether that
     finding has survived the confirmation window. Reading the persisted marker
     means the answer is available before any of this tick's verdicts exist,
@@ -4770,12 +4816,14 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             # an orphan holding permanently undelivered blocks — STATE_OK can
             # never arrive on a session that will never write again — which is
             # what pinned #5190's pending authority open forever. A matured
-            # stranded-orphan marker is the second, evidence-backed exit.
+            # stranded-orphan marker is the second, evidence-backed exit, but it
+            # is NOT applied here: that release now happens below, atomically
+            # with the retirement notice actually reaching a human (#5190 R1).
             if (
                 verdict.state == STATE_OK
                 and fresh_undelivered == 0
                 and read_result.blocks
-            ) or orphan_matured:
+            ):
                 remaining_pending = [
                     pending for pending in remaining_pending if pending != path
                 ]
@@ -4890,28 +4938,15 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             superseded = set(superseded_gap_owners)
             _store_retired_transcripts(chs, retired_transcripts)
             retired_pending_paths.extend(superseded_gap_owners)
-            remaining_pending = [
-                path for path in remaining_pending if path not in superseded
-            ]
-            pending_failures = {
-                path: failures
-                for path, failures in pending_failures.items()
-                if path not in superseded
-            }
-            pending_since = {
-                path: since
-                for path, since in pending_since.items()
-                if path not in superseded
-            }
-            chs[PENDING_TRANSCRIPTS_KEY] = remaining_pending
-            if pending_failures:
-                chs[PENDING_TRANSCRIPT_FAILURES_KEY] = pending_failures
-            else:
-                chs.pop(PENDING_TRANSCRIPT_FAILURES_KEY, None)
-            if pending_since:
-                chs[PENDING_TRANSCRIPT_SINCE_KEY] = pending_since
-            else:
-                chs.pop(PENDING_TRANSCRIPT_SINCE_KEY, None)
+            remaining_pending, pending_failures, pending_since = (
+                _release_pending_authority(
+                    chs,
+                    remaining_pending,
+                    pending_failures,
+                    pending_since,
+                    superseded,
+                )
+            )
             evaluated = [
                 (candidate, verdict)
                 for candidate, verdict in evaluated
@@ -4933,10 +4968,10 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     # frozen for hours.
     #
     # The exit here rests on positive evidence rather than on silence: the path
-    # is NOT the active session, has never been seen delivering, is not growing,
-    # and — decisively — another transcript on the same channel is delivering
-    # right now. A relay that is actually down produces none of that last part,
-    # so nothing below can silence a real outage.
+    # is NOT the active session, is not growing, has been frozen past its freeze
+    # floor, and — decisively — another transcript on the same channel is
+    # delivering right now. A relay that is actually down produces none of that
+    # last part, so nothing below can silence a real outage.
     stranded_since = _validated_orphan_stranded_since(chs)
     orphan_unattributable_paths: set[str] = set()
     for candidate, verdict in evaluated:
@@ -4945,12 +4980,30 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         # shape swallows #4435: a session that has just been swapped in, is not
         # yet selected, and whose blocks are being lost RIGHT NOW looks
         # identical to an abandoned one except for how long it has been silent.
+        # #5190 R2: an orphan that once delivered is the SAME defect — it re-
+        # alerts every `realert_secs` until an unrelated idle timer expires —
+        # but its gap is a measurement, not an unknown, so excluding it was
+        # wrong and admitting it on the same terms would be reckless. It gets a
+        # strictly stronger bar: twice the freeze floor, a delivery frontier
+        # that has itself gone a full freeze floor without advancing (it is not
+        # simply lagging), and dcserver proving the channel has moved to another
+        # session. Every one of those is falsified by a live relay outage.
+        observed_history = not gap_is_unobserved(verdict)
+        freeze_floor = cfg.orphan_abandon_secs * (
+            ORPHAN_OBSERVED_FREEZE_MULTIPLIER if observed_history else 1
+        )
         eligible = (
             path != selected_path
             and verdict.state == STATE_GAP
-            and gap_is_unobserved(verdict)
             and path not in semantic_growth_paths
-            and now - candidate.mtime >= cfg.orphan_abandon_secs
+            and now - candidate.mtime >= freeze_floor
+            and (
+                not observed_history
+                or (
+                    successor_binding_proven
+                    and now - verdict.delivered_ts >= cfg.orphan_abandon_secs
+                )
+            )
         )
         if not eligible:
             # Resurrection, recovery, or promotion to the active session voids
@@ -4972,9 +5025,29 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             stranded_since[path] = now
             rt.log(
                 f"[{cid}] orphan-stranded-marker-opened path={path} "
-                f"lost={verdict.lost} selected={selected_path}"
+                f"lost={verdict.lost} selected={selected_path} "
+                f"observed_history={observed_history} "
+                f"freeze_floor={int(freeze_floor)}s"
             )
         orphan_unattributable_paths.add(path)
+    if orphan_retired_paths and not _alert_pending_retirement(
+        rt,
+        ch,
+        chs,
+        orphan_retired_paths,
+        now,
+        reason=ORPHAN_STRANDED_RETIREMENT_REASON,
+    ):
+        # #5190 R1: the notice IS the retirement. Retiring anyway would drop the
+        # pending authority, clear the gap, and delete the only surviving record
+        # of these blocks with nobody ever told — an observation failure
+        # collapsed into a success. The marker survives untouched, so the next
+        # tick resumes from exactly here and the alert keeps firing meanwhile.
+        rt.log(
+            f"[{cid}] orphan-stranded-retirement-deferred "
+            f"count={len(orphan_retired_paths)} notice=undelivered"
+        )
+        orphan_retired_paths = []
     if orphan_retired_paths:
         retired_orphans = set(orphan_retired_paths)
         for path in orphan_retired_paths:
@@ -4983,9 +5056,16 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 retired_transcripts[path] = (candidate.size, now)
             stranded_since.pop(path, None)
         _store_retired_transcripts(chs, retired_transcripts)
-        # The pending authority itself was already released in the evaluation
-        # loop above, on the same `orphan_matured` predicate; what remains is to
-        # drop the path from this tick's judgment and close the incident.
+        # Released only now, downstream of a notice that provably left the box.
+        remaining_pending, pending_failures, pending_since = (
+            _release_pending_authority(
+                chs,
+                remaining_pending,
+                pending_failures,
+                pending_since,
+                retired_orphans,
+            )
+        )
         evaluated = [
             (candidate, verdict)
             for candidate, verdict in evaluated
@@ -4997,14 +5077,6 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             f"count={len(orphan_retired_paths)} "
             f"frozen_floor={int(cfg.orphan_abandon_secs)}s "
             f"confirm={ORPHAN_STRANDED_CONFIRM_SECS}s"
-        )
-        _alert_pending_retirement(
-            rt,
-            ch,
-            chs,
-            orphan_retired_paths,
-            now,
-            reason=ORPHAN_STRANDED_RETIREMENT_REASON,
         )
         _clear_gap_alert_without_recovery(rt, chs, cid, orphan_retired_paths)
         retired_pending_paths.extend(orphan_retired_paths)

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -144,6 +144,23 @@ MAX_DEAD_WORKTREE_ABSENCES = 64
 # a transient stat failure resets the window instead of accumulating.
 DEAD_WORKTREE_CONFIRM_SECS = 600
 DEAD_WORKTREE_RETIREMENT_REASON = "dead_worktree"
+# #5190. Per-path timestamp of the FIRST tick on which an ORPHAN transcript (not
+# the channel's active session, never observed delivering) was seen holding
+# stranded blocks while another transcript on the same channel was demonstrably
+# still delivering. That co-occurrence is the only positive evidence that the
+# blocks are unrecoverable rather than symptoms of a live relay outage.
+ORPHAN_STRANDED_SINCE_KEY = "orphan_stranded_since"
+ORPHAN_STRANDED_RETIREMENT_REASON = "orphan_stranded"
+# Continuous corroboration required before a stranded-orphan marker may close
+# the authority. Same shape and rationale as DEAD_WORKTREE_CONFIRM_SECS: five
+# consecutive polls at the shipped poll_secs default, so one anomalous tick can
+# never retire anything.
+ORPHAN_STRANDED_CONFIRM_SECS = 600
+# `Verdict.gap_secs` when NO delivery was ever matched for a path. It is not a
+# duration and must never be rendered as one (#5190/#5052): "never observed"
+# and "infinitely stale" are different claims, and `float("inf")` collapsed
+# them into one that auto-passed every threshold comparison.
+GAP_SECS_UNOBSERVED = -1.0
 RECOVERED_GAP_GUARDS_KEY = "recovered_gap_replay_guards"
 ISSUE_FILING_SUPPRESSION_REASON_KEY = "issue_filing_suppression_reason"
 ISSUE_FILING_SUPPRESSION_SINCE_KEY = "issue_filing_suppression_since"
@@ -169,6 +186,9 @@ MAX_TRANSCRIPT_HISTORY = 64
 MAX_KNOWN_TRANSCRIPTS = 256
 MAX_PENDING_TRANSCRIPTS = 32
 MAX_GAP_OWNER_TRANSCRIPTS = MAX_PENDING_TRANSCRIPTS + 1
+# Stranded-orphan markers are a subset of the GAP owners, so they inherit that
+# budget and add no new delivery authority (#5190).
+MAX_ORPHAN_STRANDED_PATHS = MAX_GAP_OWNER_TRANSCRIPTS
 MAX_RECOVERED_GAP_GUARDS = MAX_KNOWN_TRANSCRIPTS
 MAX_RETIRED_TRANSCRIPTS = 32
 # Selected, pending, unresolved GAP-owner, and recovered replay-guard paths
@@ -279,6 +299,16 @@ class Config:
     # Transcript older than this ⇒ no live session; a stale gap is not a live
     # gap. Never alert on it.
     idle_quiet_secs: int = 2 * 3600
+    # #5190. How long a non-selected transcript must sit frozen before its
+    # undelivered blocks may be classified as stranded rather than as an active
+    # relay failure. This floor is what separates #5190's dead `/clear`ed
+    # session from #4435's freshly swapped-in session whose blocks are being
+    # lost right now: both are unmatched and non-selected, and only elapsed
+    # silence tells them apart. Two full re-alert cycles (`realert_secs` 900s),
+    # so a live session between turns can never be mistaken for an abandoned
+    # one. Shorter than `idle_quiet_secs` because classification additionally
+    # demands positive proof that the channel is still delivering elsewhere.
+    orphan_abandon_secs: int = 1800
     # Deploys restart dcserver, so short gaps during a deploy window are
     # expected. deploy-release.sh touches the marker file when it stops the
     # release service; alerts are suppressed while the marker is fresh.
@@ -346,6 +376,7 @@ def parse_config(raw: dict[str, Any]) -> Config:
         "gap_alert_secs",
         "realert_secs",
         "idle_quiet_secs",
+        "orphan_abandon_secs",
         "deploy_quiet_secs",
         "issue_after_secs",
         "read_fail_alert_after",
@@ -837,6 +868,115 @@ def _store_gap_owner_transcripts(
     else:
         channel_state.pop(GAP_OWNER_TRANSCRIPTS_KEY, None)
     return bounded
+
+
+def gap_is_unobserved(verdict: "Verdict") -> bool:
+    """True when no delivery was ever matched for this path (#5190).
+
+    The verdict then carries no measurement at all: its `gap_secs` is the
+    `GAP_SECS_UNOBSERVED` sentinel, not an elapsed time. Callers that render a
+    duration, rank gaps against each other, or weigh evidence must branch here
+    first.
+    """
+    return verdict.gap_secs < 0.0
+
+
+def _validated_orphan_stranded_since(
+    channel_state: Mapping[str, Any],
+) -> dict[str, float]:
+    """Return the bounded path -> first-stranded-tick map (#5190)."""
+    raw = channel_state.get(ORPHAN_STRANDED_SINCE_KEY, {})
+    if not isinstance(raw, dict):
+        return {}
+    stranded: dict[str, float] = {}
+    for path, since in raw.items():
+        if len(stranded) >= MAX_ORPHAN_STRANDED_PATHS:
+            break
+        if not isinstance(path, str) or not path:
+            continue
+        if not _is_finite_nonnegative_number(since):
+            continue
+        stranded[path] = float(since)
+    return stranded
+
+
+def _store_orphan_stranded_since(
+    channel_state: dict[str, Any], stranded: Mapping[str, float]
+) -> None:
+    bounded = dict(sorted(stranded.items())[:MAX_ORPHAN_STRANDED_PATHS])
+    if bounded:
+        channel_state[ORPHAN_STRANDED_SINCE_KEY] = bounded
+    else:
+        channel_state.pop(ORPHAN_STRANDED_SINCE_KEY, None)
+
+
+def _orphan_authority_matured(
+    channel_state: Mapping[str, Any], path: str, now: float
+) -> bool:
+    """True once a stranded-orphan marker has held long enough to close out.
+
+    The marker itself carries the evidence — it is only written on a tick where
+    the path was already frozen past `orphan_abandon_secs` AND the channel was
+    provably delivering on another transcript — so this only asks whether that
+    finding has survived the confirmation window. Reading the persisted marker
+    means the answer is available before any of this tick's verdicts exist,
+    which is what lets the pending authority be released in the same pass that
+    evaluates it.
+    """
+    since = _validated_orphan_stranded_since(channel_state).get(path)
+    if since is None:
+        return False
+    return now - since >= ORPHAN_STRANDED_CONFIRM_SECS
+
+
+def _channel_has_live_delivery(
+    evaluated: list[tuple[TranscriptCandidate, Verdict]],
+    fresh_undelivered_by_path: Mapping[str, int],
+    exclude_path: str,
+    now: float,
+    gap_alert_secs: int,
+) -> bool:
+    """Is some OTHER transcript on this channel demonstrably still delivering?
+
+    This is the whole safety hinge of the #5190 orphan handling, so it demands
+    positive proof rather than the absence of a complaint: a sibling path with a
+    clean verdict, nothing fresh outstanding, and a delivery actually matched
+    inside the same window that would have declared a gap. When the relay is
+    genuinely down every transcript fails at least one of those, this returns
+    False, and the gap alert proceeds untouched.
+    """
+    for candidate, verdict in evaluated:
+        path = str(candidate.path)
+        if path == exclude_path:
+            continue
+        if verdict.state != STATE_OK:
+            continue
+        if fresh_undelivered_by_path.get(path, 0) > 0:
+            continue
+        if gap_is_unobserved(verdict) or not verdict.delivered_ts:
+            continue
+        if now - verdict.delivered_ts > gap_alert_secs:
+            continue
+        return True
+    return False
+
+
+def _confirmed_gap_minutes(
+    verdict: Verdict, last_actual_delivery_at: float, now: float
+) -> int | None:
+    """Minutes since the last CONFIRMED delivery, or None when there is none.
+
+    None means "no delivery is on record for this session" — a fact the caller
+    has to state in words. The old code substituted `999` here and the alert
+    rendered it as "999 minutes since the last delivery" (#5190 §2): a sentinel
+    wearing the clothes of a measurement, which then propagated into the title
+    of the issue the watchdog filed about itself.
+    """
+    if last_actual_delivery_at:
+        return int(max(0.0, now - last_actual_delivery_at) // 60)
+    if gap_is_unobserved(verdict) or not math.isfinite(verdict.gap_secs):
+        return None
+    return int(verdict.gap_secs // 60)
 
 
 def _validated_recovered_gap_guards(
@@ -1565,6 +1705,8 @@ class Verdict:
     stale: int
     lost: int
     delivered_ts: float
+    # `GAP_SECS_UNOBSERVED` when no delivery was ever matched for this path.
+    # Read it through `gap_is_unobserved()`; never render it as a duration.
     gap_secs: float
 
 
@@ -2381,8 +2523,19 @@ def evaluate(
         for block, matched in stale
         if block[0] > delivered_ts and not matched
     ]
-    gap_secs = (now - delivered_ts) if delivered_ts else float("inf")
-    if lost and gap_secs > gap_alert_secs:
+    # #5190/#5052: "this path never delivered anything we could match" is
+    # UNKNOWN, not "the gap is infinitely old". `float("inf")` collapsed the two
+    # so an orphan transcript — a `/clear`ed session that can never deliver
+    # again — auto-passed the threshold comparison AND outranked every real,
+    # measured gap in the verdict ordering below. The unobserved case still
+    # reaches STATE_GAP on its own explicit branch (a relay that died before it
+    # ever delivered must alert); what it no longer does is masquerade as the
+    # oldest measurement on the channel.
+    delivered_observed = delivered_ts > 0.0
+    gap_secs = (
+        (now - delivered_ts) if delivered_observed else GAP_SECS_UNOBSERVED
+    )
+    if lost and (not delivered_observed or gap_secs > gap_alert_secs):
         state = STATE_GAP
     elif lost:
         state = STATE_LAGGING
@@ -2995,19 +3148,38 @@ class Runtime:
             self.log(f"discord-sendmessage error: {e}")
         return False
 
-    def file_github_issue(self, ch: ChannelConfig, gap_min: int, lost: int) -> str:
+    def file_github_issue(
+        self, ch: ChannelConfig, gap_min: int | None, lost: int
+    ) -> str:
         """Auto-file a GitHub issue for a persistent gap (06-29 relay-gap-watch
-        behavior, see #3893). Best-effort: failure is logged, never fatal."""
+        behavior, see #3893). Best-effort: failure is logged, never fatal.
+
+        `gap_min is None` means no delivery was ever confirmed for the session.
+        It is reported as that sentence, never as a number: #5190 was filed by
+        this method with `999m since last delivery` in its own title, and the
+        false measurement survived into human triage.
+        """
         gh = shutil.which("gh") or "/opt/homebrew/bin/gh"
+        elapsed_phrase = (
+            f"{gap_min}m since last delivery"
+            if gap_min is not None
+            else "no confirmed delivery on record for this session"
+        )
         title = (
             f"[auto][relay-watchdog] relay gap on channel {ch.channel_id}: "
-            f"{lost} undelivered blocks, {gap_min}m since last delivery"
+            f"{lost} undelivered blocks, {elapsed_phrase}"
+        )
+        elapsed_line = (
+            f"- minutes since last successful delivery: **{gap_min}**\n"
+            if gap_min is not None
+            else "- last successful delivery: **none on record for this "
+            "session**\n"
         )
         body = (
             f"Filed automatically by the out-of-band relay watchdog (#4381).\n\n"
             f"- channel: `{ch.channel_id}`\n"
             f"- undelivered assistant blocks: **{lost}**\n"
-            f"- minutes since last successful delivery: **{gap_min}**\n"
+            f"{elapsed_line}"
             f"- runtime snapshot: {self.dcserver_snapshot()}\n\n"
             f"The watchdog compares session transcripts against delivered "
             f"Discord messages; see `scripts/relay_watchdog.py`."
@@ -3508,6 +3680,16 @@ def _alert_pending_retirement(
         detail = (
             "세션 활동이 idle 한계를 넘겨 더 이상 live GAP으로 반복 평가하지 "
             "않습니다. 미도달 여부가 해결됐다고 주장하는 복구 알림은 보내지 않습니다."
+        )
+    elif reason == ORPHAN_STRANDED_RETIREMENT_REASON:
+        title = "고아 세션의 미도달 블록 회수 불가 확정"
+        detail = (
+            "현재 활성 세션이 아닌 과거 세션의 트랜스크립트가 계속 정지해 있는 "
+            "동안 이 채널의 다른 세션은 정상 배달을 이어갔습니다 — 릴레이 장애가 "
+            "아니라 그 세션이 다시 배달할 수 없는 상태입니다. 해당 미도달 블록을 "
+            "회수 불가로 확정하고 반복 평가에서 내립니다. 배달이 확인됐다는 뜻이 "
+            "아니며(복구 알림은 보내지 않습니다), 이 경보가 해당 경로에 대한 "
+            "마지막 통지입니다."
         )
     elif reason == DEAD_WORKTREE_RETIREMENT_REASON:
         title = "죽은 세션의 릴레이 loss-state 종결"
@@ -4389,6 +4571,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     chs.pop(LAST_ACTUAL_DELIVERY_AT_KEY, None)
     unreadable_paths: list[str] = []
     escalated_pending_paths: list[str] = []
+    orphan_retired_paths: list[str] = []
     remaining_pending = list(pending_paths)
     for candidate in active_candidates:
         path = str(candidate.path)
@@ -4555,6 +4738,16 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             and not matched
         )
         fresh_undelivered_by_path[path] = fresh_undelivered
+        # #5190: a stranded-orphan marker written on an earlier tick matures
+        # into an abandonment once the window has elapsed and the file is still
+        # frozen. Resurrection (semantic growth) voids it below, so a session
+        # that starts writing again is never closed out behind its own back.
+        orphan_matured = (
+            path not in semantic_growth_paths
+            and _orphan_authority_matured(chs, path, now)
+        )
+        if orphan_matured:
+            orphan_retired_paths.append(path)
         if tombstone_update.newly_tombstoned:
             rt.log(
                 f"[{cid}] permanent-loss-confirmed path={path} "
@@ -4573,11 +4766,16 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 f"state={verdict.state} lost={verdict.lost} "
                 f"fresh_undelivered={fresh_undelivered}"
             )
+            # A clean verdict is the normal release. It is also unreachable for
+            # an orphan holding permanently undelivered blocks — STATE_OK can
+            # never arrive on a session that will never write again — which is
+            # what pinned #5190's pending authority open forever. A matured
+            # stranded-orphan marker is the second, evidence-backed exit.
             if (
                 verdict.state == STATE_OK
                 and fresh_undelivered == 0
                 and read_result.blocks
-            ):
+            ) or orphan_matured:
                 remaining_pending = [
                     pending for pending in remaining_pending if pending != path
                 ]
@@ -4724,9 +4922,108 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 f"successor={selected_path} count={len(superseded_gap_owners)}"
             )
 
+    # ── Stranded orphan transcripts (#5190) ──────────────────────────────────
+    # A session abandoned by `/clear` can leave blocks that no future delivery
+    # can ever recover: its delivery frontier cannot advance, so the tombstone
+    # path (which requires two advances) never confirms; its worktree is still
+    # alive, so dead-worktree retirement never fires; and STATE_OK can never
+    # arrive, so the pending authority never releases. Every exit the watchdog
+    # had was blocked by the very condition it was built to resolve, and the
+    # channel re-alerted every `realert_secs` about a session that had been
+    # frozen for hours.
+    #
+    # The exit here rests on positive evidence rather than on silence: the path
+    # is NOT the active session, has never been seen delivering, is not growing,
+    # and — decisively — another transcript on the same channel is delivering
+    # right now. A relay that is actually down produces none of that last part,
+    # so nothing below can silence a real outage.
+    stranded_since = _validated_orphan_stranded_since(chs)
+    orphan_unattributable_paths: set[str] = set()
+    for candidate, verdict in evaluated:
+        path = str(candidate.path)
+        # The freeze floor is load-bearing, not cosmetic. Without it this same
+        # shape swallows #4435: a session that has just been swapped in, is not
+        # yet selected, and whose blocks are being lost RIGHT NOW looks
+        # identical to an abandoned one except for how long it has been silent.
+        eligible = (
+            path != selected_path
+            and verdict.state == STATE_GAP
+            and gap_is_unobserved(verdict)
+            and path not in semantic_growth_paths
+            and now - candidate.mtime >= cfg.orphan_abandon_secs
+        )
+        if not eligible:
+            # Resurrection, recovery, or promotion to the active session voids
+            # the marker: this path is back under ordinary judgment.
+            if stranded_since.pop(path, None) is not None:
+                rt.log(f"[{cid}] orphan-stranded-marker-cleared path={path}")
+            continue
+        if path not in stranded_since and not _channel_has_live_delivery(
+            evaluated,
+            fresh_undelivered_by_path,
+            path,
+            now,
+            cfg.gap_alert_secs,
+        ):
+            # No corroborating delivery anywhere on the channel — this may well
+            # be a live outage. Leave it to the normal gap path.
+            continue
+        if path not in stranded_since:
+            stranded_since[path] = now
+            rt.log(
+                f"[{cid}] orphan-stranded-marker-opened path={path} "
+                f"lost={verdict.lost} selected={selected_path}"
+            )
+        orphan_unattributable_paths.add(path)
+    if orphan_retired_paths:
+        retired_orphans = set(orphan_retired_paths)
+        for path in orphan_retired_paths:
+            candidate = candidate_by_path.get(path)
+            if candidate is not None:
+                retired_transcripts[path] = (candidate.size, now)
+            stranded_since.pop(path, None)
+        _store_retired_transcripts(chs, retired_transcripts)
+        # The pending authority itself was already released in the evaluation
+        # loop above, on the same `orphan_matured` predicate; what remains is to
+        # drop the path from this tick's judgment and close the incident.
+        evaluated = [
+            (candidate, verdict)
+            for candidate, verdict in evaluated
+            if str(candidate.path) not in retired_orphans
+        ]
+        orphan_unattributable_paths -= retired_orphans
+        rt.log(
+            f"[{cid}] orphan-stranded-authority-retired "
+            f"count={len(orphan_retired_paths)} "
+            f"frozen_floor={int(cfg.orphan_abandon_secs)}s "
+            f"confirm={ORPHAN_STRANDED_CONFIRM_SECS}s"
+        )
+        _alert_pending_retirement(
+            rt,
+            ch,
+            chs,
+            orphan_retired_paths,
+            now,
+            reason=ORPHAN_STRANDED_RETIREMENT_REASON,
+        )
+        _clear_gap_alert_without_recovery(rt, chs, cid, orphan_retired_paths)
+        retired_pending_paths.extend(orphan_retired_paths)
+    _store_orphan_stranded_since(chs, stranded_since)
+    if not evaluated:
+        observe_coverage()
+        return
+
     state_rank = {STATE_OK: 0, STATE_LAGGING: 1, STATE_GAP: 2}
+    # An unattributable orphan must never be the channel's alert subject while a
+    # path with real evidence is available; it stays in `evaluated` (and thus a
+    # GAP owner) so it keeps being judged until it matures or resurrects.
+    rankable = [
+        item
+        for item in evaluated
+        if str(item[0].path) not in orphan_unattributable_paths
+    ] or evaluated
     verdict_candidate, v = max(
-        evaluated,
+        rankable,
         key=lambda item: (
             state_rank[item[1].state],
             item[1].gap_secs,
@@ -4906,11 +5203,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         last_actual_delivery_at = last_actual_delivery_by_path.get(
             verdict_path, 0.0
         )
-        gap_min = (
-            int(max(0.0, now - last_actual_delivery_at) // 60)
-            if last_actual_delivery_at
-            else (int(v.gap_secs // 60) if v.delivered_ts else 999)
-        )
+        gap_min = _confirmed_gap_minutes(v, last_actual_delivery_at, now)
         if not chs.get("gap_since"):
             chs["gap_since"] = now
         issue_due = (
@@ -4932,12 +5225,42 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             issue_line = (
                 f"\n자동 등록 이슈: {chs['issue_url']}" if chs.get("issue_url") else ""
             )
+            # #5190 R2: an unknown elapsed time is stated as unknown. The old
+            # code printed the sentinel 999 into "마지막 정상 도달 이후 999분
+            # 경과" and into the title of the issue it filed about itself.
+            elapsed_line = (
+                f"마지막 정상 도달 이후 **{gap_min}분** 경과.\n"
+                if gap_min is not None
+                else "이 세션에서 배달이 확인된 이력이 없습니다 "
+                "(경과 시간을 측정할 기준점 없음).\n"
+            )
+            # #5190 R4/R5: the alerting transcript is not always the channel's
+            # active session, and the two cases call for different responses.
+            # Naming the file and narrowing the claim is the difference between
+            # "the relay is down right now" and "a past session left blocks
+            # behind".
+            orphan_gap = bool(selected_path) and verdict_path != selected_path
+            headline = (
+                "🚨 **릴레이 갭 감지 (out-of-band 워치독) — 고아 세션**"
+                if orphan_gap
+                else "🚨 **릴레이 갭 감지 (out-of-band 워치독)**"
+            )
+            scope_line = (
+                f"대상 세션: `{Path(verdict_path).name}` — "
+                "**고아 세션(현재 활성 세션 아님)**. 현재 활성 세션은 "
+                f"`{Path(str(selected_path)).name}` 입니다. 즉 이 경보는 "
+                "\"지금 릴레이가 죽었다\"가 아니라 \"과거 세션에 미도달 블록이 "
+                "남아 있다\"는 뜻입니다.\n"
+                if orphan_gap
+                else f"대상 세션: `{Path(verdict_path).name}` (현재 활성 세션).\n"
+            )
             rt.alert(
                 ch,
-                f"🚨 **릴레이 갭 감지 (out-of-band 워치독)**\n\n"
+                f"{headline}\n\n"
                 f"소스(세션 트랜스크립트)에는 있는데 Discord에 도착하지 않은 "
                 f"assistant 블록 **{v.lost}건**.\n"
-                f"마지막 정상 도달 이후 **{gap_min}분** 경과.\n\n"
+                f"{scope_line}"
+                f"{elapsed_line}\n"
                 f"런타임: {rt.dcserver_snapshot()}{issue_line}\n\n"
                 f"이 알림은 turn-relay 경로가 아니라 out-of-band로 직접 나갑니다 — "
                 f"릴레이가 죽어도 도착합니다.",
@@ -4945,7 +5268,9 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             chs["last_alert"] = now
             chs["alerting"] = True
             rt.log(
-                f"[{cid}] ALERT path={verdict_path} lost={v.lost} gap_min={gap_min}"
+                f"[{cid}] ALERT path={verdict_path} lost={v.lost} "
+                f"gap_min={gap_min if gap_min is not None else 'unobserved'} "
+                f"orphan={orphan_gap}"
             )
         else:
             rt.log(

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -905,9 +905,25 @@ class EvaluateBoundaryTests(unittest.TestCase):
         self.assertEqual(v.state, STATE_GAP)
 
     def test_no_delivery_ever_with_stale_lost_is_gap(self):
+        # The VERDICT is unchanged: a relay that died before it ever delivered
+        # must still alert. What changed with #5190 is that the verdict no
+        # longer carries `inf` as if it were a measured elapsed time — the two
+        # claims ("never observed" vs "infinitely stale") had collapsed into
+        # one value that auto-passed every threshold and outranked every real
+        # measurement in tick_channel's verdict ordering.
         v = self._eval([(self.NOW - 4000, "never arrived")], "")
         self.assertEqual(v.state, STATE_GAP)
-        self.assertEqual(v.gap_secs, float("inf"))
+        self.assertEqual(v.gap_secs, relay_watchdog.GAP_SECS_UNOBSERVED)
+        self.assertTrue(relay_watchdog.gap_is_unobserved(v))
+        self.assertNotEqual(v.gap_secs, float("inf"))
+
+    def test_5190_a_measured_gap_is_never_reported_as_unobserved(self):
+        delivered_block = (self.NOW - self.GAP - 1, "delivered payload")
+        lost_block = (self.NOW - self.GRACE - 60, "missing payload")
+        v = self._eval([delivered_block, lost_block], "delivered payload")
+        self.assertEqual(v.state, STATE_GAP)
+        self.assertFalse(relay_watchdog.gap_is_unobserved(v))
+        self.assertAlmostEqual(v.gap_secs, self.GAP + 1)
 
     def test_no_blocks_is_ok(self):
         v = self._eval([], "")
@@ -2210,6 +2226,9 @@ class FakeRuntime(Runtime):
         self.log_lines: list[str] = []
         self.haystack: str | None = ""
         self.issue_calls = 0
+        # #5190: what the watchdog would put in the auto-filed issue. `None`
+        # means "no delivery on record"; the defect was rendering that as 999.
+        self.issue_gap_mins: list[int | None] = []
         self.alert_succeeds = True
         self.live_sessions: set[str] | None = set()
         self.watcher_probe = WatcherStateProbe(None)
@@ -2235,8 +2254,9 @@ class FakeRuntime(Runtime):
         self.alerts.append((body, trigger_turn))
         return self.alert_succeeds
 
-    def file_github_issue(self, ch, gap_min: int, lost: int) -> str:
+    def file_github_issue(self, ch, gap_min: int | None, lost: int) -> str:
         self.issue_calls += 1
+        self.issue_gap_mins.append(gap_min)
         return f"https://example.test/issues/{self.issue_calls}"
 
 
@@ -5110,6 +5130,288 @@ class TickChannelTests(unittest.TestCase):
         self.assertTrue(chs.get("alerting"), (chs, rt.log_lines))
         self.assertIn(str(owner), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY])
         self.assertNotIn(str(owner), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {}))
+
+    # ── #5190: an orphan transcript must not pin the channel in GAP ──────────
+    #
+    # A `/clear`ed session leaves a frozen transcript holding blocks that no
+    # future delivery can recover: its delivery frontier cannot advance (so the
+    # tombstone path, which needs two advances, never confirms), its worktree is
+    # still alive (so dead-worktree retirement never fires), and STATE_OK can
+    # never arrive (so the pending authority never releases). Live incident:
+    # three identical alerts 16 minutes apart, each claiming "999 minutes since
+    # the last delivery" about a session that had been frozen for half an hour
+    # while the channel kept delivering normally on a different transcript.
+    #
+    # The counter-pressure runs through every test below: the orphan handling
+    # buys its silence with positive proof of delivery elsewhere, so a relay
+    # that is actually down never gets quieter.
+
+    ORPHAN_STRANDED_KEY = relay_watchdog.ORPHAN_STRANDED_SINCE_KEY
+
+    @staticmethod
+    def _5190_record(epoch: float, text: str) -> str:
+        return json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": time.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                ),
+                "message": {"content": [{"type": "text", "text": text}]},
+            }
+        )
+
+    def _5190_live_channel(self) -> tuple[FakeRuntime, dict, Path, Path]:
+        """Tick 1: only the live session exists, and it is delivering."""
+        live = self.proj_dir / "4648aa76-0239-47a7-9a39-8487c7fd216a.jsonl"
+        orphan = self.proj_dir / "67f48e65-74dd-4751-92c2-405145f1370b.jsonl"
+        live.write_text(
+            self._5190_record(self.now - 60, "live session first block") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(live, (self.now, self.now))
+        rt = self.make_rt()
+        rt.haystack = norm("live session first block")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        return rt, state, live, orphan
+
+    def _5190_strand_orphan(self, orphan: Path, frozen_at: float) -> None:
+        """The blocks #5188 stranded, and then the session goes silent forever.
+
+        The watchdog only meets this file after it froze, so whatever it once
+        delivered has long rolled out of the bounded Discord window: from here
+        on it has never been seen delivering anything.
+        """
+        orphan.write_text(
+            self._5190_record(frozen_at - 600, "stranded orphan block one")
+            + "\n"
+            + self._5190_record(frozen_at - 500, "stranded orphan block two")
+            + "\n",
+            encoding="utf-8",
+        )
+        os.utime(orphan, (frozen_at, frozen_at))
+
+    def _5190_live_delivery(
+        self, rt: FakeRuntime, live: Path, at: float, text: str
+    ) -> None:
+        with live.open("a", encoding="utf-8") as stream:
+            stream.write(self._5190_record(at - 30, text) + "\n")
+        os.utime(live, (at, at))
+        rt.haystack = norm(f"{rt.haystack} {text}")
+
+    def _5190_retire_orphan(
+        self, rt: FakeRuntime, state: dict, live: Path, orphan: Path
+    ) -> float:
+        """Run the channel forward until the stranded orphan is closed out."""
+        discovered_at = self.now + rt.cfg.orphan_abandon_secs + 600
+        self._5190_strand_orphan(orphan, self.now)
+        self._5190_live_delivery(rt, live, discovered_at, "live block two")
+        tick_channel(rt, TICK_CHANNEL, state, discovered_at)
+        retire_at = (
+            discovered_at + relay_watchdog.ORPHAN_STRANDED_CONFIRM_SECS
+        )
+        self._5190_live_delivery(rt, live, retire_at, "live block three")
+        tick_channel(rt, TICK_CHANNEL, state, retire_at)
+        return retire_at
+
+    def test_5190_frozen_orphan_stops_pinning_a_delivering_channel_in_gap(self):
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+
+        discovered_at = self.now + rt.cfg.orphan_abandon_secs + 600
+        self._5190_strand_orphan(orphan, self.now)
+        self._5190_live_delivery(rt, live, discovered_at, "live block two")
+        tick_channel(rt, TICK_CHANNEL, state, discovered_at)
+
+        # The channel is provably delivering on `live`, so `orphan`'s unmatched
+        # blocks are not evidence of a relay gap and must not be alerted as one.
+        self.assertEqual(chs[SELECTED_TRANSCRIPT_KEY], str(live))
+        self.assertEqual(
+            [body for body, _ in rt.alerts if "릴레이 갭 감지" in body],
+            [],
+            rt.log_lines,
+        )
+        self.assertIn(str(orphan), chs[self.ORPHAN_STRANDED_KEY])
+        self.assertTrue(
+            any("orphan-stranded-marker-opened" in line for line in rt.log_lines)
+        )
+
+        retire_at = discovered_at + relay_watchdog.ORPHAN_STRANDED_CONFIRM_SECS
+        self._5190_live_delivery(rt, live, retire_at, "live block three")
+        tick_channel(rt, TICK_CHANNEL, state, retire_at)
+
+        # ...and once the finding has held through the confirmation window the
+        # authority is closed out, which is the exit #5190 had none of.
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.PENDING_TRANSCRIPTS_KEY, [])
+        )
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY, [])
+        )
+        self.assertIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertNotIn(str(orphan), chs.get(self.ORPHAN_STRANDED_KEY, {}))
+        self.assertFalse(chs.get("alerting"), (chs, rt.log_lines))
+        self.assertNotIn("gap_since", chs)
+        retirement = [body for body, _ in rt.alerts if "고아 세션" in body]
+        self.assertEqual(len(retirement), 1, rt.alerts)
+        self.assertIn("회수 불가", retirement[0])
+        # Retirement is not a delivery claim: no recovery notice may go out.
+        self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
+        self.assertTrue(
+            any(
+                "orphan-stranded-authority-retired" in line
+                for line in rt.log_lines
+            )
+        )
+
+        # A full re-alert cycle later the channel is still quiet: the 15-minute
+        # forever-loop is gone, not merely delayed.
+        quiet_at = retire_at + rt.cfg.realert_secs + 1
+        self._5190_live_delivery(rt, live, quiet_at, "live block four")
+        tick_channel(rt, TICK_CHANNEL, state, quiet_at)
+        self.assertEqual(
+            [body for body, _ in rt.alerts if "릴레이 갭 감지" in body], []
+        )
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "고아 세션" in body]), 1
+        )
+
+    def test_5190_reverse_frozen_orphan_still_alerts_when_nothing_delivers(self):
+        """THE reverse direction: no delivery anywhere ⇒ no silence anywhere.
+
+        Same frozen orphan, same elapsed time — only the corroborating delivery
+        is missing, because the relay is down. Nothing may be reclassified.
+        """
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+
+        outage_at = self.now + rt.cfg.orphan_abandon_secs + 600
+        self._5190_strand_orphan(orphan, self.now)
+        # The live session keeps writing and NOTHING arrives in Discord.
+        with live.open("a", encoding="utf-8") as stream:
+            stream.write(
+                self._5190_record(outage_at - 700, "live block lost in outage")
+                + "\n"
+            )
+        os.utime(live, (outage_at, outage_at))
+        tick_channel(rt, TICK_CHANNEL, state, outage_at)
+
+        gap_alerts = [body for body, _ in rt.alerts if "릴레이 갭 감지" in body]
+        self.assertEqual(len(gap_alerts), 1, (rt.alerts, rt.log_lines))
+        self.assertIn(live.name, gap_alerts[0])
+        self.assertTrue(chs.get("alerting"))
+        self.assertNotIn(str(orphan), chs.get(self.ORPHAN_STRANDED_KEY, {}))
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+
+    def test_5190_reverse_relay_death_after_orphan_retirement_still_alerts(self):
+        """The retirement must not desensitize the channel it retired from."""
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+        retire_at = self._5190_retire_orphan(rt, state, live, orphan)
+        self.assertIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertEqual(
+            [body for body, _ in rt.alerts if "릴레이 갭 감지" in body], []
+        )
+
+        outage_at = retire_at + 3600
+        with live.open("a", encoding="utf-8") as stream:
+            stream.write(
+                self._5190_record(outage_at - 700, "post-retirement block lost")
+                + "\n"
+            )
+        os.utime(live, (outage_at, outage_at))
+        tick_channel(rt, TICK_CHANNEL, state, outage_at)
+
+        gap_alerts = [body for body, _ in rt.alerts if "릴레이 갭 감지" in body]
+        self.assertEqual(len(gap_alerts), 1, (rt.alerts, rt.log_lines))
+        self.assertIn(live.name, gap_alerts[0])
+        self.assertTrue(chs.get("alerting"))
+
+    def test_5190_young_orphan_gap_names_the_session_and_narrows_the_claim(self):
+        """Below the freeze floor nothing is reclassified — #4435 lives here.
+
+        A session swapped in moments ago and losing blocks right now is also
+        unmatched, also not the selected transcript, and also has a delivering
+        sibling. Only elapsed silence separates it from #5190's corpse, so the
+        alert still fires; what changes is that it now says WHICH session it is
+        talking about and stops claiming a live relay failure.
+        """
+        rt, state, live, orphan = self._5190_live_channel()
+        young_at = self.now + rt.cfg.orphan_abandon_secs - 600
+        self._5190_strand_orphan(orphan, self.now)
+        self._5190_live_delivery(rt, live, young_at, "live block two")
+        tick_channel(rt, TICK_CHANNEL, state, young_at)
+
+        gap_alerts = [body for body, _ in rt.alerts if "릴레이 갭 감지" in body]
+        self.assertEqual(len(gap_alerts), 1, (rt.alerts, rt.log_lines))
+        body = gap_alerts[0]
+        self.assertIn(orphan.name, body)
+        self.assertIn(live.name, body)
+        self.assertIn("고아 세션(현재 활성 세션 아님)", body)
+        self.assertIn("과거 세션에 미도달 블록이", body)
+        # R2: an unknown elapsed time is stated as unknown, not as 999 minutes.
+        self.assertIn("배달이 확인된 이력이 없습니다", body)
+        self.assertNotIn("999분", body)
+        self.assertNotIn("**999**", body)
+        self.assertNotIn(
+            str(orphan), state["999"].get(self.ORPHAN_STRANDED_KEY, {})
+        )
+
+    def test_5190_unobserved_elapsed_time_never_renders_as_a_measurement(self):
+        rt = self.gap_rt(github_repo="owner/repo")
+        rt.watcher_probe = WatcherStateProbe(200, True, False)
+        # A populated by-path delivery map with no entry for this transcript is
+        # the production shape: the watchdog met the file after its deliveries
+        # had already rolled out of the bounded Discord window.
+        state = {
+            "999": {
+                "gap_since": self.now - rt.cfg.issue_after_secs - 1,
+                relay_watchdog.LAST_ACTUAL_DELIVERY_BY_PATH_KEY: {
+                    "/other/session.jsonl": self.now,
+                },
+            }
+        }
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        body = rt.alerts[0][0]
+        self.assertIn("릴레이 갭 감지", body)
+        self.assertIn("배달이 확인된 이력이 없습니다", body)
+        self.assertNotIn("999분", body)
+        self.assertNotIn("**999**", body)
+        # The sentinel must not reach the issue the watchdog files about itself.
+        self.assertEqual(rt.issue_gap_mins, [None])
+
+        channel = ChannelConfig(
+            channel_id="555", sendmessage_key="k", worktree_root=WORKTREE_ROOT
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(list(argv))
+            return subprocess.CompletedProcess(
+                argv, 0, stdout="https://example.test/issues/9\n", stderr=""
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            real = Runtime(
+                Config(channels=(channel,), github_repo="owner/repo"), Path(tmp)
+            )
+            with mock.patch.object(
+                relay_watchdog.subprocess, "run", side_effect=fake_run
+            ):
+                real.file_github_issue(channel, None, 2)
+
+        # The runtime snapshot shells out first; find the `gh issue create`.
+        create = next(argv for argv in calls if "--title" in argv)
+        title = create[create.index("--title") + 1]
+        self.assertNotIn("999", title)
+        self.assertIn("no confirmed delivery on record", title)
 
     def test_invariant_4435_retiring_one_of_two_gap_owners_keeps_incident_clock(self):
         owner_a = self.proj_dir / "multi-gap-a.jsonl"

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -5333,6 +5333,178 @@ class TickChannelTests(unittest.TestCase):
         self.assertIn(live.name, gap_alerts[0])
         self.assertTrue(chs.get("alerting"))
 
+    def test_5190_r1_undelivered_retirement_notice_keeps_the_authority_open(self):
+        """The notice IS the retirement (#5190 R1).
+
+        `_alert_pending_retirement` returns False when nothing left the box.
+        Retiring anyway deletes the loss record with nobody ever told — the
+        observation failure collapsed into a success this campaign keeps finding.
+        """
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+        discovered_at = self.now + rt.cfg.orphan_abandon_secs + 600
+        self._5190_strand_orphan(orphan, self.now)
+        self._5190_live_delivery(rt, live, discovered_at, "live block two")
+        tick_channel(rt, TICK_CHANNEL, state, discovered_at)
+        self.assertIn(str(orphan), chs[self.ORPHAN_STRANDED_KEY])
+
+        retire_at = discovered_at + relay_watchdog.ORPHAN_STRANDED_CONFIRM_SECS
+        self._5190_live_delivery(rt, live, retire_at, "live block three")
+        rt.alert_succeeds = False
+        tick_channel(rt, TICK_CHANNEL, state, retire_at)
+
+        self.assertIn(
+            str(orphan), chs.get(relay_watchdog.PENDING_TRANSCRIPTS_KEY, [])
+        )
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertIn(str(orphan), chs.get(self.ORPHAN_STRANDED_KEY, {}))
+        self.assertTrue(
+            any(
+                "orphan-stranded-retirement-deferred" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+        self.assertFalse(
+            any(
+                "orphan-stranded-authority-retired" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+        # A deferral, not a dead end: the first tick that reaches a human
+        # completes exactly the same retirement.
+        rt.alert_succeeds = True
+        retry_at = retire_at + 1
+        self._5190_live_delivery(rt, live, retry_at, "live block four")
+        tick_channel(rt, TICK_CHANNEL, state, retry_at)
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.PENDING_TRANSCRIPTS_KEY, [])
+        )
+        self.assertIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "회수 불가" in body]),
+            2,
+            rt.alerts,
+        )
+
+    def _5190_observed_orphan(
+        self, rt: FakeRuntime, orphan: Path, frozen_at: float
+    ) -> None:
+        """An orphan that DID deliver once and then stranded the rest (R2).
+
+        Its `gap_secs` is a real measurement, not the unobserved sentinel, which
+        is exactly why silencing it needs a stronger bar than the never-seen case.
+        """
+        orphan.write_text(
+            self._5190_record(frozen_at - 900, "orphan block that did arrive")
+            + "\n"
+            + self._5190_record(frozen_at - 700, "orphan block stranded one")
+            + "\n"
+            + self._5190_record(frozen_at - 600, "orphan block stranded two")
+            + "\n",
+            encoding="utf-8",
+        )
+        os.utime(orphan, (frozen_at, frozen_at))
+        rt.haystack = norm(f"{rt.haystack} orphan block that did arrive")
+
+    def _5190_observed_orphan_tick(
+        self, *, bind_successor: bool, elapsed: float
+    ) -> tuple[FakeRuntime, dict, dict, Path, Path]:
+        for stale in self.proj_dir.glob("*.jsonl"):
+            stale.unlink()
+        rt, state, live, orphan = self._5190_live_channel()
+        self._5190_observed_orphan(rt, orphan, self.now)
+        at = self.now + elapsed
+        self._5190_live_delivery(rt, live, at, "live block two")
+        if bind_successor:
+            rt.watcher_probe = WatcherStateProbe(
+                200, attached=True, desynced=False, bound_output_path=str(live)
+            )
+        tick_channel(rt, TICK_CHANNEL, state, at)
+        return rt, state, state["999"], live, orphan
+
+    def test_5190_r2_observed_history_orphan_retires_on_stronger_evidence(self):
+        """R2: delivery history does not make the same defect out of scope.
+
+        A `/clear`ed session that delivered before stranding its tail is pinned
+        by the identical loop — every exit blocked, re-alerting every 15 minutes
+        until an unrelated idle timer expires. It is admitted, but only on
+        evidence strictly stronger than the never-observed case.
+        """
+        doubled = (
+            relay_watchdog.Config().orphan_abandon_secs
+            * relay_watchdog.ORPHAN_OBSERVED_FREEZE_MULTIPLIER
+        )
+        rt, state, chs, live, orphan = self._5190_observed_orphan_tick(
+            bind_successor=True, elapsed=doubled + 60
+        )
+        self.assertIn(str(orphan), chs[self.ORPHAN_STRANDED_KEY])
+        self.assertTrue(
+            any(
+                "orphan-stranded-marker-opened" in line
+                and "observed_history=True" in line
+                and f"freeze_floor={doubled}s" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+        discovered_at = self.now + doubled + 60
+        retire_at = discovered_at + relay_watchdog.ORPHAN_STRANDED_CONFIRM_SECS
+        self._5190_live_delivery(rt, live, retire_at, "live block three")
+        tick_channel(rt, TICK_CHANNEL, state, retire_at)
+
+        self.assertIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.PENDING_TRANSCRIPTS_KEY, [])
+        )
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "회수 불가" in body]), 1
+        )
+        self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
+
+    def test_5190_r2_reverse_a_measured_gap_survives_a_weaker_evidence_bar(self):
+        """THE reverse direction for R2 — the bar is what keeps it loud.
+
+        Drop either half of the extra evidence and the measured gap must keep
+        alerting, still naming its elapsed time as a measurement. This is the
+        pin against R2's fix quietly widening into "orphans are never reported".
+        """
+        cfg = relay_watchdog.Config()
+        doubled = cfg.orphan_abandon_secs * (
+            relay_watchdog.ORPHAN_OBSERVED_FREEZE_MULTIPLIER
+        )
+        cases = (
+            ("dcserver never confirmed the channel moved on", False, doubled + 60),
+            ("frozen past the unobserved floor only", True, cfg.orphan_abandon_secs + 60),
+        )
+        for label, bind_successor, elapsed in cases:
+            with self.subTest(label):
+                rt, _state, chs, _live, orphan = self._5190_observed_orphan_tick(
+                    bind_successor=bind_successor, elapsed=elapsed
+                )
+                gap_alerts = [
+                    body for body, _ in rt.alerts if "릴레이 갭 감지" in body
+                ]
+                self.assertEqual(len(gap_alerts), 1, (rt.alerts, rt.log_lines))
+                self.assertIn(orphan.name, gap_alerts[0])
+                # The measurement is reported AS a measurement.
+                self.assertIn("마지막 정상 도달 이후", gap_alerts[0])
+                self.assertNotIn("배달이 확인된 이력이 없습니다", gap_alerts[0])
+                self.assertNotIn(str(orphan), chs.get(self.ORPHAN_STRANDED_KEY, {}))
+                self.assertNotIn(
+                    str(orphan),
+                    chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {}),
+                )
+
     def test_5190_young_orphan_gap_names_the_session_and_narrows_the_claim(self):
         """Below the freeze floor nothing is reclassified — #4435 lives here.
 

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -5513,6 +5513,11 @@ class TickChannelTests(unittest.TestCase):
         sibling. Only elapsed silence separates it from #5190's corpse, so the
         alert still fires; what changes is that it now says WHICH session it is
         talking about and stops claiming a live relay failure.
+
+        #5190 R5: r1's version of this test pinned the WRONG rendering — it
+        asserted that this very target was announced as a "고아 세션 / 과거
+        세션". Non-selection is not pastness; only the freeze floor this target
+        has not yet crossed could carry that claim.
         """
         rt, state, live, orphan = self._5190_live_channel()
         young_at = self.now + rt.cfg.orphan_abandon_secs - 600
@@ -5525,8 +5530,14 @@ class TickChannelTests(unittest.TestCase):
         body = gap_alerts[0]
         self.assertIn(orphan.name, body)
         self.assertIn(live.name, body)
-        self.assertIn("고아 세션(현재 활성 세션 아님)", body)
-        self.assertIn("과거 세션에 미도달 블록이", body)
+        # Not proved, therefore not claimed.
+        self.assertNotIn("고아 세션", body)
+        self.assertNotIn("과거 세션에 미도달 블록이", body)
+        self.assertIn("아직 과거 세션이라고 단정할 수 없습니다", body)
+        # Proved this tick, therefore stated: it is not the active session, and
+        # a sibling really did deliver.
+        self.assertIn("현재 활성 세션(`%s`)이 아닙니다" % live.name, body)
+        self.assertIn("실제로 배달이 확인됐습니다", body)
         # R2: an unknown elapsed time is stated as unknown, not as 999 minutes.
         self.assertIn("배달이 확인된 이력이 없습니다", body)
         self.assertNotIn("999분", body)
@@ -5534,6 +5545,89 @@ class TickChannelTests(unittest.TestCase):
         self.assertNotIn(
             str(orphan), state["999"].get(self.ORPHAN_STRANDED_KEY, {})
         )
+
+    def test_5190_r3_a_block_that_arrives_during_the_window_is_not_retired(self):
+        """Maturity is a timer, not a finding (#5190 R3).
+
+        The confirmation window exists so the finding can be falsified. If a
+        stranded block finally reaches Discord inside it, "회수 불가" becomes a
+        false statement about blocks that had already arrived — so the claim is
+        re-checked against the current verdict before it is made.
+        """
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+        discovered_at = self.now + rt.cfg.orphan_abandon_secs + 600
+        self._5190_strand_orphan(orphan, self.now)
+        self._5190_live_delivery(rt, live, discovered_at, "live block two")
+        tick_channel(rt, TICK_CHANNEL, state, discovered_at)
+        self.assertIn(str(orphan), chs[self.ORPHAN_STRANDED_KEY])
+
+        # The relay was slow, not dead: both stranded blocks land during the
+        # confirmation window.
+        recovered_at = (
+            discovered_at + relay_watchdog.ORPHAN_STRANDED_CONFIRM_SECS
+        )
+        rt.haystack = norm(
+            f"{rt.haystack} stranded orphan block one stranded orphan block two"
+        )
+        tick_channel(rt, TICK_CHANNEL, state, recovered_at)
+
+        self.assertEqual([b for b, _ in rt.alerts if "회수 불가" in b], [])
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertNotIn(str(orphan), chs.get(self.ORPHAN_STRANDED_KEY, {}))
+        self.assertTrue(
+            any(
+                "orphan-stranded-maturity-voided" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+    def test_5190_r4_a_stale_watermark_is_not_proof_of_live_delivery(self):
+        """R4: the safety hinge must prove a match NOW, not a match once.
+
+        `Verdict.delivered_ts` is `max(persisted watermark, current match)`, so
+        an idle sibling that delivered minutes ago voted "the channel is fine"
+        for a full `gap_alert_secs` on an empty haystack — and that vote is the
+        only thing standing between a real gap and being marked stranded.
+
+        R5 rides along: this orphan HAS crossed the freeze floor, so the "고아
+        세션" wording is earned here, while the relay-health clause must stay
+        honest because nothing was seen delivering.
+        """
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+        # A delivery recent enough that its watermark is younger than
+        # `gap_alert_secs` at probe time.
+        mid_at = self.now + rt.cfg.orphan_abandon_secs + 50
+        self._5190_live_delivery(rt, live, mid_at, "live block two")
+        tick_channel(rt, TICK_CHANNEL, state, mid_at)
+
+        probe_at = mid_at + 100
+        self._5190_strand_orphan(orphan, self.now)
+        # The bounded Discord read window rolled over: nothing matches now.
+        rt.haystack = ""
+        tick_channel(rt, TICK_CHANNEL, state, probe_at)
+
+        self.assertLessEqual(
+            probe_at - relay_watchdog.delivered_watermark_for_path(chs, live),
+            rt.cfg.gap_alert_secs,
+            "watermark must still be fresh, or the test proves nothing",
+        )
+        self.assertNotIn(str(orphan), chs.get(self.ORPHAN_STRANDED_KEY, {}))
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        gap_alerts = [body for body, _ in rt.alerts if "릴레이 갭 감지" in body]
+        self.assertEqual(len(gap_alerts), 1, (rt.alerts, rt.log_lines))
+        body = gap_alerts[0]
+        self.assertIn(orphan.name, body)
+        self.assertIn("고아 세션", body)
+        self.assertIn("분째 새 기록이 없습니다", body)
+        self.assertIn("릴레이 장애 가능성이 남아 있습니다", body)
+        self.assertNotIn("실제로 배달이 확인됐습니다", body)
 
     def test_5190_unobserved_elapsed_time_never_renders_as_a_measurement(self):
         rt = self.gap_rt(github_repo="owner/repo")

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -5629,6 +5629,608 @@ class TickChannelTests(unittest.TestCase):
         self.assertIn("릴레이 장애 가능성이 남아 있습니다", body)
         self.assertNotIn("실제로 배달이 확인됐습니다", body)
 
+    # ── #5190 R3: a matured marker is a claim, and claims get re-checked ─────
+    #
+    # r2 re-verified STATE_GAP and semantic growth at maturity and stopped
+    # there, so three of the four conditions that justified OPENING the marker
+    # were never asked again before it was cashed in. Each test below is one of
+    # the ways that let a retirement — a user-facing "회수 불가" statement — be
+    # made on evidence nobody had re-read.
+
+    def _5190_marker_open(
+        self, rt: FakeRuntime, state: dict, live: Path, orphan: Path
+    ) -> float:
+        """Tick the channel to the point where the stranded marker is open."""
+        discovered_at = self.now + rt.cfg.orphan_abandon_secs + 600
+        self._5190_strand_orphan(orphan, self.now)
+        self._5190_live_delivery(rt, live, discovered_at, "live block two")
+        tick_channel(rt, TICK_CHANNEL, state, discovered_at)
+        self.assertIn(str(orphan), state["999"][self.ORPHAN_STRANDED_KEY])
+        return discovered_at
+
+    def test_5190_r3_a_matured_marker_does_not_close_through_an_outage(self):
+        """(a) The relay dies inside the confirmation window.
+
+        The marker was opened on proof that a sibling was delivering. If that
+        stops being true before the window elapses, the finding has lost the
+        one piece of evidence that distinguished a dead session from a dead
+        relay — and retiring anyway sends "회수 불가" about blocks whose only
+        real problem is that the relay is down. This is the exact inversion the
+        whole mechanism exists to prevent.
+        """
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+        discovered_at = self._5190_marker_open(rt, state, live, orphan)
+
+        outage_at = (
+            discovered_at + relay_watchdog.ORPHAN_STRANDED_CONFIRM_SECS + 400
+        )
+        with live.open("a", encoding="utf-8") as stream:
+            stream.write(
+                self._5190_record(outage_at - 700, "live block lost in outage")
+                + "\n"
+            )
+        os.utime(live, (outage_at, outage_at))
+        tick_channel(rt, TICK_CHANNEL, state, outage_at)
+
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertEqual([b for b, _ in rt.alerts if "회수 불가" in b], [])
+        # The finding is not disproved either — the marker survives, so the
+        # first tick that can prove it again completes the retirement.
+        self.assertIn(str(orphan), chs.get(self.ORPHAN_STRANDED_KEY, {}))
+        self.assertTrue(
+            any(
+                "orphan-stranded-maturity-unconfirmed" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+        # And the outage is loud, not silent.
+        self.assertTrue(chs.get("alerting"))
+
+    def test_5190_r3_a_pre_marker_delivery_cannot_corroborate_a_retirement(self):
+        """(a') The write-epoch window — #5190 R3 P2-D's 900-second blind spot.
+
+        `current_delivered_by_path` holds block WRITE epochs, not delivery
+        times, so an idle sibling whose last block still matches keeps voting
+        "the relay is alive" for a full `gap_alert_secs`. That is LONGER than
+        the confirmation window it is carrying, so a relay that died the moment
+        the marker opened was indistinguishable from a healthy one for the
+        entire window. Nothing here writes a new block; the only evidence is a
+        match that predates the finding.
+        """
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+        discovered_at = self._5190_marker_open(rt, state, live, orphan)
+
+        retire_at = (
+            discovered_at + relay_watchdog.ORPHAN_STRANDED_CONFIRM_SECS
+        )
+        # The sibling's newest matched block is the one from the marker tick,
+        # and it is still inside the freshness bound — or this proves nothing.
+        self.assertLess(
+            retire_at - (discovered_at - 30),
+            rt.cfg.gap_alert_secs,
+            "stale match must still pass the freshness bound",
+        )
+        tick_channel(rt, TICK_CHANNEL, state, retire_at)
+
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertEqual([b for b, _ in rt.alerts if "회수 불가" in b], [])
+        self.assertIn(str(orphan), chs.get(self.ORPHAN_STRANDED_KEY, {}))
+        self.assertTrue(
+            any(
+                "orphan-stranded-maturity-unconfirmed" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+    def test_5190_r3_an_orphan_promoted_to_the_active_session_is_not_retired(
+        self,
+    ):
+        """(b) The orphan IS the channel's current session by the time it matures.
+
+        The worst of the three: retiring the selected transcript drops the
+        channel's GAP ownership to zero, so the session that is running RIGHT
+        NOW loses its own loss record and the incident closes with nobody told.
+        `eligible` already rejects a selected path — what was missing is that
+        maturity never consulted it.
+        """
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+        discovered_at = self._5190_marker_open(rt, state, live, orphan)
+
+        # The live transcript is gone, so the selector falls back to the only
+        # candidate left: the orphan itself.
+        live.unlink()
+        retire_at = (
+            discovered_at + relay_watchdog.ORPHAN_STRANDED_CONFIRM_SECS
+        )
+        tick_channel(rt, TICK_CHANNEL, state, retire_at)
+
+        self.assertEqual(chs.get(SELECTED_TRANSCRIPT_KEY), str(orphan))
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertEqual([b for b, _ in rt.alerts if "회수 불가" in b], [])
+        # Gap ownership did NOT drop to zero.
+        self.assertIn(
+            str(orphan), chs.get(relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY, [])
+        )
+        self.assertTrue(
+            any(
+                "orphan-stranded-marker-cleared" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+    def test_5190_r3_a_marker_that_matured_unevaluated_still_needs_proof(self):
+        """(c) The path was not judged for a tick and came back to an expired timer.
+
+        The marker is persisted state and its clock does not care whether
+        anyone was looking. A path that drops out of the candidate set for a
+        tick — a transient enumeration or read failure — returns to find the
+        window already elapsed, and the pre-fix code closed it out on the first
+        tick that saw it again, without ④ ever having been asked since the
+        finding was made.
+        """
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+        discovered_at = self._5190_marker_open(rt, state, live, orphan)
+        content = orphan.read_text(encoding="utf-8")
+
+        orphan.unlink()
+        tick_channel(rt, TICK_CHANNEL, state, discovered_at + 60)
+        self.assertIn(str(orphan), chs.get(self.ORPHAN_STRANDED_KEY, {}))
+
+        orphan.write_text(content, encoding="utf-8")
+        os.utime(orphan, (self.now, self.now))
+        back_at = discovered_at + relay_watchdog.ORPHAN_STRANDED_CONFIRM_SECS
+        tick_channel(rt, TICK_CHANNEL, state, back_at)
+
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertEqual([b for b, _ in rt.alerts if "회수 불가" in b], [])
+
+        # A deferral, not a dead end: a tick that CAN prove the channel is
+        # delivering completes exactly the same retirement.
+        proven_at = back_at + 60
+        self._5190_live_delivery(rt, live, proven_at, "live block three")
+        tick_channel(rt, TICK_CHANNEL, state, proven_at)
+        self.assertIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertEqual(
+            len([b for b, _ in rt.alerts if "회수 불가" in b]), 1, rt.alerts
+        )
+
+    def test_5190_r3_reverse_a_fully_corroborated_orphan_still_retires(self):
+        """THE reverse direction for every re-check added above.
+
+        Four new conditions now stand between a matured marker and a
+        retirement, and a guard that can never be satisfied is not a guard —
+        it is the #5190 defect with extra steps. A genuine orphan on a
+        genuinely delivering channel must still close out, in one notice, with
+        no unconfirmed deferral anywhere in the log.
+        """
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+        self._5190_retire_orphan(rt, state, live, orphan)
+
+        self.assertIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertNotIn(str(orphan), chs.get(self.ORPHAN_STRANDED_KEY, {}))
+        self.assertEqual(
+            len([b for b, _ in rt.alerts if "회수 불가" in b]), 1, rt.alerts
+        )
+        self.assertFalse(
+            any(
+                "orphan-stranded-maturity-unconfirmed" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+        self.assertTrue(
+            any(
+                "orphan-stranded-authority-retired" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+    def test_5190_r3_a_marker_may_not_close_before_the_confirmation_window(
+        self,
+    ):
+        """⑤ on its own: the window is what makes one anomalous tick harmless.
+
+        Everything else the retirement needs is true here — the orphan is
+        frozen, unselected, still in GAP, and the channel is delivering fresh
+        blocks. Only the clock has not run out. Nothing may close.
+        """
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+        discovered_at = self._5190_marker_open(rt, state, live, orphan)
+
+        early_at = (
+            discovered_at + relay_watchdog.ORPHAN_STRANDED_CONFIRM_SECS - 60
+        )
+        self._5190_live_delivery(rt, live, early_at, "live block three")
+        tick_channel(rt, TICK_CHANNEL, state, early_at)
+
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertIn(str(orphan), chs.get(self.ORPHAN_STRANDED_KEY, {}))
+        self.assertEqual([b for b, _ in rt.alerts if "회수 불가" in b], [])
+        self.assertFalse(
+            any(
+                "orphan-stranded-authority-retired" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+        # ...and the tick that DOES reach the window closes it, so this pins
+        # the window rather than "nothing ever retires".
+        retire_at = (
+            discovered_at + relay_watchdog.ORPHAN_STRANDED_CONFIRM_SECS
+        )
+        self._5190_live_delivery(rt, live, retire_at, "live block four")
+        tick_channel(rt, TICK_CHANNEL, state, retire_at)
+        self.assertIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+
+    def test_5190_r3_live_delivery_freshness_bound_rejects_a_stale_match(self):
+        """② of `_channel_has_live_delivery`, exercised on its own.
+
+        Every end-to-end test reaches this helper through the `matched_ts <=
+        0.0` branch (an empty haystack), so the freshness clause — the
+        difference between "this sibling matched something" and "this sibling
+        matched something RECENTLY" — was never executed by any assertion.
+        Deleting it changed no test result, which is the definition of an
+        untested safeguard. The reachable production shape is an idle sibling
+        whose old block is still inside the bounded Discord read window.
+        """
+        now = 1_000_000.0
+        gap_alert_secs = 900
+        sibling = relay_watchdog.TranscriptCandidate(
+            path=Path("/tmp/sibling.jsonl"), size=10, mtime=now
+        )
+        verdict = relay_watchdog.Verdict(
+            state=relay_watchdog.STATE_OK,
+            blocks=1,
+            stale=0,
+            lost=0,
+            delivered_ts=now - 10,
+            gap_secs=10.0,
+        )
+        evaluated = [(sibling, verdict)]
+
+        def probe(matched_ts: float, **kwargs) -> bool:
+            return relay_watchdog._channel_has_live_delivery(
+                evaluated,
+                {},
+                {str(sibling.path): matched_ts},
+                "/tmp/orphan.jsonl",
+                now,
+                gap_alert_secs,
+                **kwargs,
+            )
+
+        self.assertTrue(probe(now))
+        self.assertTrue(probe(now - (gap_alert_secs - 1)))
+        # The boundary is inclusive on the fresh side...
+        self.assertTrue(probe(now - gap_alert_secs))
+        # ...and one second past it the match is no longer evidence that
+        # anything is delivering now.
+        self.assertFalse(probe(now - (gap_alert_secs + 1)))
+
+        # `newer_than` is a SEPARATE, stricter lower bound: it does not replace
+        # the freshness bound, and neither one alone is sufficient.
+        self.assertFalse(probe(now - 100, newer_than=now - 50))
+        self.assertTrue(probe(now - 30, newer_than=now - 50))
+        self.assertFalse(probe(now - (gap_alert_secs + 1), newer_than=0.0))
+
+    def test_5190_r3_retirement_notice_reports_cooldown_apart_from_failure(
+        self,
+    ):
+        """#5190 R3 P2-E: "nothing went out" has two causes, not one.
+
+        The retirement notice shares ONE cooldown key across every reason, so
+        an unrelated idle/read_failure/dead_worktree notice within
+        `realert_secs` suppresses this one. The old code answered a bare bool
+        and the caller logged `notice=undelivered` for both — a false statement
+        about the relay written into the record every time the real cause was a
+        cooldown.
+        """
+        rt = self.make_rt()
+        chs: dict = {}
+        now = self.now
+
+        self.assertEqual(
+            relay_watchdog._alert_pending_retirement(
+                rt, TICK_CHANNEL, chs, [], now, reason="idle"
+            ),
+            "empty",
+        )
+        self.assertEqual(
+            relay_watchdog._alert_pending_retirement(
+                rt, TICK_CHANNEL, chs, ["/a.jsonl"], now, reason="idle"
+            ),
+            "sent",
+        )
+        # A DIFFERENT reason, moments later, on the shared key.
+        self.assertEqual(
+            relay_watchdog._alert_pending_retirement(
+                rt,
+                TICK_CHANNEL,
+                chs,
+                ["/b.jsonl"],
+                now + 60,
+                reason=relay_watchdog.ORPHAN_STRANDED_RETIREMENT_REASON,
+            ),
+            "cooldown",
+        )
+        self.assertFalse(
+            any(
+                "transcript-retirement-alert undelivered" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+        rt.alert_succeeds = False
+        self.assertEqual(
+            relay_watchdog._alert_pending_retirement(
+                rt,
+                TICK_CHANNEL,
+                chs,
+                ["/c.jsonl"],
+                now + rt.cfg.realert_secs + 1,
+                reason="idle",
+            ),
+            "undelivered",
+        )
+        self.assertTrue(
+            any(
+                "transcript-retirement-alert undelivered" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+
+    def test_5190_r3_orphan_retirement_deferred_by_cooldown_says_cooldown(self):
+        """The same distinction where a human reads it: the deferral log line."""
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+        discovered_at = self._5190_marker_open(rt, state, live, orphan)
+
+        retire_at = (
+            discovered_at + relay_watchdog.ORPHAN_STRANDED_CONFIRM_SECS
+        )
+        self._5190_live_delivery(rt, live, retire_at, "live block three")
+        # An unrelated retirement notice went out moments ago on the shared key.
+        chs[relay_watchdog.LAST_PENDING_TRANSCRIPT_RETIREMENT_ALERT_KEY] = (
+            retire_at - 10
+        )
+        tick_channel(rt, TICK_CHANNEL, state, retire_at)
+
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertTrue(
+            any(
+                "orphan-stranded-retirement-deferred" in line
+                and "notice=cooldown" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+        self.assertFalse(
+            any("notice=undelivered" in line for line in rt.log_lines),
+            rt.log_lines,
+        )
+
+    def test_5190_r3_a_rewound_mtime_cannot_manufacture_an_orphan(self):
+        """② alone, where it is the ONLY thing holding the line (#5190 R3 P2-C).
+
+        Safeguard ① (the doubled freeze floor) reads `mtime` — filesystem
+        METADATA, which any restore can set to whatever it likes: `cp -p`,
+        `rsync -t` and `tar -x` all stamp a file with an mtime older than the
+        newest record it actually contains. Safeguard ② reads the block
+        timestamps the watchdog parsed out of the file's CONTENT, so it is the
+        one check a rewound mtime cannot fool.
+
+        On honest metadata ② is slack — ① implies it, which is why forcing ②
+        true changed no test result before this one existed. Here the metadata
+        lies: the file claims to have been frozen for over an hour while its
+        own records show it delivering 16 minutes ago. ① passes. Only ② stands
+        between a live session and a "회수 불가" notice about its blocks.
+        """
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+        at = self.now + 4000
+        floor = rt.cfg.orphan_abandon_secs * (
+            relay_watchdog.ORPHAN_OBSERVED_FREEZE_MULTIPLIER
+        )
+
+        # Content: delivered 1000s ago, stranded a block 950s ago. That gap is
+        # past `gap_alert_secs` (so STATE_GAP) but well inside
+        # `orphan_abandon_secs` (so the frontier is NOT stale).
+        orphan.write_text(
+            self._5190_record(at - 1000, "orphan block that did arrive")
+            + "\n"
+            + self._5190_record(at - 950, "orphan block stranded")
+            + "\n",
+            encoding="utf-8",
+        )
+        rt.haystack = norm(f"{rt.haystack} orphan block that did arrive")
+        # Metadata: rewound to look frozen for over an hour.
+        os.utime(orphan, (at - 3700, at - 3700))
+        self._5190_live_delivery(rt, live, at, "live block two")
+        rt.watcher_probe = WatcherStateProbe(
+            200, attached=True, desynced=False, bound_output_path=str(live)
+        )
+        tick_channel(rt, TICK_CHANNEL, state, at)
+
+        # The preconditions this test exists to isolate: ① passes on the lie,
+        # every other safeguard is satisfied, and ② is the sole objection.
+        self.assertGreaterEqual(at - orphan.stat().st_mtime, floor)
+        frontier = relay_watchdog.delivered_watermark_for_path(chs, orphan)
+        self.assertGreater(frontier, 0.0)
+        self.assertLess(at - frontier, rt.cfg.orphan_abandon_secs)
+        self.assertGreater(at - frontier, rt.cfg.gap_alert_secs)
+
+        # Therefore: no marker, no retirement, and the gap stays loud.
+        self.assertNotIn(str(orphan), chs.get(self.ORPHAN_STRANDED_KEY, {}))
+        self.assertNotIn(
+            str(orphan), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {})
+        )
+        self.assertEqual([b for b, _ in rt.alerts if "회수 불가" in b], [])
+        gap_alerts = [body for body, _ in rt.alerts if "릴레이 갭 감지" in body]
+        self.assertEqual(len(gap_alerts), 1, (rt.alerts, rt.log_lines))
+        self.assertIn(orphan.name, gap_alerts[0])
+
+    def test_5190_r3_reverse_an_honest_frontier_still_opens_the_marker(self):
+        """The reverse of the above: ② must not block a genuine orphan.
+
+        The freshest delivery frontier an observed orphan can honestly have is
+        one where the last block it ever wrote is one that arrived. On truthful
+        metadata ① already implies ②, so the marker opens — a guard that is
+        slack in the normal case and binding only when `mtime` lies is exactly
+        what it should be.
+        """
+        rt, state, live, orphan = self._5190_live_channel()
+        chs = state["999"]
+        floor = rt.cfg.orphan_abandon_secs * (
+            relay_watchdog.ORPHAN_OBSERVED_FREEZE_MULTIPLIER
+        )
+        orphan.write_text(
+            self._5190_record(self.now - 2, "orphan tail that did arrive")
+            + "\n"
+            + self._5190_record(self.now - 1, "orphan tail stranded")
+            + "\n",
+            encoding="utf-8",
+        )
+        os.utime(orphan, (self.now, self.now))
+        rt.haystack = norm(f"{rt.haystack} orphan tail that did arrive")
+        at = self.now + floor + 60
+        self._5190_live_delivery(rt, live, at, "live block two")
+        rt.watcher_probe = WatcherStateProbe(
+            200, attached=True, desynced=False, bound_output_path=str(live)
+        )
+        tick_channel(rt, TICK_CHANNEL, state, at)
+
+        self.assertIn(str(orphan), chs[self.ORPHAN_STRANDED_KEY])
+        self.assertTrue(
+            any(
+                "orphan-stranded-marker-opened" in line
+                and "observed_history=True" in line
+                for line in rt.log_lines
+            ),
+            rt.log_lines,
+        )
+        frontier = relay_watchdog.delivered_watermark_for_path(chs, orphan)
+        self.assertLessEqual(frontier, orphan.stat().st_mtime)
+        self.assertGreaterEqual(at - frontier, rt.cfg.orphan_abandon_secs)
+
+    def _5190_no_selection_tick(self) -> tuple[FakeRuntime, dict, dict, Path]:
+        """Drive the channel to a tick that alerts with NOTHING selected.
+
+        Reachability, not hypothesis (#5190 R3 P2-F). The route, all of it
+        ordinary production behaviour:
+
+        1. `live` delivers, is selected, and therefore leaves the pending set.
+        2. `live` strands a block. It becomes a GAP owner — and because it is
+           not pending, no pending expiry can ever remove it.
+        3. A brand-new transcript debuts with a later mtime and takes the
+           selection on the `unseen_newer` rule. It has delivered nothing, so
+           it stays pending.
+        4. The channel goes quiet past `idle_quiet_secs`. The pending expiry
+           fires on the SELECTED path and clears `tr` — and it does so upstream
+           of the line that resolves `selected` from `tr`, so `selected` is None
+           for the rest of the pass while `live` is still a GAP owner and still
+           the alert subject.
+        """
+        rt, state, live, _orphan = self._5190_live_channel()
+        chs = state["999"]
+        anchor = self.now
+
+        with live.open("a", encoding="utf-8") as stream:
+            stream.write(
+                self._5190_record(anchor + 300, "live block never delivered")
+                + "\n"
+            )
+        os.utime(live, (anchor + 1000, anchor + 1000))
+        tick_channel(rt, TICK_CHANNEL, state, anchor + 1000)
+        self.assertIn(
+            str(live), chs.get(relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY, [])
+        )
+        self.assertNotIn(
+            str(live), chs.get(relay_watchdog.PENDING_TRANSCRIPTS_KEY, [])
+        )
+
+        successor = self.proj_dir / "aaaaaaaa-1111-2222-3333-444444444444.jsonl"
+        successor.write_text(
+            self._5190_record(anchor + 1950, "successor block undelivered")
+            + "\n",
+            encoding="utf-8",
+        )
+        os.utime(successor, (anchor + 2000, anchor + 2000))
+        tick_channel(rt, TICK_CHANNEL, state, anchor + 2000)
+        self.assertEqual(chs[SELECTED_TRANSCRIPT_KEY], str(successor))
+        self.assertIn(
+            str(successor), chs.get(relay_watchdog.PENDING_TRANSCRIPTS_KEY, [])
+        )
+
+        quiet_at = anchor + 2000 + rt.cfg.idle_quiet_secs + 60
+        before = len(rt.alerts)
+        tick_channel(rt, TICK_CHANNEL, state, quiet_at)
+        return rt, state, chs, live, before
+
+    def test_5190_r6_a_tick_with_no_active_session_never_claims_one(self):
+        """No selection means no claim about selection (#5190 R3 P2-F).
+
+        `not_selected` was `bool(selected_path) and path != selected_path`, so a
+        tick that selected nothing collapsed into the "it IS the selection" arm
+        and rendered "대상 세션: X (현재 활성 세션)" on a channel that had no
+        active session at all. It is the mirror image of the overclaim R5
+        removed: there an unproven pastness was asserted, here an unproven
+        presentness.
+        """
+        rt, _state, chs, live, before = self._5190_no_selection_tick()
+
+        # The precondition this test exists to exercise: nothing is selected.
+        self.assertIsNone(chs.get(SELECTED_TRANSCRIPT_KEY))
+        self.assertIn(
+            str(live), chs.get(relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY, [])
+        )
+        gap_alerts = [
+            body for body, _ in rt.alerts[before:] if "릴레이 갭 감지" in body
+        ]
+        self.assertEqual(len(gap_alerts), 1, (rt.alerts[before:], rt.log_lines))
+        body = gap_alerts[0]
+        self.assertIn(live.name, body)
+        # The false claim, and the true statement that replaced it.
+        self.assertNotIn("(현재 활성 세션)", body)
+        self.assertIn("현재 활성 세션으로 판정된 트랜스크립트가 없습니다", body)
+        self.assertIn("이번 점검으로 판정되지 않았습니다", body)
+        # Pastness is not asserted either — non-selection cannot be read off a
+        # tick that selected nothing.
+        self.assertNotIn("고아 세션", body)
+        self.assertNotIn("아니냐", body)
+        # And the relay-health clause stays honest: nothing delivered here.
+        self.assertIn("릴레이 장애 가능성이 남아 있습니다", body)
+
     def test_5190_unobserved_elapsed_time_never_renders_as_a_measurement(self):
         rt = self.gap_rt(github_repo="owner/repo")
         rt.watcher_probe = WatcherStateProbe(200, True, False)


### PR DESCRIPTION
Fixes #5190

## 무엇이 문제였나

`/clear` 된 세션이 **어떤 미래 배달로도 회수할 수 없는 블록을 쥔 채 얼어붙은 transcript** 를 남긴다. 워치독이 가진 모든 탈출구가 정확히 그 조건에 막혀 있었다 — 프런티어가 전진 못 하니 tombstone 이 확정되지 않고, worktree 는 살아 있으니 dead-worktree 은퇴가 안 걸리고, `STATE_OK` 는 영원히 못 오니 pending authority 가 해제되지 않는다.

결과: 채널이 **15분마다 "마지막 배달 이후 999분"** 을 주장하며 재경보했다. **999는 측정값이 아니라 센티넬**이고, 그 세션은 30분 전에 죽었으며 채널은 그동안 *다른* transcript 로 정상 배달 중이었다. 이 거짓 숫자가 워치독이 자동 발행한 이슈의 **제목까지** 올라갔다.

## 무엇을 고쳤나

- **R1** — `evaluate()` 가 "배달을 한 번도 관측 못 함" 을 `float("inf")` 로 뭉개지 않는다. 미관측은 모든 실측정 아래에 랭크되는 **자기 자신의 센티넬**이고, 별도 분기로 여전히 `STATE_GAP` 에 도달한다. 배달 한 번 못 해보고 죽은 릴레이는 계속 경보한다.
- **R2** — 확정된 것이 없으면 경과 시간은 `None` 이고, 경보와 자동 발행 이슈 **양쪽 모두 999 대신 말로** 그렇게 적는다.
- **R3** — stranded-orphan 마커가 authority 를 은퇴시키되, **적극적 증명에만** 게이트된다: 경로가 `orphan_abandon_secs` 를 넘겨 얼어 있고, 활성 세션이 아니며, 같은 채널의 **다른** transcript 가 실증적으로 배달 중이다. 죽은 릴레이는 이런 증명을 만들어내지 못하므로 **조용해지는 것이 하나도 없다**.
- **R4/R5** — 경보가 transcript 를 지목하고, 그것이 활성 세션이 아닐 때는 그렇게 말한 뒤 **주장 범위를 좌초된 과거 세션 블록으로 좁힌다**.

세 라운드의 적대적 리뷰(P1 2건 → P2 3건 → R3 재증명)를 거쳤다. 마지막 검증 리뷰 **`VERDICT: CLEAN` (P0/P1 0건)**.

핵심 안전 축:
- **은퇴는 통지가 실제로 나갔을 때만** 한다. `_alert_pending_retirement()` 가 False 를 반환하면 pending 이 유지되고 다음 틱이 여기서 재시도한다 (`_release_pending_authority` 로 세 pending 맵을 원자적으로 처리).
- **만기(maturity) 는 타이머가 아니라 재확인**이다. 마커를 열었던 4개 조건 중 3개가 현금화 전에 한 번도 재확인되지 않았었다. 이제 **닫는 데 필요한 확증이 여는 데 필요했던 것보다 엄격하다** — 형제 transcript 의 블록이 **finding 이후에 쓰였어야** 한다. `current_delivered_by_path` 가 배달 시각이 아니라 **블록 write epoch** 을 담고 있어서, 유휴 형제의 오래됐지만 여전히 매치되는 블록 하나가 `gap_alert_secs` 내내 "살아있음" 표를 던지던 write-epoch 창을 닫는다.
- 얼음 바닥(freeze floor) 이 이 픽스를 **#4435**(방금 스왑인된 세션이 지금 블록을 잃는 중)와 분리한다. 이걸 제거하면 #4435 스위트 자신의 테스트가 깨진다 — `-k 4435` **67 passed 불변**으로 고정.

## ★ 라인 상한 초과 — 명시적 waiver

**1864줄 / 상한 800 → 초과. 파일 2/20 통과.** 오케스트레이터가 **단일 PR + 명시적 waiver** 로 결정했다. 근거:

1. **파일 2개 / 20** — 파일 예산은 거의 쓰지 않았다.
2. 1864줄 중 **프로덕션 코드는 `scripts/relay_watchdog.py` 739줄**이고, **1174줄은 세 라운드의 리뷰가 명시적으로 요구한 판별 테스트**다. 상한의 목적은 리뷰 부담이며, 여기서 부담을 만드는 것은 프로덕션 739줄이다.
3. **검증 리뷰가 "뺄 수 있는 줄이 실질적으로 없다" 를 실측했다** — 신규 테스트 23개 중 **22개**가 리뷰어 뮤턴트 17건 중 **최소 1건의 단독 킬러**다. 원칙적 제거 가능분은 **≤68줄(≤6%)**이고, 그마저 4상태 계약의 **유일한 직접 테스트**다.
4. **절단해도 이득이 없다** — 어떤 절단면도 후반부를 상한 아래로 내리지 못하고, 줄이 앞 단위에서 뒤 단위로 옮겨져 **뒤가 1300 → 1736 으로 커진다**.
5. **상한을 맞추려 판별 테스트를 빼는 것은 이 캠페인이 금지한 행위다.**

## 검증

머지 전 워크트리에서 **전건 직접 재실행** (base = `5f16693e1`, 리베이스 불필요 — origin/main 미전진):

| 게이트 | 결과 |
|---|---|
| `python3 -m unittest tests.test_relay_watchdog` | rc=0 — **321 passed** |
| `python3 -m unittest -k 4435 tests.test_relay_watchdog` | rc=0 — **67 passed (불변)** |
| base 두 파일 체크아웃 시 | **298 passed** — 원본 테스트 **제거·개명 0건**, 순수 추가 **23건** |
| `scripts/ci-script-checks.sh` | rc=0 |
| docs 게이트 (`generate_inventory_docs.py`) | rc=0, **diff 없음** |
| `scripts/check_relay_authority_contract.py` | rc=0 |
| `cargo fmt --all --check` | rc=0 |

**뮤테이션**: 20건 전부 자기 assert 로 사망 — 리뷰어 독립 하네스 7/7, 구현자 r2 하네스 8/8, r3 신규 5/5.

### ★ 신규 스위트는 이 PR 의 CI 에서 **실행되지 않았다** (GitHub Actions 장애)

**결론: 미실행.** CI 초록이 아니라 **CI 미실행**이다. 정직하게 적는다.

`scripts/ci-script-checks.sh:235` 가 `"$PYTHON" -m unittest tests.test_relay_watchdog tests.test_pg_tunnel` 를 무조건 호출하므로 신규 테스트 23건은 **원래대로라면** `Script checks` 잡에서 실행된다. 그러나 이번 실행에서 `Script checks` 는 **`skipped`** 로 끝났다.

원인은 코드가 아니라 **GitHub Actions 전면 장애**다:

- GitHub 인시던트 시작 **2026-08-06 15:22:49 UTC**, 상태 **major outage**, 17:02 UTC 업데이트 기준 **미해결**
- 공식 문구: *"Workflow runs are still failing or delayed in starting, and some queued jobs may time out."*
- 이 PR 은 **16:42 UTC** 에 열렸다 — 장애 한복판
- 게이팅 잡 `Changed paths` / `relay-authority-contract` 가 hosted `ubuntu-latest` 큐에서 **15분 02초** 대기 후 **스텝을 하나도 실행하지 못한 채 `cancelled`**. `changes` 가 죽자 하위 잡이 전부 `skipped` 되고, `if: always()` 로 fail-closed 인 `*_required_context` 미러가 `failure` 를 냈다
- `CI macOS Trusted` 의 `Resolve macOS runner`(역시 `ubuntu-latest`) 도 **동일하게 15분 01초에 zero-step cancelled**. 재실행 1회도 같은 방식으로 실패
- 같은 워크플로가 오늘 직전까지 12연속 `success` 였고, 이 diff 는 **Rust 파일도 워크플로 파일도 건드리지 않는다**

리포 자체 정책도 이 신호를 인프라 실패로 분류한다 — `scripts/ci/infra-failure-rerun.sh:45` 의 패턴에 `the operation was cancelled` 가 포함된다.

**그러므로 이 PR 은 Actions 복구 후 재실행하여 `Script checks` 가 실제로 초록인 것을 확인하기 전까지 머지하면 안 된다.** 게이트를 우회하거나 완화해서 머지하지 않았다.

대신 **머지 전 워크트리에서 전건을 직접 재실행**했고 위 표가 그 결과다 (`321 passed`, `-k 4435` `67 passed`, `ci-script-checks.sh` rc=0 — 로컬에서는 `Relay watchdog + PG tunnel supervisor tests (#4381/#4378)` 섹션이 실제로 실행됨).

## ⚠️ 배포 전까지 미적용

`scripts/relay_watchdog.py` 는 **리포 파일**이고, 실제로 도는 것은 **배포 사본 `~/.adk/release/bin/relay-watchdog.py`** 다. **이 PR 을 머지해도 프로덕션 워치독의 동작은 바뀌지 않는다.** 배포가 이뤄지기 전까지 #5190 의 증상(999분 오탐 재경보)은 라이브에서 계속된다. **오늘 밤은 무배포 방침**이므로 적용은 다음 배포 사이클로 넘어간다.

## 후속 (별건, 이 PR 범위 밖)

검증 리뷰가 P2 로 남기고 후속으로 넘기라고 명시한 2건을 별도 이슈로 발행한다 (`Refs #5190`):
- Refs #5205 — R7 "두 규약 공존" 의 보상 통제가 무테스트이고 이 브랜치가 침묵 은퇴 빈도를 늘린다
- Refs #5206 — `orphan_stranded_since` 마커가 알려진 경로로 프룬되지 않는다 (`sorted(items)[:33]` 상한을 죽은 마커가 잠식할 수 있음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

