### PR TITLE
fix(discord): give guarded finalizer mailbox residue a recovery owner (#5068)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1018,6 +1018,9 @@ src/
 │   │   │   ├── watcher_handoff.rs
 │   │   │   └── watcher_orphan_cleanup.rs
 │   │   ├── turn_finalizer/
+│   │   │   ├── finalize/
+│   │   │   │   └── tests/
+│   │   │   │       └── residue_tests.rs
 │   │   │   ├── actor_state.rs
 │   │   │   ├── cleanup.rs
 │   │   │   ├── completion_admission.rs
@@ -1026,6 +1029,7 @@ src/
 │   │   │   ├── delivery_lease.rs
 │   │   │   ├── finalize.rs
 │   │   │   ├── finalize_context.rs
+│   │   │   ├── guarded_finish_residue.rs
 │   │   │   ├── reconcile.rs
 │   │   │   └── watcher_backstop.rs
 │   │   ├── turn_view_reconciler/

--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -5815,6 +5815,10 @@ services::discord::turn_finalizer::finalize::tests::finalize_chokepoint_publishe
 services::discord::turn_finalizer::finalize::tests::guarded_miss_preserves_parent_mapping_and_skips_parent_kickoff
 services::discord::turn_finalizer::finalize::tests::identity_guard_mismatch_does_not_release_wrong_owner_and_logs
 services::discord::turn_finalizer::finalize::tests::non_thread_finalize_schedules_no_parent_kickoff
+services::discord::turn_finalizer::finalize::tests::residue_tests::guarded_miss_residue_reconcile_preserves_live_newer_episode
+services::discord::turn_finalizer::finalize::tests::residue_tests::guarded_miss_residue_reconcile_releases_same_terminal_episode_and_rearms_queue
+services::discord::turn_finalizer::finalize::tests::residue_tests::guarded_miss_residue_without_terminal_nonce_is_held
+services::discord::turn_finalizer::finalize::tests::residue_tests::issue_shape_surviving_inflight_row_holds_recovery_on_every_tick
 services::discord::turn_finalizer::finalize::tests::thread_finalize_removes_parent_mapping_and_schedules_parent_kickoff
 services::discord::turn_finalizer::finalize_context::tests::watcher_after_pre_panel_release_only_flips_expected_guard_miss
 services::discord::turn_finalizer::tests::already_finalized_loser_cleans_same_turn_mailbox_and_inflight

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -42,6 +42,7 @@ pub(in crate::services::discord) mod completion_signal;
 mod delivery_lease;
 mod finalize;
 mod finalize_context;
+mod guarded_finish_residue;
 mod reconcile;
 mod watcher_backstop;
 
@@ -59,6 +60,7 @@ use self::completion_admission_actor::{
 pub(in crate::services::discord) use self::completion_signal::{
     CompletionSignal, completion_signal_from_transcript,
 };
+pub(in crate::services::discord) use self::guarded_finish_residue::GuardedFinishResidue;
 // #3479 r9: dormant delivery-lease handlers extracted to the child module; the
 // actor-loop call sites below reference them unqualified, byte-identical.
 #[allow(unused_imports)] // handlers are `#[cfg(unix)]`-conditional + dormant.
@@ -288,6 +290,7 @@ pub(in crate::services::discord) enum FinalizeOutcome {
 /// submit-or-await wrappers.
 pub(in crate::services::discord) struct TurnFinalizer {
     tx: mpsc::UnboundedSender<FinalizeMsg>,
+    guarded_finish_residues: guarded_finish_residue::GuardedFinishResidues,
 }
 
 impl TurnFinalizer {
@@ -303,7 +306,10 @@ impl TurnFinalizer {
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(actor_loop(rx));
         }
-        Arc::new(Self { tx })
+        Arc::new(Self {
+            tx,
+            guarded_finish_residues: Default::default(),
+        })
     }
 
     /// #3018 — register a turn so the ledger knows it exists before any

--- a/src/services/discord/turn_finalizer/cleanup.rs
+++ b/src/services/discord/turn_finalizer/cleanup.rs
@@ -186,6 +186,7 @@ pub(super) fn should_ensure_synthetic_claim_marker(
 #[derive(Clone, Debug)]
 pub(in crate::services::discord) struct SyntheticClaimSnapshot {
     pub(in crate::services::discord) user_msg_id: u64,
+    pub(in crate::services::discord) turn_nonce: Option<String>,
     pub(in crate::services::discord) turn_source_external: bool,
     pub(in crate::services::discord) relay_owner_watcher: bool,
     pub(in crate::services::discord) injected_prompt_message_id: Option<u64>,
@@ -207,6 +208,7 @@ impl SyntheticClaimSnapshot {
         use crate::services::discord::inflight::{RelayOwnerKind, TurnSource};
         Self {
             user_msg_id: row.user_msg_id,
+            turn_nonce: row.turn_nonce.clone(),
             turn_source_external: row.turn_source == TurnSource::ExternalInput,
             relay_owner_watcher: row.relay_owner_kind == RelayOwnerKind::Watcher,
             injected_prompt_message_id: row.injected_prompt_message_id,

--- a/src/services/discord/turn_finalizer/finalize.rs
+++ b/src/services/discord/turn_finalizer/finalize.rs
@@ -26,6 +26,17 @@ pub(super) async fn do_finalize(
     shared: &Arc<SharedData>,
 ) -> FinalizeOutcome {
     let channel_id = key.channel_id;
+    // Capture the terminal episode before any caller-owned/in-function inflight
+    // clear can erase it. Watcher submitters provide the pre-clear snapshot;
+    // other paths may still have the matching row on disk here.
+    let terminal_turn_nonce = submit_snapshot
+        .filter(|snapshot| snapshot.user_msg_id == key.user_msg_id)
+        .and_then(|snapshot| snapshot.turn_nonce.clone())
+        .or_else(|| {
+            crate::services::discord::inflight::load_inflight_state(&provider, channel_id.get())
+                .filter(|state| state.effective_finalizer_turn_id() == key.user_msg_id)
+                .and_then(|state| state.turn_nonce)
+        });
 
     // #3866: test-only injection point — fire a panic INSIDE the finalize
     // side-effect surface, AFTER the caller (`handle_terminal` /
@@ -155,10 +166,30 @@ pub(super) async fn do_finalize(
     // release and counter decrement. (An id-0 orphan keeps today's behaviour.)
     let guarded_finish_missed = key.user_msg_id != 0 && finish.removed_token.is_none();
     if guarded_finish_missed {
-        let active_user_message_id = crate::services::discord::mailbox_snapshot(shared, channel_id)
-            .await
-            .active_user_message_id
-            .map(|id| id.get());
+        let active_snapshot = crate::services::discord::mailbox_snapshot(shared, channel_id).await;
+        let active_user_message_id = active_snapshot.active_user_message_id.map(|id| id.get());
+        let residue_recorded = if let Some(active_user_msg_id) = active_user_message_id
+            && active_snapshot.cancel_token.is_some()
+        {
+            shared.turn_finalizer.guarded_finish_residues().insert(
+                channel_id,
+                GuardedFinishResidue {
+                    expected_user_msg_id: key.user_msg_id,
+                    active_user_msg_id,
+                    generation: key.generation,
+                    provider: provider.clone(),
+                    terminal_turn_nonce: terminal_turn_nonce.clone(),
+                    active_turn_nonce: active_snapshot.active_turn_nonce.clone(),
+                    observed_before: std::time::Instant::now(),
+                    allow_completion_cleanup: ctx.allow_completion_cleanup,
+                    drain_voice: ctx.drain_voice,
+                    terminal_was_cancel: matches!(event, TerminalEvent::Cancel),
+                },
+            );
+            true
+        } else {
+            false
+        };
         if ctx.is_backstop_reconcile_path() {
             tracing::debug!(
                 provider = %provider.as_str(),
@@ -166,6 +197,7 @@ pub(super) async fn do_finalize(
                 expected_user_msg_id = key.user_msg_id,
                 active_user_message_id = active_user_message_id.unwrap_or(0),
                 generation = key.generation,
+                residue_recorded,
                 expected_idempotent = true,
                 "TurnFinalizer identity-guarded mailbox release skipped; active mailbox owner did not match finalizer turn identity"
             );
@@ -176,6 +208,7 @@ pub(super) async fn do_finalize(
                 expected_user_msg_id = key.user_msg_id,
                 active_user_message_id = active_user_message_id.unwrap_or(0),
                 generation = key.generation,
+                residue_recorded,
                 expected_idempotent = false,
                 "TurnFinalizer identity-guarded mailbox release skipped; active mailbox owner did not match finalizer turn identity"
             );
@@ -591,4 +624,6 @@ mod tests {
             "no removed thread-parent mapping means no parent kick"
         );
     }
+
+    mod residue_tests;
 }

--- a/src/services/discord/turn_finalizer/finalize/tests/residue_tests.rs
+++ b/src/services/discord/turn_finalizer/finalize/tests/residue_tests.rs
@@ -1,0 +1,409 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use serenity::model::id::{ChannelId, MessageId, UserId};
+
+use super::*;
+use crate::services::discord::inflight::RelayOwnerKind;
+use crate::services::provider::{CancelToken, ProviderKind};
+use crate::services::turn_orchestrator::{Intervention, InterventionMode};
+
+fn terminal_snapshot(user_msg_id: u64, turn_nonce: &str) -> SyntheticClaimSnapshot {
+    SyntheticClaimSnapshot {
+        user_msg_id,
+        turn_nonce: Some(turn_nonce.to_string()),
+        turn_source_external: false,
+        relay_owner_watcher: false,
+        injected_prompt_message_id: None,
+        tmux_session_name: None,
+        started_at: String::new(),
+        status_message_id: None,
+        status_panel_generation: 0,
+        save_generation: 0,
+        current_tool_line: None,
+        turn_start_offset: None,
+        relay_ownership_only: false,
+        relay_owner_kind: RelayOwnerKind::None,
+    }
+}
+
+fn queued_intervention(message_id: u64) -> Intervention {
+    Intervention {
+        author_id: UserId::new(7),
+        author_is_bot: false,
+        message_id: MessageId::new(message_id),
+        queued_generation: crate::services::discord::runtime_store::load_generation(),
+        source_message_ids: vec![MessageId::new(message_id)],
+        source_message_queued_generations: Vec::new(),
+        source_text_segments: Vec::new(),
+        text: "queued after residual owner".to_string(),
+        mode: InterventionMode::Soft,
+        created_at: std::time::Instant::now(),
+        reply_context: None,
+        has_reply_boundary: false,
+        merge_consecutive: false,
+        pending_uploads: Vec::new(),
+        voice_announcement: None,
+    }
+}
+
+/// Stand in for "a turn-bridge loop still owns this turn": the release gate only
+/// asks whether the row exists, so a placeholder body is enough.
+fn seed_inflight_row(channel_id: ChannelId) -> std::path::PathBuf {
+    let root = crate::services::discord::inflight::inflight_runtime_root().expect("isolated root");
+    let path = crate::services::discord::inflight::inflight_state_path(
+        &root,
+        &ProviderKind::Claude,
+        channel_id.get(),
+    );
+    std::fs::create_dir_all(path.parent().expect("provider dir")).expect("create provider dir");
+    std::fs::write(&path, "{}").expect("seed inflight row");
+    path
+}
+
+async fn reconcile_once(shared: &Arc<SharedData>) {
+    let mut ledger = HashMap::new();
+    let mut pending_admission = HashMap::new();
+    reconcile::reconcile(&mut ledger, &mut pending_admission, shared).await;
+}
+
+async fn seed_active_with_queue(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    active_user_msg_id: u64,
+    queued_user_msg_id: u64,
+) -> Arc<CancelToken> {
+    seed_owner(
+        shared,
+        channel_id,
+        active_user_msg_id,
+        queued_user_msg_id,
+        Arc::new(CancelToken::new()),
+    )
+    .await
+}
+
+async fn seed_owner(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    active_user_msg_id: u64,
+    queued_user_msg_id: u64,
+    token: Arc<CancelToken>,
+) -> Arc<CancelToken> {
+    assert!(
+        crate::services::discord::mailbox_try_start_turn(
+            shared,
+            channel_id,
+            token.clone(),
+            UserId::new(7),
+            MessageId::new(active_user_msg_id),
+        )
+        .await
+    );
+    shared
+        .mailbox(channel_id)
+        .replace_queue(
+            vec![queued_intervention(queued_user_msg_id)],
+            crate::services::discord::queue_persistence_context(
+                shared,
+                &ProviderKind::Claude,
+                channel_id,
+            ),
+        )
+        .await;
+    shared.restart.global_active.store(1, Ordering::Relaxed);
+    token
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn guarded_miss_residue_reconcile_releases_same_terminal_episode_and_rearms_queue() {
+    crate::services::discord::turn_finalizer::tests::with_isolated_runtime_root(|| async move {
+        let shared = crate::services::discord::make_shared_data_for_tests_with_storage(None);
+        let channel_id = ChannelId::new(5_068_100);
+        let terminal_user_msg_id = 5_068_101;
+        let residual_user_msg_id = 5_068_102;
+        let queued_user_msg_id = 5_068_103;
+        let token = seed_active_with_queue(
+            &shared,
+            channel_id,
+            residual_user_msg_id,
+            queued_user_msg_id,
+        )
+        .await;
+        let nonce = token.turn_nonce().expect("fresh token nonce").to_string();
+        let terminal_snapshot = terminal_snapshot(terminal_user_msg_id, &nonce);
+
+        let outcome = do_finalize(
+            TurnKey::new(channel_id, terminal_user_msg_id, 0),
+            ProviderKind::Claude,
+            &TerminalEvent::Complete,
+            FinalizeContext::bridge(),
+            Some(&terminal_snapshot),
+            &shared,
+        )
+        .await;
+        assert!(matches!(
+            outcome,
+            FinalizeOutcome::Finalized {
+                removed_token: None,
+                ..
+            }
+        ));
+        assert!(
+            shared
+                .turn_finalizer
+                .guarded_finish_residues()
+                .contains_key(&channel_id),
+            "guarded miss must leave a reconciler-owned residue"
+        );
+        let residue = shared
+            .turn_finalizer
+            .guarded_finish_residues()
+            .get(&channel_id)
+            .expect("residue asserted present");
+        assert_eq!(residue.expected_user_msg_id, terminal_user_msg_id);
+        assert_eq!(residue.active_user_msg_id, residual_user_msg_id);
+        assert_eq!(residue.reason(), "active_owner_identity_mismatch");
+        drop(residue);
+
+        // #5068 r2 (R4): the inflight conjunct was vacuously true in every r1
+        // fixture. A live turn-bridge owner holds the release even here, where
+        // the terminal episode is proven, and the residue survives for retry.
+        let inflight_row = seed_inflight_row(channel_id);
+        reconcile_once(&shared).await;
+        assert!(
+            crate::services::discord::mailbox_snapshot(&shared, channel_id)
+                .await
+                .cancel_token
+                .is_some(),
+            "an inflight owner must hold the release despite a proven terminal episode"
+        );
+        assert!(
+            shared
+                .turn_finalizer
+                .guarded_finish_residues()
+                .contains_key(&channel_id),
+            "a held residue stays armed for the next reconcile tick"
+        );
+        std::fs::remove_file(&inflight_row).expect("clear inflight row");
+
+        reconcile_once(&shared).await;
+
+        let snapshot = crate::services::discord::mailbox_snapshot(&shared, channel_id).await;
+        assert!(
+            snapshot.cancel_token.is_none(),
+            "the same terminal episode must release its residual mailbox owner"
+        );
+        assert_eq!(
+            snapshot
+                .intervention_queue
+                .iter()
+                .map(|item| item.message_id)
+                .collect::<Vec<_>>(),
+            vec![MessageId::new(queued_user_msg_id)],
+            "recovery must preserve the queued user message"
+        );
+        assert!(
+            shared
+                .restart
+                .deferred_hook_channels
+                .contains_key(&channel_id),
+            "residual release must leave a queue kickoff owner"
+        );
+        assert!(
+            !shared
+                .turn_finalizer
+                .guarded_finish_residues()
+                .contains_key(&channel_id)
+        );
+        assert_eq!(shared.restart.global_active.load(Ordering::Relaxed), 0);
+    })
+    .await;
+}
+
+/// #5068 r3 (R5) — the REPORTED incident, and this fix's honest scope boundary.
+///
+/// In the report (2026-07-31) the guarded miss at `13:19:48` is followed by
+/// `13:22:12`–`13:22:36` `tui_direct_pending_start` finding a FOREIGN prior
+/// inflight *still live on the same channel*, aborting "without overwriting".
+/// Nothing in that window clears the row, so the fixture seeds it BEFORE the
+/// finalize and never removes it. Even in the shape most favourable to recovery
+/// (the terminal carries the owner's own episode nonce, so `release_authorized`
+/// holds and only the inflight conjunct is left), every tick holds: a live
+/// turn-bridge owner is precisely the evidence #5176 forbids releasing under,
+/// and overriding it is the #5191 double-execution hazard. So this commit gives
+/// the residue a recovery OWNER and reclaims the mailbox as soon as the row goes
+/// away (pinned by the release test above) — but while the row survives, so does
+/// the user-visible symptom. Draining a stranded FOREIGN row is a different
+/// owner's job (`STALE_FOREIGN_INFLIGHT_MIN_AGE_SECS` demotion), not this fix.
+#[tokio::test(flavor = "current_thread")]
+async fn issue_shape_surviving_inflight_row_holds_recovery_on_every_tick() {
+    crate::services::discord::turn_finalizer::tests::with_isolated_runtime_root(|| async move {
+        let shared = crate::services::discord::make_shared_data_for_tests_with_storage(None);
+        let channel_id = ChannelId::new(5_068_400);
+        let terminal_user_msg_id = 5_068_401;
+        let token = seed_active_with_queue(&shared, channel_id, 5_068_402, 5_068_403).await;
+        let nonce = token.turn_nonce().expect("fresh token nonce").to_string();
+        let inflight_row = seed_inflight_row(channel_id);
+
+        do_finalize(
+            TurnKey::new(channel_id, terminal_user_msg_id, 0),
+            ProviderKind::Claude,
+            &TerminalEvent::Complete,
+            FinalizeContext::bridge(),
+            Some(&terminal_snapshot(terminal_user_msg_id, &nonce)),
+            &shared,
+        )
+        .await;
+        assert!(
+            inflight_row.exists(),
+            "the incident's premise is a row the guarded-miss finalize does NOT clear"
+        );
+
+        // The report's escalation budget spans ~24s of 1s reconcile ticks.
+        for _ in 0..5 {
+            reconcile_once(&shared).await;
+        }
+
+        assert!(
+            crate::services::discord::mailbox_snapshot(&shared, channel_id)
+                .await
+                .cancel_token
+                .is_some(),
+            "MEASURED: while the FOREIGN row survives the reconciler holds every tick, so the \
+             reported symptom is NOT recovered by this commit alone"
+        );
+        assert!(
+            shared
+                .turn_finalizer
+                .guarded_finish_residues()
+                .contains_key(&channel_id),
+            "the residue stays armed, so recovery is owned rather than abandoned"
+        );
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn guarded_miss_residue_reconcile_preserves_live_newer_episode() {
+    crate::services::discord::turn_finalizer::tests::with_isolated_runtime_root(|| async move {
+        let shared = crate::services::discord::make_shared_data_for_tests_with_storage(None);
+        let channel_id = ChannelId::new(5_068_200);
+        let stale_terminal_user_msg_id = 5_068_201;
+        let live_user_msg_id = 5_068_202;
+        let queued_user_msg_id = 5_068_203;
+        let live_token =
+            seed_active_with_queue(&shared, channel_id, live_user_msg_id, queued_user_msg_id).await;
+        let stale_terminal_snapshot =
+            terminal_snapshot(stale_terminal_user_msg_id, "different-terminal-episode");
+
+        let outcome = do_finalize(
+            TurnKey::new(channel_id, stale_terminal_user_msg_id, 0),
+            ProviderKind::Claude,
+            &TerminalEvent::Complete,
+            FinalizeContext::bridge(),
+            Some(&stale_terminal_snapshot),
+            &shared,
+        )
+        .await;
+        assert!(matches!(
+            outcome,
+            FinalizeOutcome::Finalized {
+                removed_token: None,
+                ..
+            }
+        ));
+
+        reconcile_once(&shared).await;
+
+        let snapshot = crate::services::discord::mailbox_snapshot(&shared, channel_id).await;
+        assert_eq!(
+            snapshot.active_user_message_id,
+            Some(MessageId::new(live_user_msg_id))
+        );
+        assert!(Arc::ptr_eq(
+            snapshot.cancel_token.as_ref().expect("live token survives"),
+            &live_token
+        ));
+        assert!(!live_token.cancelled.load(Ordering::Relaxed));
+        assert_eq!(snapshot.intervention_queue.len(), 1);
+        assert_eq!(shared.restart.global_active.load(Ordering::Relaxed), 1);
+        assert!(
+            !shared
+                .turn_finalizer
+                .guarded_finish_residues()
+                .contains_key(&channel_id),
+            "a nonce-proven newer episode consumes the stale residue without being released"
+        );
+    })
+    .await;
+}
+
+/// #5068: a residue with NO terminal episode nonce must be held, never released.
+///
+/// A recovery-restored token carries no persisted nonce, so the mailbox reports
+/// `active_turn_nonce = None` and the terminal carries none either. Comparing
+/// the two as `Option == Option` reads `None`/`None` as "same episode"
+/// (fail-open); `same_terminal_episode` is fail-closed, so nothing here proves a
+/// release. This fixture is what makes the "held pending terminal evidence"
+/// branch non-vacuous: granting release authority unconditionally — in
+/// `reconcile.rs` or inside `release_authorized` — releases a mailbox nobody
+/// proved terminal and the assertions below fail on their own.
+#[tokio::test(flavor = "current_thread")]
+async fn guarded_miss_residue_without_terminal_nonce_is_held() {
+    crate::services::discord::turn_finalizer::tests::with_isolated_runtime_root(|| async move {
+        let shared = crate::services::discord::make_shared_data_for_tests_with_storage(None);
+        let channel_id = ChannelId::new(5_068_300);
+        let terminal_user_msg_id = 5_068_301;
+        let token = seed_owner(
+            &shared,
+            channel_id,
+            5_068_302,
+            5_068_303,
+            Arc::new(CancelToken::from_persisted_turn_nonce(None)),
+        )
+        .await;
+        let mut nonceless_terminal = terminal_snapshot(terminal_user_msg_id, "");
+        nonceless_terminal.turn_nonce = None;
+
+        do_finalize(
+            TurnKey::new(channel_id, terminal_user_msg_id, 0),
+            ProviderKind::Claude,
+            &TerminalEvent::Complete,
+            FinalizeContext::bridge(),
+            Some(&nonceless_terminal),
+            &shared,
+        )
+        .await;
+
+        let observed = crate::services::discord::mailbox_snapshot(&shared, channel_id).await;
+        assert!(
+            observed.active_turn_nonce.is_none(),
+            "this fixture exists to exercise the both-nonces-absent shape"
+        );
+        reconcile_once(&shared).await;
+
+        let after = crate::services::discord::mailbox_snapshot(&shared, channel_id).await;
+        assert!(
+            Arc::ptr_eq(
+                after
+                    .cancel_token
+                    .as_ref()
+                    .expect("a missing terminal nonce must never authorize a release"),
+                &token
+            ),
+            "the residual owner is still the exact token the reconciler refused to release"
+        );
+        assert!(!token.cancelled.load(Ordering::Relaxed));
+        assert_eq!(shared.restart.global_active.load(Ordering::Relaxed), 1);
+        assert!(
+            shared
+                .turn_finalizer
+                .guarded_finish_residues()
+                .contains_key(&channel_id),
+            "a residue held for want of evidence stays armed instead of being dropped"
+        );
+    })
+    .await;
+}

--- a/src/services/discord/turn_finalizer/guarded_finish_residue.rs
+++ b/src/services/discord/turn_finalizer/guarded_finish_residue.rs
@@ -1,0 +1,148 @@
+use std::sync::Arc;
+
+use serenity::model::id::{ChannelId, MessageId};
+
+use super::SharedData;
+use crate::services::provider::ProviderKind;
+use crate::services::turn_orchestrator::ChannelMailboxSnapshot;
+
+pub(super) type GuardedFinishResidues = dashmap::DashMap<ChannelId, GuardedFinishResidue>;
+
+impl super::TurnFinalizer {
+    pub(in crate::services::discord) const fn guarded_finish_residues(
+        &self,
+    ) -> &GuardedFinishResidues {
+        &self.guarded_finish_residues
+    }
+}
+
+/// A guarded finalize that could not release the mailbox owner it observed.
+///
+/// This is deliberately richer than a log line: the actor reconciler keeps
+/// retrying the exact observed owner and health can distinguish residual
+/// foreground ownership from ordinary queued work. Missing episode nonces are
+/// fail-closed and therefore never authorize a release on their own.
+///
+/// KNOWN GAP (#5068 r2, deliberate): in-memory only, so a dcserver restart
+/// drops any residue awaiting recovery. Restart rebuilds mailbox state from the
+/// persisted inflight rows, so it does not strand the mailbox; what is lost is
+/// the skip reason and owner identity #5068 §1 asked to keep durable. Follow-up
+/// work, not smuggled into this fix.
+#[derive(Clone, Debug)]
+pub(in crate::services::discord) struct GuardedFinishResidue {
+    pub(in crate::services::discord) expected_user_msg_id: u64,
+    pub(in crate::services::discord) active_user_msg_id: u64,
+    pub(in crate::services::discord) generation: u64,
+    pub(in crate::services::discord) provider: ProviderKind,
+    pub(in crate::services::discord) terminal_turn_nonce: Option<String>,
+    pub(in crate::services::discord) active_turn_nonce: Option<String>,
+    pub(in crate::services::discord) observed_before: std::time::Instant,
+    pub(in crate::services::discord) allow_completion_cleanup: bool,
+    pub(in crate::services::discord) drain_voice: bool,
+    pub(in crate::services::discord) terminal_was_cancel: bool,
+}
+
+impl GuardedFinishResidue {
+    pub(in crate::services::discord) const fn reason(&self) -> &'static str {
+        "active_owner_identity_mismatch"
+    }
+
+    /// Does `snapshot` still show the exact foreground owner this residue
+    /// recorded? A successor can reuse a Discord message id during recovery, so
+    /// the nonce is mandatory alongside the id.
+    pub(in crate::services::discord) fn matches_observed_owner(
+        &self,
+        snapshot: &ChannelMailboxSnapshot,
+    ) -> bool {
+        snapshot.cancel_token.is_some()
+            && snapshot.active_user_message_id.map(|id| id.get()) == Some(self.active_user_msg_id)
+            && snapshot.active_turn_nonce == self.active_turn_nonce
+    }
+
+    /// The recorded terminal provably belongs to the SAME episode the mailbox
+    /// still anchors. Fail-closed: an absent or empty terminal nonce proves
+    /// nothing, including against an owner that itself has no nonce.
+    pub(super) fn same_terminal_episode(&self, snapshot: &ChannelMailboxSnapshot) -> bool {
+        self.terminal_turn_nonce
+            .as_deref()
+            .filter(|nonce| !nonce.is_empty())
+            .is_some_and(|terminal_nonce| {
+                snapshot.active_turn_nonce.as_deref() == Some(terminal_nonce)
+            })
+    }
+
+    /// #5068 r2 — THE release-authority question, asked in exactly one place.
+    /// The reconciler ACTS on it and health REPORTS it; a second spelling is the
+    /// #5052 failure mode (health once read `None`/`None` nonces as "same
+    /// episode", fail-open, where this is fail-closed).
+    pub(in crate::services::discord) fn release_authorized(
+        &self,
+        snapshot: &ChannelMailboxSnapshot,
+    ) -> bool {
+        self.same_terminal_episode(snapshot)
+            || snapshot
+                .cancel_token
+                .as_ref()
+                .is_some_and(|token| token.cancelled.load(std::sync::atomic::Ordering::Relaxed))
+    }
+}
+
+/// Release the exact residual episode after the reconciler has proved it
+/// terminal. The mailbox actor rechecks owner id, episode nonce, and the
+/// pre-observation start cutoff atomically, closing both the different-id and
+/// same-id-successor races before it removes the token.
+pub(super) async fn release(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    residue: &GuardedFinishResidue,
+) -> bool {
+    let owned_role_override = super::cleanup::snapshot_role_override(shared, channel_id);
+    let finish = super::super::mailbox_finish_turn_if_matches_episode_started_before(
+        shared,
+        &residue.provider,
+        channel_id,
+        MessageId::new(residue.active_user_msg_id),
+        residue.active_turn_nonce.clone(),
+        residue.observed_before,
+    )
+    .await;
+    let Some(token) = finish.removed_token.as_ref() else {
+        return false;
+    };
+
+    if residue.allow_completion_cleanup && !residue.terminal_was_cancel {
+        token.mark_completion_cleanup();
+    }
+    token
+        .cancelled
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    super::super::saturating_decrement_global_active(shared);
+    super::cleanup::clear_watchdog_and_kick_thread_parents_after_turn_release(
+        shared,
+        &residue.provider,
+        channel_id,
+    )
+    .await;
+
+    let voice_deferred_enqueued = if residue.drain_voice {
+        shared
+            .voice_barge_in
+            .drain_deferred_after_turn(shared, &residue.provider, channel_id)
+            .await
+    } else {
+        false
+    };
+    let has_pending = finish.has_pending || voice_deferred_enqueued;
+    if !has_pending {
+        super::cleanup::remove_owned_role_override(shared, channel_id, owned_role_override);
+    }
+    super::cleanup::rearm_queue_backstop_after_mailbox_release(
+        shared,
+        &residue.provider,
+        channel_id,
+        has_pending,
+        "guarded_finish_residue_release",
+    )
+    .await;
+    true
+}

--- a/src/services/discord/turn_finalizer/reconcile.rs
+++ b/src/services/discord/turn_finalizer/reconcile.rs
@@ -83,6 +83,125 @@ async fn run_backstop_finalize(
     }
 }
 
+/// Consume identity-guarded finalize misses without ever converting a stale
+/// terminal into channel-scoped release authority.
+///
+/// A different mailbox owner id or episode nonce means a newer turn won and
+/// the residue is resolved without mutation. A matching episode is released
+/// only through the same #5176 terminal-evidence conjunction: explicit release
+/// authority (same terminal episode, or a separately cancelled token), no
+/// inflight owner, and structurally idle TUI. The mailbox actor then repeats an
+/// id + nonce + start-cutoff CAS at the mutation point.
+async fn reconcile_guarded_finish_residues(shared: &Arc<SharedData>) {
+    let residues: Vec<_> = shared
+        .turn_finalizer
+        .guarded_finish_residues()
+        .iter()
+        .map(|entry| (*entry.key(), entry.value().clone()))
+        .collect();
+
+    for (channel_id, residue) in residues {
+        let snapshot = crate::services::discord::mailbox_snapshot(shared, channel_id).await;
+        // The owner we recorded is gone — idle mailbox, different id, or a
+        // successor that reused the id under a new nonce. Nothing of ours is
+        // left to recover, so consume the record without mutating anything.
+        if !residue.matches_observed_owner(&snapshot) {
+            shared
+                .turn_finalizer
+                .guarded_finish_residues()
+                .remove(&channel_id);
+            continue;
+        }
+        let same_terminal_episode = residue.same_terminal_episode(&snapshot);
+        let proven_different_episode = match (
+            residue.terminal_turn_nonce.as_deref(),
+            snapshot.active_turn_nonce.as_deref(),
+        ) {
+            (Some(terminal_nonce), Some(active_nonce)) => {
+                !terminal_nonce.is_empty()
+                    && !active_nonce.is_empty()
+                    && terminal_nonce != active_nonce
+            }
+            _ => false,
+        };
+        if proven_different_episode {
+            // This is the protected counter-direction: a stale terminal saw a
+            // genuinely newer episode. The record has been consumed; no
+            // recovery work belongs to that live owner.
+            shared
+                .turn_finalizer
+                .guarded_finish_residues()
+                .remove(&channel_id);
+            tracing::debug!(
+                provider = residue.provider.as_str(),
+                channel_id = channel_id.get(),
+                expected_user_msg_id = residue.expected_user_msg_id,
+                active_user_msg_id = residue.active_user_msg_id,
+                reason = residue.reason(),
+                "TurnFinalizer guarded miss resolved as a different live episode"
+            );
+            continue;
+        }
+        let token = snapshot
+            .cancel_token
+            .as_ref()
+            .expect("active residual snapshot must carry its token");
+        let separately_cancelled = token.cancelled.load(std::sync::atomic::Ordering::Relaxed);
+        // Single definition, shared with the health reporter (#5068 r2).
+        let release_authorized = residue.release_authorized(&snapshot);
+        let inflight_state_present = crate::services::discord::inflight::inflight_state_file_exists(
+            &residue.provider,
+            channel_id.get(),
+        );
+        let tui_structurally_idle =
+            crate::services::discord::zombie_foreground_release::tui_structurally_idle(
+                &residue.provider,
+                token,
+            );
+        let release = crate::services::discord::zombie_foreground_release::terminal_evidence_allows_mailbox_release(
+            true,
+            release_authorized,
+            inflight_state_present,
+            tui_structurally_idle,
+        );
+        if !release {
+            tracing::debug!(
+                provider = residue.provider.as_str(),
+                channel_id = channel_id.get(),
+                expected_user_msg_id = residue.expected_user_msg_id,
+                active_user_msg_id = residue.active_user_msg_id,
+                generation = residue.generation,
+                reason = residue.reason(),
+                same_terminal_episode,
+                separately_cancelled,
+                inflight_state_present,
+                tui_structurally_idle,
+                "TurnFinalizer residual mailbox ownership held pending terminal evidence"
+            );
+            continue;
+        }
+
+        let released = super::guarded_finish_residue::release(shared, channel_id, &residue).await;
+        if released {
+            shared
+                .turn_finalizer
+                .guarded_finish_residues()
+                .remove(&channel_id);
+            tracing::warn!(
+                provider = residue.provider.as_str(),
+                channel_id = channel_id.get(),
+                expected_user_msg_id = residue.expected_user_msg_id,
+                released_user_msg_id = residue.active_user_msg_id,
+                generation = residue.generation,
+                reason = residue.reason(),
+                same_terminal_episode,
+                separately_cancelled,
+                "TurnFinalizer reconciler released terminal residual mailbox ownership"
+            );
+        }
+    }
+}
+
 /// The one reconciler. Finalizes deadline-armed gate-timeouts whose backstop
 /// elapsed, GUARANTEES the phase-5a watcher far-backstop for watcher-owned
 /// `register_start` Pending entries that never received a terminal (re-checking
@@ -95,6 +214,11 @@ pub(super) async fn reconcile(
     shared: &Arc<SharedData>,
 ) {
     let now = Instant::now();
+
+    // #5068: the finalizer actor owns guarded-miss recovery. Run before other
+    // deadline work so releasing a terminal residue promptly publishes the
+    // mailbox completion edge and re-arms queued delivery.
+    reconcile_guarded_finish_residues(shared).await;
 
     // #3041 P1-1 (B3): reclaim any delivery lease whose acquire deadline has
     // elapsed (a dead/stuck holder), so a legitimate successor can acquire. This

--- a/src/services/discord/zombie_foreground_release.rs
+++ b/src/services/discord/zombie_foreground_release.rs
@@ -97,6 +97,14 @@ impl ZombieForegroundVerdict {
 pub(in crate::services::discord) fn classify_zombie_foreground(
     evidence: ZombieForegroundEvidence,
 ) -> ZombieForegroundVerdict {
+    if terminal_evidence_allows_mailbox_release(
+        evidence.mailbox_holds_active_turn,
+        evidence.active_turn_cancelled,
+        evidence.inflight_state_present,
+        evidence.tui_structurally_idle,
+    ) {
+        return ZombieForegroundVerdict::Release;
+    }
     if !evidence.mailbox_holds_active_turn {
         return ZombieForegroundVerdict::HoldNoActiveTurn;
     }
@@ -109,7 +117,37 @@ pub(in crate::services::discord) fn classify_zombie_foreground(
     if !evidence.tui_structurally_idle {
         return ZombieForegroundVerdict::HoldTuiNotIdle;
     }
-    ZombieForegroundVerdict::Release
+    // Dead by construction. Staying total keeps the P0 relay cancel path free of
+    // a panic point, and the fall-through HOLDS rather than releasing: reaching
+    // it can only mean a conjunct was added above without its negation arm, i.e.
+    // evidence this function cannot account for — and unaccounted evidence is
+    // fail-closed everywhere else in #5068. `debug_assert!` makes that loud in
+    // tests; release builds hold and retry on the next tick.
+    debug_assert!(
+        false,
+        "classify_zombie_foreground negation chain is not exhaustive"
+    );
+    ZombieForegroundVerdict::HoldTuiNotIdle
+}
+
+/// Shared #5176 terminal-evidence conjunction.
+///
+/// Cancel surfaces pass `release_authorized = token.cancelled`.  The #5068
+/// finalizer reconciler passes an exact episode-nonce match between the
+/// terminal submission and the residual mailbox token.  Both callers must
+/// independently prove that no inflight bridge owns the turn and that the TUI
+/// is structurally terminal. Keeping the conjunction here prevents the two
+/// recovery surfaces from drifting toward different definitions of a zombie.
+pub(in crate::services::discord) const fn terminal_evidence_allows_mailbox_release(
+    mailbox_holds_active_turn: bool,
+    release_authorized: bool,
+    inflight_state_present: bool,
+    tui_structurally_idle: bool,
+) -> bool {
+    mailbox_holds_active_turn
+        && release_authorized
+        && !inflight_state_present
+        && tui_structurally_idle
 }
 
 /// What a cancel surface actually accomplished at the mailbox.
@@ -147,7 +185,10 @@ fn readiness_is_structurally_idle(readiness: IndependentTmuxReadiness) -> bool {
 /// means. A token with no bound tmux session has no pane to contradict the
 /// other two evidences, so it is treated as structurally idle — the inflight
 /// and cancelled gates still have to pass.
-fn tui_structurally_idle(provider: &ProviderKind, token: &Arc<CancelToken>) -> bool {
+pub(in crate::services::discord) fn tui_structurally_idle(
+    provider: &ProviderKind,
+    token: &Arc<CancelToken>,
+) -> bool {
     let Some(tmux_session) = token
         .tmux_session_name()
         .filter(|session| !session.trim().is_empty())


### PR DESCRIPTION
## What

A finalizer that misses the identity guard leaves the mailbox occupied by an owner nobody will release: `idle_queue_snapshot_has_kickable_backlog` returns false for as long as `cancel_token.is_some()`, so the queued user message is parked indefinitely and never retried. The queue item is preserved, not dropped — but the user-visible damage is the same, because no code path owns the reclaim.

This PR records the miss as a `GuardedFinishResidue` (observed owner id, both episode nonces, the pre-observation cutoff) and makes the turn-finalizer actor its owner. Each reconcile tick re-snapshots the mailbox and either consumes the record (owner gone, or a nonce proves a genuinely newer episode owns the channel) or releases it through the shared #5176 terminal-evidence conjunction. The mailbox actor repeats an id + nonce + start-cutoff CAS at the mutation point, closing the different-id and same-id-successor races.

Release authority is defined **once**, in `GuardedFinishResidue::release_authorized`, and is fail-closed: an absent or empty terminal nonce proves nothing, including against an owner that has no nonce either. A second spelling of this question is the #5052 failure mode, so there is exactly one.

`classify_zombie_foreground` now derives its Release arm from the shared conjunction instead of restating it, and its dead fall-through **holds** instead of releasing — an unaccounted conjunct must not silently drop a mailbox the shared predicate declined to authorize.

## Scope — measured, not asserted

`issue_shape_surviving_inflight_row_holds_recovery_on_every_tick` reproduces the report *including* the FOREIGN inflight row the logs show surviving, and pins that the reconciler HOLDS on every tick while that row exists. This commit owns the residue and reclaims it the moment the inflight owner goes away; **draining a stranded FOREIGN row remains a separate owner's job.**

Issue proposal 2 (requeue / failed transition) is deliberately **NOT** implemented — requeuing preserved work is the #5191 double-execution hazard.

## ⚠️ Landing condition (from review — do not drop this)

> 착지 승인. 단 한 가지 조건: **이 PR로 #5068을 닫지 마라.** 사용자 피해의 핵심(큐된 메시지가 끝내 실행되지 않음)은 stale FOREIGN inflight 행이 살아 있는 동안 그대로 남아 있고, 그 행의 demotion 소유자는 이 레인 범위 밖이다.

**#5068 stays OPEN after this merges.** The follow-up owner for the stale FOREIGN inflight row demotion is already filed as **#5208**.

Refs #5068
Refs #5208
Refs #5176
Refs #5052

## Redlines — untouched

`relay-authority-contract` redline files are not touched by this diff:
- `scripts/run_relay_authority_mutations.sh`
- `scripts/check_relay_authority_contract.py`
- `src/services/discord/session_relay_sink/terminal_handoff.rs`

## Diff size

787 lines (780 insertions / 7 deletions), within the 800-line lane cap. Commit `f208ea844`, on base `5f16693e1`.

## Local gates

Measured values are posted as a follow-up comment on this PR once the local run completes.

## Split

This is **PR A** of a two-part split. PR B (`5bc2d31b8`, 376 lines — surfaces stranded mailbox residue in health + the kickoff log) is rebased and opened **after** this one merges.
