### PR TITLE
feat(discord): surface stranded mailbox residue in health and the kickoff log (#5068)

### DIFF
--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -2324,6 +2324,7 @@ services::discord::health::liveness_authority::tests::single_observe_per_tick
 services::discord::health::liveness_authority::tests::transient_unknown_expires_after_monotonic_budget
 services::discord::health::liveness_authority::tests::verdict_overwrite_child
 services::discord::health::liveness_authority::tests::vouch_enforces_ttl_identity_and_absolute_ceiling
+services::discord::health::mailbox::tests::agent_turn_status_separates_releasable_and_permanently_held_residue
 services::discord::health::provider_probe::tests::classifier_preserves_healthy_provider
 services::discord::health::provider_probe::tests::classifier_reports_probe_degradation_reasons
 services::discord::health::provider_probe::tests::mixed_gateway_and_standby_is_not_classified_as_cluster_standby
@@ -2419,6 +2420,7 @@ services::discord::health::snapshot::tests::bound_selector_absent_when_no_source
 services::discord::health::snapshot::tests::bound_selector_falls_back_to_runtime_binding
 services::discord::health::snapshot::tests::bound_selector_prefers_inflight_over_binding
 services::discord::health::snapshot::tests::enriched_tmux_identity_precedes_mailbox_fallback
+services::discord::health::snapshot::tests::health_detail_marks_same_episode_guarded_finish_occupancy_residual
 services::discord::health::snapshot::tests::mailbox_snapshot_absent_channel_is_peek_only_for_health
 services::discord::health::snapshot::tests::provider_scoped_snapshot_timeout_does_not_fallback_to_provider_scan
 services::discord::health::snapshot::tests::rebind_origin_idle_only_without_cancel_token
@@ -5818,7 +5820,10 @@ services::discord::turn_finalizer::finalize::tests::non_thread_finalize_schedule
 services::discord::turn_finalizer::finalize::tests::residue_tests::guarded_miss_residue_reconcile_preserves_live_newer_episode
 services::discord::turn_finalizer::finalize::tests::residue_tests::guarded_miss_residue_reconcile_releases_same_terminal_episode_and_rearms_queue
 services::discord::turn_finalizer::finalize::tests::residue_tests::guarded_miss_residue_without_terminal_nonce_is_held
+services::discord::turn_finalizer::finalize::tests::residue_tests::health_names_the_permanently_held_residue_instead_of_calling_it_active
+services::discord::turn_finalizer::finalize::tests::residue_tests::health_still_shows_residual_while_an_inflight_owner_holds_the_release
 services::discord::turn_finalizer::finalize::tests::residue_tests::issue_shape_surviving_inflight_row_holds_recovery_on_every_tick
+services::discord::turn_finalizer::finalize::tests::residue_tests::kickoff_guard_skip_preserves_queue_and_arms_recovery
 services::discord::turn_finalizer::finalize::tests::thread_finalize_removes_parent_mapping_and_schedules_parent_kickoff
 services::discord::turn_finalizer::finalize_context::tests::watcher_after_pre_panel_release_only_flips_expected_guard_miss
 services::discord::turn_finalizer::tests::already_finalized_loser_cleans_same_turn_mailbox_and_inflight

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -22,7 +22,7 @@ use crate::services::provider::ProviderKind;
 //     send-to-agent/outbound dispatch, re-exported here for compatibility
 mod headless_turn;
 pub(in crate::services::discord) mod liveness_authority;
-mod mailbox;
+pub(in crate::services::discord) mod mailbox;
 mod provider_probe;
 #[path = "health/rebind_request.rs"]
 mod rebind_request;

--- a/src/services/discord/health/mailbox.rs
+++ b/src/services/discord/health/mailbox.rs
@@ -5,6 +5,7 @@ use poise::serenity_prelude::ChannelId;
 use crate::services::discord::SharedData;
 use crate::services::discord::relay_health::{RelayHealthSnapshot, RelayStallState};
 use crate::services::provider::ProviderKind;
+use crate::services::turn_orchestrator::ChannelMailboxSnapshot;
 use crate::services::turn_orchestrator::registry_purge::MailboxPurgeOutcome;
 
 use super::HealthRegistry;
@@ -29,6 +30,70 @@ pub(super) struct MailboxHealthSnapshot {
     pub(super) stall_shadow_verdict: Option<StallVerdict>,
     pub(super) relay_stall_state: RelayStallState,
     pub(super) relay_health: RelayHealthSnapshot,
+}
+
+/// How a guarded-finish residue is sitting on this channel's mailbox, as the
+/// finalizer reconciler's own predicates answer it (#5068 r3).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::services::discord) enum ResidualOccupancy {
+    /// No residue is anchored to the owner the mailbox currently reports.
+    None,
+    /// A residue is anchored but the reconciler has NOT been handed release
+    /// authority. Nothing resolves this on its own: it takes a user cancel or a
+    /// newer episode taking the channel. Reporting it as `active` — which is
+    /// what this surface did before r3 — makes a permanently stranded mailbox
+    /// indistinguishable from a turn that is simply running.
+    Held,
+    /// A residue is anchored AND authorized. The reconciler releases it as soon
+    /// as its I/O evidence gates clear, so this state is transient by
+    /// construction.
+    Releasable,
+}
+
+pub(in crate::services::discord) const fn mailbox_agent_turn_status(
+    has_cancel_token: bool,
+    residual: ResidualOccupancy,
+) -> &'static str {
+    match residual {
+        ResidualOccupancy::Releasable => "residual",
+        ResidualOccupancy::Held => "residual_held",
+        ResidualOccupancy::None if has_cancel_token => "active",
+        ResidualOccupancy::None => "idle",
+    }
+}
+
+/// #5068: health REPORTS the question the finalizer reconciler DECIDES, by
+/// calling its predicates instead of restating them — an observer that says
+/// `residual` where the decider says "held, evidence insufficient" is the #5052
+/// split-brain shape.
+///
+/// r3 splits the answer in two rather than collapsing it. Both arms come from
+/// the SAME two predicates the reconciler branches on
+/// (`matches_observed_owner`, `release_authorized`), so there is still exactly
+/// one definition of release authority in the codebase; what changed is only
+/// that health stopped throwing away the second bit. Health deliberately does
+/// NOT consult the I/O evidence gates (`inflight_state_present`,
+/// `tui_structurally_idle`) — those decide WHEN the reconciler acts, not whether
+/// a residue exists, and a residue waiting on them is still one an operator
+/// wants to see. That keeps this a projection of the decider's state, never a
+/// second opinion about it.
+pub(in crate::services::discord) fn residual_occupancy(
+    shared: &super::super::SharedData,
+    channel: ChannelId,
+    snapshot: &ChannelMailboxSnapshot,
+) -> ResidualOccupancy {
+    shared
+        .turn_finalizer
+        .guarded_finish_residues()
+        .get(&channel)
+        .filter(|residue| residue.matches_observed_owner(snapshot))
+        .map_or(ResidualOccupancy::None, |residue| {
+            if residue.release_authorized(snapshot) {
+                ResidualOccupancy::Releasable
+            } else {
+                ResidualOccupancy::Held
+            }
+        })
 }
 
 /// #3293 (c): probe a channel's mailbox state WITHOUT creating a registry
@@ -109,5 +174,31 @@ pub async fn purge_idle_channel_mailbox_registry_entry(
     MailboxRegistryPurgeResult {
         removed,
         skipped_reason,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ResidualOccupancy, mailbox_agent_turn_status};
+
+    #[test]
+    fn agent_turn_status_separates_releasable_and_permanently_held_residue() {
+        assert_eq!(
+            mailbox_agent_turn_status(true, ResidualOccupancy::Releasable),
+            "residual"
+        );
+        assert_eq!(
+            mailbox_agent_turn_status(true, ResidualOccupancy::Held),
+            "residual_held",
+            "a residue nothing will release on its own must never read as an ordinary active turn"
+        );
+        assert_eq!(
+            mailbox_agent_turn_status(true, ResidualOccupancy::None),
+            "active"
+        );
+        assert_eq!(
+            mailbox_agent_turn_status(false, ResidualOccupancy::None),
+            "idle"
+        );
     }
 }

--- a/src/services/discord/health/snapshot.rs
+++ b/src/services/discord/health/snapshot.rs
@@ -819,11 +819,10 @@ async fn build_health_snapshot_with_options(
                     recovery_started: snapshot.recovery_started_at.is_some(),
                     active_request_owner: snapshot.active_request_owner.map(|id| id.get()),
                     active_user_message_id: mailbox_active_user_msg_id,
-                    agent_turn_status: if mailbox_has_cancel_token {
-                        "active"
-                    } else {
-                        "idle"
-                    },
+                    agent_turn_status: super::mailbox::mailbox_agent_turn_status(
+                        mailbox_has_cancel_token,
+                        super::mailbox::residual_occupancy(&entry.shared, channel, &snapshot),
+                    ),
                     watcher_attached: session.watcher_attached,
                     inflight_state_present: session.inflight_state_present,
                     tmux_present,
@@ -1275,5 +1274,63 @@ mod tests {
             crate::services::discord::ChannelMailboxRegistry::global_handle(channel).is_none(),
             "health snapshot construction must remain peek-only for absent channels"
         );
+    }
+
+    #[test]
+    fn health_detail_marks_same_episode_guarded_finish_occupancy_residual() {
+        let _lock = crate::services::turn_orchestrator::test_support::lock_test_env();
+        let tmp = tempfile::tempdir().expect("temp runtime root");
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path().to_str().unwrap()) };
+        let _env_guard = EnvGuard;
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("health detail test runtime")
+            .block_on(async {
+                let registry = HealthRegistry::new();
+                let shared = crate::services::discord::make_shared_data_for_tests();
+                registry
+                    .register(ProviderKind::Claude.as_str().to_string(), shared.clone())
+                    .await;
+                let channel =
+                    ChannelId::new(NEXT_ABSENT_MAILBOX_CHANNEL.fetch_add(1, Ordering::Relaxed));
+                let active_user_msg_id = 5_068_301;
+                let token = Arc::new(CancelToken::new());
+                let nonce = token.turn_nonce().expect("fresh token nonce").to_string();
+                assert!(
+                    crate::services::discord::mailbox_try_start_turn(
+                        &shared,
+                        channel,
+                        token,
+                        UserId::new(7),
+                        MessageId::new(active_user_msg_id),
+                    )
+                    .await
+                );
+                shared.turn_finalizer.guarded_finish_residues().insert(
+                    channel,
+                    crate::services::discord::turn_finalizer::GuardedFinishResidue {
+                        expected_user_msg_id: 5_068_300,
+                        active_user_msg_id,
+                        generation: 0,
+                        provider: ProviderKind::Claude,
+                        terminal_turn_nonce: Some(nonce.clone()),
+                        active_turn_nonce: Some(nonce),
+                        observed_before: std::time::Instant::now(),
+                        allow_completion_cleanup: true,
+                        drain_voice: true,
+                        terminal_was_cancel: false,
+                    },
+                );
+
+                let json = serde_json::to_value(build_health_snapshot(&registry).await)
+                    .expect("serialize residual mailbox health");
+                assert_eq!(json["mailboxes"][0]["agent_turn_status"], "residual");
+                assert_eq!(
+                    json["mailboxes"][0]["active_user_message_id"],
+                    active_user_msg_id
+                );
+            });
     }
 }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -2987,11 +2987,8 @@ async fn kickoff_idle_queue_channel(
     let fresh_snapshot = mailbox_snapshot(shared, channel_id).await;
     if !idle_queue_channel_has_kickable_backlog(shared, provider, channel_id, &fresh_snapshot).await
     {
-        tracing::info!(
-            channel_id = channel_id.get(),
-            provider = provider.as_str(),
-            "KICKOFF: skipped queued turn after fresh mailbox/TUI guard"
-        );
+        turn_finalizer::handle_idle_queue_guard_skip(shared, provider, channel_id, &fresh_snapshot)
+            .await;
         return IdleQueueKickoffChannelOutcome::default();
     }
 

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -61,6 +61,7 @@ pub(in crate::services::discord) use self::completion_signal::{
     CompletionSignal, completion_signal_from_transcript,
 };
 pub(in crate::services::discord) use self::guarded_finish_residue::GuardedFinishResidue;
+pub(in crate::services::discord) use self::guarded_finish_residue::handle_idle_queue_guard_skip;
 // #3479 r9: dormant delivery-lease handlers extracted to the child module; the
 // actor-loop call sites below reference them unqualified, byte-identical.
 #[allow(unused_imports)] // handlers are `#[cfg(unix)]`-conditional + dormant.

--- a/src/services/discord/turn_finalizer/finalize/tests/residue_tests.rs
+++ b/src/services/discord/turn_finalizer/finalize/tests/residue_tests.rs
@@ -116,6 +116,154 @@ async fn seed_owner(
     token
 }
 
+/// What `/health` would print for this channel right now.
+async fn health_status(shared: &Arc<SharedData>, channel_id: ChannelId) -> &'static str {
+    use crate::services::discord::health::mailbox;
+    let snapshot = crate::services::discord::mailbox_snapshot(shared, channel_id).await;
+    mailbox::mailbox_agent_turn_status(
+        snapshot.cancel_token.is_some(),
+        mailbox::residual_occupancy(shared, channel_id, &snapshot),
+    )
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn kickoff_guard_skip_preserves_queue_and_arms_recovery() {
+    crate::services::discord::turn_finalizer::tests::with_isolated_runtime_root(|| async move {
+        let shared = crate::services::discord::make_shared_data_for_tests_with_storage(None);
+        let channel_id = ChannelId::new(5_068_050);
+        let active_user_msg_id = 5_068_051;
+        let queued_user_msg_id = 5_068_052;
+        seed_active_with_queue(&shared, channel_id, active_user_msg_id, queued_user_msg_id).await;
+
+        let snapshot = crate::services::discord::mailbox_snapshot(&shared, channel_id).await;
+        super::handle_idle_queue_guard_skip(&shared, &ProviderKind::Claude, channel_id, &snapshot)
+            .await;
+
+        let after = crate::services::discord::mailbox_snapshot(&shared, channel_id).await;
+        assert_eq!(
+            after.intervention_queue.len(),
+            1,
+            "guard skip must not dequeue"
+        );
+        assert_eq!(
+            after.intervention_queue[0].message_id.get(),
+            queued_user_msg_id
+        );
+        assert!(
+            shared
+                .restart
+                .deferred_hook_channels
+                .contains_key(&channel_id),
+            "guard skip with preserved backlog must leave a retry owner"
+        );
+    })
+    .await;
+}
+
+/// #5068 r3 (R2) — the state health used to be unable to name.
+///
+/// A residue with no terminal episode nonce is held by the reconciler FOREVER:
+/// no I/O gate clears, and nothing but a user cancel or a newer episode changes
+/// the answer. Before r3 `residual_occupancy` collapsed to a single bool, so
+/// this channel reported `active` — byte-identical to a turn that is simply
+/// running, which is precisely the case an operator most needs to spot. Health
+/// still refuses to claim `residual` (the reconciler will not act), but it now
+/// says the mailbox is held rather than pretending it is busy.
+#[tokio::test(flavor = "current_thread")]
+async fn health_names_the_permanently_held_residue_instead_of_calling_it_active() {
+    crate::services::discord::turn_finalizer::tests::with_isolated_runtime_root(|| async move {
+        let shared = crate::services::discord::make_shared_data_for_tests_with_storage(None);
+        let channel_id = ChannelId::new(5_068_500);
+        let terminal_user_msg_id = 5_068_501;
+        seed_owner(
+            &shared,
+            channel_id,
+            5_068_502,
+            5_068_503,
+            Arc::new(CancelToken::from_persisted_turn_nonce(None)),
+        )
+        .await;
+        let mut nonceless_terminal = terminal_snapshot(terminal_user_msg_id, "");
+        nonceless_terminal.turn_nonce = None;
+
+        do_finalize(
+            TurnKey::new(channel_id, terminal_user_msg_id, 0),
+            ProviderKind::Claude,
+            &TerminalEvent::Complete,
+            FinalizeContext::bridge(),
+            Some(&nonceless_terminal),
+            &shared,
+        )
+        .await;
+        reconcile_once(&shared).await;
+
+        assert!(
+            crate::services::discord::mailbox_snapshot(&shared, channel_id)
+                .await
+                .cancel_token
+                .is_some(),
+            "fixture premise: the reconciler holds this residue and never resolves it"
+        );
+        assert_eq!(
+            health_status(&shared, channel_id).await,
+            "residual_held",
+            "an indefinitely stranded mailbox must not be reported as an ordinary active turn"
+        );
+    })
+    .await;
+}
+
+/// #5068 r3 (R3) — the documented asymmetry, on the shape that actually has an
+/// inflight row instead of one where the conjunct is vacuous.
+///
+/// `residual_occupancy` claims it does not consult the I/O evidence gates,
+/// because a residue waiting on a turn-bridge owner is transient and still worth
+/// showing. This pins that claim against the reconciler's real behaviour in the
+/// same fixture: the reconciler HOLDS (the row is on disk) and health
+/// nevertheless reports `residual`, not `active` and not `residual_held`.
+#[tokio::test(flavor = "current_thread")]
+async fn health_still_shows_residual_while_an_inflight_owner_holds_the_release() {
+    crate::services::discord::turn_finalizer::tests::with_isolated_runtime_root(|| async move {
+        let shared = crate::services::discord::make_shared_data_for_tests_with_storage(None);
+        let channel_id = ChannelId::new(5_068_600);
+        let terminal_user_msg_id = 5_068_601;
+        let token = seed_active_with_queue(&shared, channel_id, 5_068_602, 5_068_603).await;
+        let nonce = token.turn_nonce().expect("fresh token nonce").to_string();
+        let inflight_row = seed_inflight_row(channel_id);
+
+        do_finalize(
+            TurnKey::new(channel_id, terminal_user_msg_id, 0),
+            ProviderKind::Claude,
+            &TerminalEvent::Complete,
+            FinalizeContext::bridge(),
+            Some(&terminal_snapshot(terminal_user_msg_id, &nonce)),
+            &shared,
+        )
+        .await;
+        reconcile_once(&shared).await;
+
+        assert!(
+            crate::services::discord::mailbox_snapshot(&shared, channel_id)
+                .await
+                .cancel_token
+                .is_some(),
+            "fixture premise: the inflight row makes the reconciler hold this tick"
+        );
+        assert_eq!(
+            health_status(&shared, channel_id).await,
+            "residual",
+            "a residue held only by an I/O gate stays visible as residual"
+        );
+
+        // And the label tracks the decider: once the gate clears and the
+        // reconciler releases, health stops reporting occupancy at all.
+        std::fs::remove_file(&inflight_row).expect("clear inflight row");
+        reconcile_once(&shared).await;
+        assert_eq!(health_status(&shared, channel_id).await, "idle");
+    })
+    .await;
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn guarded_miss_residue_reconcile_releases_same_terminal_episode_and_rearms_queue() {
     crate::services::discord::turn_finalizer::tests::with_isolated_runtime_root(|| async move {

--- a/src/services/discord/turn_finalizer/guarded_finish_residue.rs
+++ b/src/services/discord/turn_finalizer/guarded_finish_residue.rs
@@ -16,6 +16,61 @@ impl super::TurnFinalizer {
     }
 }
 
+/// #5068 §2: the kickoff guard that parks a queued turn. The issue's retracted
+/// proposal 2 wanted this path to requeue; it must NOT — the item is preserved
+/// right where it is, and requeuing preserved work is the #5191 double-execution
+/// hazard. What is true is that every caller of this path is a race or a
+/// deferred kick, so `INFO: skipped` understated a park that only a residue
+/// owner or an active-turn completion will ever undo. Say so, name the owner,
+/// and make sure a retry is actually armed.
+pub(in crate::services::discord) async fn handle_idle_queue_guard_skip(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    snapshot: &ChannelMailboxSnapshot,
+) {
+    if !super::super::idle_queue_snapshot_has_pending_or_marker_backlog(
+        shared, provider, channel_id, snapshot,
+    ) {
+        tracing::debug!(
+            channel_id = channel_id.get(),
+            provider = provider.as_str(),
+            "KICKOFF: stale channel selection had no queued backlog after fresh mailbox/TUI guard"
+        );
+        return;
+    }
+
+    let slow_backstop_armed =
+        super::super::queue_io::arm_slow_idle_queue_backstop_if_queue_nonempty(
+            shared,
+            provider,
+            channel_id,
+            "fresh_mailbox_tui_guard_skip",
+        )
+        .await;
+    let residue_recorded = shared
+        .turn_finalizer
+        .guarded_finish_residues()
+        .contains_key(&channel_id);
+    tracing::warn!(
+        channel_id = channel_id.get(),
+        provider = provider.as_str(),
+        active_user_message_id = snapshot
+            .active_user_message_id
+            .map(|id| id.get())
+            .unwrap_or(0),
+        queue_depth = snapshot.intervention_queue.len(),
+        residue_recorded,
+        slow_backstop_armed,
+        recovery_owner = if residue_recorded {
+            "turn_finalizer_reconcile"
+        } else {
+            "active_turn_completion"
+        },
+        "KICKOFF: queued turn preserved after fresh mailbox/TUI guard; recovery remains armed"
+    );
+}
+
 /// A guarded finalize that could not release the mailbox owner it observed.
 ///
 /// This is deliberately richer than a log line: the actor reconciler keeps


### PR DESCRIPTION
## What

**PR B of a two-part split.** PR A (#5211, merged as `62025546f`) gave the guarded finalizer mailbox residue a recovery *owner*. This PR makes that residue **observable**: it surfaces stranded mailbox residue in the health snapshot and in the kickoff log, so a channel parked behind a residue record is visible instead of silently stuck.

- `health/mailbox.rs` (new) exposes the stranded-residue view.
- `health/snapshot.rs` folds it into the existing snapshot.
- The kickoff log records the residue so the stall is attributable at the point a user notices it.

## Split / base

- Rebased onto the post-A `main` (`62025546f`), **not** reusing PR A's base.
- Content drift vs the reviewed commit `5bc2d31b8`: **zero** (`git diff 5bc2d31b8 HEAD` is empty).
- 376 lines (365 insertions / 11 deletions) across 8 files.

## ⚠️ Landing condition (from review — do not drop this)

> 착지 승인. 단 한 가지 조건: **이 PR로 #5068을 닫지 마라.** 사용자 피해의 핵심(큐된 메시지가 끝내 실행되지 않음)은 stale FOREIGN inflight 행이 살아 있는 동안 그대로 남아 있고, 그 행의 demotion 소유자는 이 레인 범위 밖이다.

**#5068 stays OPEN.** Follow-up owner for the stale FOREIGN inflight row demotion: **#5208**.

Refs #5068
Refs #5208

## Redlines — untouched

`scripts/run_relay_authority_mutations.sh`, `scripts/check_relay_authority_contract.py`, `src/services/discord/session_relay_sink/terminal_handoff.rs` are not in this diff.

## Gates

GitHub Actions is still in `major_outage` with webhooks throttled, so CI is expected to publish nothing here either. The local landing gate is re-run **fresh against this PR's own code** — PR A's gate result is explicitly **not** reused. Results are posted as a comment before merge, and any `FAIL` blocks the merge.
