### PR TITLE
fix(ci): re-anchor the recovery family on the file that writes its delivery (T1 S5a)

### DIFF
--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -1,5 +1,24 @@
 # Discord Outbound Migration — Coverage Map (#1006 v3 / #1280 / #1436 / #1457)
 
+> Last refreshed: 2026-08-08 (#5071 T1 S5a — the shadow journal's **family map**
+> was corrected; no family gained instrumentation and the uninstrumented baseline
+> stays 2. The recovery / fresh-send / orphan family was anchored on
+> `tmux_reaper.rs::reap_fresh_routine_orphan`, a file that writes no delivery at
+> all — no durable frontier write, no completed-turn ledger append, no transport,
+> no journal — and matched the family only by the words "fresh" and "orphan" in a
+> symbol name. The anchor now names
+> `recovery_engine/terminal_text_idempotency.rs::record_successful_fresh_send`,
+> the entry point of the one funnel that holds all three of this family's durable
+> writes. A new rule test requires EVERY family anchor to show delivery work in
+> its own file, so the next mis-anchor fails rather than being measured; the audit
+> behind it found one more anchor with no delivery work, `pipe stream epoch`
+> (`tmux_watcher/turn_stream_collector.rs`), which is carried as a single named
+> exemption pinned to stay empty rather than being silently accepted or fixed out
+> of scope. `fresh_send.rs`'s durable write stays out of the map because
+> `OutputPlan::SendFresh` has no production constructor, pinned so the S1r-2~5
+> owner cutovers must answer it. No Rust changes, no delivery behaviour changes,
+> so the coverage rows below are unchanged.)
+
 > Last refreshed: 2026-08-06 (#5071 T1 S3b — the five **no-transport** watcher
 > frontier advances now record themselves. Silent-turn suppression, cancel-tombstone
 > suppression, fresh ready-for-input idle, post-terminal-without-inflight suppression

--- a/scripts/check_delivery_journal_raw_writer.py
+++ b/scripts/check_delivery_journal_raw_writer.py
@@ -22,7 +22,7 @@ FAMILY_REGISTRY = (
     ("sink direct family (referenced / edit / split / long-chunk receipt)", "src/services/discord/session_relay_sink.rs", "deliver_response"),
     ("watcher terminal family (무전송 5곳 포함)", "src/services/discord/tmux_watcher.rs", "tmux_output_watcher_with_restore"),
     ("turn_bridge / controller family", "src/services/discord/turn_bridge/terminal_controller_cutover.rs", "deliver_short_replace_via_controller"),
-    ("recovery / fresh-send / orphan family", "src/services/discord/tmux_reaper.rs", "reap_fresh_routine_orphan"),
+    ("recovery / fresh-send / orphan family", "src/services/discord/recovery_engine/terminal_text_idempotency.rs", "record_successful_fresh_send"),
     ("pipe stream epoch", "src/services/discord/tmux_watcher/turn_stream_collector.rs", "collect_turn_stream_until_terminal"),
 )
 # Cheap lexical text match, not Rust parsing: each complete anchor file, including
@@ -93,6 +93,57 @@ FAMILY_REGISTRY = (
 # in tests/test_delivery_journal_raw_writer.py, which owns the door path as the
 # literal `door` it scans for; see also
 # src/services/discord/turn_bridge/terminal_controller_cutover/unix_journal.rs.
+#
+# #5071 T1 S5a. THE RECOVERY FAMILY'S ANCHOR WAS POINTING AT A FILE THAT WRITES NO
+# DELIVERY, and this slice moves it. That is a correction to the family map, not
+# instrumentation: nothing here becomes instrumented, and
+# `UNINSTRUMENTED_FAMILY_BASELINE` stays 2.
+#
+# Measured on de8f3ab51, `src/services/discord/tmux_reaper.rs` contains, in
+# production and in its inline tests alike: zero `delivery_record::` /
+# `completed_turn_ledger::` calls, zero occurrences of the strings `frontier`,
+# `journal` and `delivery_record`, and no Discord transport. It kills orphaned
+# tmux sessions and finalizes stale-busy turns. It matched this family by NAME —
+# `reap_fresh_routine_orphan` carries both "fresh" and "orphan" — and by nothing
+# else, so for as long as it was the anchor this gate was counting the wrong file
+# for this family, whatever the baseline happened to be.
+#
+# The family's durable writers all sit in ONE funnel,
+# `RecoveryDeliveryContext::record_durable_frontier` in
+# `recovery_engine/terminal_text_idempotency.rs`: `write_delivered_frontier` (the
+# reuse-recorded-anchor arm), `write_proven_gone_equal_range_frontier` (the
+# re-anchor taken only after Discord proved the recorded anchor GONE — the actual
+# "orphan" of the family name) and the completed-turn ledger append above them.
+# The anchor now names that file and the funnel's confirmed-delivery entry point.
+#
+# Three tests hold the move, in tests/test_delivery_journal_raw_writer.py:
+# `test_source_contract_reaper_anchor_named_a_file_that_writes_no_delivery` keeps
+# the measurement true, `test_source_contract_recovery_anchor_holds_the_family_durable_writers`
+# keeps the new anchor holding the writers, and
+# `test_every_family_anchor_sits_on_its_family_delivery_path` turns the whole
+# thing into a RULE rather than a snapshot — every anchor must show delivery work
+# in its own file. That rule is what would have caught this in the first place,
+# and it is what fails if the anchor is ever moved back.
+#
+# The audit behind the move covered all six anchors, and it found a SECOND one
+# with the same shape: "pipe stream epoch"
+# (`tmux_watcher/turn_stream_collector.rs`) shows no durable write, no transport
+# and no facade token either. It owns the epoch state the family is named for, so
+# whether it is the wrong anchor or merely a family whose writer lives elsewhere
+# is a real question — and it is not this slice's to answer. It is carried as the
+# single named exemption in that rule test, pinned to stay empty so the exemption
+# cannot be used to admit a different bad anchor. Of the four remaining anchors,
+# three show durable writes or transport in their own file; `tmux_watcher.rs`
+# shows neither and passes on its facade calls alone, its durable writes being
+# delegated to child modules under `tmux_watcher/` through the `dr` alias it
+# imports for them.
+#
+# WHAT THIS MOVE DOES NOT FIX. The gate reads ONE file per family. A durable write
+# added to any other file of this family — `recovery_paths/controller_cutover.rs`,
+# say — is caught by nothing here and by no source contract. That hole is the same
+# one the S2 block declares, it is unchanged by S5a, and it is measured: adding an
+# uninstrumented `write_delivered_frontier` to a non-anchor family file leaves
+# this gate green and every test in the suite green.
 JOURNAL_FACADE_CALL = re.compile(
     r"\bself\.journal\.(?:begin_fresh|finish_fresh)\s*\("
     r"|\bjournal_watcher::(?:begin_watcher_terminal|settle_watcher_terminal|settle_without_transport)\s*\("

--- a/tests/test_delivery_journal_raw_writer.py
+++ b/tests/test_delivery_journal_raw_writer.py
@@ -454,5 +454,184 @@ class RawWriterAllowlistTests(unittest.TestCase):
             source.index("settle_without_transport("),
             "the guard is computed before the settlement it gates",
         )
+    # #5071 T1 S5a additions — the family MAP, not the instrumentation.
+
+    # A file that participates in its family's delivery does at least one of three
+    # observable things: it writes the durable record, it reaches the journal, or
+    # it runs the transport. This vocabulary is the text form of that claim. It is
+    # a token list, so it inherits every lexical limit declared above -- but it is
+    # a RULE about what an anchor must contain, which is what the previous
+    # snapshot-shaped checks could not express.
+    DELIVERY_WORK_TOKENS = (
+        "write_delivered_frontier(",
+        "write_proven_gone_equal_range_frontier(",
+        "shadow_mirror_delivered_frontier(",
+        "record_long_chunk_terminal_delivery(",
+        "commit_ordered_jsonl_range(",
+        "record_delivered_content_fingerprint(",
+        "append_completed_turn(",
+        "finish_sink_delivery(",
+        "settle_without_transport(",
+        "send_long_message",
+        "replace_long_message",
+    )
+    # The one family whose anchor does none of the three, carried by name rather
+    # than by silence. `turn_stream_collector.rs` owns the `pause_epoch` /
+    # `epoch_snapshot` / `turn_delivered` state its family is named for, but it
+    # writes no durable record, runs no transport and holds no facade call, so
+    # either the anchor is wrong or this family's writer lives somewhere else
+    # entirely. Answering that is not #5071 T1 S5a's scope; declaring it is.
+    ANCHORS_WITH_NO_DELIVERY_WORK = ("pipe stream epoch",)
+
+    def test_every_family_anchor_sits_on_its_family_delivery_path(self):
+        """The rule that would have caught the reaper anchor when it was written.
+
+        Every family anchor must show delivery work IN ITS OWN FILE: a durable
+        record write, a journal facade call, or a transport call. An anchor that
+        shows none of the three is a file the gate reads while measuring a family
+        it has no part in -- which is exactly what
+        `tmux_reaper.rs::reap_fresh_routine_orphan` was for the recovery family.
+
+        Exemptions are named, not silent, and an exemption must itself be EMPTY:
+        a family listed in `ANCHORS_WITH_NO_DELIVERY_WORK` whose anchor starts
+        showing delivery work fails here too, so the list cannot be reused to
+        admit a different wrong anchor, and it has to shrink rather than drift
+        when that family's anchor is settled.
+
+        What it does not do: it reads one file per family and cannot say whether
+        the delivery work it finds belongs to THAT family, nor whether the anchor
+        is the best of several candidates. It says only that the anchor is not a
+        bystander."""
+        bystanders = []
+        wrongly_exempt = []
+        for name, rel, _symbol in guard.FAMILY_REGISTRY:
+            code = "\n".join(
+                line.split("//", 1)[0]
+                for line in (ROOT / rel).read_text(encoding="utf-8").splitlines()
+            )
+            does_work = any(token in code for token in self.DELIVERY_WORK_TOKENS) or bool(
+                guard.JOURNAL_FACADE_CALL.search(code)
+            )
+            if name in self.ANCHORS_WITH_NO_DELIVERY_WORK:
+                if does_work:
+                    wrongly_exempt.append(f"{name} ({rel})")
+            elif not does_work:
+                bystanders.append(f"{name} ({rel})")
+        self.assertEqual(
+            bystanders,
+            [],
+            "these family anchors show no durable write, no journal facade call and no "
+            "transport, so the gate is measuring a file that takes no part in the family",
+        )
+        self.assertEqual(
+            wrongly_exempt,
+            [],
+            "an anchor exempted as showing no delivery work now shows some; remove it "
+            "from ANCHORS_WITH_NO_DELIVERY_WORK instead of leaving the exemption to rot",
+        )
+        self.assertEqual(
+            self.ANCHORS_WITH_NO_DELIVERY_WORK,
+            ("pipe stream epoch",),
+            "the exemption list is a measured finding, not a place to park a new anchor",
+        )
+
+    def test_source_contract_reaper_anchor_named_a_file_that_writes_no_delivery(self):
+        """Why the recovery family's anchor moved, kept measurable.
+
+        Until S5a this family was anchored on
+        `tmux_reaper.rs::reap_fresh_routine_orphan`, which matched by NAME
+        ("fresh", "orphan") and not by behaviour: the reaper kills tmux sessions
+        and finalizes stale-busy turns, and writes no delivery of any kind. This
+        pins that measurement, so the move cannot quietly become wrong -- the day
+        the reaper does advance a frontier, append to the ledger or reach the
+        journal, this fails and the family map has to be re-derived rather than
+        left pointing somewhere else.
+
+        `reap_fresh_routine_orphan` is asserted to still exist: the reaper is not
+        claimed to have disappeared, only to have no delivery in it."""
+        source = (ROOT / "src/services/discord/tmux_reaper.rs").read_text(encoding="utf-8")
+        self.assertIn("async fn reap_fresh_routine_orphan(", source)
+        for absent in (
+            "delivery_record",
+            "delivered_frontier",
+            "append_completed_turn",
+            "shadow_mirror",
+            "journal",
+        ):
+            self.assertEqual(
+                source.count(absent),
+                0,
+                f"tmux_reaper.rs now mentions {absent!r}; the family map cannot keep "
+                f"treating it as a file that writes no delivery",
+            )
+
+    def test_source_contract_recovery_anchor_holds_the_family_durable_writers(self):
+        """The other half of the move: the file the anchor now names really does
+        hold this family's durable writes, all three of them, in one funnel --
+        the completed-turn ledger append, the reuse-recorded-anchor frontier
+        write and the proven-GONE equal-range re-anchor. Adding a fourth durable
+        write to that file, or moving one out, fails here.
+
+        Counted over the production prefix only (everything before `#[cfg(test)]
+        mod tests {`), because the file's own fixtures call the same durable
+        writer twice and a whole-file count would move whenever a test is added.
+        It is a text count: it cannot prove any call is reached, and it says
+        nothing about instrumentation -- this family is still uninstrumented and
+        the baseline of 2 still says so."""
+        source = (
+            ROOT / "src/services/discord/recovery_engine/terminal_text_idempotency.rs"
+        ).read_text(encoding="utf-8")
+        production = source[: source.index("#[cfg(test)]\nmod tests {")]
+        self.assertEqual(production.count("completed_turn_ledger::append_completed_turn("), 1)
+        self.assertEqual(production.count("delivery_record::write_delivered_frontier("), 1)
+        self.assertEqual(
+            production.count("delivery_record::write_proven_gone_equal_range_frontier("), 1
+        )
+        self.assertEqual(production.count("fn record_successful_fresh_send("), 1)
+        self.assertLess(
+            production.index("fn record_successful_fresh_send("),
+            production.index("completed_turn_ledger::append_completed_turn("),
+            "the anchor symbol is the entry point of the funnel that holds the writers",
+        )
+
+    def test_source_contract_dormant_fresh_send_writer_is_pinned_uninstrumented(self):
+        """The family's other named durable writer, and why the map does not move
+        to it either.
+
+        `outbound/turn_output_controller/fresh_send.rs` calls
+        `write_delivered_frontier` once, but `OutputPlan::SendFresh` has no
+        production constructor -- every mention below is a pattern or a match arm
+        except the one in `fresh_send_tests.rs`, which is a test fixture. Nothing
+        in production reaches that write today, so it is neither the family's
+        anchor nor a gap in coverage; it is dormant.
+
+        It is pinned rather than argued: this dict is the complete set of
+        `OutputPlan::SendFresh` mentions in `src/`. The S1r-2~5 owner cutovers
+        that make the plan reachable have to add one, which fails here and forces
+        the question -- anchor, instrumentation, or both -- to be answered then."""
+        mentions = {}
+        for path in sorted((ROOT / "src").rglob("*.rs")):
+            count = path.read_text(encoding="utf-8").count("OutputPlan::SendFresh")
+            if count:
+                mentions[path.relative_to(ROOT).as_posix()] = count
+        self.assertEqual(
+            mentions,
+            {
+                "src/services/discord/outbound/turn_output_controller.rs": 3,
+                "src/services/discord/outbound/turn_output_controller/fresh_send.rs": 1,
+                "src/services/discord/outbound/turn_output_controller/fresh_send_tests.rs": 2,
+            },
+            "OutputPlan::SendFresh gained or lost a mention; if a production owner now "
+            "builds it, this family's map and its durable frontier write both need "
+            "re-deriving (#5071 T1)",
+        )
+        fresh_send = (
+            ROOT / "src/services/discord/outbound/turn_output_controller/fresh_send.rs"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(fresh_send.count("delivery_record::write_delivered_frontier("), 1)
+        self.assertIsNone(
+            guard.JOURNAL_FACADE_CALL.search(fresh_send),
+            "fresh_send.rs carries no facade token; it is declared uninstrumented, not covered",
+        )
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
T1 slice S5a of the shadow-journal work (see #5071). Map only — no Rust changes, no instrumentation.

**본론 — 앵커 두 개가 delivery work 가 없는 파일을 가리키고 있었다**

`scripts/check_delivery_journal_raw_writer.py` 의 6개 패밀리 앵커를 **이번에 전수 실측**했다. 판정 기준 셋: 앵커 파일 **자체**에 (a) durable record write, (b) journal 파사드 호출, (c) Discord transport 중 **하나라도** 있는가. `#[cfg(test)] mod` 영역은 리포 자체 splitter 로 분리해 **프로덕션 영역만** 측정했다.

| 번호 | 패밀리 | 앵커 | 판정 |
|---|---|---|---|
| 0 | fresh sink vertical slice | `session_relay_sink/task_notification_context.rs` | 통과 |
| 1 | sink direct | `session_relay_sink.rs` | 통과 |
| 2 | watcher terminal | `tmux_watcher.rs` | 통과 — **파사드 호출로만**. durable write 0, writer 는 `tmux_watcher/` 자식 모듈들에 위임 |
| 3 | turn_bridge / controller | `terminal_controller_cutover.rs` | 통과 |
| 4 | recovery / fresh-send / orphan | `tmux_reaper.rs` (이전) | **비어 있었다 — 이 PR 이 고친다** |
| 5 | pipe stream epoch | `tmux_watcher/turn_stream_collector.rs` | **비어 있다 — 미해결, 이름 붙은 면제로 노출** |

즉 **6개를 실측해 2개가 비어 있었고, 1개를 고치고 1개는 면제로 CI 에 노출한다.**

**4번 (이 PR 이 고치는 것).** `tmux_reaper.rs` 는 `de8f3ab51` 기준 durable record write 0, completed-turn ledger 0, transport 0, 그리고 문자열 `frontier` / `journal` / `delivery_record` 가 **0개**다. 이 파일은 고아 tmux 세션을 죽이고 stale-busy 턴을 finalize 한다. 이 패밀리에 매칭된 이유는 심볼 이름 `reap_fresh_routine_orphan` 안의 **"fresh" 와 "orphan" 이라는 단어뿐**이었다 — 즉 앵커로 있는 동안 이 게이트는 이 패밀리에 대해 **엉뚱한 파일을 세고 있었다.**

실제 writer 는 한 funnel 에 모여 있다 — `recovery_engine/terminal_text_idempotency.rs` 의 `RecoveryDeliveryContext::record_durable_frontier`: reuse-recorded-anchor 갈래의 `write_delivered_frontier`, Discord 가 recorded anchor 를 GONE 으로 증명한 뒤에만 타는 `write_proven_gone_equal_range_frontier` (패밀리 이름의 실제 "orphan"), 그리고 그 위의 completed-turn ledger append. 앵커를 그 파일의 confirmed-delivery 진입점 `record_successful_fresh_send` 로 옮기고 **양방향으로 못박았다** — reaper 가 계속 비어 있음을 단언 + 새 앵커가 3개 writer 를 전부 담고 있음을 단언.

**5번 (고치지 않았다 — 범위 밖).** `turn_stream_collector.rs` 는 같은 결함 형태다: durable write 0, transport 0, 파사드 토큰 0. 다만 이 파일은 패밀리 이름이 가리키는 `pause_epoch` / `epoch_snapshot` / `turn_delivered` 상태와 `commit_persistent_state!` 를 실제로 소유한다. 따라서 **앵커가 틀린 것인지, writer 가 다른 파일에 사는 패밀리인지 미규명**이고 이 슬라이스가 답할 문제가 아니다. 조용히 받아들이지도, 범위 밖에서 고치지도 않고 **이름 붙은 단일 면제**로 실어 CI 에 영구 노출시켰다. 그리고 **면제된 앵커가 delivery work 를 갖게 되면 그 자체로 테스트가 실패**하도록 못박아, 면제가 썩거나 다른 나쁜 앵커를 숨기는 통로가 되지 못하게 했다.

**게이트 스크립트는 이 회귀를 감지하지 못한다 — 계약 테스트만 잡는다**

판별력 실험 7건을 돌리고 전부 되돌렸다.

| 번호 | 뮤테이션 | 게이트 스크립트 | 잡은 것 |
|---|---|---|---|
| N1 | **앵커를 낡은 `tmux_reaper.rs` 로 되돌림** | **rc=0 — 못 잡는다** | `test_every_family_anchor_sits_on_its_family_delivery_path` |
| N2 | reaper 가 durable write 를 갖게 됨 | rc=0 | reaper 공백 단언 FAIL |
| N3 | 새 앵커에서 3개 writer 중 1개 제거 | rc=0 | writer 포함 단언 FAIL |
| N4 | **면제 목록에 두 번째 패밀리 주차**(루프홀) | rc=0 | 규칙 테스트 FAIL |
| N5 | 면제된 앵커가 delivery work 를 갖게 됨(면제 부패) | rc=0 | 규칙 테스트 FAIL |
| N6 | 프로덕션에 `OutputPlan::SendFresh` 언급 추가(휴면 writer 각성) | rc=0 | 휴면 핀 FAIL |
| N7 | **앵커 파일 밖 패밀리 파일에 미계측 durable write** | rc=0 | **아무것도 안 잡음** |

**N1 이 핵심이다** — 계약 테스트가 없으면 이 이동은 되돌려져도 게이트가 조용히 통과한다. 그래서 이 PR 의 load-bearing 산출물은 스냅샷 3건이 아니라 **규칙 1건**이다: 이름 붙여 면제한 하나를 빼고, 패밀리 앵커는 자기 파일에 delivery work 를 보여야 한다.

**남는 구멍 (N7) — 이 PR 이 닫지 않는다**

게이트는 패밀리당 **파일 하나**만 읽는다. 앵커 파일 **밖**의 패밀리 파일(예: `recovery_paths/controller_cutover.rs`)에 미계측 durable write 를 추가하면 **게이트도 초록, 계약 테스트도 초록, 스위트 전체가 초록**이다. 실측으로 확인했다. 이미 S2 블록이 선언한 구멍이고 S5a 는 그것을 바꾸지 않는다.

**부수 실측 2건**

- `session_relay_sink.rs` 의 `dr::write_delivered_frontier(` 2개는 **둘 다 테스트 영역**이다. 이 패밀리의 프로덕션 durable write 는 `commit_ordered_jsonl_range` / `finish_sink_delivery` 다.
- 2번 앵커(`tmux_watcher.rs`)는 파일 안에 writer 가 있어서 통과하는 것이 아니라 **파사드 호출만으로** 규칙을 통과한다. durable write 는 `tmux_watcher/` 자식 모듈들에 위임돼 있다.

**이 PR 이 하지 않는 것**

- **계측하지 않는다.** `UNINSTRUMENTED_FAMILY_BASELINE` 은 **2 그대로**이고, 이 패밀리는 여전히 미계측으로 보고된다 — 실제로 미계측이기 때문이다. 계측은 S5b.
- **퍼널 우회를 고치지 않는다** — S7.

**변경 범위**

3파일 / +250 −1. Rust 변경 0. 파이썬 계약 테스트 +4 (30 → 34).

- `scripts/check_delivery_journal_raw_writer.py` (+52 −1) — 앵커 1줄 교체 + 근거 블록
- `tests/test_delivery_journal_raw_writer.py` (+179) — 규칙 1 + 스냅샷 3
- `docs/agent-maintenance/discord-outbound-migration.md` (+19)

관련: see #5071, see #5243.
