### PR TITLE
fix(ci): classify GitHub action-download outages as infrastructure (#5207)

### DIFF
--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -112,7 +112,12 @@ echo "=== CI runner hardening guard ==="
 ./scripts/check-ci-runner-hardening.sh
 "$PYTHON" -m unittest tests.test_discord_thread_create_ci_wiring
 
-echo "=== PR infrastructure failure rerun classifier (#4392) ==="
+echo "=== PR infrastructure failure rerun classifier (#4392/#5207) ==="
+# The self-test also enforces the #5207 sibling-regex sync contract: the
+# classifier's INFRA_TERMINATION_REGEX must stay byte-identical to
+# log_has_infra_termination in scripts/main-ci-triage.sh, and drift fails here.
+# tests/test_infra_failure_classifier_5207.sh (tests/*.sh loop below) carries
+# the discriminating matrix and proves drift detection actually discriminates.
 ./scripts/ci/infra-failure-rerun.sh --self-test
 
 echo "=== CI timeout wrapper tests (#4413) ==="

--- a/scripts/ci/infra-failure-rerun.sh
+++ b/scripts/ci/infra-failure-rerun.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 SELF_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TRIAGE_SCRIPT="$REPO_ROOT/scripts/main-ci-triage.sh"
 TMP_DIR="$(mktemp -d)"
 SUMMARY_ROWS="$TMP_DIR/summary-rows.md"
 PG_JOB_NAME="PostgreSQL tests (ubuntu-postgres)"
@@ -13,6 +16,23 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 usage() {
   cat <<EOF
 Usage: $SELF_NAME [--self-test]
+       $SELF_NAME --classify-job <job-name> <log-path> <executed-steps>
+       $SELF_NAME --failed-job-rows <jobs-json-path>
+
+  --classify-job  Print the classification a failed job would receive.
+                  <executed-steps> is the number of steps the job ran outside
+                  the runner's own \`Set up job\` / \`Complete job\`, or the
+                  literal \`unknown\` when the jobs payload carried no steps.
+
+  --failed-job-rows
+                  Print the \`<job-id>\\t<executed-steps>\\t<job-name>\` rows
+                  the live loop consumes, from a jobs API payload, so the
+                  step-count expression itself is testable (#5207 F3).
+
+Diagnostic note (#5207): a job's \`conclusion\` is set by run-level aborts, so a
+job that completed every one of its steps successfully can still report
+\`cancelled\`. Read per-job STEP results, not \`conclusion\`, when judging whether
+a gate actually ran.
 
 Environment:
   GITHUB_REPOSITORY  owner/repository (required for a workflow run)
@@ -34,16 +54,370 @@ is_positive_integer() {
   [[ "$1" =~ ^[1-9][0-9]*$ ]]
 }
 
-# Keep the first alternation exactly aligned with the validated termination
-# regex in scripts/main-ci-triage.sh. The final alternation is deliberately
-# narrow: it matches GitHub's step-level action timeout, not arbitrary timeout
-# text from tests, dependencies, or cache statistics.
+# #5207 (F3): the sole producer of the step count R3 consumes. Inline in
+# `run_classifier` it was untestable — every test handed `classify_job` an
+# integer — so it is a named constant that `--failed-job-rows` can drive against
+# fixtures. `.name` is emitted LAST so a job name containing a tab cannot shift
+# the count the caller's `IFS=$'\t' read` picks up.
+#
+# #5207 (F4): the else-branch yields `unknown`, never `0`, for `steps` absent,
+# null, AND `[]`. An empty array is data-absence wearing an array's type — a job
+# the API calls `failure` entered `Set up job`, so a truthful payload carries at
+# least that step. Reading `[]` as 0 would auto-rerun every failed job whose
+# steps we cannot see; `unknown` makes `job_ran_no_repo_steps` decline instead.
+FAILED_JOB_ROWS_JQ='
+    .jobs[]
+    | select(.conclusion == "failure")
+    | [
+        (.id | tostring),
+        (if (.steps | type) == "array" and ((.steps | length) > 0)
+         then ([.steps[] | select((.name // "" | ascii_downcase) as $n | $n != "set up job" and $n != "complete job")] | length | tostring)
+         else "unknown"
+         end),
+        .name
+      ]
+    | @tsv'
+
+failed_job_rows() {
+  local jobs_payload="$1"
+  jq -r "$FAILED_JOB_ROWS_JQ" "$jobs_payload"
+}
+
+# #5207 (R2): this literal must stay byte-identical to the validated
+# termination regex in `log_has_infra_termination` (scripts/main-ci-triage.sh).
+# That alignment used to be a comment a human had to honour; it is now enforced
+# by `assert_termination_regex_synced`, which is exercised on every
+# `--self-test` run (wired from scripts/ci-script-checks.sh). Editing either
+# side alone makes the self-test fail.
+INFRA_TERMINATION_REGEX='signal[: ]+(9|15)([^0-9]|$)|sig(term|kill)|terminated on line [0-9]+ by signal|(exit(ed)?|code|status)[^0-9]*143([^0-9]|$)|the operation was cancell?ed|runner has received a shutdown signal'
+
+# Deliberately narrow: GitHub's step-level action timeout, not arbitrary
+# timeout text from tests, dependencies, or cache statistics.
+INFRA_ACTION_TIMEOUT_REGEX="the action '.+' has timed out after [0-9]+ minutes"
+
+# #5207 (R1): the 2026-08-07 Actions outage emitted
+# `Failed to resolve action download info. Error: Service Unavailable` ten
+# times in a single run and matched none of the termination alternations, so a
+# pure infrastructure outage was left unclassified and read as a code problem.
+#
+# The anchor is the runner-emitted action-download phrase, NOT the bare server
+# error: `Service Unavailable` / `503` alone also appear in test output and
+# dependency chatter, and widening to those would let a genuine regression be
+# auto-rerun. Requiring both halves on the SAME line also keeps out the
+# repo-config mode, which reuses this very prefix but reports
+# `… Error: Unable to resolve action \`owner/repo@ref\`, repository not found`
+# (RUNNER: LaunchHttpClientL0.cs:100; LOG: actions/runner#1006) — a real
+# regression in this repo, which must stay unmatched here.
+#
+# #5207 (r3): `internal server error` is not speculative — it was observed
+# beside `service unavailable` in the same log (LOG: ROCm/TheRock#7167).
+#
+# ★ PROVENANCE (#5207 r4, P3-1). This constant is used POSITIVELY — a match
+# turns automatic retry ON — so it needs STRICTER evidence than the withholding
+# regex below, not looser. r3 cited sources only on the withholding side, which
+# is backwards: a wrong negative alternation costs a lost retry, a wrong
+# positive one auto-retries something broken.
+#   service unavailable    LOG: the 2026-08-07 outage above (ten occurrences in
+#                          one run); also ROCm/TheRock#7167.
+#   internal server error  LOG: ROCm/TheRock#7167, beside `service unavailable`
+#                          in the same log.
+#   bad gateway            RUNNER-DERIVED ON THE V2 RESOLVER PATH — no
+#   gateway time-?out      per-phrase log needed there, and that derivation IS
+#                          the citation. For any non-422/429 response
+#                          LaunchHttpClient.cs:51,77 sets the exception message
+#                          to `response.ReasonPhrase` VERBATIM and throws a
+#                          retryable `Exception`, which ActionManager.cs:1086
+#                          prints after `Error: `. On that path the text in
+#                          this slot is therefore exactly the HTTP reason
+#                          phrase, and 502/504 are the same edge-error family
+#                          as the 500/503 observed above. `time-?out` covers
+#                          both shipped spellings: RFC 2616 wrote `Gateway
+#                          Time-out`, RFC 7231 writes `Gateway Timeout`.
+#                          #5207 (r5, D2) — THE QUALIFIER MATTERS: :51,77 live
+#                          in `GetResolveActionsDownloadInfoAsyncV2`
+#                          (LaunchHttpClient.cs:40-79), and LaunchServer.cs:
+#                          47-54 reaches it only when
+#                          `actions_display_helpful_actions_download_errors` is
+#                          on (read at ActionManager.cs:1067, default `?? false`
+#                          ). The V1 entry point, `GetResolveActionsDownload
+#                          InfoAsync` (LaunchHttpClient.cs:33-38), contains none
+#                          of that mapping, so on V1 this slot is NOT known to
+#                          hold a reason phrase and the derivation says nothing.
+#                          It still carries the observed logs: the outage line
+#                          `Failed to resolve action download info. Error:
+#                          Service Unavailable` is `Error: ` followed by a bare
+#                          reason phrase, i.e. the V2 shape. Claim scope: TRUE
+#                          ON V2, UNPROVEN ON V1 — not "true of every runner".
+#
+# REMOVED in r4 for want of provenance — both were r3 inventions of the same
+# kind the rule at REPO_CONFIG_FAULT_REGEX was written to stop:
+#   temporarily unavailable  NOT an HTTP reason phrase, so the mechanical
+#     derivation above does not reach it, and a GitHub-wide search found it in
+#     this slot zero times.
+#   too many requests / 429  UNREACHABLE ON THIS LINE ON THE V2 RESOLVER PATH,
+#     proven from source: LaunchHttpClient.cs:68-73 — inside
+#     `GetResolveActionsDownloadInfoAsyncV2` — throws
+#     `NonRetryableActionDownloadInfoException` for 429, and
+#     ActionManager.cs:1084-1086 prints the `Failed to resolve action download
+#     info. Error: …` line ONLY when the exception is neither that type nor
+#     `UnresolvableActionDownloadInfoException`. On V2 the prefix this regex
+#     requires is therefore never emitted for a 429.
+#     #5207 (r5, D2) — THAT PROOF IS PATH-SCOPED. LaunchServer.cs:47-54 routes
+#     to V2 only when `actions_display_helpful_actions_download_errors` is on
+#     (ActionManager.cs:1067, default `?? false`); the V1 entry point
+#     (LaunchHttpClient.cs:33-38) runs none of that code, so on V1 the 429
+#     handling is not established here. The removal still holds for the logs
+#     this regex is aimed at, because the observed outage line is the V2 shape
+#     (`Error: ` + a bare reason phrase).
+#     #5207 (r5, D2) — NO COVERAGE IS LOST BY THE REMOVAL, EITHER WAY. A 429
+#     aborts action resolution inside `Set up job`, so the job dies before any
+#     step this repo defines runs: `executed_steps` is 0, `job_ran_no_repo_steps`
+#     accepts it, and `job_is_infra_failure` still returns true via the
+#     zero-step path. The retry decision is bit-identical; only the summary
+#     label moves, `infra-shutdown` -> `infra-no-steps`. Do NOT re-add this
+#     alternation on the belief that 429 would otherwise go unclassified.
+#     The r3 `F5` comment argued the
+#     alternation was "kept, deliberately" and reasoned about rate-limit
+#     containment; that premise was false — the state it protected cannot occur.
+#     Containment itself is unaffected and never depended on it: at most two
+#     automatic attempts (`ci-pr-infra-retry.yml` gates on `run_attempt < 3`,
+#     `run_classifier` returns `no-op:attempt-cap` at `RUN_ATTEMPT >= 3`), one
+#     job per rerun.
+INFRA_ACTION_DOWNLOAD_REGEX='failed to resolve action download info.*(service unavailable|bad gateway|gateway time-?out|internal server error)'
+
+# #5207 (F1): repo-configuration faults that kill a job before any repo step.
+# Needed because the original R3 premise ("a job that ran no repo step cannot
+# have failed because of this repo's code") is false, and its falseness quietly
+# re-admitted what the R1 anchor was written to exclude.
+#
+# ★ PROVENANCE RULE (#5207 r3) — READ BEFORE EDITING. Two alternations shipped
+# here in r2, `no runner matching the labels` and `requesting permissions that
+# are not allowed`, are phrases NO GitHub component emits: invented in prose,
+# then reused verbatim as the test fixtures, so the suite proved only that the
+# regex matched its author's imagination. Each alternation now cites where its
+# literal was OBSERVED. Add none without such a citation. `RUNNER` = actions/
+# runner source; `LOG` = a real pasted job log (GitHub-wide issue-body search).
+#
+# [1] failed to resolve action download info\. error: bad request
+#     RUNNER ActionManager.cs:1086 prints "Failed to resolve action download
+#     info. Error: {ex.Message}"; LaunchHttpClient.cs:77 makes {ex.Message} the
+#     :51 `response.ReasonPhrase` for a non-422/429 response.
+#     #5207 (r5, D3): the throw is on :77 — :76 is the opening brace of the
+#     `else` arm — matching the :51,77 citation on the positive regex above.
+#     #5207 (r5, D2): as there, this holds ON THE V2 RESOLVER PATH
+#     (`GetResolveActionsDownloadInfoAsyncV2`), which LaunchServer.cs:47-54
+#     selects only when `actions_display_helpful_actions_download_errors` is on
+#     (ActionManager.cs:1067, default `?? false`). The log cited next carries
+#     the V2 shape, `Error: ` + reason phrase, so the alternation is bound to an
+#     observed literal regardless of how the derivation is scoped.
+#     LOG actions/runner#1247:
+#     "…Error: Bad request - freertos/ci-cd-github-actions@main is not allowed
+#     to be used in aws/aws-iot-device-sdk-embedded-C." — an Actions policy
+#     rejection, i.e. this repo's configuration, not an outage. `not found` /
+#     `unauthorized` / `forbidden` were DROPPED: no real log carries them in
+#     this slot, and the nonexistent-action case arrives as [2] inside this
+#     same line.
+# [2] unable to resolve action
+#     RUNNER LaunchHttpClientL0.cs:100 mirrors the service's 422 body: "Unable
+#     to resolve action 'owner1/invalid-action@0123456789', repository not
+#     found". LOG actions/runner#1006, google-github-actions/setup-gcloud#270,
+#     ratt-ru/tricolour#72, SpraxDev/Action-SpigotMC#21 — all wrapped as
+#     "Failed to resolve action download info. Error: Unable to resolve action
+#     `actions/chcekout@v2`, repository not found". Ref quoting varies
+#     (backtick / quote / bare / "…action. Repository not found: X"), so the
+#     anchor stops before the ref.
+# [3] no runner matching the specified labels
+#     Service-side; absent from actions/runner. LOG six unrelated repos, e.g.
+#     ianbruene/ddgo#22 "Error: No runner matching the specified labels was
+#     found: macos-15-intel" and "…was found: self-hosted, gpu". A search for
+#     the r2 wording "no runner matching the labels" returned prose only, never
+#     a log. CAVEAT: ddgo#22 names the failing step "Runner provisioning /
+#     start job" — the job never starts, so this surfaces as the run/job
+#     annotation and its presence in the DOWNLOADABLE job log is UNVERIFIED.
+# [4] the workflow is not valid
+#     RUNNER WorkflowStrings.resx:121,124 ("The workflow is not valid." /
+#     "…{0}"), raised by WorkflowValidationException.cs:13,18. LOG "The workflow
+#     is not valid. .github/workflows/ci.yml (Line: 49, Col: 3): …".
+#     CAVEAT: same reachability limit as [3], and for a sharper reason. Both
+#     literals are Sdk/WorkflowParser products, i.e. they are produced BEFORE
+#     any job exists: the run ends as `startup_failure` under `Invalid workflow
+#     file`, so there is no job and therefore no downloadable job log for this
+#     script to read. Presence in a job log is UNVERIFIED.
+# [5] is requesting '<x>', but is only allowed '<y>'
+#     RUNNER PermissionsHelper.cs:47 (and :43, nested-job wording): "Error
+#     calling workflow '{ref}'. The workflow is requesting '{requested}', but is
+#     only allowed '{allowed}'." LOG "The nested job 'release' is requesting
+#     'contents: write', but is only allowed 'contents: read'." The top-level
+#     form is normally wrapped by [4]; the nested-job form is seen standalone,
+#     so this alternation is not redundant.
+#     CAVEAT: as [4] — Sdk/WorkflowParser/Conversion/PermissionsHelper.cs is
+#     also pre-job, so job-log presence is UNVERIFIED.
+#     [3]/[4]/[5] are all kept regardless: they are used only NEGATIVELY, and a
+#     job with no log already fails closed at `no-op:unknown`.
+# [6] manifest for .* not found
+#     Docker daemon text, surfaced because the runner shells out to `docker
+#     pull` (RUNNER DockerCommandManager.cs:100). LOG "Error response from
+#     daemon: manifest for weirauchlab/reli:alpine not found: manifest unknown:
+#     manifest unknown". The `.*` is over-broad, tolerated because this constant
+#     is used only NEGATIVELY (to WITHHOLD the infrastructure label): a false
+#     positive costs a lost auto-retry, never an auto-retry of a broken repo.
+#
+# ★ RESIDUAL RISK — a repo-configuration fault NOT enumerated above is still
+# classified as infrastructure and automatically retried. That set is not small:
+# environment-name errors, concurrency expressions, composite actions, OIDC/env
+# misconfiguration, checkout auth, no-enabled-runners, the other `Invalid
+# workflow file` families (missing called workflow, unsupplied required secret,
+# unknown job dependency), missing hosted-runner images, Docker login and
+# container init all reach `infra-no-steps` today. Bounded cost, measured: one
+# wasted rerun plus a wrong label in the summary table. A DETERMINISTIC config
+# fault fails again on the retry and then hits the `run_attempt >= 3` cap, so
+# no deterministically broken repo is auto-retried into a pass.
+#
+# #5207 (r4): that conclusion is deliberately NOT stated as a universal. A
+# NON-deterministic repo-configuration fault — one whose outcome depends on
+# runner-pool availability, a flaky container registry, or an expiring token —
+# can pass on the retry, and then a real defect has been papered over by an
+# automatic rerun. The premise ("deterministic") bounds the conclusion; writing
+# "nothing broken is auto-retried into a pass" would repeat exactly the
+# over-general claim F1 was raised to remove from R3.
+#
+# Bare `Not Found` is deliberately not an alternation — too common on its own.
+REPO_CONFIG_FAULT_REGEX="failed to resolve action download info\. error: bad request|unable to resolve action|no runner matching the specified labels|the workflow is not valid|is requesting '[^']*', but is only allowed '[^']*'|manifest for .* not found"
+
+log_has_repo_config_fault() {
+  local log_path="$1"
+  [[ -s "$log_path" ]] || return 1
+  grep -a -E -i -q -- "$REPO_CONFIG_FAULT_REGEX" "$log_path"
+}
+
+# #5207: the outage's SECOND fingerprint. In run 31120826793 (PR #5204) the
+# gating `Changed paths` job waited ~16 minutes for a runner, was retired by
+# GitHub as `abandoned`, and every downstream required-check mirror then failed
+# closed, printing verbatim `CHANGED_PATHS_RESULT: abandoned` and
+# `##[error]Changed paths result is unexpected: 'abandoned'`.
+#
+# Log string and not the API, because `abandoned` is not exposed there: on that
+# run the `Changed paths` job reports `conclusion=cancelled` and the substring
+# occurs zero times in the whole `.../attempts/1/jobs` payload. It lives only in
+# the workflow expression context (`${{ needs.changes.result }}`), which
+# `scripts/required-check-mirror.sh` echoes into the mirror's log.
+#
+# A SEPARATE predicate and label, not folded into `log_has_infra_failure`,
+# because the mirror's `failure` is correct behaviour. Keeping it out of
+# `job_is_infra_failure` means nothing here can move a retry decision by one bit
+# — retrying a fail-closed gate is how you neuter it. All it changes is a label.
+#
+# Narrowness: bare `abandoned` is an ordinary English word, so each alternation
+# binds it to the mirror's `<X>_RESULT:` echo or its quoted result message.
+# #5207 (r3, P3-2): `_result:[[:space:]]+abandoned` also matches any other
+# `<x>_result:  abandoned` echo, e.g. `session_result:  abandoned`. No producer
+# of such a line exists in this repo today; if one appears, tighten the prefix.
+# #5207 (r3, P3-1): on the PG job this label is unreachable by construction —
+# `run_classifier` overwrites it with `unclassified-pg-failure` (steps >= 1) or
+# `infra-no-steps` (steps == 0). That is intended: the label diagnoses the
+# required-check MIRROR jobs, and the PG job's own label must stay tied to the
+# retry decision. Nothing is lost — the mirror jobs still carry it.
+UPSTREAM_ABANDONED_REGEX="result (is unexpected: |is |was )'abandoned'|_result:[[:space:]]+abandoned"
+
+log_has_upstream_abandoned() {
+  local log_path="$1"
+  [[ -s "$log_path" ]] || return 1
+  grep -a -E -i -q -- "$UPSTREAM_ABANDONED_REGEX" "$log_path"
+}
+
 log_has_infra_failure() {
   local log_path="$1"
   [[ -s "$log_path" ]] || return 1
   grep -a -E -i -q -- \
-    "signal[: ]+(9|15)([^0-9]|$)|sig(term|kill)|terminated on line [0-9]+ by signal|(exit(ed)?|code|status)[^0-9]*143([^0-9]|$)|the operation was cancell?ed|runner has received a shutdown signal|the action '.+' has timed out after [0-9]+ minutes" \
+    "$INFRA_TERMINATION_REGEX|$INFRA_ACTION_TIMEOUT_REGEX|$INFRA_ACTION_DOWNLOAD_REGEX" \
     "$log_path"
+}
+
+# #5207 (R2 enforcement): pull the regex literal `log_has_infra_termination`
+# hands to grep out of scripts/main-ci-triage.sh so the two siblings can be
+# compared.
+#
+# #5207 (F6): safety comes from the FINAL COMPARISON in
+# `assert_termination_regex_synced`, which compares against the non-empty
+# constant, so an extractor that returned "" still fails. The `END { exit 1 }`
+# below and the caller's `-n` guard are therefore redundant for correctness,
+# kept only for the specific `<not found>` diagnostic — untested by design.
+extract_termination_regex() {
+  local path="$1"
+  [[ -f "$path" ]] || return 1
+  awk '
+    BEGIN { q = sprintf("%c", 39); found = 0 }
+    index($0, "log_has_infra_termination() {") == 1 { inside = 1; next }
+    # #5207 (F7): accept an indented closing brace too. Anchoring on a
+    # column-0 `}` alone would let the scan run past the end of the function
+    # and pick up a later function s own literal, reporting SYNCED for a file
+    # whose `log_has_infra_termination` no longer holds one.
+    inside && $0 ~ /^[[:space:]]*}[[:space:]]*$/ { exit }
+    inside {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (substr(line, 1, 1) != q) next
+      line = substr(line, 2)
+      sub(/[[:space:]]*\\[[:space:]]*$/, "", line)
+      if (substr(line, length(line), 1) == q) line = substr(line, 1, length(line) - 1)
+      print line
+      found = 1
+      exit
+    }
+    END { if (found == 0) exit 1 }
+  ' "$path"
+}
+
+assert_termination_regex_synced() {
+  local path="$1"
+  local extracted
+  extracted="$(extract_termination_regex "$path")" || return 1
+  [[ -n "$extracted" ]] || return 1
+  [[ "$extracted" == "$INFRA_TERMINATION_REGEX" ]]
+}
+
+# #5207 (R3): purely structural test — did the job run any step this repo
+# defines? `Set up job` / `Complete job` are runner-provided housekeeping, and
+# action download happens inside `Set up job`, which is exactly where the
+# 2026-08-07 outage killed the jobs (`steps_total` was 1 or 0, with that one
+# step being `Set up job`).
+#
+# Fails closed: a non-numeric count (the jobs payload carried no usable `steps`
+# array) is treated as "not infrastructure", never as zero.
+job_ran_no_repo_steps() {
+  local executed_steps="$1"
+  [[ "$executed_steps" =~ ^[0-9]+$ ]] || return 1
+  (( executed_steps == 0 ))
+}
+
+# #5207 (F1, correcting R3): zero executed repo steps is a NECESSARY condition
+# for the structural signal, not a sufficient one. The claim R3 used to make —
+# "a job that reached none of the repo's own steps cannot have failed because of
+# this repo's code" — is false, refuted by the repo faults enumerated at
+# REPO_CONFIG_FAULT_REGEX, which die before any repo step runs. A true
+# enumeration replaces the false universal: what survives is "zero repo steps
+# AND no known repo-configuration fault". The conjunction is no longer spelled
+# here — as of r3 the repo-fault half is a single hoisted guard (P2-1 below),
+# so it now covers the R1 path as well as this one.
+#
+# #5207 (r3, P2-1): the repo-fault guard is hoisted so it covers the R1 path
+# too. r2 applied it only to the zero-step path, arguing that R1 demands a
+# positive outage fingerprint. That argument does not cover ONE LOG CARRYING
+# BOTH, which is exactly a configuration regression deployed during an outage:
+#   Failed to resolve action download info. Error: Service Unavailable
+#   Failed to resolve action download info. Error: Unable to resolve action …
+# R1 matched line 1, the guard never ran, and the job was auto-rerun.
+#
+# The cost of the fix is real and accepted: during a genuine outage a log that
+# also happens to contain an enumerated phrase loses its automatic rerun. That
+# is fail-closed — a human reruns it — whereas the other direction auto-retries
+# a broken repo. Both directions are pinned by tests.
+job_is_infra_failure() {
+  local log_path="$1"
+  local executed_steps="$2"
+  ! log_has_repo_config_fault "$log_path" || return 1
+  log_has_infra_failure "$log_path" && return 0
+  job_ran_no_repo_steps "$executed_steps"
 }
 
 # Regression markers are checked across every failed job except the explicitly
@@ -63,6 +437,40 @@ job_log_has_blocking_regression() {
 
   [[ "$job_name" != "$WINDOWS_ADVISORY_JOB_NAME" ]] || return 1
   log_has_regression "$log_path"
+}
+
+# #5207 (R4): the single classification chain used by both the live loop and
+# `--classify-job`, so the tested path and the executed path cannot drift.
+#
+# Ordering is the contract: BOTH regression predicates are consulted before any
+# infrastructure predicate, so a log carrying regression markers can never be
+# relabelled as infrastructure no matter how many infra fingerprints it also
+# carries. R1 and R3 are strictly appended below that guard.
+classify_job() {
+  local job_name="$1"
+  local log_path="$2"
+  local executed_steps="$3"
+
+  if job_log_has_blocking_regression "$job_name" "$log_path"; then
+    printf 'regression'
+  elif log_has_regression "$log_path"; then
+    printf 'advisory-regression'
+  elif log_has_repo_config_fault "$log_path"; then
+    # #5207 (r3, P2-1): an enumerated repo-configuration fault outranks the R1
+    # outage fingerprint, so a log carrying both cannot be labelled — or rerun —
+    # as pure infrastructure. See job_is_infra_failure.
+    printf 'unrelated-failure'
+  elif log_has_infra_failure "$log_path"; then
+    printf 'infra-unrelated'
+  elif log_has_upstream_abandoned "$log_path"; then
+    # Diagnosis only — see UPSTREAM_ABANDONED_REGEX. This label is intentionally
+    # NOT reachable by `job_is_infra_failure`, so it cannot cause a rerun.
+    printf 'infra-upstream-abandoned'
+  elif job_ran_no_repo_steps "$executed_steps"; then
+    printf 'infra-no-steps'
+  else
+    printf 'unrelated-failure'
+  fi
 }
 
 decide_retry() {
@@ -194,9 +602,9 @@ run_classifier() {
   local regression_count=0
   local unknown_count=0
   local pg_job_id=""
-  local job_id job_name log_path job_class
+  local job_id job_name log_path job_class executed_steps
 
-  while IFS=$'\t' read -r job_id job_name; do
+  while IFS=$'\t' read -r job_id executed_steps job_name; do
     [[ -n "$job_id" ]] || continue
     log_path="$TMP_DIR/job-$job_id.log"
     job_class="unrelated-failure"
@@ -208,25 +616,23 @@ run_classifier() {
       continue
     fi
 
-    if job_log_has_blocking_regression "$job_name" "$log_path"; then
+    job_class="$(classify_job "$job_name" "$log_path" "$executed_steps")"
+    if [[ "$job_class" == "regression" ]]; then
       regression_count=$((regression_count + 1))
-      job_class="regression"
-    elif log_has_regression "$log_path"; then
-      job_class="advisory-regression"
-    elif log_has_infra_failure "$log_path"; then
-      job_class="infra-unrelated"
     fi
 
     if [[ "$job_name" == "$PG_JOB_NAME" ]]; then
       pg_failed_count=$((pg_failed_count + 1))
       pg_job_id="$job_id"
-      if log_has_infra_failure "$log_path"; then
+      if job_is_infra_failure "$log_path" "$executed_steps"; then
         pg_classified_count=$((pg_classified_count + 1))
         if [[ "$job_class" != "regression" ]]; then
-          if grep -a -E -i -q -- "the action '.+' has timed out after [0-9]+ minutes" "$log_path"; then
+          if grep -a -E -i -q -- "$INFRA_ACTION_TIMEOUT_REGEX" "$log_path"; then
             job_class="infra-timeout"
-          else
+          elif log_has_infra_failure "$log_path"; then
             job_class="infra-shutdown"
+          else
+            job_class="infra-no-steps"
           fi
         fi
       elif [[ "$job_class" == "regression" ]]; then
@@ -241,7 +647,7 @@ run_classifier() {
     fi
 
     append_summary_row "$job_id" "$job_class"
-  done < <(jq -r '.jobs[] | select(.conclusion == "failure") | [(.id | tostring), .name] | @tsv' "$jobs_payload")
+  done < <(failed_job_rows "$jobs_payload")
 
   decision="$(decide_retry "$pg_failed_count" "$pg_classified_count" "$regression_count" "$unknown_count")"
   if [[ "$decision" != "would-rerun:infra" ]]; then
@@ -344,13 +750,255 @@ run_self_test() {
     "$(decide_retry 1 1 "$pg_regression_count" 0)" \
     "PG regression remains fail-closed"
 
+  run_action_download_assertions
+  run_zero_step_assertions
+  run_upstream_abandoned_assertions
+  run_regression_precedence_assertions
+  run_termination_sync_assertions
+
   echo "self-test passed"
+}
+
+# #5207: smoke check for the `abandoned` upstream label; the full matrix lives
+# in tests/test_infra_failure_classifier_5207.sh, which CI runs alongside this.
+run_upstream_abandoned_assertions() {
+  local mirror_log="$TMP_DIR/selftest-upstream-abandoned.log"
+  local word_log="$TMP_DIR/selftest-abandoned-word.log"
+
+  printf '%s\n' "##[error]Changed paths result is unexpected: 'abandoned'" >"$mirror_log"
+  printf '%s\n' 'test store::abandoned_session_is_reaped ... ok' >"$word_log"
+
+  assert_equal "infra-upstream-abandoned" \
+    "$(classify_job 'Fast check cross OS required context (ubuntu-latest)' "$mirror_log" 5)" \
+    "an abandoned upstream is reported as upstream infrastructure"
+  assert_equal "unrelated-failure" \
+    "$(classify_job "$PG_JOB_NAME" "$word_log" 5)" \
+    "the bare word 'abandoned' is not an infrastructure fingerprint"
+
+  # Containment: diagnosing the mirror must never make it rerunnable, or the
+  # fail-closed gate would be neutralised by retry.
+  if job_is_infra_failure "$mirror_log" 5; then
+    echo "assertion failed: an abandoned upstream must NOT satisfy the rerun predicate" >&2
+    exit 1
+  fi
+}
+
+# #5207 R1: the 2026-08-07 outage fingerprint must classify as infrastructure,
+# and the narrowness of the anchor must be proven in the same place — a pattern
+# that also matched bare server errors or `Error: Not Found` would let genuine
+# failures be auto-rerun.
+run_action_download_assertions() {
+  local outage_log="$TMP_DIR/selftest-action-download.log"
+  local bare_server_error_log="$TMP_DIR/selftest-bare-service-unavailable.log"
+  local missing_action_log="$TMP_DIR/selftest-action-not-found.log"
+
+  printf '%s\n' \
+    'Failed to resolve action download info. Error: Service Unavailable' \
+    'Failed to resolve action download info. Error: Service Unavailable' \
+    >"$outage_log"
+  # A test that merely prints the server error string must not be rerunnable.
+  printf '%s\n' \
+    'assert_eq!(body, "Service Unavailable");' \
+    'Error: Service Unavailable' \
+    'HTTP 503 Service Unavailable' \
+    >"$bare_server_error_log"
+  # A workflow referencing an action that does not exist is a repo regression.
+  # #5207 (r3): this is the REAL wording, copied from actions/runner#1006 — an
+  # earlier revision used an invented `Error: Not Found`, which no GitHub
+  # component emits. See the provenance block at REPO_CONFIG_FAULT_REGEX.
+  printf '%s\n' \
+    'Failed to resolve action download info. Error: Unable to resolve action `actions/chcekout@v2`, repository not found' \
+    >"$missing_action_log"
+
+  log_has_infra_failure "$outage_log" || {
+    echo "assertion failed: action download outage must be infrastructure" >&2
+    exit 1
+  }
+  assert_equal "infra-unrelated" \
+    "$(classify_job "$PG_JOB_NAME" "$outage_log" 0)" \
+    "action download outage classifies as infra"
+  if log_has_infra_failure "$bare_server_error_log"; then
+    echo "assertion failed: bare 'Service Unavailable' must NOT be infrastructure" >&2
+    exit 1
+  fi
+  if log_has_infra_failure "$missing_action_log"; then
+    echo "assertion failed: unresolvable action (Not Found) must NOT be infrastructure" >&2
+    exit 1
+  fi
+  # #5207 (F1): the count this failure mode actually produces is ZERO — action
+  # refs resolve inside `Set up job`, so no repo step starts. Asserting it at 1
+  # pinned a state that cannot occur and let the zero-step path re-admit the
+  # very log the anchor above excludes.
+  assert_equal "unrelated-failure" \
+    "$(classify_job "$PG_JOB_NAME" "$missing_action_log" 0)" \
+    "unresolvable action stays non-infrastructure at its real step count of 0"
+
+  # #5207 (r3, P2-1): the RETRY PREDICATE, not only the label — no `classify_job`
+  # assertion reaches `job_is_infra_failure`, which is what gates
+  # `would-rerun:infra`. Rationale and accepted cost: see that function.
+  local mixed_fault_log="$TMP_DIR/selftest-outage-plus-repo-fault.log"
+  printf '%s\n' \
+    'Failed to resolve action download info. Error: Service Unavailable' \
+    'Failed to resolve action download info. Error: Unable to resolve action `acme/gone@v1`, repository not found' \
+    >"$mixed_fault_log"
+  if job_is_infra_failure "$mixed_fault_log" 0; then
+    echo "assertion failed (P2-1): a repo-config fault beside the outage fingerprint must NOT satisfy the rerun predicate" >&2
+    exit 1
+  fi
+  job_is_infra_failure "$outage_log" 0 || {
+    echo "assertion failed (P2-1 reverse): a clean outage log must still satisfy the rerun predicate" >&2
+    exit 1
+  }
+}
+
+# #5207 R3: zero executed repo steps reaches the structural signal (once the
+# F1 repo-fault guard has cleared the log), and a job that did run steps must
+# never take that path.
+run_zero_step_assertions() {
+  local quiet_log="$TMP_DIR/selftest-zero-step.log"
+
+  printf '%s\n' 'Error: The operation could not be completed.' >"$quiet_log"
+
+  assert_equal "infra-no-steps" \
+    "$(classify_job "$PG_JOB_NAME" "$quiet_log" 0)" \
+    "zero executed repo steps classifies as infra"
+  assert_equal "unrelated-failure" \
+    "$(classify_job "$PG_JOB_NAME" "$quiet_log" 13)" \
+    "a job that executed steps must not take the zero-step path"
+  assert_equal "unrelated-failure" \
+    "$(classify_job "$PG_JOB_NAME" "$quiet_log" unknown)" \
+    "absent step data must fail closed, not read as zero"
+
+  job_ran_no_repo_steps 0 || {
+    echo "assertion failed: 0 executed steps must be a structural infra signal" >&2
+    exit 1
+  }
+  if job_ran_no_repo_steps 1; then
+    echo "assertion failed: 1 executed step must not be a structural infra signal" >&2
+    exit 1
+  fi
+  if job_ran_no_repo_steps unknown; then
+    echo "assertion failed: unknown step count must not be a structural infra signal" >&2
+    exit 1
+  fi
+}
+
+# #5207 R4: pin the precedence contract. A log carrying regression markers is a
+# regression regardless of how many infrastructure fingerprints accompany it,
+# and no infra path may reach the retry decision past that guard.
+run_regression_precedence_assertions() {
+  local regression_with_outage_log="$TMP_DIR/selftest-regression-with-outage.log"
+
+  printf '%s\n' \
+    'Failed to resolve action download info. Error: Service Unavailable' \
+    'test result: FAILED. 1 passed; 1 failed' \
+    >"$regression_with_outage_log"
+
+  log_has_infra_failure "$regression_with_outage_log" || {
+    echo "assertion failed: fixture must carry the infrastructure fingerprint" >&2
+    exit 1
+  }
+  assert_equal "regression" \
+    "$(classify_job "$PG_JOB_NAME" "$regression_with_outage_log" 0)" \
+    "regression outranks both the R1 pattern and the R3 zero-step signal"
+
+  local mixed_regression_count=0
+  if job_log_has_blocking_regression "$PG_JOB_NAME" "$regression_with_outage_log"; then
+    mixed_regression_count=$((mixed_regression_count + 1))
+  fi
+  assert_equal "no-op:regression" \
+    "$(decide_retry 1 1 "$mixed_regression_count" 0)" \
+    "regression blocks rerun even when the infra predicates match"
+}
+
+# #5207 R2: prove the sibling regexes are aligned AND that the comparison is
+# capable of rejecting drift. The negative controls are what make neutering
+# `assert_termination_regex_synced` fail here instead of passing silently.
+run_termination_sync_assertions() {
+  local synced_fixture="$TMP_DIR/selftest-triage-synced.sh"
+  local drifted_fixture="$TMP_DIR/selftest-triage-drifted.sh"
+  local absent_fixture="$TMP_DIR/selftest-triage-absent.sh"
+  local indented_close_fixture="$TMP_DIR/selftest-triage-indented-close.sh"
+
+  assert_termination_regex_synced "$TRIAGE_SCRIPT" || {
+    echo "assertion failed: scripts/ci/infra-failure-rerun.sh INFRA_TERMINATION_REGEX has drifted from log_has_infra_termination in $TRIAGE_SCRIPT" >&2
+    echo "  rerun script: $INFRA_TERMINATION_REGEX" >&2
+    echo "  triage script: $(extract_termination_regex "$TRIAGE_SCRIPT" || echo '<not found>')" >&2
+    exit 1
+  }
+
+  {
+    # The `${1}` is load-bearing: it puts a `}` on a line INSIDE the function
+    # and before the literal, so widening the F7 brace guard to a bare `/}/`
+    # truncates the scan here and this fixture stops being accepted.
+    #
+    # #5207 (r4): state the limit plainly — that discriminator exists ONLY
+    # here. The real scripts/main-ci-triage.sh writes `local log_path="$1"`,
+    # with no braces and so no `}` before its literal, so widening the guard to
+    # `/}/` changes nothing when the extractor is pointed at production alone.
+    # This fixture is what makes the mutation detectable; deleting it, or
+    # "simplifying" `${1}` to `$1`, silently retires that coverage.
+    printf '%s\n' 'log_has_infra_termination() {' '  local log_path="${1}"'
+    printf "  grep -E -i -q -- \\\\\n    '%s' \\\\\n" "$INFRA_TERMINATION_REGEX"
+    printf '%s\n' '    "$log_path"' '}'
+  } >"$synced_fixture"
+  {
+    printf '%s\n' 'log_has_infra_termination() {'
+    printf "  grep -E -i -q -- \\\\\n    '%s' \\\\\n" "sig(term|kill)"
+    printf '%s\n' '    "$log_path"' '}'
+  } >"$drifted_fixture"
+  printf '%s\n' 'log_has_something_else() {' '  :' '}' >"$absent_fixture"
+  # #5207 (r3, P2-3): the discriminating fixture for F7. `log_has_infra_termination`
+  # holds NO literal and closes with an INDENTED `  }`; the NEXT function holds a
+  # correct one. Anchoring the scan on a column-0 `}` (the pre-F7 shape) walks
+  # past the indented close, adopts the neighbour's literal, and reports SYNCED
+  # for a file whose termination check no longer has a regex at all. F7 makes it
+  # stop at the indented brace and report drift instead.
+  {
+    printf '%s\n' 'log_has_infra_termination() {' '  local log_path="$1"' '  }'
+    printf '%s\n' 'log_has_neighbour() {'
+    printf "  grep -E -i -q -- \\\\\n    '%s' \\\\\n" "$INFRA_TERMINATION_REGEX"
+    printf '%s\n' '    "$log_path"' '}'
+  } >"$indented_close_fixture"
+
+  assert_termination_regex_synced "$synced_fixture" || {
+    echo "assertion failed: an aligned sibling must be accepted" >&2
+    exit 1
+  }
+  if assert_termination_regex_synced "$drifted_fixture"; then
+    echo "assertion failed: a drifted sibling regex must be rejected" >&2
+    exit 1
+  fi
+  if assert_termination_regex_synced "$absent_fixture"; then
+    echo "assertion failed: a missing log_has_infra_termination must be rejected" >&2
+    exit 1
+  fi
+  if assert_termination_regex_synced "$indented_close_fixture"; then
+    echo "assertion failed (F7): an indented closing brace must end the scan, not let a neighbouring function's literal be read as SYNCED" >&2
+    exit 1
+  fi
 }
 
 main() {
   case "${1-}" in
     --self-test)
       run_self_test
+      ;;
+    --classify-job)
+      if [[ $# -ne 4 ]]; then
+        usage >&2
+        exit 1
+      fi
+      classify_job "$2" "$3" "$4"
+      printf '\n'
+      ;;
+    --failed-job-rows)
+      if [[ $# -ne 2 ]]; then
+        usage >&2
+        exit 1
+      fi
+      require_cmd jq
+      failed_job_rows "$2"
       ;;
     "")
       run_classifier
@@ -365,4 +1013,4 @@ main() {
   esac
 }
 
-main "${1-}"
+main "$@"

--- a/tests/test_infra_failure_classifier_5207.sh
+++ b/tests/test_infra_failure_classifier_5207.sh
@@ -1,0 +1,589 @@
+#!/usr/bin/env bash
+# #5207: discriminating tests for the PR infrastructure-failure classifier.
+#
+# The 2026-08-07 GitHub Actions major outage emitted
+# `Failed to resolve action download info. Error: Service Unavailable` ten
+# times in a single run and matched none of the classifier's patterns.
+#
+# What that cost, stated exactly: the run's summary labelled a pure
+# infrastructure outage as an ordinary unexplained failure, and humans read it
+# as a code regression. It did NOT cost a retry. Measured on run 31116949449,
+# attempts 1-3: the PostgreSQL job never appears among the failed jobs, and
+# `decide_retry` only ever reruns a single failed PostgreSQL job, so the
+# decision was `no-op:no-pg-failure` before this change and is
+# `no-op:no-pg-failure` after it — identical, bit for bit. This work changes
+# the classification LABEL, not the retry behaviour. Widening the retry scope
+# beyond the PostgreSQL job is a separate issue.
+#
+# These tests pin BOTH directions. Widening the infra patterns so a real
+# regression is auto-rerun is strictly worse than the bug being fixed, so every
+# positive case here is paired with a negative control.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/ci/infra-failure-rerun.sh"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/infra-classifier-5207.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+FAILED=0
+
+fail() {
+  echo "not ok - $1" >&2
+  FAILED=1
+}
+
+pass() {
+  echo "ok - $1"
+}
+
+# Drives the shipped classification chain through the script's own entry point,
+# so these assertions cover the same code path `run_classifier` executes.
+assert_class() {
+  local name="$1"
+  local expected="$2"
+  local job_name="$3"
+  local log_path="$4"
+  local executed_steps="$5"
+  local actual
+
+  actual="$("$SCRIPT" --classify-job "$job_name" "$log_path" "$executed_steps")"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$name"
+  else
+    fail "$name (expected '$expected', got '$actual')"
+  fi
+}
+
+write_log() {
+  local path="$WORK_DIR/$1"
+  shift
+  printf '%s\n' "$@" >"$path"
+  printf '%s' "$path"
+}
+
+PG_JOB="PostgreSQL tests (ubuntu-postgres)"
+
+# --- R1: the outage fingerprint is infrastructure -------------------------
+OUTAGE_LOG="$(write_log outage.log \
+  'Download action repository actions/checkout@v4' \
+  'Failed to resolve action download info. Error: Service Unavailable' \
+  'Failed to resolve action download info. Error: Service Unavailable')"
+assert_class "action download outage is classified as infrastructure" \
+  "infra-unrelated" "$PG_JOB" "$OUTAGE_LOG" 1
+
+# --- R4 / acceptance: regression outranks infrastructure ------------------
+# The most important direction. A log carrying regression markers must not be
+# rerun no matter how many infrastructure fingerprints sit beside it.
+REGRESSION_LOG="$(write_log regression-with-outage.log \
+  'Failed to resolve action download info. Error: Service Unavailable' \
+  'The runner has received a shutdown signal.' \
+  'test result: FAILED. 163 passed; 1 failed')"
+assert_class "regression outranks the action-download pattern" \
+  "regression" "$PG_JOB" "$REGRESSION_LOG" 1
+assert_class "regression outranks the zero-step structural signal" \
+  "regression" "$PG_JOB" "$REGRESSION_LOG" 0
+
+PANIC_LOG="$(write_log panic-with-outage.log \
+  'Failed to resolve action download info. Error: Service Unavailable' \
+  'thread panicked at src/services/relay.rs:42:9')"
+assert_class "panic outranks the action-download pattern" \
+  "regression" "$PG_JOB" "$PANIC_LOG" 0
+
+# --- R1 narrowness: negative controls -------------------------------------
+BARE_ERROR_LOG="$(write_log bare-service-unavailable.log \
+  'test tunnel::returns_503 ... ok' \
+  'assert_eq!(status_text, "Service Unavailable");' \
+  'Error: Service Unavailable' \
+  'HTTP/1.1 503 Service Unavailable')"
+assert_class "bare 'Service Unavailable' is not infrastructure" \
+  "unrelated-failure" "$PG_JOB" "$BARE_ERROR_LOG" 1
+
+# A workflow that names an action which does not exist is a repo-config
+# regression, not an outage. It shares the action-download prefix, so this is
+# the tightest negative control on the R1 anchor.
+#
+# The step count here is 0, and that is the whole point. Action references are
+# resolved inside `Set up job`, so this failure mode CANNOT produce a nonzero
+# count; asserting it at 1 (as this control first did) pinned a state that
+# never occurs, and the zero-step signal quietly re-admitted the very log the
+# anchor above was written to exclude.
+#
+# #5207 (r3): the fixture is a VERBATIM real log line (actions/runner#1006; see
+# also setup-gcloud#270, ratt-ru/tricolour#72, SpraxDev/Action-SpigotMC#21). The
+# previous fixture said `Error: Not Found`, which no GitHub component emits — it
+# was invented in the issue text and then used as its own oracle. Provenance for
+# every alternation lives at REPO_CONFIG_FAULT_REGEX.
+NOT_FOUND_LOG="$(write_log action-not-found.log \
+  'Failed to resolve action download info. Error: Unable to resolve action `actions/chcekout@v2`, repository not found')"
+assert_class "unresolvable action (real 'Unable to resolve action' wording) is not infrastructure" \
+  "unrelated-failure" "$PG_JOB" "$NOT_FOUND_LOG" 0
+
+BAD_GATEWAY_LOG="$(write_log bad-gateway.log \
+  'Failed to resolve action download info. Error: Bad gateway')"
+assert_class "action download bad gateway is infrastructure" \
+  "infra-unrelated" "$PG_JOB" "$BAD_GATEWAY_LOG" 1
+
+# #5207 (r4, P3-1): the text in this slot is `response.ReasonPhrase` verbatim
+# (LaunchHttpClient.cs:51,77 -> ActionManager.cs:1086), and servers ship both
+# RFC 2616's `Gateway Time-out` and RFC 7231's `Gateway Timeout`. The
+# `time-?out` tolerance is deliberate, so both spellings are pinned.
+assert_class "action download gateway timeout (RFC 7231 spelling) is infrastructure" \
+  "infra-unrelated" "$PG_JOB" \
+  "$(write_log gateway-timeout.log 'Failed to resolve action download info. Error: Gateway Timeout')" 1
+assert_class "action download gateway time-out (RFC 2616 spelling) is infrastructure" \
+  "infra-unrelated" "$PG_JOB" \
+  "$(write_log gateway-time-out.log 'Failed to resolve action download info. Error: Gateway Time-out')" 1
+
+# The two alternations REMOVED in r4, pinned as removed so neither can return
+# without provenance. `too many requests` is unreachable by construction:
+# LaunchHttpClient.cs:68-73 throws NonRetryableActionDownloadInfoException for a
+# 429, and ActionManager.cs:1084-1086 prints this prefix only for exceptions
+# that are neither that nor UnresolvableActionDownloadInfoException — so the
+# line below is a log GitHub does not emit. `temporarily unavailable` is not an
+# HTTP reason phrase and was found in this slot zero times.
+assert_class "r4: a 429 in the action-download slot is not infrastructure (unreachable phrasing, removed)" \
+  "unrelated-failure" "$PG_JOB" \
+  "$(write_log too-many-requests.log 'Failed to resolve action download info. Error: Too Many Requests')" 1
+assert_class "r4: 'temporarily unavailable' is not infrastructure (no provenance, removed)" \
+  "unrelated-failure" "$PG_JOB" \
+  "$(write_log temporarily-unavailable.log 'Failed to resolve action download info. Error: Temporarily Unavailable')" 1
+
+# --- R3: zero executed repo steps is a structural infrastructure signal ----
+# The failing jobs in the outage ran `Set up job` and nothing else. That count
+# is a necessary condition, not a sufficient one (see F1 below), but once the
+# repo-fault guard clears the log it carries the outage regardless of wording.
+QUIET_LOG="$(write_log quiet.log \
+  'Error: The operation could not be completed.')"
+assert_class "a job that executed no repo steps is infrastructure" \
+  "infra-no-steps" "$PG_JOB" "$QUIET_LOG" 0
+assert_class "a job that executed repo steps does not take the zero-step path" \
+  "unrelated-failure" "$PG_JOB" "$QUIET_LOG" 13
+assert_class "one executed repo step does not take the zero-step path" \
+  "unrelated-failure" "$PG_JOB" "$QUIET_LOG" 1
+# Absent step data must fail closed. Reading a missing `steps` array as zero
+# would classify every failed job as infrastructure.
+assert_class "absent step data fails closed rather than reading as zero" \
+  "unrelated-failure" "$PG_JOB" "$QUIET_LOG" unknown
+
+# --- F1: zero steps is NECESSARY, not SUFFICIENT --------------------------
+# Six repo-configuration faults, each this repo's own defect, each killing the
+# job before any repo step runs and so arriving with exactly zero executed repo
+# steps. Unguarded, all six classify as `infra-no-steps` and get auto-rerun —
+# precisely the exclusion the R1 anchor above was written to make.
+#
+# ★ #5207 (r3) — EVERY FIXTURE LINE BELOW IS A VERBATIM OBSERVED STRING, not a
+# paraphrase. r2 shipped two invented ones (`no runner matching the labels`,
+# `The workflow is requesting permissions that are not allowed`); the regex
+# matched them and nothing else, so the suite proved only self-consistency.
+# Per-alternation sources: the provenance block at REPO_CONFIG_FAULT_REGEX in
+# scripts/ci/infra-failure-rerun.sh, cases [1]..[6] in the order below.
+while IFS='|' read -r FAULT_DESC FAULT_LINE; do
+  [ -n "$FAULT_DESC" ] || continue
+  assert_class "F1: $FAULT_DESC is not infrastructure at 0 steps" \
+    "unrelated-failure" "$PG_JOB" "$(write_log repo-fault.log "$FAULT_LINE")" 0
+done <<'CASES'
+nonexistent action ref|Failed to resolve action download info. Error: Unable to resolve action `actions/chcekout@v2`, repository not found
+action blocked by Actions policy|Failed to resolve action download info. Error: Bad request - freertos/ci-cd-github-actions@main is not allowed to be used in aws/aws-iot-device-sdk-embedded-C.
+bad runs-on labels|Error: No runner matching the specified labels was found: macos-15-intel
+bad container image|Error response from daemon: manifest for weirauchlab/reli:alpine not found: manifest unknown: manifest unknown
+invalid workflow YAML|The workflow is not valid. .github/workflows/ci.yml (Line: 49, Col: 3): Unexpected value
+over-broad nested-job permissions|The nested job 'release' is requesting 'contents: write', but is only allowed 'contents: read'.
+CASES
+
+# The opposite direction, which is the reason this change exists at all. If the
+# guard ever widens far enough to swallow these, #5207 is un-fixed.
+assert_class "F1 reverse: the real outage fingerprint at 0 steps is still infrastructure" \
+  "infra-unrelated" "$PG_JOB" "$OUTAGE_LOG" 0
+# ★ LIMIT, not a feature. This pins the RESIDUAL RISK enumerated at
+# REPO_CONFIG_FAULT_REGEX: a repo-configuration fault whose wording is NOT in
+# that list is still labelled infrastructure and still auto-retried. The fixture
+# is an unrecognised string standing for ~15 measured real cases. The cost, and
+# the limit of the `run_attempt >= 3` containment argument (it bounds only
+# DETERMINISTIC faults), are stated once — at that constant.
+NOVEL_OUTAGE_LOG="$(write_log novel-outage.log \
+  'Error: a transient failure wording that no pattern here knows yet')"
+assert_class "LIMIT: an unenumerated repo-config fault at 0 steps is still auto-retried as infrastructure" \
+  "infra-no-steps" "$PG_JOB" "$NOVEL_OUTAGE_LOG" 0
+
+# --- P2-1: a repo-config fault beside an outage fingerprint ---------------
+# Both fingerprints in ONE log, on different lines — a configuration regression
+# merged while GitHub was degraded. r2 let R1 win on line 1 and never consulted
+# the repo-fault guard, so the job was labelled `infra-unrelated` and rerun.
+MIXED_FAULT_LOG="$(write_log outage-plus-repo-fault.log \
+  'Failed to resolve action download info. Error: Service Unavailable' \
+  'Failed to resolve action download info. Error: Unable to resolve action `acme/gone@v1`, repository not found')"
+assert_class "P2-1: a repo-config fault beside the outage fingerprint is not infrastructure" \
+  "unrelated-failure" "$PG_JOB" "$MIXED_FAULT_LOG" 1
+assert_class "P2-1: the same log at 0 steps is withheld from the structural path too" \
+  "unrelated-failure" "$PG_JOB" "$MIXED_FAULT_LOG" 0
+# The accepted COST of that guard, pinned so it cannot be paid by accident: a
+# genuine outage log that happens to carry an enumerated phrase loses its
+# automatic rerun. Fail-closed — a human reruns it.
+COINCIDENCE_LOG="$(write_log outage-with-incidental-manifest.log \
+  'Failed to resolve action download info. Error: Service Unavailable' \
+  'docker: Error response from daemon: manifest for ghcr.io/acme/cache:v3 not found: manifest unknown')"
+assert_class "P2-1 cost: an outage log carrying an incidental enumerated phrase is withheld too" \
+  "unrelated-failure" "$PG_JOB" "$COINCIDENCE_LOG" 1
+# The direction that must NOT change: a clean outage log still reruns.
+assert_class "P2-1 reverse: a clean outage log is unaffected by the hoisted guard" \
+  "infra-unrelated" "$PG_JOB" "$OUTAGE_LOG" 1
+
+# --- r4: the NARROWNESS of two withhold alternations, pinned ---------------
+# Both of these were previously asserted only by a comment. Because
+# REPO_CONFIG_FAULT_REGEX is consulted NEGATIVELY, over-broadening it is
+# fail-closed and so passes every other test in this file: the cost is silent —
+# a genuine outage stops being auto-retried. These two controls make that cost
+# visible. Each fixture carries the outage fingerprint (so the expected answer
+# is `infra-unrelated`) plus one line of ordinary log noise that a widened
+# alternation would seize on.
+#
+# [1]: the `failed to resolve action download info\. error: ` prefix is what
+# separates an Actions POLICY rejection from any other 400 in the log. Drop it
+# and a bare `bad request` anywhere in the run withholds the retry.
+BARE_BAD_REQUEST_LOG="$(write_log outage-with-bare-bad-request.log \
+  'Failed to resolve action download info. Error: Service Unavailable' \
+  '2026-08-07T00:00:01Z WARN relay: upstream answered 400 Bad Request, retrying')"
+assert_class "r4 [1] narrowness: a bare 'bad request' elsewhere in the log does not withhold the retry" \
+  "infra-unrelated" "$PG_JOB" "$BARE_BAD_REQUEST_LOG" 1
+
+# [5]: the quoted `'<x>' … '<y>'` shape is what makes this a permissions
+# rejection. Relaxed to `requesting.*allowed`, ordinary prose containing both
+# words on one line withholds the retry instead.
+LOOSE_PERMISSIONS_LOG="$(write_log outage-with-requesting-allowed-prose.log \
+  'Failed to resolve action download info. Error: Service Unavailable' \
+  'DEBUG scheduler: worker is requesting a slot; queue growth is allowed')"
+assert_class "r4 [5] narrowness: unquoted 'requesting … allowed' prose does not withhold the retry" \
+  "infra-unrelated" "$PG_JOB" "$LOOSE_PERMISSIONS_LOG" 1
+
+# --- second outage fingerprint: an abandoned upstream ---------------------
+# Run 31120826793 (PR #5204): the gating `Changed paths` job waited ~16 minutes
+# for a runner, was retired as `abandoned`, and every downstream mirror failed
+# closed. Those mirror failures are correct behaviour, not regressions, and
+# they must be labelled as upstream infrastructure WITHOUT ever becoming
+# rerunnable — retrying a fail-closed gate is how you neuter it.
+MIRROR_JOB='Fast check cross OS required context (ubuntu-latest)'
+ABANDONED_LOG="$(write_log upstream-abandoned.log \
+  '  CHANGED_PATHS_RESULT: abandoned' \
+  '  UPSTREAM_RESULT:      skipped' \
+  "##[error]Changed paths result is unexpected: 'abandoned'")"
+assert_class "abandoned upstream is reported as upstream infrastructure" \
+  "infra-upstream-abandoned" "$MIRROR_JOB" "$ABANDONED_LOG" 5
+
+# Narrowness: `abandoned` is an ordinary English word. The anchor must require
+# the mirror's own `<X>_RESULT:` echo or its quoted result message.
+ABANDONED_WORD_LOG="$(write_log abandoned-word.log \
+  'test store::abandoned_session_is_reaped ... ok' \
+  'INFO dropping the abandoned queue entry' \
+  'the request was abandoned by the client')"
+assert_class "the bare word 'abandoned' is not an infrastructure fingerprint" \
+  "unrelated-failure" "$PG_JOB" "$ABANDONED_WORD_LOG" 5
+
+# A mirror failing closed for a different upstream result keeps the plain
+# label — only `abandoned` means "GitHub never gave the job a runner".
+MIRROR_CANCELLED_LOG="$(write_log mirror-cancelled.log \
+  "Changed paths result is 'cancelled'; failing closed instead of treating Fast check result 'skipped' as pass")"
+assert_class "a fail-closed mirror with a non-abandoned upstream keeps the plain label" \
+  "unrelated-failure" "$PG_JOB" "$MIRROR_CANCELLED_LOG" 5
+
+# Regression precedence still outranks the new fingerprint.
+assert_class "regression outranks the abandoned-upstream fingerprint" \
+  "regression" "$PG_JOB" "$(write_log abandoned-with-regression.log \
+    "##[error]Changed paths result is unexpected: 'abandoned'" \
+    'test result: FAILED. 1 passed; 1 failed')" 5
+
+# --- F3: the step-count expression itself ---------------------------------
+# Everything above hands the classifier an integer. The jq expression that
+# PRODUCES that integer in the live loop had no test at all, so mutating away
+# the housekeeping exclusion list (permanently disabling the zero-step signal)
+# or turning its fail-closed `unknown` into `0` (making every failed job look
+# like infrastructure) both went unnoticed.
+JOBS_PAYLOAD="$WORK_DIR/jobs-payload.json"
+cat >"$JOBS_PAYLOAD" <<'JSON'
+{"total_count": 7, "jobs": [
+ {"id":101,"name":"setup-only","conclusion":"failure","steps":[{"name":"Set up job"}]},
+ {"id":102,"name":"housekeeping","conclusion":"failure","steps":[{"name":"Set up job"},{"name":"Complete job"}]},
+ {"id":103,"name":"mixed-case","conclusion":"failure","steps":[{"name":"SET UP JOB"},{"name":"complete job"}]},
+ {"id":104,"name":"one-repo-step","conclusion":"failure","steps":[{"name":"Set up job"},{"name":"Run tests"},{"name":"Complete job"}]},
+ {"id":105,"name":"no-steps-key","conclusion":"failure"},
+ {"id":106,"name":"empty-steps","conclusion":"failure","steps":[]},
+ {"id":107,"name":"green","conclusion":"success","steps":[{"name":"Set up job"},{"name":"Run tests"}]}
+]}
+JSON
+
+step_count_for() {
+  "$SCRIPT" --failed-job-rows "$JOBS_PAYLOAD" | awk -F'\t' -v id="$1" '$1 == id { print $2 }'
+}
+
+assert_step_count() {
+  local name="$1"
+  local job_id="$2"
+  local expected="$3"
+  local actual
+  actual="$(step_count_for "$job_id")"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$name"
+  else
+    fail "$name (expected '$expected', got '$actual')"
+  fi
+}
+
+# Kills "drop the housekeeping exclusion": without it these become 1, 2, 2, 3.
+assert_step_count "F3: a job that ran only 'Set up job' counts 0 repo steps" 101 0
+assert_step_count "F3: 'Set up job' + 'Complete job' counts 0 repo steps" 102 0
+assert_step_count "F3: housekeeping names are matched case-insensitively" 103 0
+assert_step_count "F3: one real step among the housekeeping counts 1" 104 1
+# Kills "fail open to 0": without the `unknown` branch these become 0, which
+# would classify every failed job with unreadable step data as infrastructure.
+assert_step_count "F3: an absent steps array yields 'unknown', never 0" 105 unknown
+# F4: an empty array is data-absence wearing an array's type. A job the API
+# calls `failure` necessarily entered `Set up job`, so a truthful payload for it
+# always carries at least that step; `[]` therefore means the steps were not
+# reported, not that the job ran none. It must fail closed like an absent key.
+assert_step_count "F4: an empty steps array yields 'unknown', never 0" 106 unknown
+
+ROW_COUNT="$("$SCRIPT" --failed-job-rows "$JOBS_PAYLOAD" | wc -l | tr -d ' ')"
+if [[ "$ROW_COUNT" == "6" ]]; then
+  pass "F3: only failed jobs produce rows"
+else
+  fail "F3: only failed jobs produce rows (expected 6, got $ROW_COUNT)"
+fi
+
+# End-to-end: the count the expression produced must drive the classification.
+assert_class "F3 end-to-end: the produced 'unknown' fails closed in the classifier" \
+  "unrelated-failure" "$PG_JOB" "$QUIET_LOG" "$(step_count_for 106)"
+assert_class "F3 end-to-end: the produced 0 reaches the structural signal" \
+  "infra-no-steps" "$PG_JOB" "$QUIET_LOG" "$(step_count_for 101)"
+
+# --- r4 P2: `run_classifier`, the production entry point -------------------
+# ★ Everything above drives `--classify-job`, a DIAGNOSTIC entry point nothing
+# in production calls. The real one is `run_classifier` — the no-argument form
+# `.github/workflows/ci-pr-infra-retry.yml:36` invokes — and it had zero
+# coverage. That gap is not cosmetic: `run_classifier` decides the retry with a
+# SECOND, independent call to `job_is_infra_failure`, and swapping that call
+# back to `log_has_infra_failure` (i.e. undoing the P2-1 guard completely, in
+# the only place where undoing it causes an actual rerun) passed every
+# assertion in this file and every assertion in the self-test.
+#
+# So the classification chain is now driven end to end: real script, real jq
+# expression, real summary writer, with only `gh` replaced. `RERUN_DRY_RUN=1`
+# stops the flow before `gh run rerun`, AND the stub refuses — and records —
+# any call it is not given a fixture for, so a case that reached the rerun would
+# fail here rather than touch a repository.
+#
+# ★ #5207 (r5, D4) — WHAT THIS HARNESS DOES NOT REACH. The classifier consumes
+# FOUR read-only endpoints, not three. The stub serves three of them:
+#   1. `repos/{repo}/actions/runs/{id}/attempts/{n}`        (script :527)
+#   2. `repos/{repo}/actions/runs/{id}/attempts/{n}/jobs`   (script :541)
+#   3. `repos/{repo}/actions/jobs/{job-id}/logs`            (script :571)
+# The fourth, `repos/{repo}/actions/runs/{id}` — the freshness re-check in
+# `latest_attempt_is_still_failed` (script :494) — is DELIBERATELY NOT SERVED.
+# It sits past the `RERUN_DRY_RUN=1` early return (script :618-622), so no case
+# here reaches it, and leaving it unserved means an accidental live-path escape
+# lands in `refused.log` instead of hitting the API.
+# The price is stated rather than hidden: everything downstream of that early
+# return is UNVERIFIED by this suite. Three `run_classifier` branches have ZERO
+# coverage — `no-op:stale-attempt`, `no-op:rerun-request-failed`, and
+# `rerun-requested:infra` (script :624-639). Do not read the E2E cases below as
+# evidence about them.
+E2E_BIN="$WORK_DIR/e2e-bin"
+mkdir -p "$E2E_BIN"
+cat >"$E2E_BIN/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+# #5207 (r4) `gh` stand-in. Serves fixtures for three of the FOUR read-only
+# endpoints the classifier consumes; the fourth -- `repos/.../actions/runs/<id>`,
+# the freshness re-check that lives past the dry-run early return -- is refused
+# on purpose, along with every other invocation, `gh run rerun` above all.
+# See the r5/D4 note above for the branches that consequently go unverified.
+set -u
+if [ "${1-}" = "api" ]; then
+  case "${2-}" in
+    */attempts/*/jobs*) src="$GH_FIXTURE_DIR/jobs.json" ;;
+    */attempts/*) src="$GH_FIXTURE_DIR/attempt.json" ;;
+    */actions/jobs/*/logs)
+      job="${2##*/actions/jobs/}"
+      src="$GH_FIXTURE_DIR/job-${job%/logs}.log"
+      ;;
+    *)
+      printf 'gh %s\n' "$*" >>"$GH_FIXTURE_DIR/refused.log"
+      exit 1
+      ;;
+  esac
+  [ -f "$src" ] || exit 1
+  cat "$src"
+  exit 0
+fi
+printf 'gh %s\n' "$*" >>"$GH_FIXTURE_DIR/refused.log"
+exit 1
+GH_STUB
+chmod +x "$E2E_BIN/gh"
+
+E2E_N=0
+E2E_CASE=""
+
+new_e2e_case() {
+  E2E_N=$((E2E_N + 1))
+  E2E_CASE="$WORK_DIR/e2e-$E2E_N"
+  mkdir -p "$E2E_CASE"
+  printf '%s\n' \
+    '{"name":"CI PR","event":"pull_request","status":"completed","conclusion":"failure","run_attempt":1}' \
+    >"$E2E_CASE/attempt.json"
+  : >"$E2E_CASE/refused.log"
+  : >"$E2E_CASE/summary.md"
+}
+
+# One failed PostgreSQL job, its `steps` array written so the real jq expression
+# derives the executed-step count the case needs.
+e2e_pg_job() {
+  local job_id="$1"
+  local steps_json="$2"
+  printf '{"total_count":1,"jobs":[{"id":%s,"name":"%s","conclusion":"failure","steps":%s}]}\n' \
+    "$job_id" "$PG_JOB" "$steps_json" >"$E2E_CASE/jobs.json"
+}
+
+assert_e2e() {
+  local name="$1"
+  local want_decision="$2"
+  local want_label="$3"
+  local out rc=0 got
+
+  out="$(
+    PATH="$E2E_BIN:$PATH" \
+    GH_FIXTURE_DIR="$E2E_CASE" \
+    GITHUB_REPOSITORY="itismyfield/AgentDesk" \
+    RUN_ID=31116949449 \
+    RUN_ATTEMPT=1 \
+    RERUN_DRY_RUN=1 \
+    GITHUB_STEP_SUMMARY="$E2E_CASE/summary.md" \
+    bash "$SCRIPT" 2>&1
+  )" || rc=$?
+
+  if [ "$rc" -ne 0 ]; then
+    fail "$name (run_classifier exited $rc: $(printf '%s' "$out" | tr '\n' ' '))"
+    return
+  fi
+  got="$(printf '%s\n' "$out" | sed -n 's/^decision=\([^ ]*\).*$/\1/p' | tail -1)"
+  if [ "$got" != "$want_decision" ]; then
+    fail "$name (expected decision '$want_decision', got '$got')"
+    return
+  fi
+  if ! grep -q "| \`$want_label\` |" "$E2E_CASE/summary.md"; then
+    fail "$name (summary lacks the \`$want_label\` row: $(tr '\n' ' ' <"$E2E_CASE/summary.md"))"
+    return
+  fi
+  if [ -s "$E2E_CASE/refused.log" ]; then
+    fail "$name (reached a forbidden gh call: $(tr '\n' ' ' <"$E2E_CASE/refused.log"))"
+    return
+  fi
+  pass "$name"
+}
+
+# E2E-1 — the wiring hole itself. A repo-config fault beside the outage
+# fingerprint, on the PostgreSQL job, at its real step count of 0. The retry
+# predicate must decline, so the run must NOT be rerun and the job must be
+# labelled `unclassified-pg-failure`. Point `run_classifier` at
+# `log_has_infra_failure` instead and both flip: `would-rerun:infra` /
+# `infra-shutdown`.
+new_e2e_case
+e2e_pg_job 901 '[{"name":"Set up job"}]'
+printf '%s\n' \
+  'Failed to resolve action download info. Error: Service Unavailable' \
+  'Failed to resolve action download info. Error: Unable to resolve action `acme/gone@v1`, repository not found' \
+  >"$E2E_CASE/job-901.log"
+assert_e2e "E2E: run_classifier withholds the rerun when a repo-config fault sits beside the outage" \
+  "no-op:unclassified-pg-failure" "unclassified-pg-failure"
+
+# E2E-2 — the label chain must reach the decision. A PostgreSQL regression that
+# also carries a shutdown fingerprint: `classify_job` calls it a regression,
+# that count blocks the rerun. Stop `run_classifier` from consulting
+# `classify_job` and the infra predicate alone reruns a red test suite.
+new_e2e_case
+e2e_pg_job 902 '[{"name":"Set up job"},{"name":"Run tests"},{"name":"Complete job"}]'
+printf '%s\n' \
+  'The runner has received a shutdown signal.' \
+  'test result: FAILED. 163 passed; 1 failed' \
+  >"$E2E_CASE/job-902.log"
+assert_e2e "E2E: run_classifier lets the regression classification block the rerun" \
+  "no-op:regression" "regression"
+
+# E2E-3 — anti-vacuity. Without this, E2E-1 and E2E-2 could both be passing
+# because the harness never reaches a rerun at all. A clean outage on the
+# PostgreSQL job at 0 steps must arrive at `would-rerun:infra` — and `gh run
+# rerun` must still never be called, which the stub's refusal log checks.
+#
+# #5207 (r5, D5) — HOW STRONG THAT CHECK ACTUALLY IS. It is a redundant second
+# guard, not a measured-independent detector. Measured: neutering the
+# `refused.log` assertion alone leaves the suite GREEN (the mutant SURVIVES);
+# neutering it together with `RERUN_DRY_RUN`, and dropping `RERUN_DRY_RUN`
+# alone, fail with the SAME message. A stub refusal always perturbs the
+# decision too, and the decision assertion above catches it first, so no
+# mutation exists for which this assertion is the sole detector. Keep it —
+# defence in depth against a future path that refuses without moving the
+# decision — but do not claim it proves anything `RERUN_DRY_RUN` does not.
+new_e2e_case
+e2e_pg_job 903 '[{"name":"Set up job"}]'
+printf '%s\n' \
+  'Failed to resolve action download info. Error: Service Unavailable' \
+  'Failed to resolve action download info. Error: Service Unavailable' \
+  >"$E2E_CASE/job-903.log"
+assert_e2e "E2E: a clean outage still reaches would-rerun:infra without calling gh run rerun" \
+  "would-rerun:infra" "infra-shutdown"
+
+# --- R2: sibling regex drift must break the build -------------------------
+# End-to-end proof, not an inspection: mirror both scripts into a scratch repo,
+# drift only the triage side, and require the classifier's self-test to fail.
+SYNC_REPO="$WORK_DIR/sync-repo"
+mkdir -p "$SYNC_REPO/scripts/ci"
+cp "$ROOT_DIR/scripts/main-ci-triage.sh" "$SYNC_REPO/scripts/main-ci-triage.sh"
+cp "$SCRIPT" "$SYNC_REPO/scripts/ci/infra-failure-rerun.sh"
+
+if bash "$SYNC_REPO/scripts/ci/infra-failure-rerun.sh" --self-test >/dev/null 2>&1; then
+  pass "mirrored, in-sync scripts pass the self-test"
+else
+  fail "mirrored, in-sync scripts pass the self-test"
+fi
+
+DRIFT_MARKER="runner has received a shutdown signal"
+if ! grep -q -- "$DRIFT_MARKER'" "$SYNC_REPO/scripts/main-ci-triage.sh"; then
+  fail "drift anchor no longer present in main-ci-triage.sh"
+fi
+# The trailing quote pins this to the regex literal, not to prose or fixtures.
+awk -v marker="$DRIFT_MARKER'" -v repl="$DRIFT_MARKER DRIFTED'" '
+  {
+    idx = index($0, marker)
+    if (idx > 0) {
+      $0 = substr($0, 1, idx - 1) repl substr($0, idx + length(marker))
+    }
+    print
+  }
+' "$SYNC_REPO/scripts/main-ci-triage.sh" >"$SYNC_REPO/scripts/main-ci-triage.drifted.sh"
+mv "$SYNC_REPO/scripts/main-ci-triage.drifted.sh" "$SYNC_REPO/scripts/main-ci-triage.sh"
+
+# F8: this is a HYGIENE check on the test itself, not a check on production
+# code — it kills no production mutation. It exists so that if the awk rewrite
+# above ever silently no-ops (marker renamed, quoting changed), the drift
+# assertion below cannot pass vacuously by testing an unmodified file.
+if grep -q -- "$DRIFT_MARKER DRIFTED'" "$SYNC_REPO/scripts/main-ci-triage.sh"; then
+  pass "drift was actually applied to the mirrored triage script"
+else
+  fail "drift was actually applied to the mirrored triage script"
+fi
+
+if bash "$SYNC_REPO/scripts/ci/infra-failure-rerun.sh" --self-test >/dev/null 2>&1; then
+  fail "drifted sibling regex must fail the classifier self-test"
+else
+  pass "drifted sibling regex fails the classifier self-test"
+fi
+
+# --- wiring: the self-test that carries these guards must run on CI --------
+if grep -q 'scripts/ci/infra-failure-rerun.sh --self-test' "$ROOT_DIR/scripts/ci-script-checks.sh"; then
+  pass "classifier self-test is wired into scripts/ci-script-checks.sh"
+else
+  fail "classifier self-test is wired into scripts/ci-script-checks.sh"
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "tests/test_infra_failure_classifier_5207.sh FAILED" >&2
+  exit 1
+fi
+
+echo "tests/test_infra_failure_classifier_5207.sh passed"


### PR DESCRIPTION
## 결함

2026-08-07 GitHub Actions major outage 에서 이 리포의 인프라 실패 분류기가 **이번 장애의 지배적 지문을 하나도 잡지 못했다.**

실제 로그 지문은 `Failed to resolve action download info. Error: Service Unavailable` 였고 **한 실행에서 10회** 나타났다. `log_has_infra_failure` 의 정규식 대안 7개(`signal[: ]+(9|15)`, `sig(term|kill)`, `terminated on line N by signal`, `exit…143`, `the operation was cancelled`, `runner has received a shutdown signal`, `the action '…' has timed out`) 중 **어느 것도 매치하지 않는다.**

매치 실패의 결과는 **fail-safe 가 아니라 오분류**다. 순수한 인프라 장애가 평범한 "설명되지 않는 실패"로 요약되고, 사람과 에이전트가 그걸 읽고 **코드 회귀로 오판**한다. 실제로 착지 레인이 이번에 재시도 예산을 태울 뻔했다.

### 이 PR 이 바꾸는 것과 바꾸지 않는 것

이번 장애에 한정하면 **재시도 동작은 바뀌지 않는다 — 분류 라벨만 정확해진다.** 재시도는 PostgreSQL 잡의 실패를 조건으로 하는데 이번 장애의 실패 잡에 PG 잡이 없다. run `31116949449` 의 attempt 1~3 을 실측하면 결정이 이 커밋 전후로 `no-op:no-pg-failure` 로 **비트 단위 동일**하다. 재시도 범위 확대는 별개 사안이다(see #5071).

원 이슈가 이번 장애를 "`no-op:unknown` 으로 떨어졌고 재시도가 시도되지 않았다"로 서술한 것은 **두 부분 모두 틀렸고**, 커밋 메시지에서 철회했다. 실제 fall-through 는 `no-op:no-pg-failure` 다.

## R1 ~ R4

| | 상태 | 내용 |
|---|---|---|
| **R1** | 구현 | 러너가 실제로 찍는 구를 앵커로 액션-다운로드 대안을 추가하고, **같은 줄의** 일시적 서버 오류 클래스를 요구한다. 단독 `Service Unavailable` / `503` 은 매치하지 않는다(테스트가 그 문자열을 찍는다). 같은 접두사를 재사용하는 리포 설정 모드 `Failed to resolve action download info. Error: Unable to resolve action \`owner/repo@ref\`, repository not found` 도 매치하지 않는다 — 그건 장애가 아니라 진짜 리포 회귀다 |
| **R2** | 구현 | `scripts/main-ci-triage.sh` 의 `log_has_infra_termination` 과 정렬을 유지하라던 **주석 규약이 `assert_termination_regex_synced` 로 승격**됐다. `--self-test` 마다 돌고 양쪽 어느 쪽이 어긋나도 CI 가 죽는다. 비교가 실제로 판별하는지는 negative control 로 증명한다. 추출기는 **들여쓴 닫는 중괄호**에서 멈춰 이웃 함수의 리터럴을 주워오지 못하며, 그 가드 자체에도 판별 fixture 가 붙어 있다(열 0 의 `}` 로 되돌리면 self-test 가 죽는다) |
| **R3** | **구현 — 단, 원문 전제를 폐기하고 재정의한 형태** | 원 이슈의 전칭 명제("스텝 0개면 정의상 리포 코드와 무관")는 **거짓**이고 이슈 본문에서 이미 철회됐다. 대신 "스텝 0개"는 **리포 설정 오류 지문 가드를 통과한 뒤에만** 인프라 신호가 된다. 가드의 6개 대안은 전부 **관측된 리터럴에 결박**되고 각각 출처가 주석에 인용돼 있다. 이전 라운드가 실어보냈던 `no runner matching the labels` / `requesting permissions that are not allowed` 두 구는 **GitHub 이 실제로 찍지 않는 문자열**이었고(산문에서 지어낸 뒤 테스트 fixture 로 그대로 재사용해서, 테스트가 저자의 상상만 검증하고 있었다) 실제 문구로 교체했다 |
| **R4** | 구현 | 두 회귀 술어가 공유된 단일 `classify_job` 체인에서 **모든 인프라 술어보다 먼저** 평가된다. 회귀 마커를 가진 로그는 인프라 지문이 함께 있어도 재시도되지 않는다 |

### R3 의 잔여 위험 — 숨기지 않고 적는다

열거에 없는 리포 설정 결함은 **여전히 인프라로 분류돼 자동 재시도된다.** 그 집합은 작지 않다(환경 이름 오류, concurrency 표현식, composite action, OIDC/env 오설정, checkout 인증, no-enabled-runners, 나머지 `Invalid workflow file` 계열, 누락된 hosted-runner 이미지, Docker login/컨테이너 초기화).

비용은 측정됐다: **재시도 1회 낭비 + 요약 표의 잘못된 라벨.** 결정적(deterministic) 설정 결함은 재시도에서도 다시 죽고 `run_attempt >= 3` 상한에 걸리므로, 결정적으로 깨진 리포가 자동 재시도로 통과되는 일은 없다.

**이 결론은 전제에 갇혀 있고, 일부러 전칭으로 쓰지 않았다.** 비결정적 설정 결함(러너 풀 가용성·불안정한 컨테이너 레지스트리·만료되는 토큰에 결과가 좌우되는 것)은 재시도에서 통과할 수 있고, 그러면 진짜 결함이 자동 재실행으로 덮인다. 그 잔여를 고정한 테스트 이름이 `LIMIT: …` 인 것은 **그걸 바람직한 동작으로 읽지 못하게 하기 위해서**다.

### 같은 장애의 두 번째 지문

run `31120826793` 에서 게이팅 잡 `Changed paths` 가 러너를 못 받아 GitHub 이 `abandoned` 로 회수했고, 하류의 필수 체크 미러가 전부 `Changed paths result is unexpected: 'abandoned'` 로 fail-closed 했다. `abandoned` 는 REST API 로 노출되지 않으므로(그 잡은 `conclusion=cancelled` 로 보고되고 jobs payload 어디에도 그 부분 문자열이 없다) **로그에서** 매치하되, 맨 영어 단어가 아니라 미러 자신의 `<X>_RESULT:` 에코 또는 인용된 결과 메시지에 앵커한다. 전용 라벨 `infra-upstream-abandoned` 를 받고 **재시도 술어에서는 의도적으로 제외**된다 — 미러의 실패는 올바른 동작이고, fail-closed 게이트를 재시도하는 것이 바로 그 게이트를 무력화하는 방법이다.

## ⚠️ PR 상한 초과 — waiver

**초과 사실을 먼저 적는다. 이 PR 은 ±800줄 상한을 초과한다.**

| | 값 | 상한 |
|---|---|---|
| 파일 | 3 | 20 ✅ |
| 변경 줄 | **1261 삽입 / 19 삭제** | ±800 ❌ **초과** |

### 내역 분해 (실측)

| 파일 | 추가 | 주석 | 공백 | **실 코드** | 삭제 |
|---|---|---|---|---|---|
| `scripts/ci/infra-failure-rerun.sh` | 666 | 331 | 39 | **296** | 18 |
| `tests/test_infra_failure_classifier_5207.sh` (신규) | 589 | 199 | 50 | **340** | 0 |
| `scripts/ci-script-checks.sh` | 6 | 5 | 0 | **1** | 1 |
| **합계** | **1261** | **535** | **89** | **637** | **19** |

추가된 1261줄 중 **535줄(42%)이 주석**이다. 이건 팽창이 아니라 이 변경의 성격이다 — R3 가드의 6개 대안은 **각각 관측된 리터럴의 출처(파일·줄번호·실제 사건 로그)를 주석에 인용해야** 한다. 앞선 라운드가 정확히 그 출처 요구 없이 문자열 두 개를 지어내서 실어보냈고, 테스트가 그걸 fixture 로 재사용해 통과했기 때문이다. 출처 주석은 그 재발을 막는 **유일한 기계적 장치가 아닌 부분**이고, 지우면 같은 결함이 돌아온다.

### 분할 가능성 — 주장이 아니라 실측으로 판정했다

격리된 프로브 워크트리에서 두 분할 시나리오를 실제로 돌렸다.

**시나리오 A — 판별 테스트를 먼저 착지 (테스트 589줄만):**
```
main 분류기 + 신규 테스트 → exit 1, 49건 중 0건 통과
```
테스트가 첫 훅에서 즉시 죽는다(신규 CLI 표면이 없어 usage 를 찍는다). 게다가 `scripts/ci-script-checks.sh` 의 `for shell_test in tests/*.sh` 글롭이 이 파일을 자동으로 집어가므로 **`Script checks` 가 즉시 빨강**이 된다. **빨간 중간 커밋이 main 에 남는다 → 불가.**

**시나리오 B — 분류기를 먼저 착지 (테스트 파일 제외):**
```
신규 분류기, 테스트 파일 제거 → --self-test 통과 (초록)
```
트리는 초록이지만 이건 **더 나쁜 쪽**이다. 내부 `--self-test` 는 assertion **23건**으로 주로 동기화 계약을 지킨다. 외부 매트릭스의 **49건** — R3 가드의 F1 거짓양성 울타리 6종, P2-1 hoisted guard, 스텝 데이터 부재 시 `unknown` fail-closed, `run_classifier` 엔드투엔드 — 이 전부 빠진다. 즉 **자동 재시도 정책 변경이 그 판별 근거 없이 main 에 먼저 들어간다.** 이 변경의 위험이 정확히 "진짜로 깨진 빌드를 자동 재시도하는 것"인데, 그 위험을 막는 증거만 다음 PR 로 미루는 분할이다.

실제로 이게 이론이 아님을 이 라운드가 실측했다: `run_classifier` 는 `job_is_infra_failure` 를 통해 **두 번째 독립 결정**을 내리는데, 그 호출 하나만 `log_has_infra_failure` 로 되돌리면 **리포 설정 가드가 완전히 무효화되면서도 모든 단위 assertion 이 초록으로 남았다.** 엔드투엔드 하네스가 없었다면 잡히지 않는다.

### waiver 문구

**분할 불가. 한 덩어리로 착지한다.** A 는 빨간 중간 커밋을 만들고, B 는 "게이트만 있고 대상이 없는" 상태 — 정확히는 그 역인 "대상만 있고 게이트가 없는" 상태 — 를 만든다. 초과분의 대부분은 신규 테스트 파일(589줄)과 출처 주석(535줄)이며, **실 로직은 296줄**이다. 로직만 놓고 보면 상한 안이다.

## 검증

- 로컬 `bash tests/test_infra_failure_classifier_5207.sh` → **49건 통과**
- 로컬 `./scripts/ci/infra-failure-rerun.sh --self-test` → 통과
- 리베이스 후 base `d6a5aa09f` 기준 **내용 드리프트 0줄** (index/`@@` 헤더 제외), 실체 파일 2개의 blob 해시 리베이스 전후 **동일**
- 레드라인 파일 무접촉: `scripts/run_relay_authority_mutations.sh`, `scripts/check_relay_authority_contract.py`, `src/services/discord/session_relay_sink/terminal_handoff.rs`
- `log_has_regression` 우선 규약 유지 — R4 가 테스트로 고정

Fixes #5207
