### PR TITLE
fix(discord): keep delivery on the session Claude actually rotated to (R1)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -538,6 +538,7 @@ src/
 │   │   │   ├── snapshot.rs
 │   │   │   ├── stall_liveness.rs
 │   │   │   ├── stall_verdict.rs
+│   │   │   ├── transcript_binding_stall.rs
 │   │   │   └── watcher_respawn.rs
 │   │   ├── idle_recap/
 │   │   │   ├── card.rs

--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -2488,6 +2488,14 @@ services::discord::health::stall_verdict::tests::verdict_serializes_for_health_d
 services::discord::health::tests::reload_bot_tokens_keeps_previous_client_when_credential_is_missing
 services::discord::health::tests::reload_bot_tokens_reports_success_and_invalidates_user_id_cache
 services::discord::health::tests::utility_bot_user_id_cache_rejects_stale_http_after_reload
+services::discord::health::transcript_binding_stall::tests::a_binding_left_on_a_superseded_session_alerts_after_the_rotation_record_is_gone
+services::discord::health::transcript_binding_stall::tests::a_dead_pane_or_detached_relay_is_somebody_elses_verdict
+services::discord::health::transcript_binding_stall::tests::a_live_turn_waiting_on_a_frozen_transcript_alerts
+services::discord::health::transcript_binding_stall::tests::a_pending_rotation_makes_a_frozen_binding_a_confirmed_fault
+services::discord::health::transcript_binding_stall::tests::a_superseded_binding_whose_transcript_still_grows_is_not_alerted_on
+services::discord::health::transcript_binding_stall::tests::a_transcript_that_grew_recently_is_healthy_even_mid_rotation
+services::discord::health::transcript_binding_stall::tests::an_idle_channel_is_never_alerted_on
+services::discord::health::transcript_binding_stall::tests::an_unresolvable_bound_transcript_is_not_this_verdict
 services::discord::health::watcher_respawn::tests::deadman_switch_escalates_after_threshold_then_clears_on_watcher_return
 services::discord::health::watcher_respawn::tests::deadman_switch_ignores_idle_channel_without_relay_work
 services::discord::health::watcher_respawn::tests::force_clean_respawn_offset_floor_ignores_stale_prior_generation_frontier
@@ -5154,7 +5162,12 @@ services::discord::tui_prompt_relay::rehydration::tests::markerless_codex_tui_fa
 services::discord::tui_prompt_relay::rehydration::tests::markerless_codex_tui_fallback_rejects_ambiguous_same_cwd_sessions
 services::discord::tui_prompt_relay::session_rotation_settle::tests::a_committed_terminal_settles_even_with_bytes_left_over
 services::discord::tui_prompt_relay::session_rotation_settle::tests::a_fully_drained_frozen_transcript_settles_its_unfinalizable_inflight
+services::discord::tui_prompt_relay::session_rotation_settle::tests::a_hook_adopted_binding_outranks_the_stale_launch_script
+services::discord::tui_prompt_relay::session_rotation_settle::tests::a_hook_adopted_binding_with_no_transcript_on_disk_does_not_win
+services::discord::tui_prompt_relay::session_rotation_settle::tests::a_launch_script_that_caught_up_takes_authority_back
+services::discord::tui_prompt_relay::session_rotation_settle::tests::a_pane_with_no_adoption_on_record_still_yields_to_the_launch_script
 services::discord::tui_prompt_relay::session_rotation_settle::tests::a_stalled_drain_gives_up_and_settles_at_the_bound
+services::discord::tui_prompt_relay::session_rotation_settle::tests::rehydration_does_not_revert_an_adopted_binding_after_the_settle_pass_runs
 services::discord::tui_prompt_relay::session_rotation_settle::tests::rotation_without_a_pinned_inflight_rebinds_immediately
 services::discord::tui_prompt_relay::session_rotation_settle::tests::undelivered_bytes_in_the_frozen_transcript_are_drained_before_the_rotation_settles
 services::discord::tui_prompt_relay::synthetic_orphan_reclaim::tests::orphan_row_is_reclaimable_matches_stale_session_bound_orphan_on_caller_session
@@ -7031,6 +7044,8 @@ services::tui_prompt_control::tests::recognizes_known_local_controls_without_mat
 services::tui_prompt_control::tests::recognizes_raw_and_envelope_without_using_them_as_a_dedup_key
 services::tui_prompt_dedupe::session_rotation::tests::drain_progress_resets_the_stall_counter_and_stall_accumulates
 services::tui_prompt_dedupe::session_rotation::tests::second_hop_preserves_the_original_frozen_transcript
+services::tui_prompt_dedupe::session_rotation::tests::settling_a_rotation_does_not_retire_the_adopted_session_authority
+services::tui_prompt_dedupe::session_rotation::tests::the_adopted_authority_is_writable_without_a_rotation_record
 services::tui_prompt_dedupe::tests::advance_offset_rejects_mismatched_path_when_relay_override_differs
 services::tui_prompt_dedupe::tests::advances_runtime_binding_offset_for_same_output_path
 services::tui_prompt_dedupe::tests::advances_runtime_binding_relay_offset_separately_from_runtime_path

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -36,6 +36,8 @@ mod session_enrichment;
 mod snapshot;
 mod stall_liveness;
 mod stall_verdict;
+// #5188 (R5/R6): a delivery binding pointed at a transcript Claude abandoned.
+mod transcript_binding_stall;
 mod watcher_respawn;
 
 // `HeadlessAgentTurnReservation` has no external referent today (callers

--- a/src/services/discord/health/liveness_authority.rs
+++ b/src/services/discord/health/liveness_authority.rs
@@ -619,6 +619,7 @@ mod tests {
             mailbox_active_turn_nonce: None,
             bound_output_path: None,
             bound_session_id: None,
+            transcript_binding_stall: "none",
             inflight_terminal_delivery_committed: false,
             inflight_identity: None,
             inflight_finalizer_turn_id: None,

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -815,6 +815,7 @@ mod tests {
             mailbox_active_turn_nonce: None,
             bound_output_path: None,
             bound_session_id: None,
+            transcript_binding_stall: "none",
             inflight_terminal_delivery_committed: false,
             inflight_identity: Some(crate::services::discord::inflight::InflightTurnIdentity {
                 user_msg_id: 9001,

--- a/src/services/discord/health/relay_dead_reattach.rs
+++ b/src/services/discord/health/relay_dead_reattach.rs
@@ -198,6 +198,7 @@ mod tests {
             mailbox_active_turn_nonce: None,
             bound_output_path: None,
             bound_session_id: None,
+            transcript_binding_stall: "none",
             inflight_terminal_delivery_committed: false,
             inflight_identity: None,
             inflight_finalizer_turn_id: None,

--- a/src/services/discord/health/snapshot.rs
+++ b/src/services/discord/health/snapshot.rs
@@ -7,6 +7,7 @@ use super::provider_probe::{self, ProviderHealthSnapshot};
 use super::redaction;
 use super::session_enrichment::SessionEnrichment;
 use super::stall_verdict;
+use super::transcript_binding_stall::{self, resolve_bound_selector};
 use super::{BotTokenReloadScopes, HealthRegistry, bot_token_reload_scopes};
 use crate::services::discord;
 use crate::services::discord::SharedData;
@@ -111,6 +112,10 @@ pub struct WatcherStateSnapshot {
     /// advances a watermark) is intentionally never consulted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bound_session_id: Option<String>,
+    /// #5188 (R5/R6): `"none"`, or why a delivery binding is pointed at a
+    /// transcript that stopped growing. See
+    /// [`super::transcript_binding_stall::TranscriptBindingStall`].
+    pub transcript_binding_stall: &'static str,
     /// #3126: `true` when the in-flight row records a turn whose terminal
     /// assistant response has already been committed
     /// (`InflightTurnState::terminal_delivery_committed`). A row with this set
@@ -208,39 +213,6 @@ fn ownerless_external_input_inflight_is_idle(
     inflight: Option<&discord::inflight::InflightTurnState>,
 ) -> bool {
     inflight.is_some_and(discord::inflight::ownerless_external_input_inflight_is_stale)
-}
-
-/// #4408 phase-2 (I1): resolve the transcript path / provider session the relay
-/// tail is bound to, surfaced on `watcher-state` so the out-of-band watchdog can
-/// compare the server's asserted selector (B) against its own growth-aware
-/// transcript pick (F).
-///
-/// Precedence is per field: a live inflight row's persisted `output_path` /
-/// `session_id` win because they are the authoritative binding; when the inflight
-/// row is absent — or leaves a field blank — we fall back to the in-memory tmux
-/// runtime binding's `relay_output_path` / `session_id`. Both inputs come from
-/// sync single-shot lookups that never straddle an await (so no
-/// `await_holding_lock` allow is introduced), and the side-effecting
-/// claude-session-id GET path is intentionally NOT consulted. A field is `None`
-/// when neither source knows it, so serialization omits it and the watchdog fails
-/// closed instead of alarming on an unknown bind.
-fn resolve_bound_selector(
-    inflight_output_path: Option<&str>,
-    inflight_session_id: Option<&str>,
-    binding: Option<&crate::services::tui_prompt_dedupe::TuiRuntimeBinding>,
-) -> (Option<String>, Option<String>) {
-    fn non_blank(value: Option<&str>) -> Option<String> {
-        value
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string)
-    }
-
-    let bound_output_path = non_blank(inflight_output_path)
-        .or_else(|| non_blank(binding.map(|binding| binding.relay_output_path())));
-    let bound_session_id = non_blank(inflight_session_id)
-        .or_else(|| non_blank(binding.and_then(|binding| binding.session_id.as_deref())));
-    (bound_output_path, bound_session_id)
 }
 
 fn relay_active_turn_from_inflight(
@@ -640,6 +612,15 @@ async fn watcher_state_snapshot_for_shared(
             .and_then(|state| state.session_id.as_deref()),
         tmux_runtime_binding.as_ref(),
     );
+    let transcript_binding_stall = transcript_binding_stall::resolve_transcript_binding_stall(
+        provider_name,
+        authoritative_tmux_session.as_deref(),
+        bound_output_path.as_deref(),
+        bound_session_id.as_deref(),
+        session.attached,
+        tmux_session_alive,
+        session.inflight_state_present,
+    );
     Some(WatcherStateSnapshot {
         provider: provider_name.to_string(),
         attached: session.attached,
@@ -663,6 +644,7 @@ async fn watcher_state_snapshot_for_shared(
         mailbox_active_turn_nonce: mailbox_snapshot.active_turn_nonce.clone(),
         bound_output_path,
         bound_session_id,
+        transcript_binding_stall: transcript_binding_stall.as_str(),
         inflight_terminal_delivery_committed: session.inflight_terminal_delivery_committed(),
         inflight_identity: session
             .inflight

--- a/src/services/discord/health/stall_liveness.rs
+++ b/src/services/discord/health/stall_liveness.rs
@@ -1097,6 +1097,7 @@ mod tests {
             mailbox_active_turn_nonce: None,
             bound_output_path: None,
             bound_session_id: None,
+            transcript_binding_stall: "none",
             inflight_terminal_delivery_committed: false,
             inflight_identity: None,
             inflight_finalizer_turn_id: None,

--- a/src/services/discord/health/stall_liveness/redrive_grace.rs
+++ b/src/services/discord/health/stall_liveness/redrive_grace.rs
@@ -817,6 +817,7 @@ mod tests {
             mailbox_active_turn_nonce: None,
             bound_output_path: None,
             bound_session_id: None,
+            transcript_binding_stall: "none",
             inflight_terminal_delivery_committed: false,
             inflight_identity: Some(
                 crate::services::discord::inflight::InflightTurnIdentity {

--- a/src/services/discord/health/stall_verdict.rs
+++ b/src/services/discord/health/stall_verdict.rs
@@ -570,6 +570,7 @@ mod tests {
             mailbox_active_turn_nonce: None,
             bound_output_path: None,
             bound_session_id: None,
+            transcript_binding_stall: "none",
             inflight_terminal_delivery_committed: false,
             inflight_identity: None,
             inflight_finalizer_turn_id: None,

--- a/src/services/discord/health/transcript_binding_stall.rs
+++ b/src/services/discord/health/transcript_binding_stall.rs
@@ -1,0 +1,381 @@
+//! #5188 (R5/R6): make a transcript binding that points at a DEAD file visible.
+//!
+//! ## Why this needs its own signal
+//! When `/clear` rotated the Claude session and delivery stayed bound to the
+//! frozen transcript, the relay ran for 31 minutes and exited reporting
+//! `RelayMetricsSnapshot { frames_received: 0, frames_delivered: 0,
+//! terminal_commits: 0, terminal_skips: 0, dropped_frames: 0, sink_errors: 0 }`.
+//!
+//! Every failure counter was zero. Nothing had failed — the relay simply never
+//! looked at a file that was growing, so there was nothing to fail at. That
+//! snapshot is **byte-identical to a healthy idle channel**, which is exactly why
+//! the incident was silent: no `ERROR`, and the only clue was a `WARN` whose
+//! wording read like success.
+//!
+//! So "zero frames" alone must never raise an alarm — it would fire on every idle
+//! channel and be tuned out. It only becomes evidence when CROSSED with proof
+//! that the pane should be producing output right now. This module is that
+//! cross-check, and it deliberately returns [`TranscriptBindingStall::None`] for
+//! the ambiguous cases rather than guessing.
+
+/// How long the bound transcript may stand still before it counts as frozen.
+///
+/// Comfortably longer than a slow tool call so an ordinary long turn never trips
+/// it, and far shorter than the ~31 minutes the observed incident stayed silent.
+pub(in crate::services::discord) const BOUND_TRANSCRIPT_FROZEN_ALERT_SECS: u64 = 5 * 60;
+
+/// Evidence for the cross-check, captured by the caller.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub(in crate::services::discord) struct TranscriptBindingStallView {
+    /// A relay is attached for this session.
+    pub relay_attached: bool,
+    /// The tmux pane is alive — the TUI still exists to produce output.
+    pub tmux_alive: bool,
+    /// Seconds since the transcript the binding points at last grew. `None` when
+    /// no bound transcript could be resolved or stat'ed, which is a different
+    /// (already-reported) problem and never this verdict.
+    pub bound_transcript_idle_secs: Option<u64>,
+    /// An inflight turn is waiting on that transcript. A turn in flight is a
+    /// promise that bytes are owed.
+    pub inflight_present: bool,
+    /// A Claude session rotation for this pane is on record and not yet fully
+    /// propagated (`tui_prompt_dedupe::claude_session_rotation_for_tmux`).
+    ///
+    /// SHORT-LIVED: the settle pass retires that record within a poll or two of
+    /// the rotation, which is orders of magnitude sooner than the 5-minute
+    /// freeze threshold below. It is therefore almost never the field that
+    /// catches a real incident — see `binding_session_is_superseded`.
+    pub rotation_pending: bool,
+    /// Delivery is bound to a session id that is NOT the one the running Claude
+    /// process last reported for this pane
+    /// (`tui_prompt_dedupe::hook_adopted_claude_session_id`).
+    ///
+    /// This is the field that makes the verdict reachable. It is derived from
+    /// the pane-lifetime adoption store, so unlike `rotation_pending` it is still
+    /// true five minutes later — which is exactly when a frozen transcript
+    /// becomes reportable. It is also positive proof rather than a guess: the
+    /// process itself named a different session, so the file this binding points
+    /// at cannot grow again.
+    pub binding_session_is_superseded: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::services::discord) enum TranscriptBindingStall {
+    /// Nothing to report, INCLUDING the genuinely ambiguous "quiet channel with a
+    /// quiet transcript" — reporting that would be crying wolf on every idle pane.
+    None,
+    /// Confirmed #5188 shape: the pane is alive, the bound transcript has stopped
+    /// growing, and a session rotation is on record — delivery is reading a file
+    /// Claude has abandoned.
+    FrozenAfterSessionRotation,
+    /// The pane is alive with a turn in flight, but the transcript that turn is
+    /// waiting on has not grown for minutes. Bytes are owed and nothing is
+    /// arriving, whatever the cause.
+    FrozenWithLiveTurn,
+}
+
+impl TranscriptBindingStall {
+    pub(in crate::services::discord) const fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::FrozenAfterSessionRotation => "frozen_after_session_rotation",
+            Self::FrozenWithLiveTurn => "frozen_with_live_turn",
+        }
+    }
+
+    pub(in crate::services::discord) const fn is_alerting(self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
+
+/// Classify a bound transcript that has stopped growing. Pure.
+pub(in crate::services::discord) fn classify_transcript_binding_stall(
+    view: TranscriptBindingStallView,
+) -> TranscriptBindingStall {
+    if !view.relay_attached || !view.tmux_alive {
+        return TranscriptBindingStall::None;
+    }
+    let Some(idle_secs) = view.bound_transcript_idle_secs else {
+        return TranscriptBindingStall::None;
+    };
+    if idle_secs < BOUND_TRANSCRIPT_FROZEN_ALERT_SECS {
+        return TranscriptBindingStall::None;
+    }
+    // Positive proof that Claude moved on: the file this binding names cannot
+    // ever grow again.
+    //
+    // Two independent witnesses, because the obvious one is nearly always gone
+    // by the time this check can fire. `rotation_pending` lives for a poll or
+    // two; `binding_session_is_superseded` lives as long as the pane does. The
+    // residual shape that matters in production — rotation record already
+    // retired, no inflight left, binding still naming the frozen transcript — is
+    // reachable ONLY through the second witness, and it is the shape the #5188
+    // incident actually sat in for 31 minutes.
+    if view.rotation_pending || view.binding_session_is_superseded {
+        return TranscriptBindingStall::FrozenAfterSessionRotation;
+    }
+    if view.inflight_present {
+        return TranscriptBindingStall::FrozenWithLiveTurn;
+    }
+    // Alive pane, quiet transcript, nothing owed: an idle channel. This is the
+    // case that makes a bare `frames_received == 0` alarm useless, so it stays
+    // silent here on purpose.
+    TranscriptBindingStall::None
+}
+
+/// #4408 phase-2 (I1): resolve the transcript path / provider session the relay
+/// tail is bound to, surfaced on `watcher-state` so the out-of-band watchdog can
+/// compare the server's asserted selector (B) against its own growth-aware
+/// transcript pick (F).
+///
+/// Precedence is per field: a live inflight row's persisted `output_path` /
+/// `session_id` win because they are the authoritative binding; when the inflight
+/// row is absent — or leaves a field blank — we fall back to the in-memory tmux
+/// runtime binding's `relay_output_path` / `session_id`. Both inputs come from
+/// sync single-shot lookups that never straddle an await (so no
+/// `await_holding_lock` allow is introduced), and the side-effecting
+/// claude-session-id GET path is intentionally NOT consulted. A field is `None`
+/// when neither source knows it, so serialization omits it and the watchdog fails
+/// closed instead of alarming on an unknown bind.
+pub(in crate::services::discord) fn resolve_bound_selector(
+    inflight_output_path: Option<&str>,
+    inflight_session_id: Option<&str>,
+    binding: Option<&crate::services::tui_prompt_dedupe::TuiRuntimeBinding>,
+) -> (Option<String>, Option<String>) {
+    fn non_blank(value: Option<&str>) -> Option<String> {
+        value
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    }
+
+    let bound_output_path = non_blank(inflight_output_path)
+        .or_else(|| non_blank(binding.map(|binding| binding.relay_output_path())));
+    let bound_session_id = non_blank(inflight_session_id)
+        .or_else(|| non_blank(binding.and_then(|binding| binding.session_id.as_deref())));
+    (bound_output_path, bound_session_id)
+}
+
+/// #5188 (R5/R6): gather the evidence for [`classify_transcript_binding_stall`]
+/// and emit the bounded incident when it alerts.
+///
+/// Lives here rather than inline in the snapshot builder because it is the same
+/// concern as [`resolve_bound_selector`] above — what transcript is delivery
+/// bound to, and is that transcript still alive — and because `snapshot.rs` sits
+/// against the 1000-line giant-file threshold.
+///
+/// Costs one `stat` of a path the caller already resolved plus an in-memory
+/// ledger lookup, so it is safe on the health-endpoint path.
+pub(in crate::services::discord) fn resolve_transcript_binding_stall(
+    provider_name: &str,
+    tmux_session: Option<&str>,
+    bound_output_path: Option<&str>,
+    bound_session_id: Option<&str>,
+    relay_attached: bool,
+    tmux_session_alive: Option<bool>,
+    inflight_present: bool,
+) -> TranscriptBindingStall {
+    let bound_transcript_idle_secs = bound_output_path
+        .map(std::path::Path::new)
+        .and_then(|path| std::fs::metadata(path).ok())
+        .and_then(|metadata| metadata.modified().ok())
+        .and_then(|modified| modified.elapsed().ok())
+        .map(|elapsed| elapsed.as_secs());
+    // Compare what delivery is bound to against what the running Claude process
+    // last told us it is writing. Both sides must be known: an unknown bound
+    // session, or a pane that never reported an adoption, is not evidence of
+    // anything and must fail closed to `None`.
+    let hook_adopted_session_id =
+        tmux_session.and_then(crate::services::tui_prompt_dedupe::hook_adopted_claude_session_id);
+    let binding_session_is_superseded = match (
+        bound_session_id.map(str::trim),
+        hook_adopted_session_id.as_deref(),
+    ) {
+        (Some(bound), Some(adopted)) if !bound.is_empty() => bound != adopted,
+        _ => false,
+    };
+    let stall = classify_transcript_binding_stall(TranscriptBindingStallView {
+        relay_attached,
+        // Unknown liveness must not alert: an unprobed pane is not evidence that
+        // a live TUI is being starved.
+        tmux_alive: tmux_session_alive == Some(true),
+        bound_transcript_idle_secs,
+        inflight_present,
+        rotation_pending: tmux_session.is_some_and(|tmux| {
+            crate::services::tui_prompt_dedupe::claude_session_rotation_for_tmux(tmux).is_some()
+        }),
+        binding_session_is_superseded,
+    });
+    if stall.is_alerting() {
+        tracing::warn!(
+            provider = provider_name,
+            tmux_session = tmux_session.unwrap_or(""),
+            bound_output_path = bound_output_path.unwrap_or(""),
+            bound_session_id = bound_session_id.unwrap_or(""),
+            hook_adopted_session_id = hook_adopted_session_id.as_deref().unwrap_or(""),
+            binding_session_is_superseded,
+            bound_transcript_idle_secs = bound_transcript_idle_secs.unwrap_or(0),
+            transcript_binding_stall = stall.as_str(),
+            "#5188: delivery binding points at a transcript that stopped growing while the \
+             pane is alive and output is owed; relay frame counters cannot show this because \
+             nothing is ever attempted against a file that does not grow"
+        );
+    }
+    stall
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frozen() -> TranscriptBindingStallView {
+        TranscriptBindingStallView {
+            relay_attached: true,
+            tmux_alive: true,
+            bound_transcript_idle_secs: Some(BOUND_TRANSCRIPT_FROZEN_ALERT_SECS),
+            inflight_present: false,
+            rotation_pending: false,
+            binding_session_is_superseded: false,
+        }
+    }
+
+    /// The shape the #5188 incident actually sat in, and the one the first cut of
+    /// this classifier returned `None` for.
+    ///
+    /// By the time a transcript has been frozen for five minutes the rotation
+    /// record is long gone (the settle pass retires it within a poll or two) and
+    /// the stranded inflight has been settled, so BOTH of the original witnesses
+    /// are false. What remains true — and stays true for the life of the pane —
+    /// is that delivery is bound to a session the running Claude process has
+    /// moved off. Without that witness this verdict was reachable only through
+    /// the narrow window where an unresolved owner channel kept the rotation
+    /// record alive.
+    #[test]
+    fn a_binding_left_on_a_superseded_session_alerts_after_the_rotation_record_is_gone() {
+        let residual = TranscriptBindingStallView {
+            rotation_pending: false,
+            inflight_present: false,
+            binding_session_is_superseded: true,
+            ..frozen()
+        };
+        assert_eq!(
+            classify_transcript_binding_stall(residual),
+            TranscriptBindingStall::FrozenAfterSessionRotation,
+            "rotation record retired + no inflight + binding still on the frozen \
+             transcript is the residual #5188 shape; returning None here is what \
+             let it stay silent for 31 minutes"
+        );
+        assert!(classify_transcript_binding_stall(residual).is_alerting());
+    }
+
+    /// The new witness must not turn the classifier into the bare zero-frames
+    /// alarm it was written to avoid: a superseded binding whose transcript is
+    /// still growing is a rotation mid-flight, which is normal.
+    #[test]
+    fn a_superseded_binding_whose_transcript_still_grows_is_not_alerted_on() {
+        assert_eq!(
+            classify_transcript_binding_stall(TranscriptBindingStallView {
+                bound_transcript_idle_secs: Some(BOUND_TRANSCRIPT_FROZEN_ALERT_SECS - 1),
+                binding_session_is_superseded: true,
+                ..frozen()
+            }),
+            TranscriptBindingStall::None,
+            "a rotation that is still draining the old transcript is expected"
+        );
+        assert_eq!(
+            classify_transcript_binding_stall(TranscriptBindingStallView {
+                tmux_alive: false,
+                binding_session_is_superseded: true,
+                ..frozen()
+            }),
+            TranscriptBindingStall::None,
+            "a dead pane owes nothing, whatever session it is bound to"
+        );
+    }
+
+    #[test]
+    fn an_idle_channel_is_never_alerted_on() {
+        assert_eq!(
+            classify_transcript_binding_stall(frozen()),
+            TranscriptBindingStall::None,
+            "a quiet transcript on a quiet channel is the normal idle shape; \
+             alerting here is what made a bare zero-frames signal worthless"
+        );
+    }
+
+    #[test]
+    fn a_pending_rotation_makes_a_frozen_binding_a_confirmed_fault() {
+        let stall = classify_transcript_binding_stall(TranscriptBindingStallView {
+            rotation_pending: true,
+            ..frozen()
+        });
+        assert_eq!(stall, TranscriptBindingStall::FrozenAfterSessionRotation);
+        assert!(stall.is_alerting());
+    }
+
+    #[test]
+    fn a_live_turn_waiting_on_a_frozen_transcript_alerts() {
+        assert_eq!(
+            classify_transcript_binding_stall(TranscriptBindingStallView {
+                inflight_present: true,
+                ..frozen()
+            }),
+            TranscriptBindingStall::FrozenWithLiveTurn,
+            "bytes are owed to a turn in flight and none are arriving"
+        );
+    }
+
+    #[test]
+    fn a_transcript_that_grew_recently_is_healthy_even_mid_rotation() {
+        assert_eq!(
+            classify_transcript_binding_stall(TranscriptBindingStallView {
+                bound_transcript_idle_secs: Some(BOUND_TRANSCRIPT_FROZEN_ALERT_SECS - 1),
+                rotation_pending: true,
+                inflight_present: true,
+                ..frozen()
+            }),
+            TranscriptBindingStall::None,
+            "a rotation mid-drain is expected and must not alert while the old \
+             transcript is still being consumed"
+        );
+    }
+
+    #[test]
+    fn a_dead_pane_or_detached_relay_is_somebody_elses_verdict() {
+        for view in [
+            TranscriptBindingStallView {
+                tmux_alive: false,
+                rotation_pending: true,
+                inflight_present: true,
+                ..frozen()
+            },
+            TranscriptBindingStallView {
+                relay_attached: false,
+                rotation_pending: true,
+                inflight_present: true,
+                ..frozen()
+            },
+        ] {
+            assert_eq!(
+                classify_transcript_binding_stall(view),
+                TranscriptBindingStall::None,
+                "a dead pane / detached relay already has its own dedicated \
+                 stall states; this verdict is only about a LIVE pane whose \
+                 delivery is pointed at a dead file"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unresolvable_bound_transcript_is_not_this_verdict() {
+        assert_eq!(
+            classify_transcript_binding_stall(TranscriptBindingStallView {
+                bound_transcript_idle_secs: None,
+                rotation_pending: true,
+                inflight_present: true,
+                ..frozen()
+            }),
+            TranscriptBindingStall::None,
+        );
+    }
+}

--- a/src/services/discord/health/watcher_respawn.rs
+++ b/src/services/discord/health/watcher_respawn.rs
@@ -680,6 +680,7 @@ mod tests {
             mailbox_active_turn_nonce: None,
             bound_output_path: None,
             bound_session_id: None,
+            transcript_binding_stall: "none",
             inflight_terminal_delivery_committed: false,
             inflight_identity: None,
             inflight_finalizer_turn_id: None,

--- a/src/services/discord/router/intake_gate/stale_turn.rs
+++ b/src/services/discord/router/intake_gate/stale_turn.rs
@@ -418,6 +418,7 @@ mod thread_guard_stale_pure_tests {
             mailbox_active_turn_nonce: None,
             bound_output_path: None,
             bound_session_id: None,
+            transcript_binding_stall: "none",
             inflight_terminal_delivery_committed: false,
             inflight_identity: None,
             inflight_finalizer_turn_id: None,

--- a/src/services/discord/tui_prompt_relay/rehydration.rs
+++ b/src/services/discord/tui_prompt_relay/rehydration.rs
@@ -113,6 +113,13 @@ pub(super) fn evict_dead_orphaned_claude_tui_mirrors(shared: &Arc<SharedData>) {
         shared
             .tmux_watchers
             .clear_restored_owner_for_tmux_session(&tmux_session_name);
+        // #5188 (P1-A): the adopted-session authority is scoped to the PANE, so
+        // confirmed pane death is the one event that retires it. This is the
+        // only caller — the settle pass must never reach it, or the authority
+        // goes back to expiring on a ~500ms timer.
+        crate::services::tui_prompt_dedupe::forget_hook_adopted_claude_session_id(
+            &tmux_session_name,
+        );
         let mirror_channel =
             crate::services::tui_prompt_dedupe::owner_channel_for_tmux_session(&tmux_session_name)
                 .unwrap_or(0);
@@ -274,25 +281,33 @@ pub(super) fn rehydrate_existing_claude_tui_bindings(shared: &Arc<SharedData>) {
                 );
             }
         }
-        if let (Some(existing), Some(_)) = (&existing_binding, existing_channel) {
-            if existing.runtime_kind == RuntimeHandoffKind::ClaudeTui
-                && Path::new(&existing.output_path).exists()
-                && match fresh_binding.as_ref() {
-                    Some(fresh) => {
-                        claude_tui_runtime_binding_matches_launch(existing, fresh)
-                            || claude_continuation_binding_supersedes_launch(existing, fresh)
-                    }
-                    None => true,
-                }
-            {
-                continue;
-            }
+        // #5188 (R1): both gates below consult the session id a live hook payload
+        // most recently reported for this pane. A `/clear` rotates Claude onto a
+        // new transcript while the launch script keeps naming the launch-time
+        // UUID forever, so that payload is the only evidence which outranks the
+        // stale artifact. Both decisions live in `session_rotation_settle` — they
+        // were unreachable from any test while inlined here, and production takes
+        // no other path to them.
+        if let (Some(existing), Some(_)) = (&existing_binding, existing_channel)
+            && super::session_rotation_settle::existing_claude_binding_outranks_launch_script(
+                &tmux_session_name,
+                existing,
+                fresh_binding.as_ref(),
+            )
+        {
+            continue;
         }
         if let Some(fresh) = fresh_binding {
             let should_refresh = match existing_binding.as_ref() {
+                // Second gate on purpose: the first one requires a resolved
+                // `existing_channel`, and a pane whose dedupe mirror has no
+                // channel yet would otherwise still be reverted here.
                 Some(existing) => {
-                    !claude_tui_runtime_binding_matches_launch(existing, &fresh)
-                        || !Path::new(&existing.output_path).exists()
+                    super::session_rotation_settle::launch_script_may_replace_binding(
+                        &tmux_session_name,
+                        existing,
+                        &fresh,
+                    )
                 }
                 None => true,
             };

--- a/src/services/discord/tui_prompt_relay/session_rotation_settle.rs
+++ b/src/services/discord/tui_prompt_relay/session_rotation_settle.rs
@@ -89,6 +89,113 @@ pub(in crate::services::discord) fn plan_claude_session_rotation(
     ClaudeRotationPlan::SettleStaleInflight
 }
 
+/// #5188 (R1): does `existing` carry a session id ADOPTED from a live Claude
+/// hook payload, making it authoritative over the on-disk launch script?
+///
+/// [`claude_continuation_binding_supersedes_launch`] is the pre-existing,
+/// filesystem-only cutover test. It is conservative by design and can decline a
+/// REAL rotation — it demands that the new transcript's FIRST timestamp be
+/// strictly later than the frozen transcript's LAST one, which a trailing
+/// rotation-boundary record appended to the old file (or a leading untimestamped
+/// record in the new one) defeats. When it declines, the rehydration pass falls
+/// through and re-registers the LAUNCH-script binding, silently reverting
+/// delivery to the transcript Claude has stopped writing to. That is the observed
+/// #5188 signature: `adopted Claude continuation session …` immediately followed
+/// by `rehydrated Claude TUI direct relay binding from launch script …
+/// transcript_path=<frozen>.jsonl`, after which nothing is ever delivered again.
+///
+/// A hook payload is different evidence in kind: it was emitted by the running
+/// Claude process and names the session it is writing RIGHT NOW, whereas the
+/// launch script is a start-time artifact that a `/clear` makes stale forever. So
+/// once a payload-adopted id is on record for the pane, a binding carrying that
+/// id outranks the launch script.
+///
+/// Deliberately narrow: it only holds for a ClaudeTui pair where `existing`
+/// carries exactly the adopted id, the LAUNCH binding does NOT (so a launch
+/// script that has caught up still wins the ordinary `matches_launch` path), and
+/// `existing`'s transcript is a real file on disk (a vanished transcript must
+/// still fall through to re-derivation).
+#[cfg(unix)]
+pub(in crate::services::discord) fn hook_adopted_binding_supersedes_launch(
+    existing: &crate::services::tui_prompt_dedupe::TuiRuntimeBinding,
+    launch: &crate::services::tui_prompt_dedupe::TuiRuntimeBinding,
+    hook_adopted_session_id: Option<&str>,
+) -> bool {
+    let Some(adopted) = hook_adopted_session_id
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return false;
+    };
+    existing.runtime_kind == RuntimeHandoffKind::ClaudeTui
+        && launch.runtime_kind == RuntimeHandoffKind::ClaudeTui
+        && existing.session_id.as_deref() == Some(adopted)
+        && launch.session_id.as_deref() != Some(adopted)
+        && Path::new(&existing.output_path).is_file()
+}
+
+/// #5188 (R1): the launch-script rehydration pass's FIRST gate — may the binding
+/// already registered for this pane be kept as-is?
+///
+/// Extracted from the pass so the adopted-session override is exercised through
+/// the SAME code production runs, ledger lookup included. Inline in the loop it
+/// was unreachable from any test, and deleting the override there changed no
+/// test outcome at all.
+#[cfg(unix)]
+pub(in crate::services::discord) fn existing_claude_binding_outranks_launch_script(
+    tmux_session_name: &str,
+    existing: &crate::services::tui_prompt_dedupe::TuiRuntimeBinding,
+    fresh: Option<&crate::services::tui_prompt_dedupe::TuiRuntimeBinding>,
+) -> bool {
+    if existing.runtime_kind != RuntimeHandoffKind::ClaudeTui
+        || !Path::new(&existing.output_path).exists()
+    {
+        return false;
+    }
+    // No launch script to compare against: there is nothing that could replace
+    // this binding, so it stands.
+    let Some(fresh) = fresh else {
+        return true;
+    };
+    claude_tui_runtime_binding_matches_launch(existing, fresh)
+        || claude_continuation_binding_supersedes_launch(existing, fresh)
+        || hook_adopted_binding_supersedes_launch(
+            existing,
+            fresh,
+            crate::services::tui_prompt_dedupe::hook_adopted_claude_session_id(tmux_session_name)
+                .as_deref(),
+        )
+}
+
+/// #5188 (R1): the rehydration pass's SECOND gate — may the launch script's
+/// re-derived binding overwrite the one already registered?
+///
+/// A separate gate on purpose: the first one only runs for a pane whose dedupe
+/// mirror already resolves to a channel, and a pane that has not got one yet
+/// would otherwise still be reverted here.
+///
+/// Returning `true` for a payload-adopted binding is the #5188 production
+/// failure itself — `rehydrated Claude TUI direct relay binding from launch
+/// script … transcript_path=<frozen>.jsonl`, after which delivery reads a file
+/// that never grows again.
+#[cfg(unix)]
+pub(in crate::services::discord) fn launch_script_may_replace_binding(
+    tmux_session_name: &str,
+    existing: &crate::services::tui_prompt_dedupe::TuiRuntimeBinding,
+    fresh: &crate::services::tui_prompt_dedupe::TuiRuntimeBinding,
+) -> bool {
+    if hook_adopted_binding_supersedes_launch(
+        existing,
+        fresh,
+        crate::services::tui_prompt_dedupe::hook_adopted_claude_session_id(tmux_session_name)
+            .as_deref(),
+    ) {
+        return false;
+    }
+    !claude_tui_runtime_binding_matches_launch(existing, fresh)
+        || !Path::new(&existing.output_path).exists()
+}
+
 /// Finalize context for the rotation settle: clear the unfinalizable row and let
 /// the queue kick, but do not run completion cleanup (there is no completion to
 /// clean up — the transcript that would have carried it is frozen) and do not
@@ -391,6 +498,174 @@ mod tests {
             last_offset: 0,
             relay_last_offset: None,
         }
+    }
+
+    // Direction (a), the R1 half: after `/clear` the launch script still names the
+    // LAUNCH-time UUID forever. The rehydration pass must not use it to drag the
+    // binding back onto the frozen transcript, or delivery reads a dead file for
+    // the rest of the pane's life — the exact #5188 production signature.
+    #[cfg(unix)]
+    #[test]
+    fn a_hook_adopted_binding_outranks_the_stale_launch_script() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let frozen = dir.path().join("4648aa76.jsonl");
+        let rotated = dir.path().join("67f48e65.jsonl");
+        std::fs::write(&frozen, b"{}\n").expect("write frozen transcript");
+        std::fs::write(&rotated, b"{}\n").expect("write rotated transcript");
+
+        let adopted = binding(&rotated, "67f48e65");
+        let launch = binding(&frozen, "4648aa76");
+
+        assert!(
+            hook_adopted_binding_supersedes_launch(&adopted, &launch, Some("67f48e65")),
+            "the running Claude process reported this session id; the launch script \
+             is a start-time artifact that `/clear` made stale forever"
+        );
+        assert!(
+            !hook_adopted_binding_supersedes_launch(&adopted, &launch, None),
+            "with no adoption on record the launch script keeps its authority"
+        );
+        assert!(
+            !hook_adopted_binding_supersedes_launch(&adopted, &launch, Some("4648aa76")),
+            "an id that is the LAUNCH binding's own must never promote the existing one"
+        );
+    }
+
+    /// P1-A regression, and the one that matters most in this change.
+    ///
+    /// Sequence is the production one, in production order:
+    ///   1. a `/clear` hook adopts the new session (rotation recorded),
+    ///   2. the ~500ms settle tick finds nothing pinned to the frozen
+    ///      transcript, plans `RebindOnly`, and retires the rotation record,
+    ///   3. the 5s rehydration tick then re-derives the LAUNCH-script binding
+    ///      and asks whether it may overwrite the adopted one.
+    ///
+    /// Step 3 must answer NO. It previously answered YES for every run in which
+    /// step 2 got there first — which is nearly all of them — and that answer is
+    /// the whole #5188 incident: delivery went back to a transcript Claude had
+    /// abandoned and stayed there for 31 minutes with every failure counter at
+    /// zero.
+    #[cfg(unix)]
+    #[test]
+    fn rehydration_does_not_revert_an_adopted_binding_after_the_settle_pass_runs() {
+        let _serial = crate::services::tui_prompt_dedupe::lock_claude_session_rotations_for_tests();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let frozen = dir.path().join("4648aa76.jsonl");
+        let rotated = dir.path().join("67f48e65.jsonl");
+        std::fs::write(&frozen, b"{}\n").expect("write frozen transcript");
+        std::fs::write(&rotated, b"{}\n").expect("write rotated transcript");
+
+        let adopted = binding(&rotated, "67f48e65");
+        let launch = binding(&frozen, "4648aa76");
+
+        crate::services::tui_prompt_dedupe::record_claude_session_rotation(
+            crate::services::tui_prompt_dedupe::ClaudeSessionRotation {
+                tmux_session_name: "pane-5188".to_string(),
+                old_session_id: Some("4648aa76".to_string()),
+                old_output_path: frozen.display().to_string(),
+                old_last_offset: 0,
+                new_session_id: "67f48e65".to_string(),
+                new_output_path: rotated.display().to_string(),
+                observed_drain_frontier: 0,
+                polls_without_drain_progress: 0,
+            },
+        );
+
+        // Step 2: exactly what `RebindOnly` does on the first ~500ms tick.
+        assert!(
+            crate::services::tui_prompt_dedupe::clear_claude_session_rotation("pane-5188"),
+            "the settle pass retires the record it just finished with"
+        );
+
+        // Step 3, both gates, ~4.5s later.
+        assert!(
+            !launch_script_may_replace_binding("pane-5188", &adopted, &launch),
+            "the launch script must NOT overwrite a payload-adopted binding — \
+             surviving the settle pass is the entire point of keeping the \
+             adopted-session authority in its own store"
+        );
+        assert!(
+            existing_claude_binding_outranks_launch_script("pane-5188", &adopted, Some(&launch)),
+            "and the keep-as-is gate must agree, or the pane is reverted through \
+             the other branch instead"
+        );
+    }
+
+    /// The override is scoped to the pane that actually rotated. A different
+    /// pane's binding gets no free pass.
+    #[cfg(unix)]
+    #[test]
+    fn a_pane_with_no_adoption_on_record_still_yields_to_the_launch_script() {
+        let _serial = crate::services::tui_prompt_dedupe::lock_claude_session_rotations_for_tests();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let frozen = dir.path().join("4648aa76.jsonl");
+        let rotated = dir.path().join("67f48e65.jsonl");
+        std::fs::write(&frozen, b"{}\n").expect("write frozen transcript");
+        std::fs::write(&rotated, b"{}\n").expect("write rotated transcript");
+
+        crate::services::tui_prompt_dedupe::record_hook_adopted_claude_session_id(
+            "some-other-pane",
+            "67f48e65",
+        );
+
+        assert!(
+            launch_script_may_replace_binding(
+                "pane-with-no-adoption",
+                &binding(&rotated, "67f48e65"),
+                &binding(&frozen, "4648aa76"),
+            ),
+            "an adoption recorded for a DIFFERENT pane must not keep this pane's \
+             binding alive; the ledger lookup has to be keyed by tmux session"
+        );
+    }
+
+    /// Once `persist_claude_continuation_session` has rewritten the launch
+    /// script, the adopted id is no longer evidence of a conflict and the
+    /// ordinary match-launch path takes over. This is why the authority needs no
+    /// timed expiry: it stops applying by itself.
+    #[cfg(unix)]
+    #[test]
+    fn a_launch_script_that_caught_up_takes_authority_back() {
+        let _serial = crate::services::tui_prompt_dedupe::lock_claude_session_rotations_for_tests();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rotated = dir.path().join("67f48e65.jsonl");
+        std::fs::write(&rotated, b"{}\n").expect("write rotated transcript");
+
+        crate::services::tui_prompt_dedupe::record_hook_adopted_claude_session_id(
+            "pane-5188",
+            "67f48e65",
+        );
+        let caught_up = binding(&rotated, "67f48e65");
+
+        assert!(
+            !hook_adopted_binding_supersedes_launch(&caught_up, &caught_up, Some("67f48e65")),
+            "a launch script naming the adopted id is not stale evidence"
+        );
+        assert!(
+            !launch_script_may_replace_binding("pane-5188", &caught_up, &caught_up),
+            "and an identical launch binding needs no overwrite anyway"
+        );
+    }
+
+    // The override must not resurrect a transcript that no longer exists: a
+    // vanished file has to fall through to ordinary re-derivation, otherwise a
+    // deleted transcript would pin delivery to nothing at all.
+    #[cfg(unix)]
+    #[test]
+    fn a_hook_adopted_binding_with_no_transcript_on_disk_does_not_win() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let frozen = dir.path().join("4648aa76.jsonl");
+        std::fs::write(&frozen, b"{}\n").expect("write frozen transcript");
+        let missing = dir.path().join("gone.jsonl");
+
+        assert!(
+            !hook_adopted_binding_supersedes_launch(
+                &binding(&missing, "67f48e65"),
+                &binding(&frozen, "4648aa76"),
+                Some("67f48e65"),
+            ),
+            "an adopted id cannot pin delivery to a transcript that is not on disk"
+        );
     }
 
     // The drain wait must be BOUNDED: a tail that died mid-drain must not hold the

--- a/src/services/tui_prompt_dedupe/runtime_binding.rs
+++ b/src/services/tui_prompt_dedupe/runtime_binding.rs
@@ -565,6 +565,15 @@ pub(crate) fn adopt_claude_continuation_session(
     {
         // Subsequent hooks still carry the launch-time query UUID. Do not reset
         // the already-adopted continuation cursor to zero on every event.
+        //
+        // #5188 (P1-A): but DO refresh the adopted-session authority. This is
+        // the branch every hook after the first one takes, so leaving it out
+        // made the authority a write-once fact tied to a single instant instead
+        // of a standing statement about what this pane is running now.
+        super::session_rotation::record_hook_adopted_claude_session_id(
+            &tmux_session_name,
+            payload_session_id,
+        );
         state.tmux_by_provider_session.insert(
             PromptKey::new("claude", payload_session_id),
             TimedValue {

--- a/src/services/tui_prompt_dedupe/session_rotation.rs
+++ b/src/services/tui_prompt_dedupe/session_rotation.rs
@@ -5,12 +5,23 @@
 //! the first place AgentDesk learns about it — `adopt_claude_continuation_session`
 //! rebinds the in-memory [`super::TuiRuntimeBinding`] there.
 //!
-//! Rebinding the mirror is necessary but NOT sufficient. **The inflight pinned to
-//! the frozen transcript** can never receive a terminal — nothing will ever append
-//! to the file it is waiting on — so every later turn on the channel reads
-//! `FOREIGN prior inflight is still live` and aborts. This ledger carries the
-//! rotation to the per-tick settle pass
-//! (`discord::tui_prompt_relay::session_rotation_settle`) that resolves it.
+//! Rebinding the mirror is necessary but NOT sufficient, and this ledger is what
+//! carries the event to the two places that also have to react:
+//!
+//! 1. **The launch-script rehydration pass** (`tui_prompt_relay::rehydration`)
+//!    re-derives a binding from the on-disk launch script every few seconds. That
+//!    artifact still names the LAUNCH-time UUID, so without an explicit record of
+//!    "this session id came from a live hook payload" the pass happily overwrote
+//!    the freshly adopted binding back to the FROZEN transcript. That is the
+//!    observed production signature: `adopted Claude continuation session …`
+//!    followed by `rehydrated Claude TUI direct relay binding from launch script
+//!    … transcript_path=<old>.jsonl`, and delivery never followed the rotation.
+//!
+//! 2. **The inflight pinned to the frozen transcript** can never receive a
+//!    terminal — nothing will ever append to the file it is waiting on — so every
+//!    later turn on the channel reads `FOREIGN prior inflight is still live` and
+//!    aborts. It has to be settled deliberately at the rotation boundary
+//!    (`discord::claude_session_rotation`).
 //!
 //! The record deliberately keeps the FIRST observed `old_output_path`: repeated
 //! hooks may report further hops, but the delivery-critical fact is which
@@ -20,26 +31,70 @@
 //! persisted artifacts (`persist_claude_continuation_session` rewrites them at
 //! adoption time), so a lost record cannot strand delivery across a restart.
 //!
-//! ## Scope: this ledger is pending WORK, not a standing authority
-//! It answers "is there rotation cleanup still owed for this pane?", and the
-//! settle pass retires the record as soon as the answer is no — typically on the
-//! first ~500ms tick after the rotation.
+//! ## Two stores, two lifetimes — and why that separation is load-bearing
+//! The two consumers above want the SAME event but on OPPOSITE schedules, so
+//! they cannot share one record:
 //!
-//! That makes it the wrong home for the OTHER half of #5188, the launch-script
-//! rehydration authority: that consumer runs on a 5s tick and needs an answer
-//! that stays true for the life of the pane, so reading it out of this
-//! short-lived record would give a signal that is almost always already gone.
-//! The authority therefore lives in its own pane-lifetime store, added
-//! separately; nothing here may be repurposed to serve it.
+//! * consumer 2 (settle) is *pending work*. It runs on the ~500ms idle tick and
+//!   must retire its record the moment the work is done, or it would re-settle
+//!   forever.
+//! * consumer 1 (rehydration) is a *standing authority*. It runs on the 5s
+//!   rehydrate tick and must keep out-ranking the launch script for as long as
+//!   the pane keeps that adopted session — which is the rest of the pane's life,
+//!   not the few hundred milliseconds the settle work takes.
+//!
+//! An earlier revision of this module served consumer 1 out of the settle ledger.
+//! That made the authority signal self-destruct: the settle pass reached
+//! `RebindOnly` on its very first tick (a `/clear` creates no inflight to drain),
+//! called [`clear_claude_session_rotation`], and the adopted id vanished ~500ms
+//! after adoption — normally BEFORE the 5s rehydration pass ever read it. The
+//! signal was therefore present for about one tick in ten and absent forever
+//! after, so rehydration reverted the binding to the frozen launch-script
+//! transcript in exactly the failure mode it was written to prevent.
+//!
+//! So the adopted session id lives in its OWN pane-lifetime store
+//! ([`ADOPTED_SESSIONS`]) that the settle path never touches. Its availability no
+//! longer depends on which of the two polls wins a race, because the pass that
+//! used to destroy it — the ~500ms settle tick — can no longer reach it.
+//!
+//! To be precise about lifetime, the record leaves the store by exactly three
+//! paths, and none of them fires while the pane is alive and still running the
+//! adopted session:
+//!
+//! * a newer adoption for the same pane OVERWRITES the entry. That is the
+//!   authority being restated, not lost.
+//! * [`forget_hook_adopted_claude_session_id`] removes it. Its only caller is
+//!   the 5s rehydrate pass, so this IS timer-driven — but it is gated on that
+//!   pass having confirmed the pane DEAD/orphaned, and a dead pane has no
+//!   delivery left to protect.
+//! * the [`ROTATION_RECORD_TTL`] `retain` in `lock_adopted_sessions` prunes it.
+//!   That runs on EVERY access rather than on a timer, but only evicts entries
+//!   older than 12h; see that constant for why reaching it is harmless.
+//!
+//! (see [`hook_adopted_claude_session_id`] for how the authority is read)
 
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
-/// Rotation records are pruned after this long. Generous relative to the ~500ms
-/// idle poll that consumes them: a record normally lives for one or two ticks,
-/// and this bound only exists so a pane whose owner channel never resolves
-/// cannot leak an entry for the lifetime of the process.
+/// Records in BOTH stores are pruned after this long.
+///
+/// For [`ROTATIONS`] the bound is nearly always moot — the settle pass retires a
+/// record within a poll or two — and exists only so a pane whose owner channel
+/// never resolves cannot leak an entry for the life of the process. For
+/// [`ADOPTED_SESSIONS`] it is a backstop behind the real retirement paths (a
+/// newer adoption overwrites the entry; confirmed pane death forgets it).
+///
+/// Reaching this bound is harmless — but NOT because "the ordinary launch-script
+/// comparison takes over". That comparison reverting the binding to the FROZEN
+/// transcript is the very bug this store exists to stop, so it cannot also be
+/// the safety net. It is harmless because adoption is made DURABLE at the same
+/// instant the authority is recorded: the hook guard that detects the rotation
+/// (`claude_tui::hook_server`, the `command_session_id != payload_session_id`
+/// branch) calls `persist_claude_continuation_session`, which rewrites the
+/// on-disk launch script to name the adopted session. Long before 12h elapse the
+/// launch script and the adopted binding already agree, so losing the in-memory
+/// authority at that point changes nothing.
 const ROTATION_RECORD_TTL: Duration = Duration::from_secs(12 * 60 * 60);
 
 /// One observed Claude session rotation for a tmux pane.
@@ -79,6 +134,27 @@ fn lock_rotations() -> std::sync::MutexGuard<'static, HashMap<String, TimedRotat
     guard
 }
 
+struct TimedAdoption {
+    session_id: String,
+    recorded_at: Instant,
+}
+
+/// Session ids adopted from live hook payloads, keyed by tmux session name.
+///
+/// Deliberately NOT part of [`ROTATIONS`]: see the module doc. This store is
+/// pane-scoped and is never emptied by the settle pass, so its contents do not
+/// depend on poll ordering.
+static ADOPTED_SESSIONS: LazyLock<Mutex<HashMap<String, TimedAdoption>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn lock_adopted_sessions() -> std::sync::MutexGuard<'static, HashMap<String, TimedAdoption>> {
+    let mut guard = ADOPTED_SESSIONS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    guard.retain(|_, entry| entry.recorded_at.elapsed() < ROTATION_RECORD_TTL);
+    guard
+}
+
 /// Record a rotation observed at binding-adoption time.
 ///
 /// Idempotent per pane in the delivery-critical direction: a second hop updates
@@ -87,6 +163,11 @@ fn lock_rotations() -> std::sync::MutexGuard<'static, HashMap<String, TimedRotat
 /// the transcript whose undelivered tail must still be drained. A hook that
 /// merely re-reports the rotation already recorded is a no-op.
 pub(crate) fn record_claude_session_rotation(rotation: ClaudeSessionRotation) {
+    // The adopted-session authority is recorded from here too so the rotation
+    // path cannot forget it, but it is stored SEPARATELY and outlives this
+    // record — `clear_claude_session_rotation` must not take it down with the
+    // pending-work marker (see the module doc).
+    record_hook_adopted_claude_session_id(&rotation.tmux_session_name, &rotation.new_session_id);
     let mut rotations = lock_rotations();
     match rotations.get_mut(&rotation.tmux_session_name) {
         Some(existing) => {
@@ -123,6 +204,58 @@ pub(crate) fn pending_claude_session_rotations() -> Vec<ClaudeSessionRotation> {
         .collect()
 }
 
+/// Record the session id a live hook payload just reported for this pane.
+///
+/// Called on EVERY adoption-path hook, including the "already adopted" one that
+/// records no rotation, so the authority signal is refreshed rather than written
+/// exactly once per rotation.
+pub(crate) fn record_hook_adopted_claude_session_id(tmux_session_name: &str, session_id: &str) {
+    let tmux_session_name = tmux_session_name.trim();
+    let session_id = session_id.trim();
+    if tmux_session_name.is_empty() || session_id.is_empty() {
+        return;
+    }
+    lock_adopted_sessions().insert(
+        tmux_session_name.to_string(),
+        TimedAdoption {
+            session_id: session_id.to_string(),
+            recorded_at: Instant::now(),
+        },
+    );
+}
+
+/// The session id most recently ADOPTED from a live hook payload for this pane.
+///
+/// This is the R1 authority signal: a launch script on disk is a LAUNCH-time
+/// artifact, while this id came from the running Claude process itself, so a
+/// binding carrying it must not be reverted to the launch script's stale UUID.
+///
+/// Read from the pane-lifetime [`ADOPTED_SESSIONS`] store, NOT from the settle
+/// ledger — the settle ledger is retired within ~500ms of adoption while this
+/// answer must stay true for the 5s rehydration pass and every one after it.
+///
+/// It needs no explicit retirement: the predicate built on it
+/// (`hook_adopted_binding_supersedes_launch`) also requires that the LAUNCH
+/// binding does not already carry this id, so once
+/// `persist_claude_continuation_session` has rewritten the launch script the
+/// signal stops applying on its own and the ordinary match-launch path wins
+/// again.
+pub(crate) fn hook_adopted_claude_session_id(tmux_session_name: &str) -> Option<String> {
+    lock_adopted_sessions()
+        .get(tmux_session_name.trim())
+        .map(|entry| entry.session_id.clone())
+}
+
+/// Forget the adopted-session authority for a pane that is being torn down.
+///
+/// Only for genuine pane death / mirror eviction. The settle path must NEVER
+/// call this — that coupling is the exact defect the two-store split removes.
+pub(crate) fn forget_hook_adopted_claude_session_id(tmux_session_name: &str) -> bool {
+    lock_adopted_sessions()
+        .remove(tmux_session_name.trim())
+        .is_some()
+}
+
 /// Fold a fresh drain observation into the record and return the resulting
 /// `polls_without_drain_progress`. A frontier that advanced resets the counter to
 /// zero; a frontier that stood still increments it.
@@ -146,19 +279,26 @@ pub(crate) fn record_rotation_drain_progress(tmux_session_name: &str, frontier: 
 /// Drop the record once the rotation has been fully propagated (stale inflight
 /// settled, delivery rebound). The pane keeps its adopted binding; only the
 /// pending-work marker goes away.
+///
+/// Touches [`ROTATIONS`] ONLY. The adopted-session authority in
+/// [`ADOPTED_SESSIONS`] deliberately survives: this function runs on the ~500ms
+/// settle tick, and taking the authority down with it is what previously left
+/// the 5s rehydration pass with nothing to out-rank the launch script.
 pub(crate) fn clear_claude_session_rotation(tmux_session_name: &str) -> bool {
     lock_rotations().remove(tmux_session_name.trim()).is_some()
 }
 
-/// Serializes every test that touches the process-wide ledger above.
+/// Serializes every test that touches the two process-wide stores above.
 ///
-/// Module-scoped (not buried inside `mod tests`) so tests in OTHER modules that
-/// drive the ledger the way production does can take the same lock instead of
-/// clearing each other's fixtures.
+/// Module-scoped (not buried inside `mod tests`) because the stores are read
+/// from OTHER modules' tests too — notably the rehydration-gate predicates in
+/// `discord::tui_prompt_relay::session_rotation_settle`, which look the adopted
+/// id up exactly the way production does. Without one shared lock those tests
+/// would clear each other's fixtures.
 #[cfg(test)]
 static ROTATION_TEST_SERIAL: Mutex<()> = Mutex::new(());
 
-/// Take the shared lock and start from an empty ledger.
+/// Take the shared lock and start from empty stores.
 #[cfg(test)]
 pub(crate) fn lock_claude_session_rotations_for_tests() -> std::sync::MutexGuard<'static, ()> {
     let guard = ROTATION_TEST_SERIAL
@@ -171,6 +311,10 @@ pub(crate) fn lock_claude_session_rotations_for_tests() -> std::sync::MutexGuard
 #[cfg(test)]
 pub(crate) fn reset_claude_session_rotations_for_tests() {
     ROTATIONS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .clear();
+    ADOPTED_SESSIONS
         .lock()
         .unwrap_or_else(|error| error.into_inner())
         .clear();
@@ -216,8 +360,9 @@ mod tests {
         );
         assert_eq!(stored.new_output_path, "/tmp/c.jsonl");
         assert_eq!(
-            stored.new_session_id, "third-uuid",
-            "the NEW side still tracks the newest hop"
+            hook_adopted_claude_session_id("pane").as_deref(),
+            Some("third-uuid"),
+            "the adopted-session authority tracks the NEWEST hop"
         );
     }
 
@@ -236,5 +381,59 @@ mod tests {
         assert_eq!(record_rotation_drain_progress("pane", 64), 1);
         assert!(clear_claude_session_rotation("pane"));
         assert!(claude_session_rotation_for_tmux("pane").is_none());
+    }
+
+    /// P1-A. The settle pass retires the rotation record on its FIRST ~500ms
+    /// tick (a `/clear` leaves no inflight to drain, so the plan is
+    /// `RebindOnly`), while the rehydration pass that consumes the adopted id
+    /// only runs every 5s. If the two shared one record the authority signal
+    /// would be gone before its reader ever woke up — present for roughly one
+    /// tick in ten, absent forever after.
+    #[test]
+    fn settling_a_rotation_does_not_retire_the_adopted_session_authority() {
+        let _serial = serial();
+        record_claude_session_rotation(rotation("pane", "/tmp/a.jsonl", "/tmp/b.jsonl"));
+        assert_eq!(
+            hook_adopted_claude_session_id("pane").as_deref(),
+            Some("new-uuid")
+        );
+
+        assert!(clear_claude_session_rotation("pane"));
+
+        assert!(
+            claude_session_rotation_for_tmux("pane").is_none(),
+            "the pending-work marker is done and must not be re-settled"
+        );
+        assert_eq!(
+            hook_adopted_claude_session_id("pane").as_deref(),
+            Some("new-uuid"),
+            "the adopted-session authority must OUTLIVE the settle record; it is \
+             read by a slower poll and is what stops the launch script from \
+             reverting delivery to the frozen transcript"
+        );
+    }
+
+    /// The authority is refreshed by hooks that record no rotation at all (the
+    /// already-adopted early return), so it does not depend on a rotation
+    /// happening to be in flight.
+    #[test]
+    fn the_adopted_authority_is_writable_without_a_rotation_record() {
+        let _serial = serial();
+        record_hook_adopted_claude_session_id("pane", "hook-uuid");
+        assert!(claude_session_rotation_for_tmux("pane").is_none());
+        assert_eq!(
+            hook_adopted_claude_session_id("pane").as_deref(),
+            Some("hook-uuid")
+        );
+
+        record_hook_adopted_claude_session_id("pane", "  ");
+        assert_eq!(
+            hook_adopted_claude_session_id("pane").as_deref(),
+            Some("hook-uuid"),
+            "a blank payload id must not erase a real one"
+        );
+
+        assert!(forget_hook_adopted_claude_session_id("pane"));
+        assert!(hook_adopted_claude_session_id("pane").is_none());
     }
 }


### PR DESCRIPTION
Refs #5188 (R1 half). PR-A 는 #5214 로 착지했다(`ab579ba20`).

## 무엇이 고쳐지는가

PR-A 는 로테이션이 채널을 **막는** 것을 풀었다. 이 PR 은 **배달이 Claude 가 실제로 옮겨간 세션을 따라가게** 한다.

`adopt_claude_continuation_session` 이 인메모리 바인딩을 재결속해도, **launch-script rehydration 패스**(5초 주기)가 디스크의 launch script 를 다시 읽어 **LAUNCH 시점 UUID** 로 바인딩을 되돌렸다. 프로덕션 시그니처가 정확히 이것이다 — `adopted Claude continuation session …` 직후 `rehydrated Claude TUI direct relay binding from launch script … transcript_path=<old>.jsonl`, 그리고 배달은 로테이션을 따라가지 않았다.

그래서 **채택된 세션 id 를 페인 수명 스토어(`ADOPTED_SESSIONS`)로 분리**했다. 이전 리비전은 이 신호를 settle 원장에서 꺼내 썼는데, `/clear` 는 드레인할 inflight 를 만들지 않으므로 settle 패스가 **첫 틱에 `RebindOnly` 에 도달해 `clear_claude_session_rotation` 을 호출**했고, 채택 id 가 **채택 ~500ms 뒤에, 즉 5초 rehydration 이 읽기 전에** 사라졌다. 신호가 열 틱에 한 번만 존재하고 그 뒤로는 영원히 부재하는 구조였다. 두 소비자는 **같은 이벤트를 정반대 스케줄로** 원하므로 레코드를 공유할 수 없다.

여기에 `watcher-state` 스톨 신호(`transcript_binding_stall.rs`)를 더해, 로테이션 이후 바인딩이 어긋난 상태가 health 표면에 드러나게 했다.

## ★ 크기 상한(±800) waiver — 리뷰가 판정함

헤드라인은 `17 files, +962 −75` 로 ±800 을 넘는다. 그럼에도 waiver 대상으로 판정됐다.

1. **신규 코드는 ≈513 줄로 상한 미만이다.** 헤드라인 초과분의 상당량이 **이례적으로 두꺼운 모듈 doc**(왜 두 스토어를 분리해야 하는지에 대한 근거 서술, 그리고 그 근거가 되는 실패 모드의 정확한 타이밍)이다.
2. **재절단이 문제를 풀지 못한다.** 지배 단위가 상한의 1.8× 라 어떻게 잘라도 상한 안에 들어오지 않는다. 재절단은 "초과 PR 1개"를 "초과 PR 1개 + 소형 PR 1개"로 바꾸는 거래일 뿐이다.

## 리뷰가 지적한 문구 정정 2건 (주석 전용, 코드 무변경)

- `session_rotation.rs` 모듈 doc 의 *"no timer-driven code path deletes it at all"* 은 **문자 그대로 거짓**이었다. 조건 게이트 때문에 실질은 옳지만 서술이 틀렸다. **참인 3항 열거**로 교체했다: ① 새 채택이 엔트리를 덮어씀(권위의 재진술이지 소실이 아님) ② `forget_hook_adopted_claude_session_id` 는 **실제로 5s rehydrate 패스가 부르는 타이머 구동**이지만 그 패스가 페인을 DEAD/orphaned 로 확정한 경우에만 게이트를 통과함 ③ `lock_adopted_sessions` 의 `retain` 은 타이머가 아니라 **매 접근** 프룬이며 12h 초과분만 축출.
- `ROTATION_RECORD_TTL` doc 의 *"평범한 launch-script 비교로 폴백"* 은 오도였다 — **그 비교가 곧 이 스토어가 막으려는 버그**라서 안전망일 수 없다. 진짜 무해 근거로 교체했다: 로테이션을 탐지하는 훅 가드(`hook_server`, `command_session_id != payload_session_id` 분기)가 **같은 순간** `persist_claude_continuation_session` 을 불러 **디스크의 launch script 를 채택 세션 이름으로 다시 쓴다.** 12h 이 지나기 훨씬 전에 launch script 와 채택 바인딩이 일치하므로 인메모리 권위를 잃어도 달라지는 것이 없다.

## M2 에 대한 정직한 서술

뮤테이션 증거를 인용할 때 **M2 의 KILLED 는 정의적(definitional)이며 판별력의 증거가 아니다.** r1 이 지적한 배선 무커버리지를 실제로 해소한 것은 **M3 · M4** 다. **M2 를 배선 커버리지의 증거로 인용하지 마라.**

## 미해결 후속 (리뷰가 남긴 P2, 착지 차단 아님)

- #5212 — 훅 재보고 경로(`runtime_binding.rs` 의 "이미 채택된 세션" 분기)의 `record_hook_adopted_claude_session_id` 호출을 **지워도 495개 테스트가 전부 통과**한다. 이 호출이 살아있는 페인에서 12h TTL 을 도달 불가로 만드는 기전인데 배선 무커버리지다.
- #5213 — settle WARN 의 `observed_drain_frontier` / `polls_without_drain_progress` 가 스냅샷 클론에서 읽혀 **한 폴 stale** 이다. 스톨 상한(`ROTATION_DRAIN_STALL_POLLS = 20`) 트립 시 로그는 `polls_without_drain_progress=19` 로 찍힌다. 같은 줄의 `undelivered_bytes` 는 신선하다. 제어 흐름은 정확하고 진단만 어긋난다.

## 게이트

- **레드라인 3파일 무접촉**: `scripts/run_relay_authority_mutations.sh`, `scripts/check_relay_authority_contract.py`, `src/services/discord/session_relay_sink/terminal_handoff.rs`.
- **거대파일 게이트**: `src/services/discord/health/snapshot.rs` **prod 998 → 980** (임계 1000, 여유 2줄 → 20줄). 프로덕션 라인을 **내린다**.
- **핫파일 래칫 무변경**: `tui_prompt_relay.rs` 는 PR-A 가 확정한 899/899 그대로. 천장을 올리지 않는다.
- **생성 매니페스트**: 리베이스 후 `--write-lib-inventory-manifest` 로 재생성했고 blob 해시가 재생성 전후 동일, tracked diff 0.
