### PR TITLE
fix(deploy): the deploy shell writes and reads both restart-marker directories (#5245 phase 1)

### DIFF
--- a/scripts/_defaults.sh
+++ b/scripts/_defaults.sh
@@ -787,6 +787,12 @@ assert_restart_helpers_loaded() {
   # restart-drain helpers. Returns non-zero (so callers can `if !` and exit 1)
   # instead of letting a missing function silently `command not found`. See
   # #1447: silent fail of agentdesk-restart when these helpers were absent.
+  # Public entry points only. The #5245 internal helpers (_set_restart_marker_roots,
+  # _restart_marker_consumed_root, _release_unacknowledged_restart_lease) are
+  # deliberately NOT listed: this contract is checked against a possibly older
+  # mirror of this file (restart_agentdesk.sh sources the release workspace copy),
+  # and such a copy is self-consistent — listing them would make the restart skill
+  # hard-fail on an un-updated node for no correctness gain.
   local missing=()
   local fn
   for fn in \

--- a/scripts/_defaults.sh
+++ b/scripts/_defaults.sh
@@ -860,6 +860,36 @@ _restart_marker_consumed_root() {
   return 1
 }
 
+_release_unacknowledged_restart_lease() {
+  # Called once the runtime has acknowledged durability. The runtime that
+  # published the acknowledgement removes its own restart_pending and exits
+  # (runtime_bootstrap/spawns.rs). The other root has no consumer at all — no
+  # Rust code reads "$ROOT/runtime/restart_*" — so its marker would outlive
+  # this deploy and make the next request fail O_EXCL acquisition with
+  # "restart drain marker already owned". Before #5245 this leak was
+  # unreachable because the acknowledgement never arrived and every exit from
+  # the gate went through clear_restart_drain_mode.
+  #
+  # The acknowledged root is deliberately left alone: deleting its marker would
+  # race the runtime's post-rename recheck, which reads a missing marker as
+  # "superseded" and withdraws the acknowledgement it just published.
+  local expected_nonce="$1"; shift
+  local ack_root="$1"; shift
+  local root marker
+  for root in "$@"; do
+    if [ "$root" = "$ack_root" ]; then
+      continue
+    fi
+    marker="$root/restart_pending"
+    # Only ever release the lease this request owns.
+    if [ -f "$marker" ] \
+      && grep -Fqx "nonce=${expected_nonce}" "$marker" 2>/dev/null; then
+      rm -f "$marker" 2>/dev/null || true
+    fi
+  done
+  return 0
+}
+
 clear_restart_drain_mode() {
   local runtime_root="$1"
   local roots=()
@@ -977,6 +1007,7 @@ wait_for_restart_persistence_or_fail() {
       if [ -f "$ack" ] \
         && grep -Fqx "nonce=${expected_nonce}" "$ack" 2>/dev/null; then
         echo "✓ [gate] ${scope} restart persistence acknowledged by runtime at ${root}"
+        _release_unacknowledged_restart_lease "$expected_nonce" "$root" "${roots[@]}"
         return 0
       fi
     done

--- a/scripts/_defaults.sh
+++ b/scripts/_defaults.sh
@@ -806,26 +806,96 @@ assert_restart_helpers_loaded() {
   return 0
 }
 
+# --- #5245 phase 1: the shell and the runtime watch different directories ---
+#
+# deploy-release.sh passes "$ADK_REL/runtime" as the restart marker directory
+# (scripts/deploy-release.sh, the request_restart_drain_mode_or_fail call).
+# The runtime resolves its own marker directory through
+# crate::agentdesk_runtime_root() (src/config.rs), which returns
+# $AGENTDESK_ROOT_DIR verbatim — i.e. "$ADK_REL", without the "runtime"
+# component. No Rust code reads or writes "$ROOT/runtime/restart_*". The two
+# writers therefore never met: the deploy wrote restart_pending where nothing
+# was watching, and waited for restart_persisted where nothing was writing.
+#
+# Moving the Rust side alone cannot repair a node, because the process that has
+# to observe a deploy's restart request is always the binary that is *already
+# running* — the old one. So phase 1 makes the shell write to and read from
+# BOTH directories; the Rust move and the removal of the old directory are
+# separate, later slices.
+#
+# The second directory is never derived from the first. `dirname` would be
+# wrong for skills/agentdesk-restart/scripts/restart_agentdesk.sh, which passes
+# "$HOME/.adk/release" — already the runtime's own root, whose dirname is
+# "$HOME/.adk". The caller states the mirror explicitly through
+# AGENTDESK_RESTART_MARKER_MIRROR_ROOT; deploy-release.sh sets it to the same
+# $ADK_REL it appends "/runtime" to. Unset or empty (every other caller) keeps
+# the single-root behaviour byte for byte.
+_set_restart_marker_roots() {
+  local primary="$1"
+  local mirror="${AGENTDESK_RESTART_MARKER_MIRROR_ROOT:-}"
+  RESTART_MARKER_ROOTS=()
+  if [ -z "$primary" ]; then
+    return 1
+  fi
+  RESTART_MARKER_ROOTS+=("$primary")
+  if [ -n "$mirror" ] && [ "$mirror" != "$primary" ]; then
+    RESTART_MARKER_ROOTS+=("$mirror")
+  fi
+  return 0
+}
+
+_restart_marker_consumed_root() {
+  # Prints the first root whose restart_pending has disappeared, or returns 1
+  # when every root still holds its marker. "Any", not "all": during this
+  # transition exactly one of the two markers gets consumed, because the
+  # running binary watches exactly one directory. Requiring both to vanish
+  # would silently delete the idle-runtime acknowledgement path.
+  local root
+  for root in "$@"; do
+    if [ ! -e "$root/restart_pending" ]; then
+      printf '%s' "$root"
+      return 0
+    fi
+  done
+  return 1
+}
+
 clear_restart_drain_mode() {
   local runtime_root="$1"
-  local marker="$runtime_root/restart_pending"
-  local cancel="$runtime_root/restart_cancelled"
-  local cancel_tmp="${cancel}.$$"
+  local roots=()
+  local root marker cancel cancel_tmp
   local nonce=""
+  local rc=0
   if [ -z "$runtime_root" ]; then
     echo "✗ [gate] runtime root is required to clear restart drain mode" >&2
     return 1
   fi
-  if [ -f "$marker" ]; then
-    nonce=$(grep '^nonce=' "$marker" 2>/dev/null | cut -d= -f2- | tr -d '\n')
-  fi
-  # Publish cancellation before removing the request. A poller dropped in
-  # this handoff then still finds its nonce-bound cancellation marker and
-  # rolls its admission fence back instead of leaving restart state stranded.
-  {
-    [ -n "$nonce" ] && printf 'nonce=%s\n' "$nonce"
-    printf 'cancelled_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-  } >"$cancel_tmp" && mv "$cancel_tmp" "$cancel" && rm -f "$marker"
+  _set_restart_marker_roots "$runtime_root" || return 1
+  roots=("${RESTART_MARKER_ROOTS[@]}")
+
+  # One request writes one nonce to every root, so the first marker that still
+  # carries a nonce describes the whole request. Read before any removal: the
+  # root whose marker the runtime already consumed must still receive a
+  # nonce-bound cancellation, otherwise a poller mid-handoff there is stranded.
+  for root in "${roots[@]}"; do
+    if [ -z "$nonce" ] && [ -f "$root/restart_pending" ]; then
+      nonce=$(grep '^nonce=' "$root/restart_pending" 2>/dev/null | cut -d= -f2- | tr -d '\n')
+    fi
+  done
+
+  for root in "${roots[@]}"; do
+    marker="$root/restart_pending"
+    cancel="$root/restart_cancelled"
+    cancel_tmp="${cancel}.$$"
+    # Publish cancellation before removing the request. A poller dropped in
+    # this handoff then still finds its nonce-bound cancellation marker and
+    # rolls its admission fence back instead of leaving restart state stranded.
+    {
+      [ -n "$nonce" ] && printf 'nonce=%s\n' "$nonce"
+      printf 'cancelled_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    } >"$cancel_tmp" && mv "$cancel_tmp" "$cancel" && rm -f "$marker" || rc=1
+  done
+  return "$rc"
 }
 
 _health_origin_header() {
@@ -881,26 +951,43 @@ wait_for_restart_persistence_or_fail() {
   local expected_nonce="$3"
   local max_wait="${4:-30}"
   local waited=0
-  local marker="$runtime_root/restart_pending"
-  local ack="$runtime_root/restart_persisted"
+  local roots=()
+  local root ack
 
   if [ -z "$runtime_root" ]; then
     echo "✗ [gate] ${scope} runtime root is required for restart persistence" >&2
     return 1
   fi
+  if [ -z "$expected_nonce" ]; then
+    # Widening WHERE the acknowledgement may appear must not widen WHAT counts
+    # as one. With an empty expected nonce the `grep -Fqx` below would match a
+    # bare "nonce=" line, so an empty nonce is refused rather than compared.
+    echo "✗ [gate] ${scope} restart persistence requires this request's nonce" >&2
+    return 1
+  fi
+  _set_restart_marker_roots "$runtime_root" || return 1
+  roots=("${RESTART_MARKER_ROOTS[@]}")
 
   while [ "$waited" -lt "$max_wait" ]; do
-    if [ -f "$ack" ] \
-      && grep -Fqx "nonce=${expected_nonce}" "$ack" 2>/dev/null; then
-      echo "✓ [gate] ${scope} restart persistence acknowledged by runtime"
-      return 0
-    fi
+    for root in "${roots[@]}"; do
+      ack="$root/restart_persisted"
+      # Nonce equality remains the entire gate. An acknowledgement carrying any
+      # other nonce belongs to another request and proves nothing about this
+      # one; absence of the file at every root proves nothing either.
+      if [ -f "$ack" ] \
+        && grep -Fqx "nonce=${expected_nonce}" "$ack" 2>/dev/null; then
+        echo "✓ [gate] ${scope} restart persistence acknowledged by runtime at ${root}"
+        return 0
+      fi
+    done
     sleep 1
     waited=$((waited + 1))
   done
 
   clear_restart_drain_mode "$runtime_root" || true
-  rm -f "$ack" 2>/dev/null || true
+  for root in "${roots[@]}"; do
+    rm -f "$root/restart_persisted" 2>/dev/null || true
+  done
   echo "✗ [gate] ${scope} restart persistence was not acknowledged within ${max_wait}s" >&2
   echo "  Cleared restart_pending and refused bootout: the in-flight delivery frontier is not durable." >&2
   return 1
@@ -980,7 +1067,10 @@ request_restart_drain_mode_or_fail() {
   local exempt_csv="${6:-${AGENTDESK_RESTART_EXEMPT_CHANNELS:-}}"
   local ack_wait="${AGENTDESK_RESTART_DRAIN_ACK_WAIT:-20}"
   local waited=0
-  local marker
+  local roots=()
+  local acquired=()
+  local root
+  local consumed_root
   local tmp_marker
   local job_state
   local nonce
@@ -992,6 +1082,8 @@ request_restart_drain_mode_or_fail() {
     echo "✗ [gate] ${scope} runtime root is required for restart drain mode" >&2
     return 1
   fi
+  _set_restart_marker_roots "$runtime_root" || return 1
+  roots=("${RESTART_MARKER_ROOTS[@]}")
 
   # 2026-05-26 adk-cdx incident: block restart_pending when any non-exempt
   # channel has a live turn. Without this, destructive E2E that restart
@@ -1003,27 +1095,38 @@ request_restart_drain_mode_or_fail() {
     return 1
   fi
 
-  rm -f "$runtime_root/restart_persisted" "$runtime_root/restart_cancelled" 2>/dev/null || true
+  for root in "${roots[@]}"; do
+    rm -f "$root/restart_persisted" "$root/restart_cancelled" 2>/dev/null || true
+  done
 
-  mkdir -p "$runtime_root" || {
-    echo "✗ [gate] failed to create ${scope} runtime root: $runtime_root" >&2
-    return 1
-  }
+  for root in "${roots[@]}"; do
+    mkdir -p "$root" || {
+      echo "✗ [gate] failed to create ${scope} runtime root: $root" >&2
+      return 1
+    }
+  done
 
-  marker="$runtime_root/restart_pending"
   nonce="$(date -u '+%Y%m%dT%H%M%S')-$$-${RANDOM:-0}"
   # O_EXCL ownership: never overwrite another restart nonce. The marker is the
-  # process-wide restart lease, shared with standby promotion.
-  if ! ( set -o noclobber; {
-    printf 'nonce=%s\n' "$nonce"
-    printf 'source=%s\n' "$source"
-    printf 'scope=%s\n' "$scope"
-    printf 'label=%s\n' "$label"
-    date -u '+requested_at=%Y-%m-%dT%H:%M:%SZ'
-  } >"$marker" ) 2>/dev/null; then
-    echo "✗ [gate] restart drain marker already owned: $marker" >&2
-    return 1
-  fi
+  # process-wide restart lease, shared with standby promotion. Every root must
+  # be acquired under the same nonce or none is: a half-owned lease would let
+  # this deploy proceed while another owner still holds the other directory.
+  for root in "${roots[@]}"; do
+    if ! ( set -o noclobber; {
+      printf 'nonce=%s\n' "$nonce"
+      printf 'source=%s\n' "$source"
+      printf 'scope=%s\n' "$scope"
+      printf 'label=%s\n' "$label"
+      date -u '+requested_at=%Y-%m-%dT%H:%M:%SZ'
+    } >"$root/restart_pending" ) 2>/dev/null; then
+      echo "✗ [gate] restart drain marker already owned: $root/restart_pending" >&2
+      if [ "${#acquired[@]}" -gt 0 ]; then
+        rm -f "${acquired[@]}" 2>/dev/null || true
+      fi
+      return 1
+    fi
+    acquired+=("$root/restart_pending")
+  done
 
   while [ "$waited" -lt "$ack_wait" ]; do
     if _restart_pending_acknowledged "$port"; then
@@ -1033,10 +1136,10 @@ request_restart_drain_mode_or_fail() {
     fi
     # #1447 review P2: idle runtime may consume the marker (restart_ctrl
     # deletes restart_pending and calls exit(0) once all turns drain) before
-    # our 1s poll observes the in-memory flag. If the marker we just wrote
+    # our 1s poll observes the in-memory flag. If a marker we just wrote
     # has disappeared, the runtime acknowledged it the only way it can.
-    if [ ! -e "$marker" ]; then
-      echo "▸ [gate] ${scope} restart drain marker consumed by runtime — treating as acknowledged"
+    if consumed_root="$(_restart_marker_consumed_root "${roots[@]}")"; then
+      echo "▸ [gate] ${scope} restart drain marker consumed by runtime at ${consumed_root} — treating as acknowledged"
       AGENTDESK_RESTART_REQUEST_NONCE="$nonce"
       return 0
     fi
@@ -1051,16 +1154,18 @@ request_restart_drain_mode_or_fail() {
     # and call exit(0) — flapping under KeepAlive. The service is not
     # running, so there is nothing to drain; clear the marker and report
     # success.
-    rm -f "$marker" "$runtime_root/restart_persisted" \
-      "$runtime_root/restart_cancelled" 2>/dev/null || true
+    for root in "${roots[@]}"; do
+      rm -f "$root/restart_pending" "$root/restart_persisted" \
+        "$root/restart_cancelled" 2>/dev/null || true
+    done
     AGENTDESK_RESTART_PERSISTENCE_NOT_REQUIRED=1
     echo "▸ [gate] ${scope} launchd job is not running; cleared restart drain marker (no in-flight turns to drain)"
     return 0
   fi
-  # Late-arriving consumption: marker may have been consumed between the
+  # Late-arriving consumption: a marker may have been consumed between the
   # last poll and the post-loop launchd check. Same ack semantics as above.
-  if [ ! -e "$marker" ]; then
-    echo "▸ [gate] ${scope} restart drain marker consumed by runtime during timeout window — treating as acknowledged"
+  if consumed_root="$(_restart_marker_consumed_root "${roots[@]}")"; then
+    echo "▸ [gate] ${scope} restart drain marker consumed by runtime at ${consumed_root} during timeout window — treating as acknowledged"
     AGENTDESK_RESTART_REQUEST_NONCE="$nonce"
     return 0
   fi

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -2137,6 +2137,15 @@ fi
 # durable; the replacement watcher then resumes from those committed offsets.
 AGENTDESK_RESTART_ALLOW_FOREIGN_TURNS=1
 export AGENTDESK_RESTART_ALLOW_FOREIGN_TURNS
+# #5245: this deploy has always written its restart request to "$ADK_REL/runtime"
+# while the process that must observe it watches "$ADK_REL" — crate::
+# agentdesk_runtime_root() (src/config.rs) returns $AGENTDESK_ROOT_DIR verbatim,
+# and no Rust code reads "$ROOT/runtime/restart_*". At deploy time the observer
+# is always the OLD binary, so the mirror is what reaches an unupgraded node.
+# Stated, not derived: this is the same $ADK_REL the call below appends
+# "/runtime" to — `dirname` of the argument would be a different claim.
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$ADK_REL"
+export AGENTDESK_RESTART_MARKER_MIRROR_ROOT
 if ! request_restart_drain_mode_or_fail \
     "release" "$PLIST_REL" "$REL_PORT" "$ADK_REL/runtime" "deploy-release"; then
     exit 1

--- a/tests/test_restart_drain_helpers.sh
+++ b/tests/test_restart_drain_helpers.sh
@@ -507,6 +507,312 @@ set -e
 unset -f _launchd_job_state
 assert_eq "skip=1 + zero live turns returns 0" "0" "$rc"
 
+echo "== Test 8: #5245 — shell writes and reads BOTH marker directories =="
+# The deploy shell passes "$ADK_REL/runtime" while the running runtime watches
+# "$ADK_REL" (crate::agentdesk_runtime_root returns $AGENTDESK_ROOT_DIR
+# verbatim; no Rust code touches "$ROOT/runtime/restart_*"). Phase 1 mirrors
+# request/cancellation to both and accepts an acknowledgement from either.
+#
+# These cases are the discrimination: 8b/8c prove the widening works, 8d/8e/8f
+# prove it did NOT turn the gate into something that approves anything, and
+# 8a/8h/8k prove the second path is really written and really comes from the
+# explicit variable rather than from dirname.
+TMP_D=$(mktemp -d)
+trap 'rm -rf "$TMP_FIXTURE_DIR" "$TMP_RUNTIME" "$TMPDIR_TEST" "$TMP_RUNTIME2" "$TMP_RUNTIME3" "$TMP_D"' EXIT
+DUAL_PRIMARY="$TMP_D/release/runtime"
+DUAL_MIRROR="$TMP_D/release"
+mkdir -p "$DUAL_PRIMARY"
+
+dual_nonce_of() {
+  grep '^nonce=' "$1" 2>/dev/null | head -1 | cut -d= -f2-
+}
+
+# --- 8a (F): a single request lands in BOTH roots under ONE nonce ------------
+_launchd_job_state() { echo "running"; }
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  PATH="$TMP_FIXTURE_DIR/bin_fail:$PATH" \
+  AGENTDESK_RESTART_DRAIN_ACK_WAIT=1 \
+  request_restart_drain_mode_or_fail "test" "test.label" 0 "$DUAL_PRIMARY" "smoke-test" \
+  >/dev/null 2>&1
+rc=$?
+set -e
+unset -f _launchd_job_state
+assert_eq "dual-root request returns 0 (drain timeout path)" "0" "$rc"
+if [ -f "$DUAL_PRIMARY/restart_pending" ] || [ -f "$DUAL_MIRROR/restart_pending" ]; then
+  fail "timeout path clears the request marker in both roots"
+else
+  pass "timeout path clears the request marker in both roots"
+fi
+if [ -f "$DUAL_PRIMARY/restart_cancelled" ] && [ -f "$DUAL_MIRROR/restart_cancelled" ]; then
+  pass "8e: cancellation reaches both roots, not just the one the shell owns"
+else
+  fail "8e: cancellation reaches both roots, not just the one the shell owns"
+fi
+cancel_primary_nonce=$(dual_nonce_of "$DUAL_PRIMARY/restart_cancelled")
+cancel_mirror_nonce=$(dual_nonce_of "$DUAL_MIRROR/restart_cancelled")
+if [ -n "$cancel_primary_nonce" ] && [ "$cancel_primary_nonce" = "$cancel_mirror_nonce" ]; then
+  pass "both roots were cancelled under the same nonce ($cancel_primary_nonce)"
+else
+  fail "both roots were cancelled under the same nonce (primary=$cancel_primary_nonce mirror=$cancel_mirror_nonce)"
+fi
+
+# Same request again, this time observed while it is still armed: the marker
+# must exist in both roots with an identical nonce. A single-root write (the
+# pre-#5245 behaviour, or a regression that drops one of the two writes) fails
+# here even though the deploy itself would still report success.
+rm -f "$DUAL_PRIMARY/restart_cancelled" "$DUAL_MIRROR/restart_cancelled"
+mkdir -p "$TMP_FIXTURE_DIR/bin_hold"
+cat >"$TMP_FIXTURE_DIR/bin_hold/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 7
+EOF
+chmod +x "$TMP_FIXTURE_DIR/bin_hold/curl"
+_launchd_job_state() { echo "running"; }
+armed_primary=0
+armed_mirror=0
+armed_same_nonce=0
+( for _ in $(seq 1 60); do
+    if [ -f "$DUAL_PRIMARY/restart_pending" ] && [ -f "$DUAL_MIRROR/restart_pending" ]; then
+      break
+    fi
+    sleep 0.1
+  done
+  a=$(grep '^nonce=' "$DUAL_PRIMARY/restart_pending" 2>/dev/null | head -1 | cut -d= -f2- || true)
+  b=$(grep '^nonce=' "$DUAL_MIRROR/restart_pending" 2>/dev/null | head -1 | cut -d= -f2- || true)
+  printf 'primary=%s\nmirror=%s\n' \
+    "$([ -f "$DUAL_PRIMARY/restart_pending" ] && echo 1 || echo 0)" \
+    "$([ -f "$DUAL_MIRROR/restart_pending" ] && echo 1 || echo 0)" >"$TMP_D/armed"
+  printf 'same=%s\n' "$([ -n "$a" ] && [ "$a" = "$b" ] && echo 1 || echo 0)" >>"$TMP_D/armed"
+) &
+OBS_PID=$!
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  PATH="$TMP_FIXTURE_DIR/bin_hold:$PATH" \
+  AGENTDESK_RESTART_DRAIN_ACK_WAIT=4 \
+  request_restart_drain_mode_or_fail "test" "test.label" 0 "$DUAL_PRIMARY" "smoke-test" \
+  >/dev/null 2>&1
+set -e
+wait "$OBS_PID" 2>/dev/null || true
+unset -f _launchd_job_state
+armed_primary=$(grep '^primary=' "$TMP_D/armed" | cut -d= -f2)
+armed_mirror=$(grep '^mirror=' "$TMP_D/armed" | cut -d= -f2)
+armed_same_nonce=$(grep '^same=' "$TMP_D/armed" | cut -d= -f2)
+assert_eq "8a: request armed restart_pending in the shell's own root" "1" "$armed_primary"
+assert_eq "8a: request armed restart_pending in the runtime's root (mirror)" "1" "$armed_mirror"
+assert_eq "8a: both roots carry the same nonce" "1" "$armed_same_nonce"
+
+# --- 8b/8c (A/B): acknowledgement from EITHER root is accepted ---------------
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+printf 'nonce=dual-nonce\n' >"$DUAL_MIRROR/restart_persisted"
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  wait_for_restart_persistence_or_fail "test" "$DUAL_PRIMARY" "dual-nonce" 2 >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "8b (A): ack written ONLY at the runtime root is accepted" "0" "$rc"
+
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+printf 'nonce=dual-nonce\n' >"$DUAL_PRIMARY/restart_persisted"
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  wait_for_restart_persistence_or_fail "test" "$DUAL_PRIMARY" "dual-nonce" 2 >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "8c (B): ack written ONLY at the shell root is accepted" "0" "$rc"
+
+# --- 8d (C): no ack anywhere still fails ------------------------------------
+# This is the safety property of the whole change: widening WHERE we look must
+# not make "nothing acknowledged" pass.
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+touch "$DUAL_PRIMARY/restart_pending" "$DUAL_MIRROR/restart_pending"
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  wait_for_restart_persistence_or_fail "test" "$DUAL_PRIMARY" "dual-nonce" 1 >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "8d (C): ack absent from BOTH roots still refuses bootout" "1" "$rc"
+
+# The refusal must also be observable in both roots, otherwise the runtime that
+# does watch the other directory keeps a fenced admission path forever.
+if [ -f "$DUAL_PRIMARY/restart_cancelled" ] && [ -f "$DUAL_MIRROR/restart_cancelled" ]; then
+  pass "8d: refusal publishes cancellation to both roots"
+else
+  fail "8d: refusal publishes cancellation to both roots"
+fi
+
+# --- 8e (D): an ack with the wrong nonce is not an ack ----------------------
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+printf 'nonce=someone-elses-nonce\n' >"$DUAL_MIRROR/restart_persisted"
+printf 'nonce=another-nonce\n' >"$DUAL_PRIMARY/restart_persisted"
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  wait_for_restart_persistence_or_fail "test" "$DUAL_PRIMARY" "dual-nonce" 1 >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "8e (D): ack present in both roots with a different nonce still fails" "1" "$rc"
+
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+printf 'nonce=dual-nonce-suffix\n' >"$DUAL_MIRROR/restart_persisted"
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  wait_for_restart_persistence_or_fail "test" "$DUAL_PRIMARY" "dual-nonce" 1 >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "8e (D): a nonce that merely starts with ours is not a match" "1" "$rc"
+
+# --- 8f: an empty expected nonce is refused, not compared -------------------
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+printf 'nonce=\n' >"$DUAL_MIRROR/restart_persisted"
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  wait_for_restart_persistence_or_fail "test" "$DUAL_PRIMARY" "" 1 >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "8f: empty nonce is refused even when a bare 'nonce=' ack exists" "1" "$rc"
+
+# --- 8g (E): cancellation recovers the nonce from whichever root still has it
+# The runtime consumes the marker in the ONE directory it watches. The nonce
+# for the cancellation must then be read from the other root, or the surviving
+# poller receives a cancellation it cannot bind to its own request.
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+printf 'nonce=consumed-by-runtime\n' >"$DUAL_PRIMARY/restart_pending"
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  clear_restart_drain_mode "$DUAL_PRIMARY" >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "8g (E): clear succeeds when only one root still holds the marker" "0" "$rc"
+if grep -q '^nonce=consumed-by-runtime$' "$DUAL_MIRROR/restart_cancelled" 2>/dev/null \
+  && grep -q '^nonce=consumed-by-runtime$' "$DUAL_PRIMARY/restart_cancelled" 2>/dev/null; then
+  pass "8g: nonce-bound cancellation reaches the root whose marker was consumed"
+else
+  fail "8g: nonce-bound cancellation reaches the root whose marker was consumed"
+fi
+
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+printf 'nonce=only-in-mirror\n' >"$DUAL_MIRROR/restart_pending"
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  clear_restart_drain_mode "$DUAL_PRIMARY" >/dev/null 2>&1
+set -e
+if grep -q '^nonce=only-in-mirror$' "$DUAL_PRIMARY/restart_cancelled" 2>/dev/null; then
+  pass "8g: nonce is recovered from the mirror when the shell root has none"
+else
+  fail "8g: nonce is recovered from the mirror when the shell root has none"
+fi
+
+# --- 8h: the second root is the stated variable, never dirname --------------
+# skills/agentdesk-restart passes "$HOME/.adk/release", whose dirname is
+# "$HOME/.adk" — deriving the mirror would write markers into an unrelated
+# directory. Point the mirror at a sibling and require the marker to follow the
+# variable, with nothing created at dirname(primary).
+DUAL_SIBLING="$TMP_D/sibling"
+mkdir -p "$DUAL_SIBLING"
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+_launchd_job_state() { echo "not running"; }
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_SIBLING" \
+  PATH="$TMP_FIXTURE_DIR/bin_fail:$PATH" \
+  AGENTDESK_RESTART_DRAIN_ACK_WAIT=1 \
+  request_restart_drain_mode_or_fail "test" "sibling.label" 0 "$DUAL_PRIMARY" "smoke-test" \
+  >/dev/null 2>&1
+set -e
+unset -f _launchd_job_state
+# The job-not-running branch clears every root it armed; the observable proof
+# is that the sibling was cleaned and dirname(primary) was never written.
+if [ -e "$DUAL_MIRROR/restart_pending" ] || [ -e "$DUAL_MIRROR/restart_cancelled" ]; then
+  fail "8h: mirror root is taken from the variable, not from dirname(primary)"
+else
+  pass "8h: mirror root is taken from the variable, not from dirname(primary)"
+fi
+if [ -e "$DUAL_SIBLING/restart_pending" ]; then
+  fail "8h: sibling mirror marker cleared on the not-running branch"
+else
+  pass "8h: sibling mirror marker cleared on the not-running branch"
+fi
+
+# --- 8i: consumption in EITHER root is the idle-runtime acknowledgement -----
+# Only one binary is running, so only one of the two markers is ever consumed.
+# Requiring both to vanish would delete the #1447 ack path outright.
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+_launchd_job_state() { echo "running"; }
+( for _ in $(seq 1 60); do
+    [ -e "$DUAL_MIRROR/restart_pending" ] && break
+    sleep 0.1
+  done
+  command rm -f "$DUAL_MIRROR/restart_pending" ) &
+BG_PID=$!
+set +e
+consumed_out=$(AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  PATH="$TMP_FIXTURE_DIR/bin_fail:$PATH" \
+  AGENTDESK_RESTART_DRAIN_ACK_WAIT=10 \
+  request_restart_drain_mode_or_fail "test" "test.label" 0 "$DUAL_PRIMARY" "smoke-test" \
+  2>&1)
+rc=$?
+set -e
+wait "$BG_PID" 2>/dev/null || true
+unset -f _launchd_job_state
+assert_eq "8i: marker consumed in the runtime root alone counts as ack" "0" "$rc"
+case "$consumed_out" in
+  *"consumed by runtime at $DUAL_MIRROR"*)
+    pass "8i: ack names the root whose marker was consumed" ;;
+  *)
+    fail "8i: ack names the root whose marker was consumed (got: $consumed_out)" ;;
+esac
+
+# Negative twin: while BOTH markers survive, the consumed-branch must not fire.
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+_launchd_job_state() { echo "running"; }
+set +e
+survived_out=$(AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  PATH="$TMP_FIXTURE_DIR/bin_fail:$PATH" \
+  AGENTDESK_RESTART_DRAIN_ACK_WAIT=2 \
+  request_restart_drain_mode_or_fail "test" "test.label" 0 "$DUAL_PRIMARY" "smoke-test" \
+  2>&1)
+set -e
+unset -f _launchd_job_state
+case "$survived_out" in
+  *"consumed by runtime"*)
+    fail "8i: both markers intact must NOT be read as consumption" ;;
+  *)
+    pass "8i: both markers intact must NOT be read as consumption" ;;
+esac
+
+# --- 8k: a half-owned lease is never left behind ---------------------------
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+printf 'nonce=foreign-owner\n' >"$DUAL_MIRROR/restart_pending"
+_launchd_job_state() { echo "running"; }
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  PATH="$TMP_FIXTURE_DIR/bin_fail:$PATH" \
+  AGENTDESK_RESTART_DRAIN_ACK_WAIT=1 \
+  request_restart_drain_mode_or_fail "test" "test.label" 0 "$DUAL_PRIMARY" "smoke-test" \
+  >/dev/null 2>&1
+rc=$?
+set -e
+unset -f _launchd_job_state
+assert_eq "8k: request fails when the mirror root is owned by another nonce" "1" "$rc"
+if [ -e "$DUAL_PRIMARY/restart_pending" ]; then
+  fail "8k: the root acquired first is rolled back on partial acquisition"
+else
+  pass "8k: the root acquired first is rolled back on partial acquisition"
+fi
+if grep -q '^nonce=foreign-owner$' "$DUAL_MIRROR/restart_pending" 2>/dev/null; then
+  pass "8k: the foreign owner's marker is left untouched"
+else
+  fail "8k: the foreign owner's marker is left untouched"
+fi
+
+# --- 8l: with no mirror configured, behaviour is byte-for-byte the old one --
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+printf 'nonce=single-root\n' >"$DUAL_MIRROR/restart_persisted"
+set +e
+wait_for_restart_persistence_or_fail "test" "$DUAL_PRIMARY" "single-root" 1 >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "8l: without the mirror variable the parent directory is NOT consulted" "1" "$rc"
+
 echo
 echo "==== Results ===="
 echo "  PASS: $PASS"

--- a/tests/test_restart_drain_helpers.sh
+++ b/tests/test_restart_drain_helpers.sh
@@ -844,6 +844,47 @@ else
   fail "8k: the foreign owner's marker is left untouched"
 fi
 
+# --- 8n: a successful acknowledgement releases the lease nobody consumes ----
+# Before #5245 the acknowledgement never arrived, so every exit from the gate
+# ran through clear_restart_drain_mode and no marker survived. Now that the gate
+# can succeed, the root that no runtime watches keeps its marker unless it is
+# released — and the next deploy's O_EXCL acquisition would fail with
+# "restart drain marker already owned".
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+printf 'nonce=ack-release\n' >"$DUAL_PRIMARY/restart_pending"
+printf 'nonce=ack-release\n' >"$DUAL_MIRROR/restart_pending"
+printf 'nonce=ack-release\n' >"$DUAL_MIRROR/restart_persisted"
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  wait_for_restart_persistence_or_fail "test" "$DUAL_PRIMARY" "ack-release" 2 >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "8n: ack at the runtime root is accepted" "0" "$rc"
+if [ -e "$DUAL_PRIMARY/restart_pending" ]; then
+  fail "8n: the unwatched root's lease is released so the next deploy can acquire"
+else
+  pass "8n: the unwatched root's lease is released so the next deploy can acquire"
+fi
+if [ -e "$DUAL_MIRROR/restart_pending" ]; then
+  pass "8n: the acknowledging runtime's own marker is left for it to remove"
+else
+  fail "8n: the acknowledging runtime's own marker is left for it to remove"
+fi
+
+# The release is nonce-scoped: a marker owned by somebody else is never freed.
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+printf 'nonce=someone-else\n' >"$DUAL_PRIMARY/restart_pending"
+printf 'nonce=ack-release\n' >"$DUAL_MIRROR/restart_persisted"
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  wait_for_restart_persistence_or_fail "test" "$DUAL_PRIMARY" "ack-release" 2 >/dev/null 2>&1
+set -e
+if grep -q '^nonce=someone-else$' "$DUAL_PRIMARY/restart_pending" 2>/dev/null; then
+  pass "8n: a lease held under another nonce is not released"
+else
+  fail "8n: a lease held under another nonce is not released"
+fi
+
 # --- 8l: with no mirror configured, behaviour is byte-for-byte the old one --
 rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
 printf 'nonce=single-root\n' >"$DUAL_MIRROR/restart_persisted"

--- a/tests/test_restart_drain_helpers.sh
+++ b/tests/test_restart_drain_helpers.sh
@@ -524,7 +524,9 @@ DUAL_MIRROR="$TMP_D/release"
 mkdir -p "$DUAL_PRIMARY"
 
 dual_nonce_of() {
-  grep '^nonce=' "$1" 2>/dev/null | head -1 | cut -d= -f2-
+  # Never fails: a missing file yields the empty string so an assertion below
+  # reports the mismatch instead of `set -e` aborting the suite mid-run.
+  grep '^nonce=' "$1" 2>/dev/null | head -1 | cut -d= -f2- || true
 }
 
 # --- 8a (F): a single request lands in BOTH roots under ONE nonce ------------
@@ -549,8 +551,8 @@ if [ -f "$DUAL_PRIMARY/restart_cancelled" ] && [ -f "$DUAL_MIRROR/restart_cancel
 else
   fail "8e: cancellation reaches both roots, not just the one the shell owns"
 fi
-cancel_primary_nonce=$(dual_nonce_of "$DUAL_PRIMARY/restart_cancelled")
-cancel_mirror_nonce=$(dual_nonce_of "$DUAL_MIRROR/restart_cancelled")
+cancel_primary_nonce=$(dual_nonce_of "$DUAL_PRIMARY/restart_cancelled" || true)
+cancel_mirror_nonce=$(dual_nonce_of "$DUAL_MIRROR/restart_cancelled" || true)
 if [ -n "$cancel_primary_nonce" ] && [ "$cancel_primary_nonce" = "$cancel_mirror_nonce" ]; then
   pass "both roots were cancelled under the same nonce ($cancel_primary_nonce)"
 else
@@ -595,12 +597,50 @@ AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
 set -e
 wait "$OBS_PID" 2>/dev/null || true
 unset -f _launchd_job_state
-armed_primary=$(grep '^primary=' "$TMP_D/armed" | cut -d= -f2)
-armed_mirror=$(grep '^mirror=' "$TMP_D/armed" | cut -d= -f2)
-armed_same_nonce=$(grep '^same=' "$TMP_D/armed" | cut -d= -f2)
+armed_primary=$( (grep '^primary=' "$TMP_D/armed" 2>/dev/null || echo 'primary=absent') | cut -d= -f2)
+armed_mirror=$( (grep '^mirror=' "$TMP_D/armed" 2>/dev/null || echo 'mirror=absent') | cut -d= -f2)
+armed_same_nonce=$( (grep '^same=' "$TMP_D/armed" 2>/dev/null || echo 'same=absent') | cut -d= -f2)
 assert_eq "8a: request armed restart_pending in the shell's own root" "1" "$armed_primary"
 assert_eq "8a: request armed restart_pending in the runtime's root (mirror)" "1" "$armed_mirror"
 assert_eq "8a: both roots carry the same nonce" "1" "$armed_same_nonce"
+
+# --- 8m: a new request pre-cleans EVERY root it will later consult ----------
+# Not cosmetic. gateway_lease_recovery.rs (~:428) treats the mere presence of a
+# restart_persisted written during the current process lifetime as proof that a
+# promotion handoff committed — that check is lifetime-scoped, not nonce-scoped.
+# Two deploys inside one runtime lifetime is the ordinary retry pattern, so an
+# acknowledgement from the previous request left lying in the runtime root is a
+# stale positive for the next one. The old code pre-cleaned only the directory
+# it wrote to; now that both are written, both must be cleaned.
+rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true
+printf 'nonce=stale-request\n' >"$DUAL_PRIMARY/restart_persisted"
+printf 'nonce=stale-request\n' >"$DUAL_PRIMARY/restart_cancelled"
+printf 'nonce=stale-request\n' >"$DUAL_MIRROR/restart_persisted"
+printf 'nonce=stale-request\n' >"$DUAL_MIRROR/restart_cancelled"
+_launchd_job_state() { echo "running"; }
+set +e
+AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$DUAL_MIRROR" \
+  PATH="$TMP_FIXTURE_DIR/bin_fail:$PATH" \
+  AGENTDESK_RESTART_DRAIN_ACK_WAIT=1 \
+  request_restart_drain_mode_or_fail "test" "test.label" 0 "$DUAL_PRIMARY" "smoke-test" \
+  >/dev/null 2>&1
+set -e
+unset -f _launchd_job_state
+if [ -e "$DUAL_PRIMARY/restart_persisted" ]; then
+  fail "8m: stale ack removed from the shell root before the new request arms"
+else
+  pass "8m: stale ack removed from the shell root before the new request arms"
+fi
+if [ -e "$DUAL_MIRROR/restart_persisted" ]; then
+  fail "8m: stale ack removed from the runtime root before the new request arms"
+else
+  pass "8m: stale ack removed from the runtime root before the new request arms"
+fi
+if grep -q '^nonce=stale-request$' "$DUAL_MIRROR/restart_cancelled" 2>/dev/null; then
+  fail "8m: the previous request's cancellation does not survive into this one"
+else
+  pass "8m: the previous request's cancellation does not survive into this one"
+fi
 
 # --- 8b/8c (A/B): acknowledgement from EITHER root is accepted ---------------
 rm -f "$DUAL_PRIMARY"/restart_* "$DUAL_MIRROR"/restart_* 2>/dev/null || true


### PR DESCRIPTION
Phase 1 of 3 for the restart-marker path mismatch. `see #5245`, `see #5254`.

## What changed

The deploy shell now writes its restart request/cancellation to **both** marker
directories and accepts an acknowledgement from **either**.

Precisely:

- `request_restart_drain_mode_or_fail` writes `restart_pending` under one nonce
  to every configured root, under `set -o noclobber` in each; if any root is
  already owned it rolls back the roots it did acquire and refuses.
- `wait_for_restart_persistence_or_fail` accepts a `restart_persisted` whose
  `nonce=` line matches this request at **either** `$runtime_root` or the
  mirror root; nonce equality is unchanged and is still the entire gate.
- `clear_restart_drain_mode` publishes the nonce-bound `restart_cancelled` to
  every root before removing that root's marker, and recovers the nonce from
  whichever root still carries it.
- The `launchd job not running` branch clears every root it armed.
- New: after a successful acknowledgement, the lease is released in the roots
  that did **not** acknowledge (see "One thing this change exposed" below).

## How the second directory is chosen

Stated by the caller, never derived. `scripts/deploy-release.sh` sets

```
AGENTDESK_RESTART_MARKER_MIRROR_ROOT="$ADK_REL"
```

next to the call that passes `"$ADK_REL/runtime"` — the same variable, so the
relationship between the two paths is visible in one place. **`dirname` was
deliberately not used**: `skills/agentdesk-restart/scripts/restart_agentdesk.sh`
passes `"$HOME/.adk/release"`, which is already the runtime's own root, and
`dirname` of it is `"$HOME/.adk"`. With the variable unset or empty — every
caller other than `deploy-release.sh` — behaviour is the previous single-root
behaviour unchanged.

## Why the shell and not the runtime

At deploy time the process that has to observe the restart request is **always
the binary that is already running** — the old one. Moving the Rust side alone
would mean the very deploy that carries the fix cannot reach an unupgraded
node, and it fails exactly as it does today.

## What this does NOT fix (by name)

- **Rust still reads and writes the root level only.** `src/config.rs`
  `runtime_root()` still returns `$AGENTDESK_ROOT_DIR` verbatim; nothing under
  `src/` was touched (`.rs` files changed: 0).
- **The root path is not removed.** Removal is phase 3.
- **G1, G2 and G3 of `#5254` are untouched.** In particular **a phase-1 timeout
  still turns the durability gate off in silence**: `request_...` sets
  `AGENTDESK_RESTART_PERSISTENCE_NOT_REQUIRED=1` on its timeout path and
  `deploy-release.sh` then skips `wait_for_restart_persistence_or_fail` without
  logging that it did so. G3 must land **after** paths agree everywhere, not
  before: a node whose paths have not converged would hard-fail every deploy,
  including the deploy that carries the convergence.
- `_restart_pending_acknowledged` still reads the `/api/health` boolean (G1) and
  a vanished marker is still read as acknowledgement (G2).
- `skills/agentdesk-restart/scripts/restart_agentdesk.sh` was not changed: it
  already passes the root the runtime watches. It will need the mirror in
  phase 2, when Rust moves.

## One thing this change exposed

Before this PR a successful `wait_for_restart_persistence_or_fail` was
unreachable, so **every** exit from the gate went through
`clear_restart_drain_mode` and no marker survived a deploy. Once the gate can
succeed, the root that no running binary watches keeps its `restart_pending`
forever, and the **next** deploy fails `O_EXCL` acquisition with
`restart drain marker already owned`. `_release_unacknowledged_restart_lease`
releases exactly that marker, only when it carries this request's nonce, and
deliberately leaves the acknowledging root's marker alone — deleting it would
race the runtime's post-rename recheck, which reads a missing marker as
"superseded" and withdraws the acknowledgement it just published
(`runtime_bootstrap/spawns.rs`).

Measured, not asserted: two consecutive deploys against a fake root succeed on
this branch; with the release removed, the second one's phase 1 fails.

## Discrimination

Green is not the evidence. What breaks the green is.

`tests/test_restart_drain_helpers.sh` grew from 37 to 70 assertions (no new
test file). **18 mutations of `scripts/_defaults.sh`, 18 killed**, each applied
to a clean tree and reverted:

| mutation | first assertion that goes red |
|---|---|
| write only the primary root | `8a: request armed restart_pending in the runtime's root (mirror)` |
| read the ack from the primary root only | `8b (A): ack written ONLY at the runtime root is accepted` |
| read the ack from the mirror root only | `8c (B): ack written ONLY at the shell root is accepted` |
| drop the nonce comparison | `8e (D): ack present in both roots with a different nonce still fails` |
| treat a missing ack as an ack | `8d (C): ack absent from BOTH roots still refuses bootout` |
| cancel in the primary root only | `8e: cancellation reaches both roots` |
| require ALL markers to vanish for "consumed" | `8i: ack names the root whose marker was consumed` |
| derive the mirror with `dirname` | `8l: without the mirror variable the parent directory is NOT consulted` |
| drop the partial-acquisition rollback | `8k: the root acquired first is rolled back` |
| drop the empty-nonce guard | `8f: empty nonce is refused even when a bare 'nonce=' ack exists` |
| never mirror at all (pre-change behaviour) | 13 assertions |
| pre-clean the primary root only | `8m: stale ack removed from the runtime root before the new request arms` |
| not-running branch clears the primary only | `8h: sibling mirror marker cleared on the not-running branch` |
| read the cancel nonce from the primary only | `8g: nonce is recovered from the mirror when the shell root has none` |
| substring instead of whole-line nonce match | `8e (D): a nonce that merely starts with ours is not a match` |
| never release the unconsumed lease | `8n: the unwatched root's lease is released` |
| release every root including the ack root | `8n: the acknowledging runtime's own marker is left for it to remove` |
| release the lease without checking the nonce | `8n: a lease held under another nonce is not released` |

The two that matter most are the ones that prove the widening did **not** turn
the gate into something that approves anything:

- **C** — no acknowledgement in either root still refuses bootout, and still
  publishes the cancellation to both roots.
- **D** — an acknowledgement present in both roots under someone else's nonce
  still fails, and a nonce that merely *starts with* ours is not a match.

`8m` was found by mutation: it survived the first round. `gateway_lease_recovery.rs`
(~`:428`) treats the presence of any `restart_persisted` from the current process
lifetime as commit proof — that check is lifetime-scoped, not nonce-scoped — so a
previous request's acknowledgement left in the runtime root is a stale positive
for the next one. Now both roots are pre-cleaned, and the assertion says so.

## End-to-end, against a fake root

No deploy was run, no `launchctl` called, nothing written under `~/.adk`. A
harness in `/private/tmp/adk-5245-fakeroot` models the running old binary
faithfully — watches `$ROOT/restart_pending`, echoes the nonce it read into
`$ROOT/restart_persisted`, removes the request — with health reporting
`restart_pending: true` immediately, which is the mac-mini shape where phase 1
passes and phase 2 actually runs:

```
BASE (708aba214)  phase1=0 not_required=0 phase2=1   <- reproduces the failure
HEAD (this PR)    phase1=0 not_required=0 phase2=0
```

On BASE the runtime root ends up with no files at all: the request never
reached the process. On HEAD the acknowledgement is found at the runtime root
and the shell root is left clean.

## Remaining phases

2. Move the Rust side to `$ROOT/runtime`, and give
   `skills/agentdesk-restart/scripts/restart_agentdesk.sh` the mirror. Only
   after every node in the cluster runs a binary from this PR or later.
3. Remove the root path from the shell once every node runs a phase-2 binary.

`#5254` G3 lands after phase 1 is everywhere, not before.

Do not merge on my say-so — CI evidence is below and the merge decision is the
orchestrator's.
