### PR TITLE
fix(ci): grade a non-compiling mutant BUILD-BROKEN instead of KILLED

### DIFF
--- a/scripts/run_relay_authority_mutations.sh
+++ b/scripts/run_relay_authority_mutations.sh
@@ -17,6 +17,20 @@
 # In that same follow-up commit, flip condition3_mutations_present to true in
 # scripts/relay_authority_contract_targets.json and re-pin the
 # relay-authority-contract job_sha256 in scripts/check-ci-runner-hardening.sh.
+#
+# Exit codes. Every non-zero code below is a gate failure; there is no
+# "tolerated" non-zero exit.
+#     0  every mutation was killed by the test named for it
+#     1  a mutation SURVIVED the test that is supposed to kill it
+#     2  invalid invocation: bad test mode, missing fixture runner, bad source
+#    75  another relay-authority mutation run holds the lock
+#    94  NO-TEST-RAN: the named test never executed, so nothing was proven (#5243)
+#    95  BUILD-BROKEN: the mutant did not compile, so it is not a valid mutant
+#         and cargo's rc=101 does not mean "the test caught it" (#5243)
+#    96  cache proof invalid: the mutant's build was reused from cache
+#    97  source restoration or lock release failed
+#    98  per-row source restoration hash mismatch
+#   129  HUP / 130 INT / 143 TERM
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -156,35 +170,71 @@ restore_after_row() {
 }
 
 run_target() {
-  local mutation=$1 target=$2 log=$3 rc
+  local mutation=$1 target=$2 log=$3 rc compile_count test_result rest passed failed
   if [[ "$MODE" == "fixture" ]]; then
     set +e
     "$FIXTURE_RUNNER" "$mutation" "$target" >"$log" 2>&1
     rc=$?
     set -e
-    return "$rc"
+  else
+    set +e
+    (
+      cd "$REPO_ROOT"
+      env -u RUSTC_WRAPPER -u AGENTDESK_ROOT_DIR \
+        CARGO_TERM_COLOR=never CARGO_INCREMENTAL=0 CARGO_TARGET_DIR="$TARGET_DIR" \
+        cargo test --offline --lib "$target" -- --exact --test-threads=1
+    ) >"$log" 2>&1
+    rc=$?
+    set -e
+
+    compile_count="$(grep -Fc 'Compiling agentdesk v' "$log" || true)"
+    if [[ "$compile_count" != "1" ]] || grep -Fq 'Fresh agentdesk v' "$log"; then
+      printf 'ERROR mutation=%s cache-proof=invalid compile_count=%s expected=1 and no Fresh agentdesk\n' "$mutation" "$compile_count" >&2
+      cat "$log" >&2
+      return 96
+    fi
+
+    # CARGO_TERM_COLOR=never above makes both cache-proof markers stable for grep.
+    printf 'CACHE_PROOF mutation=%s compiling_agentdesk=%s fresh_agentdesk=0\n' "$mutation" "$compile_count"
   fi
 
-  set +e
-  (
-    cd "$REPO_ROOT"
-    env -u RUSTC_WRAPPER -u AGENTDESK_ROOT_DIR \
-      CARGO_TERM_COLOR=never CARGO_INCREMENTAL=0 CARGO_TARGET_DIR="$TARGET_DIR" \
-      cargo test --offline --lib "$target" -- --exact --test-threads=1
-  ) >"$log" 2>&1
-  rc=$?
-  set -e
-
-  local compile_count
-  compile_count="$(grep -Fc 'Compiling agentdesk v' "$log" || true)"
-  if [[ "$compile_count" != "1" ]] || grep -Fq 'Fresh agentdesk v' "$log"; then
-    printf 'ERROR mutation=%s cache-proof=invalid compile_count=%s expected=1 and no Fresh agentdesk\n' "$mutation" "$compile_count" >&2
+  # #5243: rc alone cannot separate "the test caught the mutant" from "the mutant
+  # did not compile" — cargo returns 101 for both. A failed build also writes no
+  # fingerprint, so it recompiles on every retry and satisfies the cache proof
+  # above with the same compiling=1 fresh=0 values a real kill produces. Judge on
+  # the log of this same single invocation. Do not add a second cargo call: a
+  # preceding `cargo check` would make this run Fresh and trip the cache proof.
+  if grep -Fq 'could not compile `agentdesk`' "$log"; then
+    printf 'MUTATION_ORACLE mutation=%s compile_ok=no tests_passed=0 tests_failed=0\n' "$mutation"
+    printf 'ERROR mutation=%s status=BUILD-BROKEN rc=%d target=%s (mutant did not compile)\n' "$mutation" "$rc" "$target" >&2
     cat "$log" >&2
-    return 96
+    return 95
   fi
 
-  # CARGO_TERM_COLOR=never above makes both cache-proof markers stable for grep.
-  printf 'CACHE_PROOF mutation=%s compiling_agentdesk=%s fresh_agentdesk=0\n' "$mutation" "$compile_count"
+  # The named test must actually have executed. `cargo test --lib <name> --exact`
+  # answers rc=0 with "0 passed; 0 failed" when the filter matches nothing, which
+  # the old script reported as "mutation survived" — red, but for the wrong
+  # reason. --exact names exactly one test, so exactly one must have run.
+  test_result="$( { grep -E '^test result: (ok|FAILED)\. [0-9]+ passed; [0-9]+ failed;' "$log" || true; } | head -n 1)"
+  case "$test_result" in
+    'test result: ok. 1 passed; 0 failed;'* | 'test result: FAILED. 0 passed; 1 failed;'*) ;;
+    *)
+      printf 'MUTATION_ORACLE mutation=%s compile_ok=yes tests_passed=0 tests_failed=0\n' "$mutation"
+      printf 'ERROR mutation=%s status=NO-TEST-RAN rc=%d target=%s (named test did not execute)\n' "$mutation" "$rc" "$target" >&2
+      cat "$log" >&2
+      return 94
+      ;;
+  esac
+
+  rest="${test_result#*. }"
+  passed="${rest%% passed;*}"
+  rest="${rest#* passed; }"
+  failed="${rest%% failed;*}"
+  # #5243: the KILLED path deletes its own log, so a green run used to leave no
+  # trace of what killed the mutant. Emit the verdict's evidence on stdout, where
+  # the existing MUTATION_* markers already go, rather than inventing a new
+  # artifact path.
+  printf 'MUTATION_ORACLE mutation=%s compile_ok=yes tests_passed=%s tests_failed=%s\n' "$mutation" "$passed" "$failed"
   return "$rc"
 }
 
@@ -209,9 +259,10 @@ run_mutation() {
     rm -f "$log"
     exit 1
   fi
-  if ((rc == 96)); then
+  # 94/95/96 already streamed the full log to stderr inside run_target.
+  if ((rc == 94 || rc == 95 || rc == 96)); then
     rm -f "$log"
-    exit 96
+    exit "$rc"
   fi
 
   printf 'MUTATION_RESULT mutation=%s status=KILLED rc=%d target=%s\n' "$mutation" "$rc" "$target"

--- a/tests/test_relay_authority_mutations.py
+++ b/tests/test_relay_authority_mutations.py
@@ -15,6 +15,67 @@ TERMINAL_HANDOFF = Path("src/services/discord/session_relay_sink/terminal_handof
 SESSION_RELAY_SINK = Path("src/services/discord/session_relay_sink.rs")
 
 
+def _cargo_log(body: str) -> str:
+    """A fixture-runner body that replays a realistic `cargo test --lib` log.
+
+    #5243: the oracle grades the log of the single cargo invocation, so a fixture
+    runner that prints nothing is no longer a stand-in for a killed mutant.
+    """
+    return "cat <<'RELAY_AUTHORITY_LOG'\n" + body + "RELAY_AUTHORITY_LOG\n"
+
+
+COMPILED_HEADER = """   Compiling agentdesk v0.1.2 (/repo)
+    Finished test profile [unoptimized + debuginfo] target(s) in 12.34s
+     Running unittests src/lib.rs (target/debug/deps/agentdesk-0123456789abcdef)
+
+"""
+
+# The test named for the mutation ran and failed: a real kill.
+KILLED_RUNNER = _cargo_log(
+    COMPILED_HEADER
+    + """running 1 test
+test the_named_target ... FAILED
+
+failures:
+    the_named_target
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 130 filtered out; finished in 0.02s
+"""
+) + "exit 101\n"
+
+# The test ran and passed: the mutation survived.
+SURVIVED_RUNNER = _cargo_log(
+    COMPILED_HEADER
+    + """running 1 test
+test the_named_target ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 130 filtered out; finished in 0.02s
+"""
+) + "exit 0\n"
+
+# rustc rejected the mutant: cargo still answers 101, and the build leaves no
+# fingerprint, so the cache proof still sees compiling=1 fresh=0.
+BUILD_BROKEN_RUNNER = _cargo_log(
+    """   Compiling agentdesk v0.1.2 (/repo)
+error[E0425]: cannot find value `terminal_not_delivered` in this scope
+   --> src/services/discord/session_relay_sink/terminal_handoff.rs:111:31
+
+error: aborting due to 1 previous error
+
+error: could not compile `agentdesk` (lib test) due to 1 previous error
+"""
+) + "exit 101\n"
+
+# The named test no longer exists: the filter matches nothing and cargo says rc=0.
+NO_TEST_RAN_RUNNER = _cargo_log(
+    COMPILED_HEADER
+    + """running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 131 filtered out; finished in 0.00s
+"""
+) + "exit 0\n"
+
+
 class RelayAuthorityMutationScriptTests(unittest.TestCase):
     maxDiff = None
 
@@ -51,18 +112,23 @@ class RelayAuthorityMutationScriptTests(unittest.TestCase):
         return runner
 
     @staticmethod
-    def write_fake_cargo(root: Path) -> Path:
+    def write_fake_cargo(root: Path, *, cached: bool = False) -> Path:
         bin_dir = root / "fake-bin"
         bin_dir.mkdir()
         cargo = bin_dir / "cargo"
+        marker = "Fresh" if cached else "Compiling"
         cargo.write_text(
-            """#!/usr/bin/env bash
+            f"""#!/usr/bin/env bash
 set -euo pipefail
-if [[ "${CARGO_TERM_COLOR-}" == "never" ]]; then
-    printf '   Compiling agentdesk v0.1.0 (fake)\\n'
+if [[ "${{CARGO_TERM_COLOR-}}" == "never" ]]; then
+    printf '   {marker} agentdesk v0.1.0 (fake)\\n'
 else
-    printf '\\033[1m\\033[92m   Compiling\\033[0m agentdesk v0.1.0 (fake)\\n'
+    printf '\\033[1m\\033[92m   {marker}\\033[0m agentdesk v0.1.0 (fake)\\n'
 fi
+printf '     Running unittests src/lib.rs (target/debug/deps/agentdesk-0123456789ab)\\n'
+printf 'running 1 test\\n'
+printf 'test the_named_target ... FAILED\\n'
+printf 'test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out\\n'
 exit 101
 """,
             encoding="utf-8",
@@ -100,10 +166,78 @@ exit 101
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertEqual(result.stdout.count("compiling_agentdesk=1"), 4, result.stdout)
         self.assertNotIn("cache-proof=invalid", result.stderr)
+        # #5243 case E control: a freshly built, genuinely killed mutant must not
+        # be misgraded by the new build/test gates.
+        self.assertNotIn("status=BUILD-BROKEN", result.stderr)
+        self.assertNotIn("status=NO-TEST-RAN", result.stderr)
+        self.assertEqual(
+            result.stdout.count("compile_ok=yes tests_passed=0 tests_failed=1"), 4, result.stdout
+        )
+
+    def test_cache_proof_still_trips_on_a_cached_tree(self) -> None:
+        root = self.copy_fixture()
+        cargo = self.write_fake_cargo(root, cached=True)
+
+        result = self.run_script_with_fake_cargo(root, cargo)
+
+        self.assertEqual(result.returncode, 96, result.stdout + result.stderr)
+        self.assertIn("cache-proof=invalid", result.stderr)
+        self.assertNotIn("status=BUILD-BROKEN", result.stderr)
+        self.assertNotIn("status=NO-TEST-RAN", result.stderr)
+        self.assert_sources_restored(self, root)
+
+    def test_killed_mutation_records_the_evidence_that_killed_it(self) -> None:
+        root = self.copy_fixture()
+        runner = self.write_runner(root, KILLED_RUNNER)
+
+        result = self.run_script(root, runner)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        for mutation in ("M10", "M6", "M8", "anchor-drop"):
+            self.assertIn(
+                f"MUTATION_ORACLE mutation={mutation} compile_ok=yes "
+                "tests_passed=0 tests_failed=1",
+                result.stdout,
+            )
+
+    def test_mutant_that_does_not_compile_is_build_broken_not_killed(self) -> None:
+        root = self.copy_fixture()
+        runner = self.write_runner(
+            root,
+            'if [[ "$1" == "M8" ]]; then\n' + BUILD_BROKEN_RUNNER + "fi\n" + KILLED_RUNNER,
+        )
+
+        result = self.run_script(root, runner)
+
+        self.assertEqual(result.returncode, 95, result.stdout + result.stderr)
+        self.assertIn("MUTATION_ORACLE mutation=M8 compile_ok=no", result.stdout)
+        self.assertIn("status=BUILD-BROKEN", result.stderr)
+        self.assertIn("mutation=M8", result.stderr)
+        self.assertNotIn("MUTATION_RESULT mutation=M8 status=KILLED", result.stdout)
+        self.assertNotIn("MUTATION_SUMMARY", result.stdout)
+        self.assertIn("could not compile `agentdesk`", result.stderr)
+        self.assert_sources_restored(self, root)
+
+    def test_lost_test_name_is_no_test_ran_not_a_survived_report(self) -> None:
+        root = self.copy_fixture()
+        runner = self.write_runner(
+            root,
+            'if [[ "$1" == "M6" ]]; then\n' + NO_TEST_RAN_RUNNER + "fi\n" + KILLED_RUNNER,
+        )
+
+        result = self.run_script(root, runner)
+
+        self.assertEqual(result.returncode, 94, result.stdout + result.stderr)
+        self.assertIn("status=NO-TEST-RAN", result.stderr)
+        self.assertIn("mutation=M6", result.stderr)
+        self.assertNotIn("mutation survived", result.stderr)
+        self.assertNotIn("status=SURVIVED", result.stderr)
+        self.assertNotIn("MUTATION_SUMMARY", result.stdout)
+        self.assert_sources_restored(self, root)
 
     def test_four_fixed_mutations_are_killed_and_sources_restore(self) -> None:
         root = self.copy_fixture()
-        runner = self.write_runner(root, "exit 101\n")
+        runner = self.write_runner(root, KILLED_RUNNER)
 
         result = self.run_script(root, runner)
 
@@ -125,7 +259,7 @@ exit 101
 
     def test_concurrent_run_fails_closed_without_modifying_sources(self) -> None:
         root = self.copy_fixture()
-        runner = self.write_runner(root, "exit 101\n")
+        runner = self.write_runner(root, KILLED_RUNNER)
         lock_dir = root / "target/relay-authority-mutations.lock"
         lock_dir.mkdir(parents=True)
         before = {
@@ -142,7 +276,7 @@ exit 101
 
     def test_normal_exit_releases_lock_for_subsequent_run(self) -> None:
         root = self.copy_fixture()
-        runner = self.write_runner(root, "exit 101\n")
+        runner = self.write_runner(root, KILLED_RUNNER)
         lock_dir = root / "target/relay-authority-mutations.lock"
 
         first = self.run_script(root, runner)
@@ -158,7 +292,7 @@ exit 101
         root = self.copy_fixture()
         runner = self.write_runner(
             root,
-            'if [[ "$1" == "M6" ]]; then exit 0; fi\nexit 101\n',
+            'if [[ "$1" == "M6" ]]; then\n' + SURVIVED_RUNNER + "fi\n" + KILLED_RUNNER,
         )
 
         result = self.run_script(root, runner)
@@ -166,11 +300,18 @@ exit 101
         self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
         self.assertIn("MUTATION_RESULT mutation=M6 status=SURVIVED rc=0", result.stderr)
         self.assertIn("ERROR mutation survived: M6", result.stderr)
+        # #5243 case D: a test that ran and passed is still SURVIVED, not
+        # NO-TEST-RAN — the two rc=0 shapes must stay distinguishable.
+        self.assertIn(
+            "MUTATION_ORACLE mutation=M6 compile_ok=yes tests_passed=1 tests_failed=0",
+            result.stdout,
+        )
+        self.assertNotIn("status=NO-TEST-RAN", result.stderr)
         self.assert_sources_restored(self, root)
 
     def test_signal_exit_releases_lock_and_restores_sources(self) -> None:
         root = self.copy_fixture()
-        runner = self.write_runner(root, 'kill -TERM "$PPID"\nsleep 1\nexit 101\n')
+        runner = self.write_runner(root, 'kill -TERM "$PPID"\nsleep 1\n' + KILLED_RUNNER)
         lock_dir = root / "target/relay-authority-mutations.lock"
 
         result = self.run_script(root, runner)
@@ -181,7 +322,7 @@ exit 101
 
     def test_missing_mutation_anchor_fails_closed_and_restores_sources(self) -> None:
         root = self.copy_fixture()
-        runner = self.write_runner(root, "exit 101\n")
+        runner = self.write_runner(root, KILLED_RUNNER)
         source = root / TERMINAL_HANDOFF
         source.write_text(
             source.read_text(encoding="utf-8").replace(
@@ -201,7 +342,7 @@ exit 101
 
     def test_mutation_count_floor_is_at_least_four(self) -> None:
         root = self.copy_fixture()
-        runner = self.write_runner(root, "exit 101\n")
+        runner = self.write_runner(root, KILLED_RUNNER)
 
         result = self.run_script(root, runner)
 


### PR DESCRIPTION
## What changed

`scripts/run_relay_authority_mutations.sh` graded a mutant that did not compile as `status=KILLED`. `run_target` now judges on the log of the same single cargo invocation and returns two new failing codes.

Measured on the `agentdesk` crate before this change (issue #5243 comments): a mutant broken by `error[E0425]` and a mutant genuinely caught by its test produced **identical** values for all four signals the script looks at — `Compiling agentdesk v` = 1, no `Fresh agentdesk v`, `rc` = 101. The cache proof passes in both cases, because a failed build writes no fingerprint and therefore recompiles on every retry. The old code path ran `:180` cache proof pass → `:188` return 101 → `:205` not 0 → `:212` not 96 → `:217` `status=KILLED rc=101`.

Concretely, `run_target` now:

1. returns **95 (`BUILD-BROKEN`)** when the log contains ``could not compile `agentdesk` ``;
2. returns **94 (`NO-TEST-RAN`)** unless the log has a `test result:` line reporting exactly one executed test (`ok. 1 passed; 0 failed;` or `FAILED. 0 passed; 1 failed;`). `cargo test --lib <name> -- --exact` answers rc=0 with `0 passed; 0 failed` when the filter matches nothing; the old script called that `mutation survived`, which was red for the wrong reason;
3. prints one `MUTATION_ORACLE mutation=… compile_ok=… tests_passed=… tests_failed=…` line on **every** judged run, including `KILLED`.

The two checks now also run in `fixture` mode, which previously returned early and skipped all log inspection. That is what makes the discrimination table below provable without a 23-minute cargo run.

### No preceding `cargo check`

The issue body proposed running `cargo check` before the test; that proposal is struck through in the body and retracted in the first comment. A preceding compile makes the following `cargo test` entirely `Fresh`, so `compile_count` drops to 0 and the **working** cache proof fires a false `rc=96`. This change adds **no** additional cargo invocation — the number of cargo calls per mutation is unchanged at one.

### Log deletion

`:194` / `:217` delete the per-mutation tempfile on the `KILLED` and `SURVIVED` paths, so a green run left no trace of what killed the mutant (issue #5243, third comment: PR #5246's green `relay-authority-contract` job had 0 occurrences of `Running unittests` and `test result:` in the mutation step). Rather than invent a CI artifact path or a log retention policy, the verdict's evidence is emitted as a single `MUTATION_ORACLE` line on stdout, next to the `CACHE_PROOF` / `MUTATION_RESULT` markers this script already writes there. `rm -f "$log"` is kept; the failing paths keep the existing `cat "$log" >&2` convention.

### Exit codes

Documented in a new header block. `94` and `95` are new and are both gate failures; `1` (SURVIVED), `2`, `75`, `96`, `97`, `98` and the signal codes are unchanged. The invocation `bash scripts/run_relay_authority_mutations.sh` pinned by `tests/test_fast_check_ci_wiring.py:399` and `scripts/check-ci-runner-hardening.sh:323` is untouched.

## Files

- `scripts/run_relay_authority_mutations.sh`
- `tests/test_relay_authority_mutations.py`

No `.rs` file changed. The four hand-written mutations' anchors and replacement strings are byte-identical to base.

## Discrimination — what breaks the green

Cases A–E run in `RELAY_AUTHORITY_MUTATION_TEST_MODE=fixture` or against a fake `cargo` on `PATH`; F is a real `cargo test` sweep of the four mutations on a clean tree.

| # | scenario | before | after |
|---|---|---|---|
| A | real mutation, test catches it | `KILLED rc=101` | `KILLED rc=101` + `MUTATION_ORACLE compile_ok=yes tests_passed=0 tests_failed=1` |
| B | mutant does not compile | **`KILLED rc=101`, summary `status=PASS`, exit 0** | **`status=BUILD-BROKEN`, exit 95, no `MUTATION_SUMMARY`** |
| C | named test no longer exists | `mutation survived`, exit 1 (misleading) | `status=NO-TEST-RAN`, exit 94 |
| D | mutation survives a passing test | `SURVIVED`, exit 1 | `SURVIVED`, exit 1 (unchanged) + oracle line `tests_passed=1 tests_failed=0` |
| E | cached tree (`Fresh agentdesk v`) | `cache-proof=invalid`, exit 96 | unchanged, exit 96 — and a freshly built genuine kill is **not** misgraded 94/95 |
| F | clean tree, all four mutations, real cargo | 4× `KILLED` with no log evidence | 4× `KILLED` with a per-mutation `test result:` receipt |

Case F, one local `RELAY_AUTHORITY_MUTATION_TEST_MODE=cargo` sweep on this branch's clean tree (macOS, `SWEEP_RC=0`):

```
CACHE_PROOF mutation=M10 compiling_agentdesk=1 fresh_agentdesk=0
MUTATION_ORACLE mutation=M10 compile_ok=yes tests_passed=0 tests_failed=1
MUTATION_RESULT mutation=M10 status=KILLED rc=101 target=…relay_deliver_preserves_tail_anchor_and_observes_persisted_proof
CACHE_PROOF mutation=M6 compiling_agentdesk=1 fresh_agentdesk=0
MUTATION_ORACLE mutation=M6 compile_ok=yes tests_passed=0 tests_failed=1
MUTATION_RESULT mutation=M6 status=KILLED rc=101 target=…fenced_terminal_without_parser_delivery_is_terminal_not_delivered
CACHE_PROOF mutation=M8 compiling_agentdesk=1 fresh_agentdesk=0
MUTATION_ORACLE mutation=M8 compile_ok=yes tests_passed=0 tests_failed=1
MUTATION_RESULT mutation=M8 status=KILLED rc=101 target=…relay_deliver_propagates_injected_transport_error
CACHE_PROOF mutation=anchor-drop compiling_agentdesk=1 fresh_agentdesk=0
MUTATION_ORACLE mutation=anchor-drop compile_ok=yes tests_passed=0 tests_failed=1
MUTATION_RESULT mutation=anchor-drop status=KILLED rc=101 target=…relay_deliver_preserves_tail_anchor_and_observes_persisted_proof
MUTATION_SUMMARY killed=4 survived=0 minimum=4 status=PASS
```

All four rows now carry `compile_ok=yes tests_passed=0 tests_failed=1`: each mutant compiled and its named test ran and failed. On base, the same four rows carried nothing but `CACHE_PROOF` and `status=KILLED`, which is also what a mutant that never compiled would have printed.

Five tests in `tests/test_relay_authority_mutations.py` fail when the old script is restored under the new tests: `test_mutant_that_does_not_compile_is_build_broken_not_killed`, `test_lost_test_name_is_no_test_ran_not_a_survived_report`, `test_killed_mutation_records_the_evidence_that_killed_it`, `test_surviving_mutation_makes_the_gate_red_and_restores_sources`, `test_color_neutralization_keeps_cache_proof_color_proof`. Under the old script, case B prints `MUTATION_RESULT mutation=M8 status=KILLED rc=101` and `MUTATION_SUMMARY killed=4 survived=0 minimum=4 status=PASS` with exit 0.

The existing fixture runners were bodies that printed nothing and `exit 101`. Those are exactly the shape this bug grades as a kill, so they were replaced with realistic `cargo test` transcripts.

## What this does not close

- **The verdict is bound to the crate-name literal `agentdesk`.** Both ``could not compile `agentdesk` `` and `Compiling agentdesk v` are hardcoded. Renaming the crate silently disarms the build check *and* the cache proof; nothing in this repo fails when that happens.
- **Bound to cargo's human-readable output.** `test result:` and ``could not compile `x` `` are libtest/cargo presentation strings, not a stable interface. A cargo release that reformats them turns every mutation into `NO-TEST-RAN` (fail-closed) — loud, but a maintenance cost.
- **`NO-TEST-RAN` requires exactly one executed test**, which is correct only because every row uses `-- --exact` with a fully qualified name. A future row using a prefix filter would be rejected.
- **A test that aborts the process** (SIGABRT, stack overflow) prints no `test result:` line and is now graded `NO-TEST-RAN` rather than `KILLED`. Fail-closed, but it is a behavior change.
- **M8's replacement still hardcodes the local variable name `terminal_not_delivered`.** This PR makes that break loudly instead of silently; it does not make the mutation robust to a rename. That is mutation-side work and is deliberately not in an oracle-fixing PR.
- **The anchor-drop oracle coupling** described in the issue's "별건" section (the killing assertion rides on the `#[cfg(test)]`-only `test_replace_anchor` path, so the production formatter never runs) is untouched here.
- Measurements in this PR are from this branch on macOS with the current toolchain. "Measured here" is not "always true".

`Fixes #5243`
