### PR TITLE
feat(#5071): instrument the turn_bridge/controller cutover durable writes (T1 S4)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -783,6 +783,7 @@ src/
 │   │   │   └── voice.rs
 │   │   ├── session_relay_sink/
 │   │   │   ├── journal/
+│   │   │   │   ├── controller.rs
 │   │   │   │   ├── pg_store.rs
 │   │   │   │   └── watcher.rs
 │   │   │   ├── delivery_commit.rs

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -959,6 +959,8 @@ src/
 │   │   │   │   └── types.rs
 │   │   │   ├── stream_tick/
 │   │   │   │   └── guarded_persist.rs
+│   │   │   ├── terminal_controller_cutover/
+│   │   │   │   └── unix_journal.rs
 │   │   │   ├── terminal_outcome_delivery/
 │   │   │   │   ├── empty_response_recovery/
 │   │   │   │   │   ├── guidance.rs

--- a/scripts/check_delivery_journal_raw_writer.py
+++ b/scripts/check_delivery_journal_raw_writer.py
@@ -90,8 +90,9 @@ FAMILY_REGISTRY = (
 # unix. Read `uninstrumented families: N/6` as "N families carry no facade token
 # on unix". The one thing that actually holds the boundary the regression broke
 # is `test_source_contract_turn_bridge_reaches_the_journal_through_one_cfg_gated_door`
-# in tests/test_delivery_journal_raw_writer.py; see also
-# src/services/discord/turn_bridge/unix_journal.rs.
+# in tests/test_delivery_journal_raw_writer.py, which owns the door path as the
+# literal `door` it scans for; see also
+# src/services/discord/turn_bridge/terminal_controller_cutover/unix_journal.rs.
 JOURNAL_FACADE_CALL = re.compile(
     r"\bself\.journal\.(?:begin_fresh|finish_fresh)\s*\("
     r"|\bjournal_watcher::(?:begin_watcher_terminal|settle_watcher_terminal|settle_without_transport)\s*\("

--- a/scripts/check_delivery_journal_raw_writer.py
+++ b/scripts/check_delivery_journal_raw_writer.py
@@ -66,19 +66,36 @@ FAMILY_REGISTRY = (
 # including a string literal or a test module, flips the family.
 #
 # #5071 T1 S4 adds the third alternative on the same terms. The turn_bridge
-# cutover family reaches the journal through `journal::controller`, aliased
-# `journal_ctl` at its anchor, so the alternative names that module path and its
-# two exact functions — a bare `journal_ctl`, a bare `controller`, or any other
-# method on either does NOT match. The baseline moves 3 -> 2 because that anchor
-# file now contains the token, and for no other reason: the two remaining
-# uninstrumented families (recovery/fresh-send/orphan, pipe stream epoch) are
-# unchanged by S4. That the drop is caused by the instrumentation rather than by
-# the widened pattern is proven in tests/test_delivery_journal_raw_writer.py by
-# the reverse mutation `test_controller_family_regresses_to_uninstrumented`.
+# cutover family reaches the journal through
+# `turn_bridge::terminal_controller_cutover::unix_journal`, which re-exports
+# `session_relay_sink::journal::controller`, so the alternative names
+# that module path and its two exact functions — a bare `unix_journal`, a bare
+# `controller`, or any other method on either does NOT match. The baseline moves
+# 3 -> 2 because that anchor file now contains the token, and for no other
+# reason: the two remaining uninstrumented families (recovery/fresh-send/orphan,
+# pipe stream epoch) are unchanged by S4. That the drop is caused by the
+# instrumentation rather than by the widened pattern is proven in
+# tests/test_delivery_journal_raw_writer.py by the reverse mutation
+# `test_controller_family_regresses_to_uninstrumented`.
+#
+# PLATFORM BLINDNESS (#5071 T1 S4, the windows regression). This whole file is a
+# TEXT SCAN. It does not parse Rust, does not evaluate `cfg`, and has no notion
+# of a compilation target, so a family it calls instrumented is instrumented on
+# SOME target, never provably on all of them. That is not hypothetical here:
+# `session_relay_sink` — and with it the entire journal — is `#[cfg(unix)]`
+# (src/services/discord/mod.rs), while `turn_bridge` compiles on every target
+# and its three durable delivered-frontier writes are NOT gated. So on
+# windows/non-unix the cutover family advances the frontier UNINSTRUMENTED, and
+# this gate reports it as instrumented anyway, byte for byte the same as on
+# unix. Read `uninstrumented families: N/6` as "N families carry no facade token
+# on unix". The one thing that actually holds the boundary the regression broke
+# is `test_source_contract_turn_bridge_reaches_the_journal_through_one_cfg_gated_door`
+# in tests/test_delivery_journal_raw_writer.py; see also
+# src/services/discord/turn_bridge/unix_journal.rs.
 JOURNAL_FACADE_CALL = re.compile(
     r"\bself\.journal\.(?:begin_fresh|finish_fresh)\s*\("
     r"|\bjournal_watcher::(?:begin_watcher_terminal|settle_watcher_terminal|settle_without_transport)\s*\("
-    r"|\bjournal_ctl::(?:begin_controller_terminal|settle_controller_terminal)\s*\("
+    r"|\bunix_journal::(?:begin_controller_terminal|settle_controller_terminal)\s*\("
 )
 UNINSTRUMENTED_FAMILY_BASELINE = 2
 

--- a/scripts/check_delivery_journal_raw_writer.py
+++ b/scripts/check_delivery_journal_raw_writer.py
@@ -64,11 +64,23 @@ FAMILY_REGISTRY = (
 # Everything the S2 block says about what a match does NOT prove applies
 # unchanged to the new alternative: one token anywhere in the anchor file,
 # including a string literal or a test module, flips the family.
+#
+# #5071 T1 S4 adds the third alternative on the same terms. The turn_bridge
+# cutover family reaches the journal through `journal::controller`, aliased
+# `journal_ctl` at its anchor, so the alternative names that module path and its
+# two exact functions — a bare `journal_ctl`, a bare `controller`, or any other
+# method on either does NOT match. The baseline moves 3 -> 2 because that anchor
+# file now contains the token, and for no other reason: the two remaining
+# uninstrumented families (recovery/fresh-send/orphan, pipe stream epoch) are
+# unchanged by S4. That the drop is caused by the instrumentation rather than by
+# the widened pattern is proven in tests/test_delivery_journal_raw_writer.py by
+# the reverse mutation `test_controller_family_regresses_to_uninstrumented`.
 JOURNAL_FACADE_CALL = re.compile(
     r"\bself\.journal\.(?:begin_fresh|finish_fresh)\s*\("
     r"|\bjournal_watcher::(?:begin_watcher_terminal|settle_watcher_terminal|settle_without_transport)\s*\("
+    r"|\bjournal_ctl::(?:begin_controller_terminal|settle_controller_terminal)\s*\("
 )
-UNINSTRUMENTED_FAMILY_BASELINE = 3
+UNINSTRUMENTED_FAMILY_BASELINE = 2
 
 
 def call_sites(root: Path) -> tuple[Counter[str], int]:

--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -4169,6 +4169,11 @@ services::discord::session_relay_sink::idle_jsonl::tests::idle_jsonl_missing_ded
 services::discord::session_relay_sink::idle_jsonl::tests::idle_jsonl_shared_dedup_sends_range_once_then_skips_committed_retry
 services::discord::session_relay_sink::idle_jsonl::tests::mismatched_inflight_log_prune_drops_unseen_sessions
 services::discord::session_relay_sink::idle_jsonl::tests::temporary_suppression_holds_until_confirmed_commit
+services::discord::session_relay_sink::journal::controller::controller_terminal_semantics_tests::c1_controller_obligation_identity_covers_every_coordinate
+services::discord::session_relay_sink::journal::controller::controller_terminal_semantics_tests::c2_controller_and_watcher_obligations_never_coincide
+services::discord::session_relay_sink::journal::controller::controller_terminal_semantics_tests::c3_only_a_real_range_under_a_known_generation_is_an_obligation
+services::discord::session_relay_sink::journal::controller::controller_terminal_semantics_tests::c4_settle_selects_the_terminal_event_and_is_single_use
+services::discord::session_relay_sink::journal::controller::controller_terminal_semantics_tests::c5_controller_family_never_classifies_as_delivered
 services::discord::session_relay_sink::journal::sink_direct_semantics_tests::t1_new_message_delegation_is_not_a_sink_direct_obligation
 services::discord::session_relay_sink::journal::sink_direct_semantics_tests::t2_cutover_short_replace_is_not_a_sink_direct_obligation
 services::discord::session_relay_sink::journal::sink_direct_semantics_tests::t3_placeholder_edit_without_cutover_is_a_sink_direct_obligation

--- a/src/services/discord/session_relay_sink/journal.rs
+++ b/src/services/discord/session_relay_sink/journal.rs
@@ -35,6 +35,35 @@ pub(super) fn process_observer() -> &'static JournalObserver {
     &PROCESS_OBSERVER
 }
 
+/// Shadow admission — mode, pool, cohort — in the same order and with the same
+/// meaning as the sink's `begin_fresh`.
+///
+/// It lived in `journal::watcher` while the watcher was the only family that
+/// could not reach `begin_fresh`; #5071 T1 S4 adds the controller family, which
+/// needs the identical gate, so it moved to the shared parent for the same
+/// reason `PROCESS_OBSERVER` did in S3a. No behaviour change: the watcher call
+/// sites now spell it `super::admit`.
+pub(super) fn admit(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    obligation_id: Uuid,
+) -> Option<sqlx::PgPool> {
+    let runtime = crate::config_live_reload::current()?.runtime.clone();
+    if runtime.delivery_journal_mode != DeliveryJournalMode::Shadow {
+        return None;
+    }
+    let pool = shared.pg_pool.clone()?;
+    let internal = runtime
+        .delivery_journal_internal_channel_ids
+        .iter()
+        .any(|id| id == &channel_id.get().to_string());
+    if !internal && cohort_bucket(obligation_id) >= runtime.delivery_journal_cohort_percent.min(100)
+    {
+        return None;
+    }
+    Some(pool)
+}
+
 /// The type is visible to the whole `discord` module so the watcher facade can
 /// return what it emitted; every field stays private to `journal`, so no caller
 /// outside can read or construct one.

--- a/src/services/discord/session_relay_sink/journal.rs
+++ b/src/services/discord/session_relay_sink/journal.rs
@@ -16,6 +16,7 @@ use crate::services::discord::outbound::DiscordTransportReceipt;
 use super::RelaySinkError;
 use super::delivery_frontier::SinkDeliveryProofResult;
 
+pub(in crate::services::discord) mod controller;
 mod pg_store;
 pub(in crate::services::discord) mod watcher;
 

--- a/src/services/discord/session_relay_sink/journal/controller.rs
+++ b/src/services/discord/session_relay_sink/journal/controller.rs
@@ -1,0 +1,364 @@
+//! #5071 T1 S4 — the turn_bridge / controller cutover family.
+//!
+//! Three production sites in `turn_bridge/terminal_controller_cutover.rs` write
+//! the durable delivered frontier: the A5 short-replace cutover
+//! (`shadow_mirror_delivered_frontier`), the S1-d long-chunk cutover and the
+//! pre-cutover long-chunk arm (both via `record_long_chunk_terminal_delivery`).
+//! This module is the only way those sites reach the journal.
+//!
+//! Shadow only: nothing here is read back by live delivery, and a row exists
+//! only when a PG pool, `DeliveryJournalMode::Shadow` and the cohort selection
+//! all agree. If this observation ever changes what production delivers, that is
+//! a bug — the facade reads process state, never mutates it (see
+//! [`confirmed_end_generation_mtime_ns`]).
+//!
+//! ## The receipt ceiling: this family can never be `CandidateDelivered`
+//!
+//! The sink and the watcher settle with a real `DiscordTransportReceipt` read
+//! off the Discord response, so their `T` event can be checked for a
+//! requested/returned channel mismatch. The controller path has no such value.
+//! The production `TurnGateway` hands `replace_long_message_raw_with_outcome`
+//! its receipt slot as `&mut None` (`gateway.rs`) and returns only
+//! `ReplaceLongMessageOutcome`; `send_long_message_with_rollback` returns bare
+//! `Vec<MessageId>`; `toc::DeliveryOutcome` carries no receipt either. The only
+//! transport evidence that survives to these sites is the anchor pair the
+//! durable frontier already records.
+//!
+//! Synthesising a receipt from that anchor would make `requested == returned` by
+//! construction — a `T` that can never trip the `channel_mismatch` branch, which
+//! is exactly the forgery `journal.rs` refuses to commit for the in-process
+//! gateway. So this family emits `O`+`A` before transport and `C` (or `U`)
+//! after, and never `T`. `classify_shadow_observation` consequently reports
+//! `Unknown` for every controller obligation — "a commit without transport
+//! confirmation is not a candidate", the rule journal.rs already tests. That is
+//! the honest ceiling and C5 pins it; lifting it means plumbing a receipt
+//! through `TurnGateway`, which is not this slice.
+//!
+//! ## What `C` asserts, and what it does not
+//!
+//! `C` carries the site's OWN commit decision — the same boolean that gates the
+//! durable-frontier write next to it (`outcome_is_shadow_delivered`, the
+//! `Delivered { new_chunks: Some(..) }` arm, the legacy `commit_and_advance`
+//! result). It does NOT assert that the durable mirror persisted: the public
+//! `shadow_mirror_delivered_frontier` discards its inner result, so no caller at
+//! these sites can observe it. Joining those funnels is #5071 T1 S7's work, not
+//! this slice's.
+
+use std::sync::atomic::Ordering;
+
+use poise::serenity_prelude::{ChannelId, MessageId};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use crate::services::discord::SharedData;
+use crate::services::provider::ProviderKind;
+
+use super::{
+    AppendCommand, JOURNAL_NAMESPACE, JournalEvent, admit, event, process_observer, push_field,
+};
+
+/// Which of the three cutover-family sites opened the obligation. Closed, so a
+/// fourth durable-frontier writer cannot appear in that file without naming
+/// itself, and so the disposition participates in obligation identity (two sites
+/// observing the same byte range are separate obligations, not a slot
+/// collision).
+#[rustfmt::skip]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::services::discord) enum ControllerDisposition {
+    /// #3089 A5 — `deliver_short_replace_via_controller`.
+    ShortReplace,
+    /// #3998 S1-d — `deliver_long_chunks_via_controller`.
+    LongChunks,
+    /// The pre-cutover arm — `apply_bridge_long_chunks_legacy`.
+    LongChunksLegacy,
+}
+
+impl ControllerDisposition {
+    #[rustfmt::skip]
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ShortReplace => "controller_short_replace",
+            Self::LongChunks => "controller_long_chunks",
+            Self::LongChunksLegacy => "controller_long_chunks_legacy",
+        }
+    }
+}
+
+/// Read-only. Deliberately NOT `SharedData::tmux_relay_coord`, which inserts a
+/// coord on first access: an observer must not mutate process state, and an
+/// obligation that never opens must leave no trace at all. `0` — no coord, or an
+/// unknown wrapper incarnation — is the same sentinel the durable writer refuses
+/// to scope a frontier to (#5154).
+fn confirmed_end_generation_mtime_ns(shared: &SharedData, channel: ChannelId) -> i64 {
+    shared
+        .tmux_relay_coords
+        .get(&channel)
+        .map(|coord| {
+            coord
+                .confirmed_end_generation_mtime_ns
+                .load(Ordering::Acquire)
+        })
+        .unwrap_or(0)
+}
+
+/// Pure admission of the coordinates themselves, so the three refusals are
+/// testable without a PG pool (which alone makes every `begin` return `None`).
+///
+/// The family observes a range only when the site holds one, when it is a real
+/// `[start, end)`, and when the wrapper generation is known. Those are the same
+/// three cases in which the durable frontier is or is not generation-scoped, so
+/// the journal's obligation set cannot drift from the writer's. Keeping the
+/// generation in identity is what makes a repeat of the same range under a NEW
+/// incarnation a NEW obligation rather than a payload conflict on an old slot.
+pub(super) fn controller_obligation_range(
+    range: Option<(u64, u64)>,
+    generation_mtime_ns: i64,
+) -> Option<(u64, u64)> {
+    range.filter(|range| range.1 > range.0 && generation_mtime_ns != 0)
+}
+
+/// `UUIDv5` over the canonical coordinates. The leading `controller` field is
+/// what keeps this family's obligations disjoint from the watcher's over the
+/// same channel/range, independently of how the disposition strings evolve.
+pub(super) fn controller_obligation_id(
+    provider: &ProviderKind,
+    frontier_channel: ChannelId,
+    generation_mtime_ns: i64,
+    range: (u64, u64),
+    disposition: ControllerDisposition,
+) -> Uuid {
+    let mut bytes = Vec::new();
+    for value in [
+        "controller",
+        provider.as_str(),
+        &frontier_channel.get().to_string(),
+        disposition.as_str(),
+    ] {
+        push_field(&mut bytes, value);
+    }
+    bytes.extend_from_slice(&generation_mtime_ns.to_be_bytes());
+    bytes.extend_from_slice(&range.0.to_be_bytes());
+    bytes.extend_from_slice(&range.1.to_be_bytes());
+    Uuid::new_v5(&JOURNAL_NAMESPACE, &bytes)
+}
+
+#[rustfmt::skip]
+fn obligation_payload(disposition: ControllerDisposition, anchor_channel: ChannelId, range: (u64, u64)) -> Value {
+    json!({"source": "controller", "disposition_class": disposition.as_str(),
+        "anchor_channel_id": anchor_channel.get(),
+        "frontier_start": range.0, "frontier_end": range.1})
+}
+
+/// An open controller obligation, held across the transport. It keeps the pool
+/// and the raw event constructors out of the anchor file's reach.
+pub(in crate::services::discord) struct ControllerTerminalObservation {
+    obligation_id: Uuid,
+    attempt_id: Uuid,
+    anchor_channel: ChannelId,
+    range: (u64, u64),
+    pool: sqlx::PgPool,
+}
+
+/// Open the obligation BEFORE transport, so a delivery that vanishes mid-POST
+/// leaves a dangling `O`+`A` instead of no trace at all.
+///
+/// `channels` is `(frontier, anchor)`: the frontier channel is the OFFSET
+/// AUTHORITY the durable write is keyed by (`watcher_owner_channel_id`), the
+/// anchor channel is the EDIT TARGET the anchor message lives in (`channel_id`).
+/// A recovered/reused-watcher bridge resolves these differently, so the pair is
+/// recorded exactly as #3610 PR-1b records it durably.
+///
+/// `range` is `Option` because the legacy long-chunk arm only has one when it
+/// actually holds a lease: no lease, no obligation. That keeps the family
+/// boundary behavioural rather than positional.
+#[rustfmt::skip]
+pub(in crate::services::discord) fn begin_controller_terminal(
+    shared: &SharedData,
+    provider: &ProviderKind,
+    disposition: ControllerDisposition,
+    channels: (ChannelId, ChannelId),
+    range: Option<(u64, u64)>,
+) -> Option<ControllerTerminalObservation> {
+    let (frontier_channel, anchor_channel) = channels;
+    let generation_mtime_ns = confirmed_end_generation_mtime_ns(shared, frontier_channel);
+    let range = controller_obligation_range(range, generation_mtime_ns)?;
+    let obligation_id =
+        controller_obligation_id(provider, frontier_channel, generation_mtime_ns, range, disposition);
+    let pool = admit(shared, frontier_channel, obligation_id)?;
+    let attempt_id = Uuid::new_v5(&obligation_id, b"attempt:0");
+    process_observer().submit(AppendCommand {
+        pool: pool.clone(),
+        events: vec![
+            event(obligation_id, None, "O", 0, obligation_payload(disposition, anchor_channel, range)),
+            event(obligation_id, Some(attempt_id), "A", 1, json!({"attempt": 0,
+                "frontier_start": range.0, "frontier_end": range.1})),
+        ],
+    });
+    Some(ControllerTerminalObservation { obligation_id, attempt_id, anchor_channel, range, pool })
+}
+
+/// The single terminal event. `C` takes slot 3 and `U` slot 2, exactly as the
+/// sink's `finish_fresh` places them; slot 2's `T` stays empty because no
+/// transport receipt is observable here (see the module docs).
+#[rustfmt::skip]
+fn terminal_events(observation: &ControllerTerminalObservation, anchor_msg_id: Option<MessageId>, committed: bool) -> Vec<JournalEvent> {
+    let (kind, seq) = if committed { ("C", 3) } else { ("U", 2) };
+    let mut payload = json!({"frontier_start": observation.range.0, "frontier_end": observation.range.1,
+        "anchor_channel_id": observation.anchor_channel.get(),
+        "anchor_msg_id": anchor_msg_id.map(|id| id.get())});
+    if !committed { payload["reason"] = json!("controller_delivery_not_committed"); }
+    vec![event(observation.obligation_id, Some(observation.attempt_id), kind, seq, payload)]
+}
+
+/// Close the obligation. `committed` is the site's own commit decision — the
+/// boolean that gates the durable-frontier write beside it.
+///
+/// Single-use, like the sink's `settle` and the watcher's
+/// `settle_watcher_terminal`: the observation is consumed, so a second call
+/// emits nothing. The long-chunk sites rely on that directly — they settle
+/// `true` inside their commit arm and then call this once more with
+/// `(None, false)` on the way out, which closes the obligation as `U` only when
+/// the commit arm did not run.
+pub(in crate::services::discord) fn settle_controller_terminal(
+    observation: &mut Option<ControllerTerminalObservation>,
+    anchor_msg_id: Option<MessageId>,
+    committed: bool,
+) -> Vec<JournalEvent> {
+    let Some(observation) = observation.take() else {
+        return Vec::new();
+    };
+    let events = terminal_events(&observation, anchor_msg_id, committed);
+    process_observer().submit(AppendCommand {
+        pool: observation.pool,
+        events: events.clone(),
+    });
+    events
+}
+
+#[rustfmt::skip]
+#[cfg(test)]
+mod controller_terminal_semantics_tests {
+    //! #5071 T1 S4 C1-C5. RUNTIME semantic assertions: each test calls the
+    //! production function and inspects its value, so a mutation that still
+    //! compiles but changes what the code means fails here.
+    use super::super::watcher::{WatcherObligationCoordinates, watcher_obligation_id};
+    use super::super::{ShadowClassification, classify_shadow_observation};
+    use super::*;
+
+    const SHORT: ControllerDisposition = ControllerDisposition::ShortReplace;
+
+    fn observation(range: (u64, u64)) -> Option<ControllerTerminalObservation> {
+        Some(ControllerTerminalObservation {
+            obligation_id: Uuid::from_u128(21), attempt_id: Uuid::from_u128(22),
+            anchor_channel: ChannelId::new(4_243), range,
+            pool: sqlx::Pool::<sqlx::Postgres>::connect_lazy("postgres://localhost/agentdesk_test")
+                .expect("lazy test pool URL is valid"),
+        })
+    }
+
+    fn obligation(channel: u64, generation: i64, range: (u64, u64), disposition: ControllerDisposition) -> Uuid {
+        controller_obligation_id(&ProviderKind::Claude, ChannelId::new(channel), generation, range, disposition)
+    }
+
+    /// C1 (kills M-C1). Obligation identity must move with every coordinate, or
+    /// two different deliveries collapse onto one row and the second one's
+    /// payload becomes an `InvariantConflict` instead of an observation.
+    #[test]
+    fn c1_controller_obligation_identity_covers_every_coordinate() {
+        let base = obligation(4_242, 77, (10, 20), SHORT);
+        assert_eq!(base, obligation(4_242, 77, (10, 20), SHORT), "deterministic");
+        assert_ne!(base, obligation(4_243, 77, (10, 20), SHORT), "frontier channel participates");
+        assert_ne!(base, obligation(4_242, 78, (10, 20), SHORT), "wrapper generation participates");
+        assert_ne!(base, obligation(4_242, 77, (11, 20), SHORT), "start offset participates");
+        assert_ne!(base, obligation(4_242, 77, (10, 21), SHORT), "end offset participates");
+        for other in [ControllerDisposition::LongChunks, ControllerDisposition::LongChunksLegacy] {
+            assert_ne!(base, obligation(4_242, 77, (10, 20), other), "{other:?} is its own disposition class");
+        }
+        assert_ne!(base, controller_obligation_id(&ProviderKind::Codex, ChannelId::new(4_242), 77, (10, 20), SHORT),
+            "provider participates");
+    }
+
+    /// C2 (kills M-C2). The controller and the watcher both observe terminal
+    /// deliveries keyed by channel + generation + range. If their obligation ids
+    /// could coincide, one family's `A` and the other's would compete for slot 1
+    /// over the same delivery.
+    #[test]
+    fn c2_controller_and_watcher_obligations_never_coincide() {
+        let watcher = watcher_obligation_id(
+            WatcherObligationCoordinates { provider: &ProviderKind::Claude, channel_id: ChannelId::new(4_242),
+                tmux_session_name: "adk-claude-s4", generation_mtime_ns: 77, range: (10, 20) },
+            "controller_short_replace",
+        );
+        assert_ne!(obligation(4_242, 77, (10, 20), SHORT), watcher,
+            "the leading `controller` field keeps the two families disjoint even under an identical disposition string");
+    }
+
+    /// C3 (kills M-C3). The three refusals, tested where they are decidable: a
+    /// pool-less test process makes every `begin_controller_terminal` return
+    /// `None`, so asserting on the facade would prove nothing.
+    #[test]
+    fn c3_only_a_real_range_under_a_known_generation_is_an_obligation() {
+        assert_eq!(controller_obligation_range(Some((10, 20)), 77), Some((10, 20)), "the ordinary case observes");
+        assert_eq!(controller_obligation_range(None, 77), None, "no lease range, no obligation");
+        assert_eq!(controller_obligation_range(Some((10, 10)), 77), None, "an empty range advances nothing");
+        assert_eq!(controller_obligation_range(Some((20, 10)), 77), None, "an inverted range is not a frontier");
+        assert_eq!(controller_obligation_range(Some((10, 20)), 0), None,
+            "an unknown wrapper incarnation is exactly where the durable writer declines to scope a frontier (#5154)");
+    }
+
+    /// C4 (kills M-C4). The commit decision selects the terminal event, and the
+    /// observation is single-use — which is what makes the long-chunk sites'
+    /// trailing `(None, false)` settle a no-op after their commit arm ran.
+    #[tokio::test]
+    async fn c4_settle_selects_the_terminal_event_and_is_single_use() {
+        let mut committed = observation((10, 20));
+        let events = settle_controller_terminal(&mut committed, Some(MessageId::new(901)), true);
+        assert_eq!(events.iter().map(|event| event.kind).collect::<Vec<_>>(), vec!["C"],
+            "a committed controller delivery emits exactly one C");
+        assert_eq!(events[0].seq, 3, "C takes the sink's commit slot");
+        assert_eq!(events[0].canonical_payload["anchor_msg_id"], 901);
+        assert_eq!(events[0].canonical_payload["frontier_end"], 20);
+        assert!(events[0].canonical_payload.get("reason").is_none(), "a commit needs no failure reason");
+        assert!(committed.is_none(), "a settled observation is consumed");
+        assert!(settle_controller_terminal(&mut committed, Some(MessageId::new(901)), true).is_empty(),
+            "a second settle on the same observation must emit nothing");
+        assert!(settle_controller_terminal(&mut committed, None, false).is_empty(),
+            "the sites' trailing unconfirmed settle must not append after a commit");
+
+        let mut uncommitted = observation((10, 20));
+        let events = settle_controller_terminal(&mut uncommitted, None, false);
+        assert_eq!(events.iter().map(|event| event.kind).collect::<Vec<_>>(), vec!["U"],
+            "a delivery the site did not commit is Unknown, never C");
+        assert_eq!(events[0].seq, 2, "U takes the slot T would have taken");
+        assert_eq!(events[0].canonical_payload["reason"], "controller_delivery_not_committed");
+        assert!(settle_controller_terminal(&mut None, Some(MessageId::new(901)), true).is_empty(),
+            "an unobserved delivery settles into nothing");
+    }
+
+    /// C5 (kills M-C5). The declared ceiling. No controller event may carry a
+    /// transport receipt, because none is observable on this path, and the
+    /// classifier must therefore refuse to call the family delivered. A future
+    /// slice that synthesises a receipt from the anchor pair — `requested ==
+    /// returned` by construction, so the mismatch branch could never fire —
+    /// fails here rather than silently promoting forgeries to Delivered.
+    #[tokio::test]
+    async fn c5_controller_family_never_classifies_as_delivered() {
+        let mut open = observation((10, 20));
+        let obligation_id = open.as_ref().expect("observation").obligation_id;
+        let attempt_id = open.as_ref().expect("observation").attempt_id;
+        let opened = vec![
+            event(obligation_id, None, "O", 0, obligation_payload(SHORT, ChannelId::new(4_243), (10, 20))),
+            event(obligation_id, Some(attempt_id), "A", 1, json!({"attempt": 0, "frontier_start": 10, "frontier_end": 20})),
+        ];
+        let settled = settle_controller_terminal(&mut open, Some(MessageId::new(901)), true);
+        let window = [opened.clone(), settled.clone()].concat();
+        assert!(window.iter().all(|event| event.receipt.is_none()),
+            "no controller event may carry a transport receipt: none is observable on this path");
+        assert_eq!(classify_shadow_observation(&window, false), ShadowClassification::Unknown,
+            "a commit without transport confirmation is not a candidate");
+        assert_ne!(classify_shadow_observation(&window, true), ShadowClassification::CandidateDelivered,
+            "an elapsed grace must not promote the ceiling into a delivery");
+        assert_ne!(classify_shadow_observation(&opened, true), ShadowClassification::CandidateDelivered,
+            "a delivery that vanished after the open is Unknown, not delivered");
+    }
+}

--- a/src/services/discord/session_relay_sink/journal/watcher.rs
+++ b/src/services/discord/session_relay_sink/journal/watcher.rs
@@ -15,7 +15,6 @@ use poise::serenity_prelude::ChannelId;
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use crate::config::DeliveryJournalMode;
 use crate::services::discord::SharedData;
 use crate::services::discord::outbound::DiscordTransportReceipt;
 // The watcher lives under the `#[cfg(unix)] mod tmux`, so every item naming its
@@ -25,7 +24,7 @@ use crate::services::discord::tmux::tmux_watcher::terminal_long_chunks::GuardedW
 use crate::services::provider::ProviderKind;
 
 use super::{
-    AppendCommand, AttemptObservation, JOURNAL_NAMESPACE, JournalEvent, cohort_bucket, event,
+    AppendCommand, AttemptObservation, JOURNAL_NAMESPACE, JournalEvent, admit, event,
     process_observer, push_field,
 };
 
@@ -105,29 +104,6 @@ pub(super) fn watcher_obligation_id(
 pub(super) fn obligation_payload(coordinates: WatcherObligationCoordinates<'_>, disposition_class: &str) -> Value {
     json!({"source": "watcher", "disposition_class": disposition_class,
         "frontier_start": coordinates.range.0, "frontier_end": coordinates.range.1})
-}
-
-/// Shadow admission — mode, pool, cohort — in the same order and with the same
-/// meaning as the sink's `begin_fresh`.
-pub(super) fn admit(
-    shared: &SharedData,
-    channel_id: ChannelId,
-    obligation_id: Uuid,
-) -> Option<sqlx::PgPool> {
-    let runtime = crate::config_live_reload::current()?.runtime.clone();
-    if runtime.delivery_journal_mode != DeliveryJournalMode::Shadow {
-        return None;
-    }
-    let pool = shared.pg_pool.clone()?;
-    let internal = runtime
-        .delivery_journal_internal_channel_ids
-        .iter()
-        .any(|id| id == &channel_id.get().to_string());
-    if !internal && cohort_bucket(obligation_id) >= runtime.delivery_journal_cohort_percent.min(100)
-    {
-        return None;
-    }
-    Some(pool)
 }
 
 /// The `O`+`S` pair for one no-transport settlement.

--- a/src/services/discord/turn_bridge/terminal_controller_cutover.rs
+++ b/src/services/discord/turn_bridge/terminal_controller_cutover.rs
@@ -17,6 +17,9 @@ use super::super::inflight::RelayOwnerKind;
 use super::super::outbound::delivery_record as dr;
 use super::super::outbound::turn_output_controller as toc;
 use super::super::placeholder_controller::{PlaceholderKey, PlaceholderLifecycle};
+use super::super::session_relay_sink::journal::controller::{
+    self as journal_ctl, ControllerDisposition as Disposition,
+};
 use super::super::turn_finalizer::TurnKey;
 use crate::services::discord::{
     DeliveryLeaseCell, DeliveryLeaseHeartbeat, DeliveryLeaseKey, LeaseHolder, lease_now_ms,
@@ -246,6 +249,10 @@ pub(super) async fn deliver_short_replace_via_controller(
         );
         true
     };
+    // #5071 T1 S4: open the controller family's shadow obligation BEFORE transport.
+    #[rustfmt::skip]
+    let mut journal = journal_ctl::begin_controller_terminal(shared, provider,
+        Disposition::ShortReplace, (watcher_owner_channel_id, channel_id), Some((start, end)));
     let outcome = toc::deliver_turn_output(
         gateway,
         toc::TurnOutputCtx {
@@ -314,13 +321,14 @@ pub(super) async fn deliver_short_replace_via_controller(
     // Some(msg_id)`. The frontier KEY stays `watcher_owner_channel_id` (offset
     // authority unchanged — B2b's fusion still shares one channel key); only the
     // recorded anchor pair points at the edit channel/message.
+    let delivered = dr::outcome_is_shadow_delivered(&outcome);
     dr::shadow_mirror_delivered_frontier(
         shared,
         provider,
         watcher_owner_channel_id,
         tmux_session_name,
         (start, end),
-        dr::outcome_is_shadow_delivered(&outcome),
+        delivered,
         Some(msg_id.get()),
         Some(channel_id.get()),
         Some(delivered_body),
@@ -328,6 +336,7 @@ pub(super) async fn deliver_short_replace_via_controller(
         // keyed by the delivery channel (`channel_id`), NOT `watcher_owner_channel_id`.
         Some(turn.user_msg_id),
     );
+    journal_ctl::settle_controller_terminal(&mut journal, Some(msg_id), delivered);
     outcome
 }
 
@@ -368,6 +377,9 @@ pub(super) async fn deliver_long_chunks_via_controller(
         true
     };
     let chunk_count = super::super::formatting::split_message(relay_text).len();
+    #[rustfmt::skip]
+    let mut journal = journal_ctl::begin_controller_terminal(shared, provider,
+        Disposition::LongChunks, (watcher_owner_channel_id, channel_id), Some((start, end)));
     let outcome = toc::deliver_turn_output(
         gateway,
         toc::TurnOutputCtx {
@@ -417,7 +429,9 @@ pub(super) async fn deliver_long_chunks_via_controller(
             // #4564: explicit inbound turn id; ledger keyed by delivery `channel_id`.
             Some(turn.user_msg_id),
         );
+        journal_ctl::settle_controller_terminal(&mut journal, chunks.tail_message_id, true);
     }
+    journal_ctl::settle_controller_terminal(&mut journal, None, false); // no-op if settled
     outcome
 }
 
@@ -529,6 +543,10 @@ pub(super) async fn apply_bridge_long_chunks_legacy(
         BridgeLeaseAcquire::Held(lease) => Some(lease),
         _ => None,
     };
+    #[rustfmt::skip]
+    let mut journal = journal_ctl::begin_controller_terminal(shared, provider,
+        Disposition::LongChunksLegacy, (watcher_owner_channel_id, channel_id),
+        lease.as_ref().map(|lease| lease.range()));
     match send_ordered_long_terminal_response(
         shared,
         gateway,
@@ -571,6 +589,7 @@ pub(super) async fn apply_bridge_long_chunks_legacy(
                         delivered_body,
                         Some(ledger_user_msg_id),
                     );
+                    journal_ctl::settle_controller_terminal(&mut journal, last_chunk_msg_id, true);
                 }
             }
         }
@@ -592,6 +611,7 @@ pub(super) async fn apply_bridge_long_chunks_legacy(
             *locals.preserve_inflight_for_cleanup_retry = true;
         }
     }
+    journal_ctl::settle_controller_terminal(&mut journal, None, false); // no-op if settled
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/services/discord/turn_bridge/terminal_controller_cutover.rs
+++ b/src/services/discord/turn_bridge/terminal_controller_cutover.rs
@@ -9,6 +9,8 @@
 //! A4's `tmux_watcher/terminal_send.rs` sibling).
 
 use super::*;
+// #5071 T1 S4: the ONE door from this file to the `#[cfg(unix)]` journal.
+mod unix_journal;
 
 use std::sync::Arc;
 
@@ -17,13 +19,11 @@ use super::super::inflight::RelayOwnerKind;
 use super::super::outbound::delivery_record as dr;
 use super::super::outbound::turn_output_controller as toc;
 use super::super::placeholder_controller::{PlaceholderKey, PlaceholderLifecycle};
-use super::super::session_relay_sink::journal::controller::{
-    self as journal_ctl, ControllerDisposition as Disposition,
-};
 use super::super::turn_finalizer::TurnKey;
 use crate::services::discord::{
     DeliveryLeaseCell, DeliveryLeaseHeartbeat, DeliveryLeaseKey, LeaseHolder, lease_now_ms,
 };
+use unix_journal::Disposition;
 
 /// #3089 A5: the bridge short-replace cut-over decision, computed at the site-5
 /// lease-acquire site (mod.rs ~6134).
@@ -250,8 +250,10 @@ pub(super) async fn deliver_short_replace_via_controller(
         true
     };
     // #5071 T1 S4: open the controller family's shadow obligation BEFORE transport.
+    // `unix_journal` — the journal is `#[cfg(unix)]` and the durable frontier write
+    // below is not, so off unix these three sites are UNINSTRUMENTED.
     #[rustfmt::skip]
-    let mut journal = journal_ctl::begin_controller_terminal(shared, provider,
+    let mut journal = unix_journal::begin_controller_terminal(shared, provider,
         Disposition::ShortReplace, (watcher_owner_channel_id, channel_id), Some((start, end)));
     let outcome = toc::deliver_turn_output(
         gateway,
@@ -336,7 +338,7 @@ pub(super) async fn deliver_short_replace_via_controller(
         // keyed by the delivery channel (`channel_id`), NOT `watcher_owner_channel_id`.
         Some(turn.user_msg_id),
     );
-    journal_ctl::settle_controller_terminal(&mut journal, Some(msg_id), delivered);
+    unix_journal::settle_controller_terminal(&mut journal, Some(msg_id), delivered);
     outcome
 }
 
@@ -378,7 +380,7 @@ pub(super) async fn deliver_long_chunks_via_controller(
     };
     let chunk_count = super::super::formatting::split_message(relay_text).len();
     #[rustfmt::skip]
-    let mut journal = journal_ctl::begin_controller_terminal(shared, provider,
+    let mut journal = unix_journal::begin_controller_terminal(shared, provider,
         Disposition::LongChunks, (watcher_owner_channel_id, channel_id), Some((start, end)));
     let outcome = toc::deliver_turn_output(
         gateway,
@@ -429,9 +431,9 @@ pub(super) async fn deliver_long_chunks_via_controller(
             // #4564: explicit inbound turn id; ledger keyed by delivery `channel_id`.
             Some(turn.user_msg_id),
         );
-        journal_ctl::settle_controller_terminal(&mut journal, chunks.tail_message_id, true);
+        unix_journal::settle_controller_terminal(&mut journal, chunks.tail_message_id, true);
     }
-    journal_ctl::settle_controller_terminal(&mut journal, None, false); // no-op if settled
+    unix_journal::settle_controller_terminal(&mut journal, None, false); // no-op if settled
     outcome
 }
 
@@ -544,7 +546,7 @@ pub(super) async fn apply_bridge_long_chunks_legacy(
         _ => None,
     };
     #[rustfmt::skip]
-    let mut journal = journal_ctl::begin_controller_terminal(shared, provider,
+    let mut journal = unix_journal::begin_controller_terminal(shared, provider,
         Disposition::LongChunksLegacy, (watcher_owner_channel_id, channel_id),
         lease.as_ref().map(|lease| lease.range()));
     match send_ordered_long_terminal_response(
@@ -589,7 +591,7 @@ pub(super) async fn apply_bridge_long_chunks_legacy(
                         delivered_body,
                         Some(ledger_user_msg_id),
                     );
-                    journal_ctl::settle_controller_terminal(&mut journal, last_chunk_msg_id, true);
+                    unix_journal::settle_controller_terminal(&mut journal, last_chunk_msg_id, true);
                 }
             }
         }
@@ -611,7 +613,7 @@ pub(super) async fn apply_bridge_long_chunks_legacy(
             *locals.preserve_inflight_for_cleanup_retry = true;
         }
     }
-    journal_ctl::settle_controller_terminal(&mut journal, None, false); // no-op if settled
+    unix_journal::settle_controller_terminal(&mut journal, None, false); // no-op if settled
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/services/discord/turn_bridge/terminal_controller_cutover/unix_journal.rs
+++ b/src/services/discord/turn_bridge/terminal_controller_cutover/unix_journal.rs
@@ -1,0 +1,94 @@
+//! #5071 T1 S4 — the cutover family's single door to the delivery journal, and
+//! the `cfg` boundary that door stands on.
+//!
+//! `session_relay_sink` is `#[cfg(unix)]` (`services/discord/mod.rs`), so
+//! `session_relay_sink::journal::controller` does not exist on non-unix targets.
+//! `turn_bridge` carries no such gate and compiles everywhere. S4 first landed a
+//! direct `use super::super::session_relay_sink::journal::controller::…` in
+//! `terminal_controller_cutover.rs`, which is a hard build break on
+//! `windows-latest` (`E0433: could not find session_relay_sink in super`).
+//! Routing the family through this module puts that boundary in ONE place
+//! instead of nine `#[cfg(unix)]` attributes scattered over the anchor file's
+//! three begins and five settles.
+//!
+//! ## On non-unix this family is UNINSTRUMENTED — that is not the same as a no-op
+//!
+//! The three durable delivered-frontier writes in
+//! `terminal_controller_cutover.rs` — one `dr::shadow_mirror_delivered_frontier`
+//! and two `dr::record_long_chunk_terminal_delivery` — are NOT `cfg`-gated: they
+//! compile on every target. The journal that observes them is gated. So on
+//! non-unix the frontier advances with no shadow observation at all, and no row
+//! for this family can ever exist there.
+//!
+//! The `#[cfg(not(unix))]` items below are that absence written down, not
+//! instrumentation that happens to do nothing. [`NoJournalOnThisPlatform`] is an
+//! uninhabited enum, so `Option<NoJournalOnThisPlatform>` has exactly one
+//! inhabitant — `None`. Off unix an observation is not merely never made; it
+//! cannot be constructed. Nothing may be added to those items: an observation
+//! that only some platforms make must never be spelled the way one that every
+//! platform makes is spelled.
+//!
+//! Both facts have to survive a reader who never opens this file, which is why
+//! the anchor imports the module under its own name instead of aliasing it:
+//! every call site reads `unix_journal::begin_controller_terminal(..)` /
+//! `unix_journal::settle_controller_terminal(..)`, so the platform bound sits in
+//! the identifier at all eight of them.
+//!
+//! ## The family gate cannot see any of this
+//!
+//! `scripts/check_delivery_journal_raw_writer.py` decides "instrumented" by
+//! matching facade-call TEXT in the anchor file. It does not parse Rust, does
+//! not evaluate `cfg`, and has no notion of a target, so its verdict for this
+//! family is byte-identical on every platform and means only "instrumented on
+//! unix". Read its `uninstrumented families: 2/6` as a unix-only enumeration,
+//! never as a claim about the build that actually broke. What holds this
+//! boundary is
+//! `test_source_contract_turn_bridge_reaches_the_journal_through_one_cfg_gated_door`
+//! in `tests/test_delivery_journal_raw_writer.py`, run by
+//! `scripts/ci-script-checks.sh`.
+
+#[cfg(unix)]
+pub(super) use super::super::super::session_relay_sink::journal::controller::{
+    ControllerDisposition as Disposition, begin_controller_terminal, settle_controller_terminal,
+};
+
+/// The non-unix observation type: an uninhabited enum, so the only value of
+/// `Option<NoJournalOnThisPlatform>` is `None`. This is the type-level statement
+/// that the cutover family holds no journal obligation off unix.
+#[cfg(not(unix))]
+pub(super) enum NoJournalOnThisPlatform {}
+
+/// Mirrors [`super::super::super::session_relay_sink::journal::controller::ControllerDisposition`]
+/// so the anchor's three call sites keep naming which durable writer they sit
+/// beside on every target. Naming a site is not observing it.
+#[cfg(not(unix))]
+pub(super) enum Disposition {
+    ShortReplace,
+    LongChunks,
+    LongChunksLegacy,
+}
+
+/// There is no journal to open. Returns `None` because no other value exists.
+#[cfg(not(unix))]
+pub(super) fn begin_controller_terminal(
+    _shared: &crate::services::discord::SharedData,
+    _provider: &crate::services::provider::ProviderKind,
+    _disposition: Disposition,
+    _channels: (
+        poise::serenity_prelude::ChannelId,
+        poise::serenity_prelude::ChannelId,
+    ),
+    _range: Option<(u64, u64)>,
+) -> Option<NoJournalOnThisPlatform> {
+    None
+}
+
+/// There is no obligation to settle: the argument is uninhabited under the
+/// `Option`, so this cannot be reached with anything to close.
+#[cfg(not(unix))]
+pub(super) fn settle_controller_terminal(
+    _observation: &mut Option<NoJournalOnThisPlatform>,
+    _anchor_msg_id: Option<poise::serenity_prelude::MessageId>,
+    _committed: bool,
+) {
+}

--- a/tests/test_delivery_journal_raw_writer.py
+++ b/tests/test_delivery_journal_raw_writer.py
@@ -14,6 +14,7 @@ FACADE_MARKERS = (
     " self.journal.begin_fresh();",
     " self.journal.begin_fresh();",
     " journal_watcher::begin_watcher_terminal();",
+    " journal_ctl::begin_controller_terminal();",
 )
 def write(root: Path, rel: str, body: str) -> None:
     path = root / rel
@@ -29,8 +30,10 @@ class RawWriterAllowlistTests(unittest.TestCase):
         write(root, "src/services/discord/session_relay_sink/journal.rs", "fn actor() { append_delivery_journal_batch(); }\n")
         # #5071 T1 S3a: the third instrumented family is the watcher, which spells
         # the facade through `journal_watcher::` because its anchor is a free
-        # function with no `self`. Using the real token here means the fixture
-        # exercises BOTH alternations of JOURNAL_FACADE_CALL, not just the sink's.
+        # function with no `self`. #5071 T1 S4 adds the fourth, the turn_bridge
+        # cutover, spelling it through `journal_ctl::`. Using the real tokens here
+        # means the fixture exercises ALL THREE alternations of
+        # JOURNAL_FACADE_CALL, not just the sink's.
         for index, (_, rel, symbol) in enumerate(guard.FAMILY_REGISTRY):
             call = FACADE_MARKERS[index] if index < len(FACADE_MARKERS) else ""
             write(root, rel, f"fn {symbol}() {{{call}}}\n")
@@ -80,7 +83,7 @@ class RawWriterAllowlistTests(unittest.TestCase):
         path = root / guard.FAMILY_REGISTRY[4][1]
         path.write_text(path.read_text(encoding="utf-8") + '#[cfg(test)] fn journal_probe() { self.journal.begin_fresh(); }\n', encoding="utf-8")
         self.assertTrue(guard.family_status(root)[0][4][1], "cfg(test) fn marker is a declared lexical match")
-        ok, message = guard.check(root); self.assertFalse(ok); self.assertIn("uninstrumented families: 2/6", message)
+        ok, message = guard.check(root); self.assertFalse(ok); self.assertIn("uninstrumented families: 1/6", message)
 
     def test_line_doc_comment_markers_are_known_limit_and_not_counted(self):
         """Known limitation and declared behavior: line doc comments are stripped after // on each line."""
@@ -94,14 +97,14 @@ class RawWriterAllowlistTests(unittest.TestCase):
         self.assertFalse(status[4][1], "line doc comment markers are excluded by the declared lexical cut")
         ok, message = guard.check(root)
         self.assertTrue(ok, message)
-        self.assertIn("uninstrumented families: 3/6", message)
+        self.assertIn("uninstrumented families: 2/6", message)
 
     def test_block_marker_strings_do_not_hide_real_facade_calls(self):
         """Evidence: block-marker strings no longer delete calls across lines."""
         root = self.fixture()
         path = root / guard.FAMILY_REGISTRY[0][1]
         path.write_text(path.read_text(encoding="utf-8") + 'const BLOCK_OPEN: &str = "/*";\nself.journal.begin_fresh();\nconst BLOCK_CLOSE: &str = "*/";\n', encoding="utf-8")
-        ok, message = guard.check(root); self.assertTrue(ok, message); self.assertIn("uninstrumented families: 3/6", message)
+        ok, message = guard.check(root); self.assertTrue(ok, message); self.assertIn("uninstrumented families: 2/6", message)
 
     def test_raw_string_marker_is_known_lexical_false_positive(self):
         """Known limit: raw strings are not parsed and may count as calls."""
@@ -127,9 +130,9 @@ class RawWriterAllowlistTests(unittest.TestCase):
     def test_family_baseline_is_measured_and_named(self):
         ok, message = guard.check(self.fixture())
         self.assertTrue(ok, message)
-        self.assertIn("uninstrumented families: 3/6", message)
+        self.assertIn("uninstrumented families: 2/6", message)
         self.assertIn("whole anchor file including tests", message)
-        self.assertIn("turn_bridge / controller family", message)
+        self.assertIn("recovery / fresh-send / orphan family", message)
 
     def test_instrumentation_rule_is_mechanical(self):
         root = self.fixture()
@@ -159,11 +162,11 @@ class RawWriterAllowlistTests(unittest.TestCase):
     def test_baseline_increase_names_families(self):
         root = self.fixture()
         old = guard.UNINSTRUMENTED_FAMILY_BASELINE
-        guard.UNINSTRUMENTED_FAMILY_BASELINE = 2
+        guard.UNINSTRUMENTED_FAMILY_BASELINE = 1
         self.addCleanup(setattr, guard, "UNINSTRUMENTED_FAMILY_BASELINE", old)
         ok, message = guard.check(root)
         self.assertFalse(ok)
-        self.assertIn("turn_bridge / controller family", message)
+        self.assertIn("recovery / fresh-send / orphan family", message)
 
     def test_baseline_decrease_requires_repin_command(self):
         root = self.fixture()
@@ -177,7 +180,7 @@ class RawWriterAllowlistTests(unittest.TestCase):
         result = subprocess.run(["python3", str(SCRIPT)], cwd=ROOT, text=True, capture_output=True)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertRegex(result.stdout, r"scanned Rust files: [1-9][0-9]*")
-        self.assertIn("uninstrumented families: 3/6", result.stdout)
+        self.assertIn("uninstrumented families: 2/6", result.stdout)
 
     # SOURCE-CONTRACT block (#5071 T1 S2). Everything below matches TEXT in .rs
     # files: call ORDER, call COUNT, symbol PRESENCE. None of it executes Rust,
@@ -306,6 +309,73 @@ class RawWriterAllowlistTests(unittest.TestCase):
         self.assertEqual(total, 5, "the design names exactly five no-transport settlement sites")
 
     # #5071 T1 S3c addition.
+
+    # #5071 T1 S4 additions.
+
+    def test_controller_facade_alternation_matches_only_its_exact_call_shape(self):
+        """The S4 alternation must not be a loosening either. Near misses stay
+        uninstrumented; only the two declared call shapes match."""
+        for near_miss in (
+            " journal_ctl::begin_controller();",
+            " journal_ctl.begin_controller_terminal();",
+            " ctl::begin_controller_terminal();",
+            " journal_ctl::controller_obligation_id();",
+            " journal_ctl::settle_controller();",
+        ):
+            self.assertIsNone(
+                guard.JOURNAL_FACADE_CALL.search(near_miss),
+                f"{near_miss!r} must not count as a facade call",
+            )
+        for exact in (
+            " journal_ctl::begin_controller_terminal(",
+            " journal_ctl::settle_controller_terminal(",
+        ):
+            self.assertIsNotNone(
+                guard.JOURNAL_FACADE_CALL.search(exact),
+                f"{exact!r} is a declared facade call",
+            )
+
+    def test_controller_family_regresses_to_uninstrumented(self):
+        """Reverse mutation, in fixture form: the 3 -> 2 baseline drop is caused
+        by the instrumentation, not by the widened regex. Drop the controller
+        token and the count returns over the re-pinned baseline of 2."""
+        root = self.fixture()
+        path = root / guard.FAMILY_REGISTRY[3][1]
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(FACADE_MARKERS[3], ""),
+            encoding="utf-8",
+        )
+        ok, message = guard.check(root)
+        self.assertFalse(ok)
+        self.assertIn("exceeds baseline", message)
+        self.assertIn("turn_bridge / controller family", message)
+
+    def test_source_contract_controller_anchor_covers_every_durable_writer(self):
+        """Source text only: the S4 design names exactly three durable delivered-
+        frontier writes in the cutover anchor -- one short-replace mirror and two
+        long-chunk records -- and each is opened by its own pre-transport begin.
+        Adding a fourth durable write, or dropping a begin, fails here. Five
+        settles, not three: the two long-chunk sites settle `true` inside their
+        commit arm and call the single-use settle once more on the way out, so a
+        completed-but-uncommitted delivery closes as `U` instead of dangling. It
+        is a text count -- it cannot prove any call is reached."""
+        source = (
+            ROOT / "src/services/discord/turn_bridge/terminal_controller_cutover.rs"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(source.count("dr::shadow_mirror_delivered_frontier("), 1)
+        self.assertEqual(source.count("dr::record_long_chunk_terminal_delivery("), 2)
+        self.assertEqual(source.count("journal_ctl::begin_controller_terminal("), 3)
+        self.assertEqual(source.count("journal_ctl::settle_controller_terminal("), 5)
+        self.assertLess(
+            source.index("journal_ctl::begin_controller_terminal("),
+            source.index("journal_ctl::settle_controller_terminal("),
+            "the first obligation opens before any settle",
+        )
+        self.assertLess(
+            source.rindex("journal_ctl::begin_controller_terminal("),
+            source.rindex("journal_ctl::settle_controller_terminal("),
+            "the last obligation opens before its settle",
+        )
 
     def test_source_contract_repeated_suppression_arm_gates_its_observation(self):
         """Source text only: the post-terminal suppression arm is the one site

--- a/tests/test_delivery_journal_raw_writer.py
+++ b/tests/test_delivery_journal_raw_writer.py
@@ -401,6 +401,17 @@ class RawWriterAllowlistTests(unittest.TestCase):
             "the gate this contract protects moved; re-derive the rule instead of relaxing it",
         )
         door = "src/services/discord/turn_bridge/terminal_controller_cutover/unix_journal.rs"
+        # This literal is self-validating below: point it at the wrong file and
+        # the real door lands in `offenders`. The gate script's PLATFORM
+        # BLINDNESS block sends readers to the same path in prose, where nothing
+        # validates it -- it went stale the moment the door moved under
+        # terminal_controller_cutover/. Pin the two copies together here so the
+        # next move cannot leave a pointer to a file that does not exist.
+        self.assertTrue(
+            door in SCRIPT.read_text(encoding="utf-8"),
+            f"scripts/check_delivery_journal_raw_writer.py points readers at a "
+            f"door path that is not {door}",
+        )
         offenders = []
         gated = 0
         for path in sorted((ROOT / "src/services/discord/turn_bridge").rglob("*.rs")):

--- a/tests/test_delivery_journal_raw_writer.py
+++ b/tests/test_delivery_journal_raw_writer.py
@@ -14,7 +14,7 @@ FACADE_MARKERS = (
     " self.journal.begin_fresh();",
     " self.journal.begin_fresh();",
     " journal_watcher::begin_watcher_terminal();",
-    " journal_ctl::begin_controller_terminal();",
+    " unix_journal::begin_controller_terminal();",
 )
 def write(root: Path, rel: str, body: str) -> None:
     path = root / rel
@@ -31,7 +31,7 @@ class RawWriterAllowlistTests(unittest.TestCase):
         # #5071 T1 S3a: the third instrumented family is the watcher, which spells
         # the facade through `journal_watcher::` because its anchor is a free
         # function with no `self`. #5071 T1 S4 adds the fourth, the turn_bridge
-        # cutover, spelling it through `journal_ctl::`. Using the real tokens here
+        # cutover, spelling it through `unix_journal::`. Using the real tokens here
         # means the fixture exercises ALL THREE alternations of
         # JOURNAL_FACADE_CALL, not just the sink's.
         for index, (_, rel, symbol) in enumerate(guard.FAMILY_REGISTRY):
@@ -316,19 +316,19 @@ class RawWriterAllowlistTests(unittest.TestCase):
         """The S4 alternation must not be a loosening either. Near misses stay
         uninstrumented; only the two declared call shapes match."""
         for near_miss in (
-            " journal_ctl::begin_controller();",
-            " journal_ctl.begin_controller_terminal();",
+            " unix_journal::begin_controller();",
+            " unix_journal.begin_controller_terminal();",
             " ctl::begin_controller_terminal();",
-            " journal_ctl::controller_obligation_id();",
-            " journal_ctl::settle_controller();",
+            " unix_journal::controller_obligation_id();",
+            " unix_journal::settle_controller();",
         ):
             self.assertIsNone(
                 guard.JOURNAL_FACADE_CALL.search(near_miss),
                 f"{near_miss!r} must not count as a facade call",
             )
         for exact in (
-            " journal_ctl::begin_controller_terminal(",
-            " journal_ctl::settle_controller_terminal(",
+            " unix_journal::begin_controller_terminal(",
+            " unix_journal::settle_controller_terminal(",
         ):
             self.assertIsNotNone(
                 guard.JOURNAL_FACADE_CALL.search(exact),
@@ -364,18 +364,68 @@ class RawWriterAllowlistTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertEqual(source.count("dr::shadow_mirror_delivered_frontier("), 1)
         self.assertEqual(source.count("dr::record_long_chunk_terminal_delivery("), 2)
-        self.assertEqual(source.count("journal_ctl::begin_controller_terminal("), 3)
-        self.assertEqual(source.count("journal_ctl::settle_controller_terminal("), 5)
+        self.assertEqual(source.count("unix_journal::begin_controller_terminal("), 3)
+        self.assertEqual(source.count("unix_journal::settle_controller_terminal("), 5)
         self.assertLess(
-            source.index("journal_ctl::begin_controller_terminal("),
-            source.index("journal_ctl::settle_controller_terminal("),
+            source.index("unix_journal::begin_controller_terminal("),
+            source.index("unix_journal::settle_controller_terminal("),
             "the first obligation opens before any settle",
         )
         self.assertLess(
-            source.rindex("journal_ctl::begin_controller_terminal("),
-            source.rindex("journal_ctl::settle_controller_terminal("),
+            source.rindex("unix_journal::begin_controller_terminal("),
+            source.rindex("unix_journal::settle_controller_terminal("),
             "the last obligation opens before its settle",
         )
+
+    def test_source_contract_turn_bridge_reaches_the_journal_through_one_cfg_gated_door(self):
+        """Source text only, and the one check that would have caught the S4
+        windows regression. `mod session_relay_sink` is `#[cfg(unix)]` while `mod
+        turn_bridge` is not, so ANY reference from turn_bridge into that module
+        which is not itself behind `#[cfg(unix)]` breaks windows-latest with
+        E0433 -- which is exactly how S4 first landed. This pins both halves of
+        the fix: the reference lives in exactly ONE turn_bridge file
+        (`unix_journal.rs`, the single door), and every occurrence there is
+        immediately preceded by `#[cfg(unix)]`.
+
+        What it is not: it does not compile anything, least of all for windows.
+        It is a line scan that strips only `//` suffixes, it looks only inside
+        `turn_bridge/`, and it says nothing about cross-`cfg` references
+        elsewhere in the tree. It substitutes a text rule for a target this
+        repository cannot build locally (the msvc target needs a Windows C
+        toolchain), so CI's `Fast check + non-PG tests (windows-latest)` stays
+        the authority."""
+        mod_rs = (ROOT / "src/services/discord/mod.rs").read_text(encoding="utf-8")
+        self.assertIn(
+            "#[cfg(unix)]\nmod session_relay_sink;",
+            mod_rs,
+            "the gate this contract protects moved; re-derive the rule instead of relaxing it",
+        )
+        door = "src/services/discord/turn_bridge/terminal_controller_cutover/unix_journal.rs"
+        offenders = []
+        gated = 0
+        for path in sorted((ROOT / "src/services/discord/turn_bridge").rglob("*.rs")):
+            rel = path.relative_to(ROOT).as_posix()
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for index, line in enumerate(lines):
+                if "session_relay_sink" not in line.split("//", 1)[0]:
+                    continue
+                previous = ""
+                for candidate in reversed(lines[:index]):
+                    stripped = candidate.strip()
+                    if stripped and not stripped.startswith("//"):
+                        previous = stripped
+                        break
+                if rel == door and previous == "#[cfg(unix)]":
+                    gated += 1
+                else:
+                    offenders.append(f"{rel}:{index + 1}: {line.strip()}")
+        self.assertEqual(
+            offenders,
+            [],
+            "turn_bridge may reach session_relay_sink only from unix_journal.rs, "
+            "and only directly behind #[cfg(unix)]",
+        )
+        self.assertEqual(gated, 1, "the door is a single re-export, not a scattered set")
 
     def test_source_contract_repeated_suppression_arm_gates_its_observation(self):
         """Source text only: the post-terminal suppression arm is the one site


### PR DESCRIPTION
**T1 의 첫 슬라이스다.** see #5071 — 이 PR 은 그 이슈를 닫지 않는다. 미계측 패밀리가 2개 남아 있고, 퍼널 합류(S7)는 아직 시작하지 않았다.

see #5243 — `relay-authority-contract` 게이트의 초록은 뮤테이션 유효성의 근거가 못 된다. 아래 "게이트가 무엇을 잡고 무엇을 못 잡나" 참조.

---

**무엇을 했나**

**unix 에서**, `turn_bridge` / controller cutover 패밀리의 durable-frontier 작성 **3개 지점**을 delivery journal 로 계측하고, `scripts/check_delivery_journal_raw_writer.py` 의 `UNINSTRUMENTED_FAMILY_BASELINE` 을 **3 → 2** 로 재핀했다.

새 파사드는 `src/services/discord/session_relay_sink/journal/controller.rs` 다. **raw writer 를 새로 만들지 않았다** — 기존 journal 부모의 admission 경로를 재사용하고, 그 admission 을 부모로 hoist 하는 리팩터가 선행 커밋이다.

| 커밋 | 내용 |
|---|---|
| `170c9b038` | refactor(journal): hoist shadow admission to the journal parent |
| `40f0831a6` | feat(journal): add the turn_bridge/controller cutover family facade |
| `cf37f7005` | feat(journal): instrument the controller cutover writes, re-pin baseline 3 to 2 |
| `f22917de1` | fix(journal): route the cutover family's journal access through one cfg door |
| `3e0e089bf` | fix(journal): pin the gate script's door pointer to the path the test scans |

9파일 / +692 −37.

---

**non-unix 에서는 계측되지 않는다 — 이것이 이 PR 의 가장 중요한 한계다**

`session_relay_sink` 는 `services/discord/mod.rs` 에서 `cfg(unix)` 로 게이트되어 있다. 반면 `turn_bridge` 는 게이트가 없어 **모든 타깃에서 컴파일된다.**

그래서 정확한 진술은 이렇다:

- durable delivered-frontier 작성 **3곳**(`dr::shadow_mirror_delivered_frontier` 1 + `dr::record_long_chunk_terminal_delivery` 2)은 **cfg 게이트가 없다. 모든 타깃에서 실행된다**
- 그것을 관측하는 저널은 **unix 에만 존재한다**
- 따라서 **windows/non-unix 에서 이 패밀리는 프론티어를 미계측 상태로 전진시킨다.** 그 타깃에서는 이 패밀리의 저널 행이 **존재할 수 없다**

`f22917de1` 이전 리비전은 `terminal_controller_cutover.rs` 에서 저널을 **cfg 없이 직접 import** 했고, 그것이 `windows-latest` 에서 하드 빌드 브레이크였다 (`E0433: could not find session_relay_sink in super`). 이 PR 의 CI 가 실제로 그것을 잡았다.

---

**수정: cfg 게이트된 단 하나의 door**

`turn_bridge` → `session_relay_sink` 참조를 **한 곳**으로 모았다: `src/services/discord/turn_bridge/terminal_controller_cutover/unix_journal.rs`.

**결정: 호출부에 cfg 를 붙이지 않고 door 를 만들었다.** (이유: 호출부 게이팅이 구조적으로 불가능했다)

- `cfg(unix)` 를 3 begin + 5 settle + import 에 붙이면 **최소 +9줄**이다. `terminal_controller_cutover.rs` 는 prod **996 / giant 임계 1000** 이라 1003 이 되어 **새 giant 가 태어난다**
- door 를 `turn_bridge/mod.rs` 에 두려던 시도는 그 파일이 hotfile ratchet **969/969 정확히 상한**이라 `FAIL: 972 > 969` 로 터졌다
- 그래서 door 를 anchor 의 **자식 모듈**로 내렸다

**"계측된 것처럼 보이는" 위험을 셋으로 차단했다:**

1. **식별자가 플랫폼을 말한다.** 모듈을 별칭 없이 그대로 import 해서, 8개 호출부가 전부 `unix_journal::begin_controller_terminal(..)` / `unix_journal::settle_controller_terminal(..)` 로 읽힌다. 이 파일을 열지 않는 독자도 호출부만 보고 플랫폼 경계를 안다
2. **non-unix 관측 타입은 거주 불가능 enum 이다** — `enum NoJournalOnThisPlatform {}`. 따라서 `Option<NoJournalOnThisPlatform>` 의 유일한 값이 `None` 이다. *"관측이 일어나지 않는다"* 가 아니라 **"관측을 구성할 수 없다"** 가 타입으로 강제된다
3. **"no-op" 이라 부르지 않았다.** 리포의 기존 관행(`idle_relay_drift.rs:433` "Cross-OS no-op")과 **의도적으로 다르게**, *"계측의 부재를 코드로 적은 것이지, 아무것도 하지 않는 계측이 아니다"* 로 문서화했다. 그 items 에는 아무것도 추가해서는 안 된다 — 일부 플랫폼만 하는 관측을, 모든 플랫폼이 하는 관측과 같은 방식으로 적어서는 안 되기 때문이다

이 사실은 **6곳에 명시**되어 있다(door 모듈 헤더, 3개 호출부 주석, 게이트 스크립트, 소스 계약 테스트).

---

**게이트는 플랫폼을 볼 수 없다 — 그 한계를 게이트 자신에 적었다**

`scripts/check_delivery_journal_raw_writer.py:77-92` 에 `PLATFORM BLINDNESS` 블록을 넣었다. 이 스크립트는 **텍스트 스캔**이다 — Rust 를 파싱하지 않고, `cfg` 를 평가하지 않으며, 타깃 개념이 없다. 그래서 그 판정은 **모든 플랫폼에서 바이트 단위로 동일**하고, 의미하는 바는 오직 **"unix 에서 계측됨"** 뿐이다.

`uninstrumented families: 2/6` 을 **"unix 에서 파사드 토큰이 없는 패밀리가 2개"** 로 읽어라. 실제로 깨졌던 빌드에 대한 진술로 읽지 마라.

그 경계를 실제로 붙잡는 것은 새 소스 계약 테스트 `test_source_contract_turn_bridge_reaches_the_journal_through_one_cfg_gated_door` **하나뿐**이다. 판별력 3종을 증명했다:

| 뮤테이션 | 결과 |
|---|---|
| door 의 `cfg` 어트리뷰트 삭제 | FAIL |
| 원래 회귀 형태(호출부 직접 import) 복원 | FAIL |
| **올바르게 cfg 게이트된 두 번째 참조 추가** | **FAIL** (single-door 규칙) |

전부 되돌린 뒤 파이썬 테스트 **30 passed**.

---

**door 포인터가 한 번 갈라졌다 — 고치고, 그 리터럴 하나를 핀으로 묶었다**

`f22917de1` 시점에 `check_delivery_journal_raw_writer.py` 의 산문이 door 를 `turn_bridge/unix_journal.rs` 로 가리켰는데, 실제 경로는 `turn_bridge/terminal_controller_cutover/unix_journal.rs` 였다.

**갈라진 원인:** door 를 `terminal_controller_cutover/` 하위로 내린 것이 작업 후반부였다(`turn_bridge/mod.rs` 가 hotfile ratchet 969 상한이라 `mod` 선언을 받지 못했다). door 자체 헤더와 계약 테스트는 이동을 따라갔는데, **스크립트 산문만 따라가지 않았다.**

**비대칭이 원인이다.** 계약 테스트의 `door` 리터럴은 **자기검증적**이다 — 틀린 파일을 가리키면 진짜 door 가 `offenders` 에 잡혀 테스트가 깨진다. 반면 스크립트 산문의 복사본은 **아무것도 검증하지 않는 죽은 문자열**이었다.

**결정: 테스트를 정본으로 삼고, 스크립트가 그것을 인용하도록 단언을 넣었다.** 계약 테스트가 자기 `door` 리터럴이 스크립트 본문 안에 실제로 존재하는지 확인한다. 판별력 증명: 산문을 낡은 경로로 되돌리면 **FAIL**, 되돌리면 **30건 통과**.

**★ 이 핀의 한계 — 전칭으로 읽지 마라**

- ✗ "스크립트의 모든 문서 참조를 검증한다"
- ✓ **"`door` 경로 리터럴 **하나**를 테스트와 스크립트 사이에 핀으로 묶었다"**

스크립트 산문에 등장하는 **다른 심볼명들은 여전히 검증되지 않는다.** 이번에 21개를 전수 대조해 지금은 전부 맞다는 것을 확인했지만, **그것을 지속적으로 지켜주는 장치는 없다.** 다음에 갈라지는 것은 이 핀이 잡지 못한다.

---

**무엇을 하지 않았나 — 전칭으로 읽지 마라**

"모든 durable 작성자를 계측했다"가 **아니다.** "이 패밀리를 계측했다"도 정확하지 않다.

- 계측한 것: **unix 에서, turn_bridge/controller 패밀리의 3개 지점**
- 계측하지 않은 것 (1): **non-unix 의 같은 3개 지점.** 게이트는 텍스트 스캔이라 이 사실을 보지 못한다
- 계측하지 않은 것 (2): **미계측 2개 패밀리 — recovery/fresh-send/orphan, pipe stream epoch.** 이 둘은 이 PR 로 전혀 바뀌지 않았고, **`UNINSTRUMENTED_FAMILY_BASELINE = 2` 가 정확히 그것을 고정한다**

baseline 이 3 에서 2 로 내려간 원인이 "정규식을 넓혀서"가 아니라 "실제로 계측해서"임은 역방향 뮤테이션 테스트 `test_controller_family_regresses_to_uninstrumented` 가 증명한다.

---

**동작 변경 0**

durable write 의 **조건·순서·인자를 하나도 바꾸지 않았다.** 기존 코드에 대한 수정은 `dr::outcome_is_shadow_delivered(&outcome)` 를 지역변수로 뽑은 것 하나뿐이다.

지금 이 저널이 하지 *않는* 것:

- **읽는 쪽이 없다.** 어떤 코드도 이 저널 항목을 소비하지 않는다
- **shadow 전용이다.** 프로덕션 배달 경로의 판단에 관여하지 않는다
- **퍼널에 합류하지 않는다.** 합류는 **S7 이고 이 PR 이 아니다**

---

**게이트가 무엇을 잡고 무엇을 못 잡나 (실측)**

판별력 실험 5건을 돌렸다. **E2 가 게이트를 통과했다.**

| 뮤테이션 | 게이트 스크립트 | 파이썬 테스트 |
|---|---|---|
| E1 계측 토큰 전부 제거 | **rc=1** | 2 FAIL |
| **E2 3곳 중 1곳의 begin 제거** | **rc=0 — 통과한다** | 1 FAIL (`2 != 3`) |
| E3 settle 1개 제거 | rc=0 | 1 FAIL (`4 != 5`) |
| E4 계측 없는 4번째 durable write 추가 | rc=0 | 1 FAIL (`3 != 2`) |
| M-C4 settle 이 항상 `C` 방출 | — | Rust C4 FAIL |

**게이트 스크립트는 패밀리당 불리언 1개다.** 앵커 파일 어딘가에 토큰이 하나라도 있으면 그 패밀리는 "계측됨"으로 뒤집힌다. 따라서 **3곳 중 1곳이 빠져도 게이트는 초록이다.**

그걸 잡는 것은 이 PR 이 새로 추가한 **`test_source_contract_controller_anchor_covers_every_durable_writer` 하나뿐이다.** 이 테스트는 앵커 파일에서 mirror 1 / record 2 / begin 3 / settle 5 의 **정확한 개수와 상대 순서**를 센다. E2·E3·E4 를 잡는 유일한 장치가 이것이므로, 이 테스트를 약화시키면 계측 커버리지 보장이 통째로 사라진다.

---

**`T` 를 방출하지 않기로 한 결정과 이유**

**결정: 이 패밀리는 O+A → `C`/`U` 만 쓰고, 항상 `Unknown` 으로 분류한다.**

이유는 구조적이다. 프로덕션 `TurnGateway` 는

- `replace_long_message_raw_with_outcome` 에 receipt 슬롯을 **`&mut None`** 으로 넘기고,
- `send_long_message_with_rollback` 은 **message id 만** 돌려주며,
- `toc::DeliveryOutcome` 에도 **receipt 가 없다.**

그래서 anchor pair 로 receipt 를 합성하면 **`requested == returned` 가 구조적으로 참**이 되어, `channel_mismatch` 분기가 **영원히 발화하지 못한다.** 발화할 수 없는 분기에 `T` 를 붙이는 것은 계측이 아니라 위장이다.

**C5 테스트(`c5_controller_family_never_classifies_as_delivered`)가 그 천장을 고의로 못박는다.** 나중에 receipt 를 합성하려는 변경은 이 테스트를 깨고 지나가야 한다 — 조용히 통과하지 못한다.

---

**추가한 테스트**

Rust 5건 (`scripts/lib_test_inventory_manifest.txt` +5 와 정확히 일치):

- `c1_controller_obligation_identity_covers_every_coordinate`
- `c2_controller_and_watcher_obligations_never_coincide`
- `c3_only_a_real_range_under_a_known_generation_is_an_obligation`
- `c4_settle_selects_the_terminal_event_and_is_single_use`
- `c5_controller_family_never_classifies_as_delivered`

파이썬 4건 (`tests/test_delivery_journal_raw_writer.py`, 파일 총 30건):

- `test_controller_facade_alternation_matches_only_its_exact_call_shape`
- `test_controller_family_regresses_to_uninstrumented`
- `test_source_contract_controller_anchor_covers_every_durable_writer`
- `test_source_contract_turn_bridge_reaches_the_journal_through_one_cfg_gated_door`

---

**남긴 부채 — 전부 적는다**

1. **`terminal_controller_cutover.rs` 의 prod 라인이 974 → 996 으로 늘었다. giant 임계값 1000 까지 여유가 4줄뿐이다.** 다음에 이 파일을 건드리는 작업은 **move-only 추출을 먼저** 해야 한다. 기능 변경과 분할을 같은 PR 에서 하면 임계값에 걸린다. `turn_bridge/mod.rs` 도 hotfile ratchet **969/969 로 정확히 상한**이라 한 줄도 못 넣는다
2. **non-unix 미계측.** durable frontier write 3곳은 모든 타깃에서 돌지만 저널은 unix 에만 있다. 게이트는 이것을 볼 수 없고, 소스 계약 테스트 1건만이 door 의 단일성과 cfg 를 붙잡는다
3. **`C` 는 사이트 자신의 commit 판단일 뿐이다.** durable mirror 가 실제로 persist 됐는지는 관측하지 않는다 — `shadow_mirror_delivered_frontier` 가 inner bool 을 버리기 때문이다. 그 합류가 **S7** 이다
4. **미계측 2개 패밀리** — recovery/fresh-send/orphan, pipe stream epoch. baseline 2 가 고정하고 있다
5. **게이트 스크립트 산문의 심볼명은 대부분 검증되지 않는다.** `3e0e089bf` 가 핀으로 묶은 것은 **door 경로 리터럴 하나뿐**이다. 나머지 21개 심볼명은 이번에 전수 대조해 현재 정확하지만, 다음에 갈라져도 잡아주는 장치가 없다. 실제로 door 가 한 번 갈라졌던 전례가 있다

---

**레드라인 무접촉 확인**

`scripts/run_relay_authority_mutations.sh`, `scripts/check_relay_authority_contract.py`, `src/services/discord/session_relay_sink/terminal_handoff.rs` — 전부 미수정(diff 0바이트). `session_relay_sink.rs` 도 diff 0바이트다(anchor-drop 앵커 무접촉).
