### PR TITLE
feat(ci): pin the durable frontier writer call sites per file (T1 S7 prime)

### DIFF
--- a/scripts/check_durable_frontier_writer_call_sites.py
+++ b/scripts/check_durable_frontier_writer_call_sites.py
@@ -54,6 +54,15 @@ test module:
   * INDIRECTION THROUGH VALUES. `let f = write_delivered_frontier;` is not a
     call site (no `(` follows the name) and the later `f(..)` is not one either.
     Trait-object dispatch to a method of the same name is likewise invisible.
+  * NAME COLLISION -- PRESENT IN THIS TREE, NOT HYPOTHETICAL. Two distinct
+    functions are both named `record_watcher_terminal_delivery`: the durable
+    funnel at `outbound/delivery_record.rs:2332` and a local wrapper at
+    `tmux_watcher/terminal_long_chunks.rs:168`. The two production sites this
+    map pins for that file are one call to each (`dr::…` at :124, bare at
+    :222). The integer is therefore a count of the SPELLING, not of calls to
+    one function. It is still the right pin here because the wrapper's only
+    job is to reach the funnel, but a future collision under a pinned name
+    would be counted the same way and the map would not say so.
   * SPELLING COUPLING. Because the completion criterion is a literal grep, the
     whole contract is bound to the spelling. Renaming a symbol does not weaken
     the gate silently -- the count drops to 0 and it fails -- but any route that
@@ -166,6 +175,27 @@ EXPECTED_CALL_SITES: dict[str, dict[str, int]] = {
     "clear_lease": {},
     "delete_record": {},
     "shadow_mirror_same_channel_frontier_with_body": {},
+    # -- store 1 + store 3: the fresh-sink family's mutation funnel -----------
+    # These three are not writers themselves; they are the fresh-sink family's
+    # only route into `WatcherDeliveryMutation::{advance, persist}`
+    # (tmux_watcher/terminal_long_chunks.rs:97 and :111), whose bodies call
+    # `advance_watcher_confirmed_end_for_generation` and
+    # `dr::record_watcher_terminal_delivery` -- both pinned above. They are
+    # pinned separately because the funnel bottom cannot distinguish a new
+    # fresh-sink entry point from an existing one, and S7's whole subject is
+    # which paths reach the funnel.
+    "begin_sink_delivery_mutation": {
+        "src/services/discord/session_relay_sink/delivery_frontier.rs": 1,
+        "src/services/discord/session_relay_sink/short_controller.rs": 1,
+    },
+    "persist_sink_delivery": {
+        "src/services/discord/session_relay_sink/delivery_frontier.rs": 1,
+        "src/services/discord/session_relay_sink/short_controller.rs": 1,
+    },
+    "finish_sink_delivery": {
+        "src/services/discord/session_relay_sink.rs": 3,
+        "src/services/discord/session_relay_sink/task_notification_context.rs": 1,
+    },
     # -- store 2: completed-turn ledger --------------------------------------
     "append_completed_turn": {
         "src/services/discord/outbound/delivery_record.rs": 2,

--- a/scripts/check_durable_frontier_writer_call_sites.py
+++ b/scripts/check_durable_frontier_writer_call_sites.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Per-file exact-count allowlist for the durable frontier writer symbols (#5071 T1 S7').
+
+WHY THIS EXISTS, AND WHY IT LANDS BEFORE S7. #5071 T1 S7 changes the recovery
+path's durable behaviour: it stops that path from bypassing the
+`shadow_mirror_delivered_frontier` funnel. Before S7 was written, NOTHING in the
+repo pinned where these symbols are called from -- the only writer allowlist
+that existed was `scripts/check_delivery_journal_raw_writer.py`, which pins one
+different symbol (`append_delivery_journal_batch`). A behaviour change with no
+gate underneath it protects nothing, so this slice builds the gate first. IT
+CHANGES NO PRODUCTION BEHAVIOUR: it only records, per symbol and per file, the
+exact number of production call sites that exist today.
+
+WHAT IS PINNED. Three stores write the relay's delivery frontier:
+
+  store 1  durable delivery record  src/services/discord/outbound/delivery_record.rs
+  store 2  completed-turn ledger    src/services/discord/outbound/completed_turn_ledger.rs
+  store 3  in-memory watermark      src/services/discord/tmux.rs
+
+`EXPECTED_CALL_SITES` below names every public write API of stores 1 and 2 that
+reaches a durable write helper, the one private shadow-mirror funnel body they
+share, and both public entry points of store 3's watermark CAS. For each symbol
+it fixes a `{file: count}` map over ALL of `src/`. Any deviation fails: a call
+added, a call deleted, a call moved to another file, or a call appearing in a
+file the map does not list.
+
+TWO HOLES IN THE MODEL GATE THAT THIS ONE DELIBERATELY DOES NOT INHERIT.
+  (1) ANCHOR BLINDNESS. `check_delivery_journal_raw_writer.py` reads ONE anchor
+      file per family, so an uninstrumented durable write added to any other
+      file of that family is caught by nothing (its own S5a comment block
+      measures this). This gate has no anchors: it walks every `.rs` file under
+      `src/`, so a new call site in a file nobody thought of still fails.
+  (2) ONE BOOLEAN PER FAMILY. That gate reduces each family to "does the anchor
+      contain the token", so N of N call sites can drop to 1 and stay green --
+      observed across three consecutive slices. This gate stores an exact
+      integer per (symbol, file), so losing one of two sites in the same file is
+      a failure.
+
+WHAT THIS GATE DOES NOT SEE. It is a LEXICAL SCAN over stripped source text; it
+does not parse Rust, does not resolve paths or types, and does not run rustc.
+Concretely, and each of these was exercised by a mutation in the accompanying
+test module:
+
+  * ALIAS AND RE-EXPORT. `use ...::write_delivered_frontier as w;` then `w(..)`
+    spells neither the symbol nor a call to it. NOT SEEN -- measured, not
+    assumed. Same for `pub use ... as ...` re-exports. A module alias is
+    different and IS seen, because the function name survives it: `dr::f(..)`,
+    `delivery_record::f(..)` and a bare `f(..)` all match identically.
+  * NAME-CONSTRUCTING MACROS. A macro whose body contains the literal spelling
+    IS counted (the text is there, once per textual occurrence, and expansion
+    count is invisible to a text scan -- a call inside a macro invoked three
+    times counts 1). A macro that ASSEMBLES the name (`paste!`,
+    `concat_idents!`) is NOT seen.
+  * INDIRECTION THROUGH VALUES. `let f = write_delivered_frontier;` is not a
+    call site (no `(` follows the name) and the later `f(..)` is not one either.
+    Trait-object dispatch to a method of the same name is likewise invisible.
+  * SPELLING COUPLING. Because the completion criterion is a literal grep, the
+    whole contract is bound to the spelling. Renaming a symbol does not weaken
+    the gate silently -- the count drops to 0 and it fails -- but any route that
+    reaches the same code under a different spelling is outside it.
+  * CFG. `#[cfg(unix)]` and friends are not evaluated: a call gated to one
+    target counts on every target, exactly as in the model gate.
+  * PROSE. Comments (`//`, `/* */`) and string literals (including raw strings)
+    are BLANKED before matching, so the symbol written in a doc comment or a
+    log message is not a call site. This differs from the model gate, which
+    strips only the `//` suffix and therefore goes red on a symbol inside a
+    string. Stripping is the right trade here because the map has to hold exact
+    per-file integers, and prose would make those integers arbitrary -- but it
+    does mean a call hidden by a stripper bug is a silent miss, which is why
+    the cross-line stripper is exercised directly in the test module.
+  * SEMANTICS. It says nothing about whether a call is reachable, reached, or
+    correct. That is what the Rust runtime tests are for.
+
+WHAT IT DOES BUY. Every textual call site under `src/`, per file, exactly
+counted. That is strictly more than the model gate: it has no anchor to escape
+and no boolean to saturate.
+
+PRODUCTION vs TEST. Files named `tests.rs` / `*_tests.rs` are skipped whole, and
+`#[cfg(test)]` / `#[cfg(all(test, ...))]` / `#[cfg(any(test, ...))]` regions are
+resolved with balanced-brace tracking over comment/string-stripped text.
+
+  DEVIATION FROM THE PORTED RESOLVER, DELIBERATE AND MEASURED. The equivalent
+  loop in `scripts/check_inflight_blind_save_ratchet.py` resolves an armed
+  `#[cfg(test)]` on `{` or `;` only. A `#[cfg(test)]` STRUCT FIELD ends in `,`,
+  so the armed state there survives the field, the struct, and latches onto the
+  next `{` it meets -- which in `session_relay_sink.rs` is the production
+  `impl SessionBoundDiscordRelaySink {` block, silently swallowing it. Measured
+  on this tree: that loop misclassifies three production call sites in that one
+  file (`commit_ordered_jsonl_range`, `record_delivered_content_fingerprint`,
+  `advance_watcher_confirmed_end`) as test code. This resolver therefore also
+  disarms on a top-level `,`, but only until an item keyword that introduces a
+  braced body (`fn`/`impl`/`mod`/`trait`/`macro_rules`) has been seen, so a
+  comma inside a generic return type cannot disarm a real test fn.
+
+  That bug is LATENT, NOT ACTIVE, in the ratchet that carries it: its symbol
+  (`save_inflight_state(`) has zero production call sites under either resolver,
+  so its baseline of 0 is correct today. It is left alone here rather than
+  repaired, because changing a landed gate's counting rule is not this slice's
+  to do -- it is recorded so the next slice can.
+
+TO CHANGE A COUNT. Edit `EXPECTED_CALL_SITES` in the same commit as the code
+move, and say in the commit message which call site moved and why. That edit is
+the reviewable artefact this gate exists to force.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Every production call site of every pinned symbol, keyed by symbol then by
+# repo-relative path. An empty map pins the symbol at zero production callers:
+# the API exists and compiles, but nothing outside tests may reach it. Measured
+# on 0bde0675b.
+EXPECTED_CALL_SITES: dict[str, dict[str, int]] = {
+    # -- store 1: durable delivery record ------------------------------------
+    "write_delivered_frontier": {
+        "src/services/discord/outbound/turn_output_controller/fresh_send.rs": 1,
+        "src/services/discord/recovery_engine/terminal_text_idempotency.rs": 1,
+    },
+    "write_proven_gone_equal_range_frontier": {
+        "src/services/discord/recovery_engine/terminal_text_idempotency.rs": 1,
+    },
+    "commit_ordered_jsonl_range": {
+        "src/services/discord/session_relay_sink.rs": 1,
+    },
+    "reanchor_current_generation_frontier": {
+        "src/services/discord/tui_prompt_relay/claude_idle_runtime.rs": 1,
+    },
+    "record_watcher_owner_channel_context": {
+        "src/services/discord/inflight/model.rs": 1,
+    },
+    "record_delivered_content_fingerprint": {
+        "src/services/discord/session_relay_sink.rs": 1,
+    },
+    "record_fresh_send_content_fingerprint": {
+        "src/services/discord/outbound/turn_output_controller/fresh_send.rs": 1,
+    },
+    # -- store 1: the shadow-mirror funnel and its four entry points ----------
+    "shadow_mirror_delivered_frontier": {
+        "src/services/discord/outbound/delivery_record.rs": 3,
+        "src/services/discord/turn_bridge/terminal_controller_cutover.rs": 1,
+    },
+    "shadow_mirror_delivered_frontier_inner": {
+        "src/services/discord/outbound/delivery_record.rs": 2,
+    },
+    "record_delivered_frontier_with_body": {
+        "src/services/discord/turn_bridge/terminal_delivery.rs": 1,
+        "src/services/discord/turn_bridge/terminal_outcome_delivery.rs": 1,
+        "src/services/discord/turn_bridge/terminal_outcome_delivery/cancel_prompt_replace.rs": 1,
+    },
+    "record_long_chunk_terminal_delivery": {
+        "src/services/discord/turn_bridge/terminal_controller_cutover.rs": 2,
+    },
+    "record_watcher_terminal_delivery": {
+        "src/services/discord/tmux_watcher/terminal_long_chunks.rs": 2,
+    },
+    # -- store 1: write APIs with no production caller, pinned at zero -------
+    # Each is `pub(in crate::services::discord)` and compiles, so the compiler
+    # does not hold this boundary; only this map does. Reached only from
+    # `#[cfg(test)]` code, or (for the lease/record lifecycle three) not even
+    # that -- their tests drive the private `*_at` variants instead.
+    "write_confirmed_delivery": {},
+    "upsert_lease": {},
+    "clear_lease": {},
+    "delete_record": {},
+    "shadow_mirror_same_channel_frontier_with_body": {},
+    # -- store 2: completed-turn ledger --------------------------------------
+    "append_completed_turn": {
+        "src/services/discord/outbound/delivery_record.rs": 2,
+        "src/services/discord/recovery_engine/terminal_text_idempotency.rs": 1,
+    },
+    # -- store 3: in-memory watermark CAS ------------------------------------
+    "advance_watcher_confirmed_end": {
+        "src/services/discord/session_relay_sink.rs": 1,
+        "src/services/discord/session_relay_sink/delivery_commit.rs": 1,
+        "src/services/discord/tmux.rs": 1,
+        "src/services/discord/tmux_watcher.rs": 1,
+        "src/services/discord/tmux_watcher/loop_poll_prologue.rs": 1,
+        "src/services/discord/tmux_watcher/no_result_exits.rs": 1,
+        "src/services/discord/tmux_watcher/terminal_preflight.rs": 2,
+        "src/services/discord/turn_finalizer/delivery_lease.rs": 1,
+    },
+    "advance_watcher_confirmed_end_for_generation": {
+        "src/services/discord/tmux_watcher/terminal_long_chunks.rs": 1,
+    },
+}
+
+# Scanning `src/` from the filesystem rather than `git ls-files` is deliberate:
+# an untracked new module is still a new call site, and the point of dropping
+# anchors is that no file gets to be invisible.
+SCAN_ROOT = Path("src")
+
+# `\b<symbol>\s*(` -- the trailing `(` is what makes longer names with the same
+# prefix (`write_delivered_frontier_at`, `..._guarded_at_with_before_lock`,
+# `shadow_mirror_delivered_frontier_inner` vs `..._frontier`,
+# `record_delivered_content_fingerprint_for_generation`) NOT match: `_` is not
+# whitespace. `\s*` tolerates the blank left by a stripped inline comment.
+def _call_re(symbol: str) -> re.Pattern[str]:
+    return re.compile(rf"\b{re.escape(symbol)}\s*\(")
+
+
+def _defn_re(symbol: str) -> re.Pattern[str]:
+    return re.compile(rf"\bfn\s+{re.escape(symbol)}\s*\(")
+
+
+CALL_RES = {symbol: _call_re(symbol) for symbol in EXPECTED_CALL_SITES}
+DEFN_RES = {symbol: _defn_re(symbol) for symbol in EXPECTED_CALL_SITES}
+
+# `#[cfg(test)]`, `#[cfg(all(test, ...))]`, `#[cfg(any(test, ...))]`.
+CFG_TEST_RE = re.compile(r"#\[\s*cfg\s*\(\s*(?:all|any)?\s*\(?\s*test\b")
+# An item keyword that introduces a braced body, in ITEM POSITION: at the start
+# of a line, or right after the `]` closing an attribute, or right after a `}`.
+# The position anchor is load-bearing. A bare `\bfn\b` also matches the `fn` in a
+# field type like `cb: Option<fn(u8, u8)>,`, which would suppress the comma rule
+# for exactly the struct-field shape the comma rule exists to handle. See the
+# DEVIATION note in the module docstring.
+ITEM_START_RE = re.compile(
+    r"(?:^|\]|\})\s*"
+    r"(?:pub(?:\([^)]*\))?\s+)?"
+    r"(?:default\s+)?(?:const\s+)?(?:async\s+)?(?:unsafe\s+)?"
+    r'(?:extern\s+(?:"[^"]*"\s+)?)?'
+    r"(?:fn|impl|mod|trait|macro_rules)\b"
+)
+
+# --- Cross-line string/comment stripper, ported verbatim from
+# scripts/check_inflight_blind_save_ratchet.py (#4259), which ported it from
+# scripts/check_log_key_drift.py (#4218). Copied rather than imported so each
+# guard stays a dependency-free single-file script, per the convention those two
+# state; if a bug is found here, fix it in all three. Blanked output keeps
+# `{` / `}` / `;` / `,` counts honest for the cfg(test) tracking below: without
+# cross-line state, an unbalanced `{` inside a multi-line raw string poisons the
+# brace depth and hides every later call in the file. ---
+
+# Char literal (so `'"'` / `'{'` cannot desync the scanners). Lifetimes (`'a`)
+# do not match and fall through harmlessly.
+_CHAR_LITERAL = re.compile(r"'(\\.|[^'\\])'")
+
+# Raw / byte string openers: r"…", r#"…"#, br"…"; b"…" is handled separately.
+_RAW_STRING_OPEN = re.compile(r'(?:r|br)(#*)"')
+
+
+class StripState:
+    """Cross-line lexer state: strings and block comments span lines."""
+
+    __slots__ = ("in_string", "raw_hashes", "block_depth")
+
+    def __init__(self) -> None:
+        self.in_string = False  # inside a normal "…" / b"…" string
+        self.raw_hashes: int | None = None  # inside r"…" / r#"…"# (hash count)
+        self.block_depth = 0  # nested /* … */ depth
+
+
+def strip_line(line: str, state: StripState) -> str:
+    """Blank out string-literal/comment content, preserving column positions."""
+    out: list[str] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        if state.block_depth > 0:
+            if line.startswith("/*", i):
+                state.block_depth += 1
+                out.append("  ")
+                i += 2
+            elif line.startswith("*/", i):
+                state.block_depth -= 1
+                out.append("  ")
+                i += 2
+            else:
+                out.append(" ")
+                i += 1
+            continue
+        if state.raw_hashes is not None:
+            closer = '"' + "#" * state.raw_hashes
+            if line.startswith(closer, i):
+                state.raw_hashes = None
+                out.append(" " * len(closer))
+                i += len(closer)
+            else:
+                out.append(" ")
+                i += 1
+            continue
+        if state.in_string:
+            if line[i] == "\\" and i + 1 < n:
+                out.append("  ")
+                i += 2
+            else:
+                if line[i] == '"':
+                    state.in_string = False
+                out.append(" ")
+                i += 1
+            continue
+        # --- normal code ---
+        if line.startswith("//", i):
+            break  # line comment: drop the rest of the line
+        if line.startswith("/*", i):
+            state.block_depth = 1
+            out.append("  ")
+            i += 2
+            continue
+        raw = _RAW_STRING_OPEN.match(line, i)
+        if raw:
+            state.raw_hashes = len(raw.group(1))
+            out.append(" " * (raw.end() - i))
+            i = raw.end()
+            continue
+        if line[i] == '"' or line.startswith('b"', i):
+            skip = 2 if line[i] == "b" else 1
+            state.in_string = True
+            out.append(" " * skip)
+            i += skip
+            continue
+        if line[i] == "'":
+            m = _CHAR_LITERAL.match(line, i)
+            if m:
+                out.append(" " * (m.end() - i))
+                i = m.end()
+                continue
+        out.append(line[i])
+        i += 1
+    return "".join(out)
+
+
+def is_test_file(name: str) -> bool:
+    return name == "tests.rs" or name.endswith("_tests.rs")
+
+
+def production_lines(path: Path):
+    """Yield ``(lineno, stripped_code, is_production)`` for one Rust file."""
+    state = StripState()
+    brace_depth = 0
+    group_depth = 0  # `(` and `[` nesting, so `;` / `,` inside them are ignored
+    mode = "normal"  # normal | armed (saw cfg(test) attr) | skip (in test item)
+    skip_start_depth = 0
+    saw_body_keyword = False
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        code = strip_line(raw, state)
+        countable = mode == "normal"
+        arm_at = None
+        if mode == "normal":
+            match = CFG_TEST_RE.search(code)
+            if match:
+                # Arm at the end of the attribute's own `test` token, so the
+                # attribute's trailing `)]` are accounted the same way its
+                # leading `#[cfg(` were, and a `,` inside `all(test, ...)`
+                # cannot resolve the arm it is part of.
+                arm_at = match.end()
+        # Resolve the item-start keyword position BEFORE walking the line: the
+        # comma that must not disarm (`-> HashMap<String, u64> {`) sits on the
+        # same line as the `fn` that suppresses the comma rule, so deciding at
+        # end-of-line is one line too late.
+        item_start = ITEM_START_RE.search(code, arm_at if arm_at is not None else 0)
+        item_start_at = item_start.end() if item_start else None
+        for index, char in enumerate(code):
+            if arm_at is not None and index == arm_at:
+                mode = "armed"
+                saw_body_keyword = False
+            if item_start_at is not None and index >= item_start_at:
+                saw_body_keyword = True
+            if char in "([":
+                group_depth += 1
+            elif char in ")]":
+                group_depth -= 1
+            elif char == "{":
+                if mode == "armed":
+                    mode = "skip"
+                    skip_start_depth = brace_depth
+                brace_depth += 1
+            elif char == "}":
+                brace_depth -= 1
+                if mode == "skip" and brace_depth <= skip_start_depth:
+                    mode = "normal"
+            elif char == ";" and mode == "armed" and group_depth <= 0:
+                mode = "normal"  # `#[cfg(test)] use ...;` / `mod tests;`
+            elif (
+                char == ","
+                and mode == "armed"
+                and group_depth <= 0
+                and not saw_body_keyword
+            ):
+                mode = "normal"  # `#[cfg(test)] field: T,` / enum variant
+        yield lineno, code, countable
+
+
+def production_call_sites(root: Path) -> tuple[dict[str, dict[str, int]], int, int]:
+    """Return ``(counts, scanned_files, skipped_test_files)`` over ``src/``."""
+    found: dict[str, dict[str, int]] = {symbol: {} for symbol in EXPECTED_CALL_SITES}
+    scanned = 0
+    skipped = 0
+    scan_root = root / SCAN_ROOT
+    for path in sorted(scan_root.rglob("*.rs")):
+        if not path.is_file():
+            continue
+        if is_test_file(path.name):
+            skipped += 1
+            continue
+        scanned += 1
+        rel = path.relative_to(root).as_posix()
+        for _lineno, code, countable in production_lines(path):
+            if not countable:
+                continue
+            for symbol, call_re in CALL_RES.items():
+                if DEFN_RES[symbol].search(code):
+                    continue
+                hits = len(call_re.findall(code))
+                if hits:
+                    found[symbol][rel] = found[symbol].get(rel, 0) + hits
+    return found, scanned, skipped
+
+
+LIMITS = (
+    "lexical scan of stripped source, not Rust parsing; not proof of reachability; "
+    "`use .. as x` aliases, re-export renames, name-constructing macros and calls "
+    "through values or trait objects are NOT seen; cfg other than cfg(test) is not "
+    "evaluated; textual occurrences are counted once regardless of macro expansion"
+)
+
+
+def check(root: Path) -> tuple[bool, str]:
+    found, scanned, skipped = production_call_sites(root)
+    problems: list[str] = []
+    for symbol, expected in EXPECTED_CALL_SITES.items():
+        actual = found[symbol]
+        if actual == expected:
+            continue
+        for rel in sorted(set(expected) | set(actual)):
+            want = expected.get(rel, 0)
+            have = actual.get(rel, 0)
+            if want != have:
+                if want == 0:
+                    problems.append(f"{symbol}: UNLISTED call site in {rel} ({have}x)")
+                elif have == 0:
+                    problems.append(f"{symbol}: call site GONE from {rel} (expected {want}x)")
+                else:
+                    problems.append(f"{symbol}: {rel} has {have}x, expected {want}x")
+    total_expected = sum(sum(m.values()) for m in EXPECTED_CALL_SITES.values())
+    total_actual = sum(sum(m.values()) for m in found.values())
+    zero_pinned = sorted(s for s, m in EXPECTED_CALL_SITES.items() if not m)
+    header = (
+        f"durable frontier writer call sites: {total_actual} production sites across "
+        f"{len(EXPECTED_CALL_SITES)} symbols "
+        f"({len(zero_pinned)} pinned at zero: {', '.join(zero_pinned)}); "
+        f"scanned {scanned} Rust files under {SCAN_ROOT.as_posix()}/, "
+        f"skipped {skipped} test files; ({LIMITS})"
+    )
+    if problems:
+        detail = "\n  ".join(problems)
+        return False, (
+            f"FAIL: durable frontier writer call sites moved (expected {total_expected}, "
+            f"found {total_actual}).\n  {detail}\n"
+            "Update EXPECTED_CALL_SITES in scripts/check_durable_frontier_writer_call_sites.py "
+            "in the same commit, and say in the commit message which site moved and why.\n"
+            f"({LIMITS})"
+        )
+    return True, f"OK: {header}"
+
+
+def main() -> int:
+    ok, message = check(Path(__file__).resolve().parent.parent)
+    print(message, file=sys.stdout if ok else sys.stderr)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -89,6 +89,17 @@ echo "=== DeliveryJournal raw-writer allowlist ==="
 "$PYTHON" scripts/check_delivery_journal_raw_writer.py
 "$PYTHON" -m unittest tests.test_delivery_journal_raw_writer
 
+echo "=== Durable frontier writer per-file call-site allowlist (#5071) ==="
+# Built for #5071 T1 S7, which changes the recovery path's durable behaviour.
+# Nothing in the repo pinned WHERE these writer symbols are called from, so this
+# fixes an exact per-file count for each of them over all of src/ before that
+# behaviour moves. It changes no production behaviour itself. Lexical scan: it
+# does not see `use .. as` aliases, renamed re-exports, or name-constructing
+# macros -- the script's docstring declares those holes and the unittest module
+# measures each one.
+"$PYTHON" scripts/check_durable_frontier_writer_call_sites.py
+"$PYTHON" -m unittest tests.test_durable_frontier_writer_call_sites
+
 echo "=== Hotfile LOC ratchet guard (#3565) ==="
 "$PYTHON" scripts/check_hotfile_ratchet.py
 "$PYTHON" -m unittest scripts.test_ratchet_admission

--- a/tests/test_durable_frontier_writer_call_sites.py
+++ b/tests/test_durable_frontier_writer_call_sites.py
@@ -1,0 +1,492 @@
+"""Contract + discrimination tests for the durable frontier writer allowlist (#5071 T1 S7').
+
+The tests below are split into two groups on purpose.
+
+SOURCE CONTRACT (against the real tree) pins the measured shape of the repo: the
+totals, the symbols pinned at zero, and the fact that CI actually runs the gate.
+These fail when the tree moves without the map moving with it.
+
+DISCRIMINATION (against synthetic fixtures) answers the only question that makes
+a green gate worth anything: WHAT BREAKS IT. Every mutation below is applied and
+asserted on, including the three that the gate provably does NOT catch --
+`use .. as` aliasing, `pub use .. as` re-export renaming, and a
+name-constructing macro. Those three are recorded here as MEASURED holes, not as
+suspicions, and the same three are declared in the script's own docstring and in
+its runtime output. A gate that hides its holes is worse than no gate.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_durable_frontier_writer_call_sites.py"
+SPEC = importlib.util.spec_from_file_location("durable_frontier_writer_guard", SCRIPT)
+guard = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(guard)
+
+# Measured on 0bde0675b, the base this slice branched from.
+TOTAL_CALL_SITES = 34
+PINNED_SYMBOLS = 20
+ZERO_PINNED = {
+    "write_confirmed_delivery",
+    "upsert_lease",
+    "clear_lease",
+    "delete_record",
+    "shadow_mirror_same_channel_frontier_with_body",
+}
+
+
+def write(root: Path, rel: str, body: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+class SourceContractTests(unittest.TestCase):
+    """Pins the real tree. These are the assertions that go red on a real move."""
+
+    def test_real_tree_passes_and_reports_its_limits(self):
+        ok, message = guard.check(ROOT)
+        self.assertTrue(ok, message)
+        self.assertIn(f"{TOTAL_CALL_SITES} production sites", message)
+        self.assertIn(f"across {PINNED_SYMBOLS} symbols", message)
+        # The success path must state its own blindness, not only the failure
+        # path: a reader who only ever sees green must still learn the limits.
+        for limit in ("use .. as x", "not Rust parsing", "not proof of reachability"):
+            self.assertIn(limit, message)
+
+    def test_expected_map_totals_are_pinned_independently_of_the_map(self):
+        """A shrunk map plus a shrunk tree would agree with itself; this does not."""
+        total = sum(sum(m.values()) for m in guard.EXPECTED_CALL_SITES.values())
+        self.assertEqual(total, TOTAL_CALL_SITES)
+        self.assertEqual(len(guard.EXPECTED_CALL_SITES), PINNED_SYMBOLS)
+        self.assertEqual(
+            {s for s, m in guard.EXPECTED_CALL_SITES.items() if not m}, ZERO_PINNED
+        )
+
+    def test_scan_root_is_all_of_src(self):
+        """Narrowing the scan is the cheapest way to fake a green gate."""
+        self.assertEqual(guard.SCAN_ROOT.as_posix(), "src")
+
+    def test_ci_script_checks_runs_this_gate_and_this_module(self):
+        """A gate nobody runs is the #5003 shape. Pin the wiring, not the intent."""
+        wiring = (ROOT / "scripts/ci-script-checks.sh").read_text(encoding="utf-8")
+        self.assertIn("scripts/check_durable_frontier_writer_call_sites.py", wiring)
+        self.assertIn("tests.test_durable_frontier_writer_call_sites", wiring)
+
+    def test_every_pinned_file_exists_and_still_spells_the_symbol(self):
+        """Keeps the map from rotting into a list of paths that no longer exist."""
+        for symbol, files in guard.EXPECTED_CALL_SITES.items():
+            for rel in files:
+                path = ROOT / rel
+                self.assertTrue(path.is_file(), f"{symbol}: missing {rel}")
+                self.assertIn(symbol, path.read_text(encoding="utf-8"), f"{symbol} in {rel}")
+
+
+class DiscriminationTests(unittest.TestCase):
+    """Every assertion here is a mutation that was applied and then reverted."""
+
+    def fixture(self) -> Path:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        root = Path(temp.name)
+        write(
+            root,
+            "src/services/discord/outbound/delivery_record.rs",
+            "pub fn write_delivered_frontier() {}\n"
+            "pub fn upsert_lease() {}\n"
+            "fn funnel() { shadow_mirror_delivered_frontier_inner(); }\n",
+        )
+        write(
+            root,
+            "src/services/discord/recovery_engine/terminal_text_idempotency.rs",
+            "fn record() {\n"
+            "    delivery_record::write_delivered_frontier();\n"
+            "    completed_turn_ledger::append_completed_turn();\n"
+            "}\n",
+        )
+        write(
+            root,
+            "src/services/discord/tmux_watcher/terminal_preflight.rs",
+            "fn a() { advance_watcher_confirmed_end(); }\n"
+            "fn b() { advance_watcher_confirmed_end(); }\n",
+        )
+        return root
+
+    def expected(self, **overrides: dict[str, int]) -> dict[str, dict[str, int]]:
+        base = {symbol: {} for symbol in guard.EXPECTED_CALL_SITES}
+        base["write_delivered_frontier"] = {
+            "src/services/discord/recovery_engine/terminal_text_idempotency.rs": 1
+        }
+        base["append_completed_turn"] = {
+            "src/services/discord/recovery_engine/terminal_text_idempotency.rs": 1
+        }
+        base["shadow_mirror_delivered_frontier_inner"] = {
+            "src/services/discord/outbound/delivery_record.rs": 1
+        }
+        base["advance_watcher_confirmed_end"] = {
+            "src/services/discord/tmux_watcher/terminal_preflight.rs": 2
+        }
+        base.update(overrides)
+        return base
+
+    def run_guard(self, root: Path, expected=None) -> tuple[bool, str]:
+        original = guard.EXPECTED_CALL_SITES
+        guard.EXPECTED_CALL_SITES = expected if expected is not None else self.expected()
+        try:
+            return guard.check(root)
+        finally:
+            guard.EXPECTED_CALL_SITES = original
+
+    # --- baseline -----------------------------------------------------------
+
+    def test_m0_unmutated_fixture_is_green(self):
+        ok, message = self.run_guard(self.fixture())
+        self.assertTrue(ok, message)
+
+    # --- M1: one call ADDED in a file the map already lists -----------------
+
+    def test_m1_one_extra_call_in_a_listed_file_is_caught(self):
+        root = self.fixture()
+        rel = "src/services/discord/tmux_watcher/terminal_preflight.rs"
+        (root / rel).write_text(
+            (root / rel).read_text(encoding="utf-8")
+            + "fn c() { advance_watcher_confirmed_end(); }\n",
+            encoding="utf-8",
+        )
+        ok, message = self.run_guard(root)
+        self.assertFalse(ok)
+        self.assertIn("advance_watcher_confirmed_end: " + rel + " has 3x, expected 2x", message)
+
+    # --- M2: one call DELETED ------------------------------------------------
+
+    def test_m2_one_deleted_call_is_caught(self):
+        root = self.fixture()
+        rel = "src/services/discord/tmux_watcher/terminal_preflight.rs"
+        (root / rel).write_text(
+            "fn a() { advance_watcher_confirmed_end(); }\nfn b() {}\n", encoding="utf-8"
+        )
+        ok, message = self.run_guard(root)
+        self.assertFalse(ok)
+        self.assertIn("has 1x, expected 2x", message)
+
+    def test_m2b_the_last_call_in_a_file_disappearing_is_caught(self):
+        """The 'call site GONE' arm: file drops to zero rather than to a lower count."""
+        root = self.fixture()
+        rel = "src/services/discord/recovery_engine/terminal_text_idempotency.rs"
+        (root / rel).write_text("fn record() {}\n", encoding="utf-8")
+        ok, message = self.run_guard(root)
+        self.assertFalse(ok)
+        self.assertIn(f"write_delivered_frontier: call site GONE from {rel}", message)
+        self.assertIn(f"append_completed_turn: call site GONE from {rel}", message)
+
+    # --- M3: a call added in a file the map does NOT list --------------------
+
+    def test_m3_call_in_an_unlisted_file_is_caught(self):
+        """The hole the anchor model cannot see: a brand new file nobody listed."""
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/recovery_paths/controller_cutover.rs",
+            "fn sneaky() { dr::write_delivered_frontier(); }\n",
+        )
+        ok, message = self.run_guard(root)
+        self.assertFalse(ok)
+        self.assertIn(
+            "write_delivered_frontier: UNLISTED call site in "
+            "src/services/discord/recovery_paths/controller_cutover.rs (1x)",
+            message,
+        )
+
+    def test_m3b_call_added_far_outside_the_discord_subtree_is_caught(self):
+        root = self.fixture()
+        write(root, "src/config.rs", "fn sneaky() { append_completed_turn(); }\n")
+        ok, message = self.run_guard(root)
+        self.assertFalse(ok)
+        self.assertIn("append_completed_turn: UNLISTED call site in src/config.rs", message)
+
+    # --- M4: calling an API pinned at zero -----------------------------------
+
+    def test_m4_single_call_to_a_zero_pinned_api_is_caught(self):
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/lease_user.rs",
+            "fn take() { delivery_record::upsert_lease(); }\n",
+        )
+        ok, message = self.run_guard(root)
+        self.assertFalse(ok)
+        self.assertIn(
+            "upsert_lease: UNLISTED call site in src/services/discord/outbound/lease_user.rs (1x)",
+            message,
+        )
+
+    def test_m4b_each_zero_pinned_api_is_individually_discriminating(self):
+        """One assertion per zero-pinned symbol: none of the five is decorative."""
+        for symbol in sorted(ZERO_PINNED):
+            with self.subTest(symbol=symbol):
+                root = self.fixture()
+                write(root, "src/probe.rs", f"fn probe() {{ {symbol}(); }}\n")
+                ok, message = self.run_guard(root)
+                self.assertFalse(ok, symbol)
+                self.assertIn(f"{symbol}: UNLISTED call site in src/probe.rs (1x)", message)
+
+    # --- M5: alias / re-export -- MEASURED HOLE, NOT CAUGHT -----------------
+
+    def test_m5_use_as_alias_is_NOT_caught_and_the_script_says_so(self):
+        """MEASURED HOLE. `use ... as w; w()` defeats the scan. Declared, not hidden.
+
+        This is the direct consequence of a literal-grep completion criterion:
+        the contract is bound to the spelling, so any route that reaches the same
+        function under a different spelling is outside it.
+        """
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/aliased_writer.rs",
+            "use crate::services::discord::outbound::delivery_record::"
+            "write_delivered_frontier as w;\n"
+            "fn sneaky() { w(); }\n",
+        )
+        ok, message = self.run_guard(root)
+        self.assertTrue(ok, "alias route is a declared blind spot; if this now fails, "
+                            "the gate got stronger -- update the docstring too")
+        self.assertIn("`use .. as x` aliases", message)
+        self.assertIn("`use ...::write_delivered_frontier as w;`", SCRIPT.read_text(encoding="utf-8"))
+
+    def test_m5b_pub_use_reexport_rename_is_NOT_caught(self):
+        """MEASURED HOLE. A renamed re-export hides the spelling from every caller."""
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/reexport.rs",
+            "pub use super::delivery_record::upsert_lease as take_lease;\n",
+        )
+        write(
+            root,
+            "src/services/discord/outbound/reexport_user.rs",
+            "fn go() { super::reexport::take_lease(); }\n",
+        )
+        ok, message = self.run_guard(root)
+        # The `pub use ... as` line itself does not spell `upsert_lease(`, and the
+        # call spells only the new name, so BOTH lines are invisible.
+        self.assertTrue(ok, message)
+
+    def test_m5c_a_module_alias_is_still_caught_because_the_fn_name_survives(self):
+        """The alias hole is specific: renaming the MODULE does not help at all."""
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/mod_alias.rs",
+            "use crate::services::discord::outbound::delivery_record as dr;\n"
+            "fn go() { dr::write_delivered_frontier(); }\n",
+        )
+        ok, message = self.run_guard(root)
+        self.assertFalse(ok)
+        self.assertIn("UNLISTED call site in src/services/discord/outbound/mod_alias.rs", message)
+
+    # --- M6: macros -- one shape caught, one MEASURED HOLE -------------------
+
+    def test_m6_macro_body_that_spells_the_symbol_is_caught_once(self):
+        """A macro is text: the literal spelling inside its body is a call site.
+
+        Note the count is TEXTUAL. This macro is invoked twice below and the gate
+        still sees exactly one occurrence, because a text scan cannot count
+        expansions. That direction is under-counting, and it is declared.
+        """
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/macro_writer.rs",
+            "macro_rules! commit {\n"
+            "    () => { delivery_record::write_delivered_frontier() };\n"
+            "}\n"
+            "fn one() { commit!(); }\n"
+            "fn two() { commit!(); }\n",
+        )
+        ok, message = self.run_guard(root)
+        self.assertFalse(ok)
+        self.assertIn(
+            "write_delivered_frontier: UNLISTED call site in "
+            "src/services/discord/outbound/macro_writer.rs (1x)",
+            message,
+        )
+
+    def test_m6b_name_constructing_macro_is_NOT_caught(self):
+        """MEASURED HOLE. `paste!`-style name assembly never spells the symbol."""
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/paste_writer.rs",
+            "paste::paste! {\n"
+            "    fn go() { [<write_delivered>]_[<frontier>](); }\n"
+            "}\n",
+        )
+        ok, message = self.run_guard(root)
+        self.assertTrue(ok, "name-assembling macros are a declared blind spot")
+        self.assertIn("name-constructing macros", message)
+
+    def test_m6c_calling_through_a_function_value_is_NOT_caught(self):
+        """MEASURED HOLE. The name without `(` is not a call site, and `f()` is not the name."""
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/fn_ptr.rs",
+            "fn go() {\n"
+            "    let f = delivery_record::write_delivered_frontier;\n"
+            "    f();\n"
+            "}\n",
+        )
+        ok, message = self.run_guard(root)
+        self.assertTrue(ok, "indirection through a value is a declared blind spot")
+
+    # --- M7: narrowing the scan ----------------------------------------------
+
+    def test_m7_narrowing_the_scan_root_is_caught(self):
+        """The mutation that would let someone hide a whole subtree."""
+        root = self.fixture()
+        original = guard.SCAN_ROOT
+        guard.SCAN_ROOT = Path("src/services/discord/outbound")
+        try:
+            ok, message = self.run_guard(root)
+        finally:
+            guard.SCAN_ROOT = original
+        self.assertFalse(ok)
+        self.assertIn("call site GONE", message)
+
+    # --- boundary declarations ----------------------------------------------
+
+    def test_prefix_suffixed_variants_are_not_counted_as_the_pinned_symbol(self):
+        """`_at` / `_inner` / `_for_generation` variants are different symbols."""
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/private_helpers.rs",
+            "fn go() {\n"
+            "    write_delivered_frontier_at();\n"
+            "    write_delivered_frontier_guarded_at_with_before_lock();\n"
+            "    shadow_mirror_delivered_frontier_inner_probe();\n"
+            "    record_delivered_content_fingerprint_for_generation();\n"
+            "}\n",
+        )
+        ok, message = self.run_guard(root)
+        self.assertTrue(ok, message)
+
+    def test_cfg_test_regions_and_test_files_are_excluded(self):
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/delivery_record_tests.rs",
+            "fn t() { upsert_lease(); }\n",
+        )
+        write(
+            root,
+            "src/services/discord/outbound/inline_tested.rs",
+            "#[cfg(test)]\nmod tests {\n    fn t() { upsert_lease(); }\n}\n",
+        )
+        write(
+            root,
+            "src/services/discord/outbound/inline_tested_fn.rs",
+            "#[cfg(all(test, unix))]\nfn probe() { clear_lease(); }\n",
+        )
+        ok, message = self.run_guard(root)
+        self.assertTrue(ok, message)
+
+    def test_cfg_test_struct_field_does_not_swallow_the_next_impl_block(self):
+        """The exact bug this resolver refuses to inherit from the ported one.
+
+        `#[cfg(test)] field: T,` ends in a comma. A resolver that only disarms on
+        `{` or `;` stays armed through the struct and latches onto the following
+        `impl ... {`, hiding every production call inside it. Measured on this
+        tree, that misclassifies three real call sites in session_relay_sink.rs.
+        """
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/field_gated.rs",
+            "pub struct Sink {\n"
+            "    journal: &'static Observer,\n"
+            "    #[cfg(test)]\n"
+            "    test_probe: Option<Arc<Probe>>,\n"
+            "    #[cfg(test)]\n"
+            "    test_gateway: Option<Arc<dyn Gateway>>,\n"
+            "}\n"
+            "\n"
+            "impl Sink {\n"
+            "    fn commit(&self) { dr::upsert_lease(); }\n"
+            "}\n",
+        )
+        ok, message = self.run_guard(root)
+        self.assertFalse(ok, "the production impl block must stay visible")
+        self.assertIn("upsert_lease: UNLISTED call site in "
+                      "src/services/discord/outbound/field_gated.rs (1x)", message)
+
+    def test_generic_comma_in_a_cfg_test_fn_signature_does_not_disarm_early(self):
+        """The counter-case for the comma rule: a real test fn stays excluded."""
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/generic_test_fn.rs",
+            "#[cfg(test)]\n"
+            "fn probe(a: u8, b: u8) -> HashMap<String, u64> {\n"
+            "    upsert_lease();\n"
+            "    HashMap::new()\n"
+            "}\n",
+        )
+        ok, message = self.run_guard(root)
+        self.assertTrue(ok, message)
+
+    def test_comments_and_string_literals_do_not_count(self):
+        """Declared boundary; this is where the gate differs from the model gate.
+
+        `check_delivery_journal_raw_writer.py` strips only the `//` suffix, so a
+        symbol inside a string or a `/* */` block makes it go red. This one runs
+        the cross-line stripper first, so neither does.
+        """
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/prose.rs",
+            "// upsert_lease();\n"
+            "/* upsert_lease(); */\n"
+            'const DOC: &str = "upsert_lease();";\n'
+            'const RAW: &str = r#"upsert_lease();"#;\n',
+        )
+        ok, message = self.run_guard(root)
+        self.assertTrue(ok, message)
+
+    def test_unbalanced_brace_in_a_raw_string_does_not_hide_later_calls(self):
+        """Without cross-line stripping this `{` poisons the depth for the file."""
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/raw_string_brace.rs",
+            "#[cfg(test)]\nmod tests {\n"
+            '    const SQL: &str = r#"SELECT {\n'
+            '        unbalanced"#;\n'
+            "}\n"
+            "fn production() { delete_record(); }\n",
+        )
+        ok, message = self.run_guard(root)
+        self.assertFalse(ok)
+        self.assertIn("delete_record: UNLISTED call site in "
+                      "src/services/discord/outbound/raw_string_brace.rs (1x)", message)
+
+    def test_fn_definition_line_is_not_a_call_site(self):
+        root = self.fixture()
+        write(
+            root,
+            "src/services/discord/outbound/defs.rs",
+            "pub(in crate::services::discord) fn clear_lease(a: u8) {}\n"
+            "pub async fn delete_record(b: u8) {}\n",
+        )
+        ok, message = self.run_guard(root)
+        self.assertTrue(ok, message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_durable_frontier_writer_call_sites.py
+++ b/tests/test_durable_frontier_writer_call_sites.py
@@ -18,6 +18,7 @@ its runtime output. A gate that hides its holes is worse than no gate.
 from __future__ import annotations
 
 import importlib.util
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -29,8 +30,8 @@ guard = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(guard)
 
 # Measured on 0bde0675b, the base this slice branched from.
-TOTAL_CALL_SITES = 34
-PINNED_SYMBOLS = 20
+TOTAL_CALL_SITES = 42
+PINNED_SYMBOLS = 23
 ZERO_PINNED = {
     "write_confirmed_delivery",
     "upsert_lease",
@@ -38,6 +39,38 @@ ZERO_PINNED = {
     "delete_record",
     "shadow_mirror_same_channel_frontier_with_body",
 }
+
+
+# CLASSIFIER PROBES: `(file, symbol, production_count, count_ignoring_cfg_test)`,
+# each verified BY HAND against the file's `#[cfg(test)]` boundaries rather than
+# taken from the scanner's own output.
+#
+# Why this table exists. The production/test classifier is an ORACLE the counts
+# depend on: if it drifts, `EXPECTED_CALL_SITES` drifts with it and both agree
+# with each other while being wrong. The pairs below break that coupling from
+# both sides -- the first number moves if the classifier starts hiding
+# production code, the second if the stripper or the call regex changes at all.
+#
+# Rows 1-4 are the shape that motivated this table. A `#[cfg(test)]` STRUCT
+# FIELD in session_relay_sink.rs makes the resolver ported from
+# check_inflight_blind_save_ratchet.py swallow the production impl block that
+# follows it, which would report the first three of these as 0. Row 5 is the
+# opposite direction: tmux.rs's only `write_confirmed_delivery(` really is
+# inside `#[cfg(test)]`, so a classifier that stops excluding test regions
+# turns that 0 into a 1. Row 7 pins the widest prod/test gap in the tree
+# (3 of 12), and row 9 pins the file where one spelling covers two functions.
+MANUAL_CLASSIFICATION = [
+    ("src/services/discord/session_relay_sink.rs", "commit_ordered_jsonl_range", 1, 1),
+    ("src/services/discord/session_relay_sink.rs", "record_delivered_content_fingerprint", 1, 3),
+    ("src/services/discord/session_relay_sink.rs", "advance_watcher_confirmed_end", 1, 1),
+    ("src/services/discord/session_relay_sink.rs", "finish_sink_delivery", 3, 4),
+    ("src/services/discord/tmux.rs", "write_confirmed_delivery", 0, 1),
+    ("src/services/discord/tmux.rs", "advance_watcher_confirmed_end", 1, 1),
+    ("src/services/discord/outbound/delivery_record.rs", "shadow_mirror_delivered_frontier", 3, 12),
+    ("src/services/discord/outbound/delivery_record.rs", "append_completed_turn", 2, 2),
+    ("src/services/discord/tmux_watcher/terminal_long_chunks.rs", "record_watcher_terminal_delivery", 2, 2),
+    ("src/services/discord/turn_bridge/terminal_controller_cutover.rs", "record_long_chunk_terminal_delivery", 2, 2),
+]
 
 
 def write(root: Path, rel: str, body: str) -> None:
@@ -77,6 +110,77 @@ class SourceContractTests(unittest.TestCase):
         wiring = (ROOT / "scripts/ci-script-checks.sh").read_text(encoding="utf-8")
         self.assertIn("scripts/check_durable_frontier_writer_call_sites.py", wiring)
         self.assertIn("tests.test_durable_frontier_writer_call_sites", wiring)
+
+    def test_classifier_matches_hand_verified_cfg_test_boundaries(self):
+        """Breaks the oracle coupling: the classifier is checked, not trusted.
+
+        Both numbers are asserted. The production count catches a classifier
+        that starts hiding production code (the struct-field bug); the
+        ignore-cfg-test count catches a stripper or regex change that would move
+        both numbers together and stay self-consistent.
+        """
+        for rel, symbol, want_prod, want_all in MANUAL_CLASSIFICATION:
+            with self.subTest(file=rel, symbol=symbol):
+                call = re.compile(rf"\b{symbol}\s*\(")
+                defn = re.compile(rf"\bfn\s+{symbol}\s*\(")
+                prod = 0
+                every = 0
+                for _lineno, code, is_production in guard.production_lines(ROOT / rel):
+                    if defn.search(code):
+                        continue
+                    hits = len(call.findall(code))
+                    every += hits
+                    if is_production:
+                        prod += hits
+                self.assertEqual(prod, want_prod, f"production count for {symbol} in {rel}")
+                self.assertEqual(every, want_all, f"cfg(test)-blind count for {symbol} in {rel}")
+
+    def test_the_two_functions_sharing_one_pinned_spelling_both_still_exist(self):
+        """`record_watcher_terminal_delivery` names two functions in this tree.
+
+        The pinned integer for terminal_long_chunks.rs counts one call to each.
+        If either definition disappears the pin silently changes meaning, so the
+        collision is asserted rather than left in a comment.
+        """
+        funnel = (ROOT / "src/services/discord/outbound/delivery_record.rs").read_text(
+            encoding="utf-8"
+        )
+        wrapper = (
+            ROOT / "src/services/discord/tmux_watcher/terminal_long_chunks.rs"
+        ).read_text(encoding="utf-8")
+        self.assertIn("fn record_watcher_terminal_delivery(", funnel)
+        self.assertIn("fn record_watcher_terminal_delivery(", wrapper)
+        self.assertIn("NAME COLLISION", SCRIPT.read_text(encoding="utf-8"))
+
+    def test_the_call_sites_no_family_anchor_covers_are_pinned(self):
+        """The sites that motivated dropping anchors, asserted one by one.
+
+        A parallel census of every production durable write on 0bde0675b found
+        these outside the reach of `check_delivery_journal_raw_writer.py`'s
+        six family anchors. Three sit in the turn_bridge family but not in its
+        anchor file; `claude_idle_runtime.rs` belongs to no family at all, so no
+        anchor could ever reach it; the two `fresh_send.rs` sites are in no
+        family either and are currently dormant (`OutputPlan::SendFresh` has no
+        production constructor), which is exactly the state in which an
+        uninstrumented write is easiest to reintroduce unnoticed.
+        """
+        anchor_blind = [
+            ("record_delivered_frontier_with_body",
+             "src/services/discord/turn_bridge/terminal_delivery.rs", 1),
+            ("record_delivered_frontier_with_body",
+             "src/services/discord/turn_bridge/terminal_outcome_delivery.rs", 1),
+            ("record_delivered_frontier_with_body",
+             "src/services/discord/turn_bridge/terminal_outcome_delivery/cancel_prompt_replace.rs", 1),
+            ("reanchor_current_generation_frontier",
+             "src/services/discord/tui_prompt_relay/claude_idle_runtime.rs", 1),
+            ("write_delivered_frontier",
+             "src/services/discord/outbound/turn_output_controller/fresh_send.rs", 1),
+            ("record_fresh_send_content_fingerprint",
+             "src/services/discord/outbound/turn_output_controller/fresh_send.rs", 1),
+        ]
+        for symbol, rel, count in anchor_blind:
+            with self.subTest(symbol=symbol, file=rel):
+                self.assertEqual(guard.EXPECTED_CALL_SITES[symbol].get(rel), count)
 
     def test_every_pinned_file_exists_and_still_spells_the_symbol(self):
         """Keeps the map from rotting into a list of paths that no longer exist."""


### PR DESCRIPTION
**What this is.** S7-prime of T1 in the tracking issue (see #5071). It is the gate that lands *before* S7, and it changes no runtime behaviour: `src/` production diff is +0, Rust diff is 0 files.

**Why it is needed.** T1's next behavioural slice, S7, fixes the recovery path's bypass of the `shadow_mirror_delivered_frontier` funnel — a slice that changes *durable* behaviour. Nothing in the repo pinned where those writer symbols are called from. The only writer allowlist that existed, `scripts/check_delivery_journal_raw_writer.py`, pins one different symbol (`append_delivery_journal_batch`). Changing durable behaviour with no gate underneath it protects nothing, so the gate lands first.

**What it does.** New `scripts/check_durable_frontier_writer_call_sites.py` pins the production call *locations* of 23 named symbols as `{symbol: {file: exact count}}` — 42 production sites — over a full sweep of `src/**/*.rs` (1264 files scanned, 72 test files skipped). One new section is wired into `scripts/ci-script-checks.sh`, running the gate and its 30-case unittest module. The `Script checks` job log goes from 48 to 49 distinct section banners (47 -> 48 of them are `echo` lines in `ci-script-checks.sh` itself; the remaining one comes from the nested `scripts/pg-audit.sh`).

Scope statement, stated precisely rather than universally: **this pins the production call sites of these 23 symbols, per file, at exact integer counts. It is a lexical scan, so aliases, name-constructing macros and calls through function values are outside it.**

---

**It does not inherit the two holes in the model gate**

- **No anchors.** `check_delivery_journal_raw_writer.py` reads one anchor file per family, so an uninstrumented durable write added to any other file of that family is caught by nothing (its own S5a comment block measures this). This gate has no anchors — it walks the whole of `src/`, so a call site in a file nobody thought of still fails.
- **No booleans.** That gate reduces each family to "does the anchor contain the token", so N of N sites can drop to 1 and stay green — and it did stay green across three consecutive slices (S4 E2, S5 M2, S5b P2/P3). This gate stores an exact integer per (symbol, file), so losing one of two sites in the same file is a failure.

**Six call sites that no family anchor covered are now nailed down individually**, each as its own `subTest`:

| file:line | note |
|---|---|
| `turn_bridge/terminal_delivery.rs:70` | outside every family anchor |
| `turn_bridge/terminal_outcome_delivery.rs:645` | outside every family anchor |
| `.../terminal_outcome_delivery/cancel_prompt_replace.rs:401` | outside every family anchor |
| `tui_prompt_relay/claude_idle_runtime.rs:284` | belonged to **none of the six families at all** |
| `outbound/turn_output_controller/fresh_send.rs:195` and `:206` | dormant |

---

**A real splitter bug in this repo was found — recorded, not fixed**

The `#[cfg(test)]` resolver in `scripts/check_inflight_blind_save_ratchet.py` disarms only on `{` or `;`. A `#[cfg(test)]` **struct field ends in `,`**. The armed state therefore survives the field and the struct and latches onto the next `{` it meets — which in `session_relay_sink.rs` is the **production `impl SessionBoundDiscordRelaySink {` block** — swallowing the block whole. Measured on this tree: **three production call sites misclassified as test code** (`commit_ordered_jsonl_range`, `record_delivered_content_fingerprint`, `advance_watcher_confirmed_end`).

In its own script the bug is **latent, not active**: that ratchet's symbol has zero production call sites under either resolver, so its baseline of 0 is correct today. Changing a landed gate's counting rule is not this slice's job, so it is left alone and **recorded as debt** for the next slice. The new gate's resolver additionally disarms on a top-level `,`, but not after an item keyword that introduces a braced body (`fn`/`impl`/`mod`/`trait`/`macro_rules`), so a comma inside a generic return type cannot disarm a real test fn.

---

**The classifier oracle coupling is broken on purpose**

`MANUAL_CLASSIFICATION` in the test module fixes 10 rows of hand-verified **(production count, cfg(test)-blind count)** pairs. If the classifier starts hiding production code the first number moves; if the stripper or the regex changes the second number moves. This blocks the state where **the classifier is wrong, so the counts are wrong, and nothing says so.**

---

**Discrimination table — including what it fails to catch**

| # | mutation | rc | verdict |
|---|---|---|---|
| R1 | add one call in an already-listed file | 1 | caught |
| R2 | delete one real call | 1 | caught |
| R3 | call from a **file not in the map** | 1 | caught |
| R4 | call a **zero-pinned API** once | 1 | caught |
| **R5** | **`use … as w; w()`** | **0** | ✗ **missed — (h)** |
| **R6** | **name-assembling `paste!` macro** | **0** | ✗ **missed — (h)** |
| R7 | narrow `SCAN_ROOT` | 1 | caught (42 -> 9) |
| R8 | module alias `dr::` | 1 | caught |

Also missed: `pub use … as` re-export renames, and function values (`let f = …; f()`). **Macro expansion count is under-counted** — a call inside a macro invoked three times still counts 1.

> The four blind spots have one cause: **a literal-grep completion criterion binds the contract to the spelling.** Renaming a pinned symbol is still caught — the count drops to 0 and the gate fails.

---

**Name collision, declared rather than papered over**

`record_watcher_terminal_delivery` is the name of **two distinct functions**: the durable funnel at `outbound/delivery_record.rs:2332`, and a local wrapper at `tmux_watcher/terminal_long_chunks.rs:168`. The `2` pinned for `terminal_long_chunks.rs` is one call to each (`dr::…` at :124, bare at :222) — so the integer counts **occurrences of the spelling, not calls to one function**. The docstring's `NAME COLLISION` section and a dedicated test nail this down so the next reader is not misled by the integer.

---

**Five zero-caller APIs sealed at zero**

`write_confirmed_delivery` · `upsert_lease` · `clear_lease` · `delete_record` · `shadow_mirror_same_channel_frontier_with_body`.

Each is `pub(in crate::services::discord)` and compiles, so **the compiler does not hold this boundary. This map is the only thing that does.**

---

**Where the limits are written down**

1. Script docstring, `WHAT THIS GATE DOES NOT SEE` — 7 items.
2. The runtime `LIMITS` string — **printed on the green path too**, not only on failure.
3. The `ci-script-checks.sh` section comment.

A test asserts that the green message actually contains the limit wording, so the limits cannot quietly fall out of the success path.

---

Related: see #5071, see #5243, see #5247. No issue is closed by this PR — it is a precondition for S7, not the fix.
