### PR TITLE
fix(deploy): post-deploy 스모크의 릴레이 wedge skip 을 회계하고 재시작 복구를 대기한다 (#5244)

### DIFF
--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -2663,7 +2663,7 @@ POST_DEPLOY_SMOKE_WEDGE_RECOVERY_POLL_SECS=5
 # in $ADK_REL/runtime and fail the smoke once they reach this limit.
 POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS="${AGENTDESK_POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS:-3}"
 POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE="$ADK_REL/runtime/post_deploy_smoke_wedge_skips.json"
-# Set by the single gate; consumed by _post_deploy_smoke_check_wedges.
+# Set to the cleared body contents by the gate; consumed by the wedge readers.
 POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED=""
 POST_DEPLOY_SMOKE_WEDGE_GATED_BODY=""
 POST_DEPLOY_SMOKE_WEDGE_GATE_JQ_OK=""
@@ -2729,52 +2729,34 @@ _post_deploy_smoke_probe_apis() {
 }
 
 # ── #5244: the single gate ───────────────────────────────────────────────────
-# Three review rounds produced the same class of defect: some site could not
-# evaluate the relay state, treated that as evaluated, and returned a clean
-# verdict. Patching site by site only exposed the next site. So "cannot
-# evaluate" is decided in ONE function, _post_deploy_smoke_wedge_gate, and its
-# verdict is enforced in ONE place, the exit assertion of
-# _post_deploy_smoke_check_wedges. A tripped gate is an accounting FAILURE, not
-# a skip.
+# "Cannot evaluate" is decided by _post_deploy_smoke_wedge_gate and enforced by
+# the exit assertion of _post_deploy_smoke_check_wedges. A trip is an accounting
+# FAILURE, not a skip.
 #
-# Cross-shell note that shapes this structure: the gate must run in the parent
-# shell. Called from inside a command substitution it could not publish
-# POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED or append to POST_DEPLOY_SMOKE_FAILURES.
-# So it runs where a body ARRIVES (entry + _post_deploy_smoke_wedge_fetch_
-# health_detail), and _post_deploy_smoke_wedge_jq — the sole jq reader of
-# /api/health/detail BODIES — refuses to parse any body the gate has not just
-# cleared. That refusal is what makes a removed gate call observable rather
-# than silent.
+# The gate runs in the parent shell so its flag and failures survive command
+# substitutions. It runs when a body arrives; the sole body reader refuses
+# content the gate did not clear.
 #
-# "Sole reader" is scoped to bodies deliberately: counted 2026-08-08, this
-# subsystem invokes jq five times across four functions, and three of those
-# functions are intentionally NOT routed through _post_deploy_smoke_wedge_jq.
+# "Sole reader" is scoped to health bodies, not every jq invocation:
 #   _post_deploy_smoke_wedge_gate_jq     two invocations, `jq --version` and the
-#       semantic self-test. The gate's own bootstrap; it necessarily runs before
-#       any body has been cleared.
+#       semantic self-test, before a body can be cleared.
 #   _post_deploy_smoke_wedge_gate_body   the gate's own schema assertion. It is
 #       what clears a body, so it cannot require a cleared body.
 #   _post_deploy_smoke_wedge_jq          every read of a cleared health body.
 #   _post_deploy_smoke_wedge_state_read  parses the local skip-state file, not
-#       a health body — a different trust domain with its own range checks.
+#       a health body.
 #
-# One more literal correction: the entry point does judge one thing before the
-# gate runs. An absent or empty POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY is failed
-# outright in _post_deploy_smoke_check_wedges. That is the only pre-gate
-# judgement, and it is unconditionally a FAILURE, never a skip.
+# Before the gate, an absent or empty primary body is a FAILURE, never a skip.
 
 # jq floor plus a semantic self-test.
 #
-# Floor. Below 1.7 the wedge filters have never been exercised here, and the
-# floor covers a dependency measured on this box 2026-08-08: the official
+# Floor. A dependency measured on this box 2026-08-08: the official
 # jq-1.6 darwin binary read {"channel_id":1234567890123456789} back as
 # 1234567890123456800, while jq-1.7.1-apple preserved the literal. channel_id
 # is a Rust u64 (src/services/discord/health/snapshot.rs:340) that the marker
 # strings interpolate verbatim, so on 1.6 a wedge marker would name the wrong
-# channel. A missing jq, a nonzero `jq --version`, and version strings whose
-# major/minor are not plain integers (jq-1.8pre, jq-1.7rc1) all fail closed. A
-# suffixed PATCH field is accepted: the release box measured 2026-08-08 reports
-# `jq-1.7.1-apple`, which is 1.7 with a vendor tag.
+# channel. Missing/old/unparseable jq versions fail closed; a patch suffix such
+# as the measured `jq-1.7.1-apple` is accepted.
 #
 # Self-test. A version string is a claim, not behaviour. A jq that exits 0
 # while printing garbage passes every version check, and downstream that garbage
@@ -2783,8 +2765,8 @@ _post_deploy_smoke_probe_apis() {
 # filters use — object indexing, array typing, ascii_downcase, test(...;"i"),
 # `//` defaulting, string interpolation via join — and demands the exact
 # expected output. What this does NOT do: it does not prove the filters below
-# are correct, only that this jq evaluates their building blocks the way the
-# filters assume.
+# are correct or that jq behaves consistently across calls. A later invocation
+# can still suppress marker output with rc=0 and manufacture a clean verdict.
 _post_deploy_smoke_wedge_gate_jq() {
     local raw version rest major minor probe
     if [ "$POST_DEPLOY_SMOKE_WEDGE_GATE_JQ_OK" = "1" ]; then
@@ -2832,30 +2814,13 @@ _post_deploy_smoke_wedge_gate_jq() {
     return 0
 }
 
-# Shape AND range. `case` proves a value is digits; it does not prove this shell
-# can compare or increment it, and every defect that reached this gate was a
-# range defect, not a shape defect.
-#
-# The bound is not a chosen constant — it is this shell's own, asked rather than
-# hardcoded, so it belongs to whichever bash actually runs the deploy. The one
-# comparison below does both jobs at once, and each half is load-bearing.
-# Measured on bash 3.2.57(1)-release (arm64-apple-darwin26) 2026-08-08:
-#
-#   value                                  $((value + 1))          [ … -gt value ]
-#   9223372036854775806 (2^63-2)           9223372036854775807     rc=0  accepted
-#   9223372036854775807 (2^63-1)           -9223372036854775808    rc=1  rejected
-#   9223372036854775808 (2^63)             -9223372036854775807    rc=2  rejected
-#   999…999 (36 digits)                    -5527149226598858752    rc=2  rejected
-#
-# Note the middle column: `$(( ))` never errors, it wraps silently, so the
-# increment alone proves nothing. It is feeding the RAW value back to `[` as the
-# right-hand operand that rejects the out-of-range ones — `[` refuses to parse
-# them ("integer expression expected", rc=2) — while the `-gt` itself rejects
-# 2^63-1, the one in-range value that wraps when the skip counter increments it.
+# Shape and range: arithmetic wraps silently, so the incremented decimal value
+# must compare greater than the raw digits. `10#` keeps leading zeroes decimal;
+# the raw `[` operand rejects values outside this shell's integer range.
 _post_deploy_smoke_wedge_usable_int() {
     local value="$1"
     case "$value" in ''|*[!0-9]*) return 1 ;; esac
-    [ "$((value + 1))" -gt "$value" ] 2>/dev/null || return 1
+    [ "$((10#$value + 1))" -gt "$value" ] 2>/dev/null || return 1
     return 0
 }
 
@@ -2870,14 +2835,16 @@ _post_deploy_smoke_wedge_usable_int() {
 _post_deploy_smoke_wedge_gate_config() {
     _post_deploy_smoke_wedge_usable_int "$POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS" || return 1
     _post_deploy_smoke_wedge_usable_int "$POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS" || return 1
+    POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS=$((10#$POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS))
+    POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS=$((10#$POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS))
     [ "$POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS" -ge 1 ]
 }
 
 # Losing a skip increment is itself a failure, so writability is a
 # precondition, not something discovered at write time. This is the only place
-# the destination's OWN shape is judged: a symlink or non-regular destination
-# is rejected here, and _post_deploy_smoke_wedge_state_write's `mv -f` replaces
-# that path by rename, which cannot follow a symlink into somewhere else.
+# the destination's OWN shape is judged. A symlink or non-regular destination
+# is rejected here; the later BSD `mv -h` also refuses to follow a directory
+# symlink substituted after this check.
 #
 # The probe path is predictable (`.probe.$$`), so writing it is not enough:
 # a pre-planted symlink there would truncate whatever it points at while
@@ -2927,23 +2894,25 @@ _post_deploy_smoke_wedge_gate_state() {
 #   ------------------------------------------   --------------  -----------------
 #   all consumers : the body itself              object          type == "object"
 #   _markers_from_file : .degraded_reasons[]?    array           (.degraded_reasons|type)
-#   _markers_from_file : .mailboxes[]?           array           (.mailboxes|type)
+#   _markers_from_file : .mailboxes[]? and the mailbox fields below
+#                                                    array        (.mailboxes|type)
 #   _fully_recovered_from_file : .fully_recovered boolean        (.fully_recovered|type)
 #
 # That is the whole set: _post_deploy_smoke_wedge_markers_from_file and
 # _post_deploy_smoke_fully_recovered_from_file are the only two callers of
-# _post_deploy_smoke_wedge_jq, and _post_deploy_smoke_wedge_jq is the only
-# reader of a cleared body.
+# _post_deploy_smoke_wedge_jq. It is the only reader of a body cleared for the
+# wedge check; the later E-1 Python guard separately reads the same primary file.
 #
-# What this gate does NOT assert, and why that is still fail-closed: the shapes
-# INSIDE .mailboxes[] (.relay_stall_state, .relay_health.*, .inflight_state_
-# present, .relay_owner_kind). Measured with jq-1.7.1-apple 2026-08-08, every
-# drift there aborts the filter with rc=5 rather than emitting nothing —
-# `{"relay_stall_state":5}` gives "explode input must be a string", a bare
-# string element gives "Cannot index string with string". A nonzero jq is a
-# parse failure at the call site, never a clean verdict, so those fields do not
-# need a top-level clause. Elements of .degraded_reasons are filtered by
-# `strings` on purpose: non-string reasons carry no marker text.
+# What this gate does NOT assert: the shapes inside `.mailboxes[]` consumed by
+# the marker filter — relay_stall_state; relay_health.desynced,
+# stale_thread_proof, and watcher_attached_stale; inflight_state_present;
+# watcher_attached; provider; and channel_id. With jq-1.7.1-apple, some present
+# type drift aborts the filter (`{"relay_stall_state":5}` returns rc=5), but
+# absent, null, false, and stringified booleans can be absorbed by defaults or
+# comparisons and emit nothing. The shell therefore cannot call those shapes
+# fail-closed. `relay_owner_kind` is deliberately not consumed: the server's
+# MailboxHealthSnapshot does not serialize it. Elements of .degraded_reasons
+# are filtered by `strings` on purpose: non-string reasons carry no marker text.
 #
 # Schema provenance, and its one assumption: measured in
 # src/server/routes/health_api.rs, the registry branch always writes
@@ -2961,12 +2930,15 @@ _post_deploy_smoke_wedge_gate_body() {
     if [ -z "$body_path" ] || [ ! -s "$body_path" ]; then
         return 1
     fi
-    jq -e '
+    if ! POST_DEPLOY_SMOKE_WEDGE_GATED_BODY=$(cat "$body_path" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"); then
+        return 1
+    fi
+    printf '%s' "$POST_DEPLOY_SMOKE_WEDGE_GATED_BODY" | jq -e '
         (type == "object")
         and ((.mailboxes | type) == "array")
         and ((.degraded_reasons | type) == "array")
         and ((.fully_recovered | type) == "boolean")
-    ' "$body_path" >/dev/null 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
+    ' >/dev/null 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
 }
 
 _post_deploy_smoke_wedge_gate() {
@@ -2984,7 +2956,6 @@ _post_deploy_smoke_wedge_gate() {
     elif ! _post_deploy_smoke_wedge_gate_body "$body_path"; then
         reason="/api/health/detail body unavailable, or not an object carrying a mailboxes array, a degraded_reasons array, and a boolean fully_recovered"
     else
-        POST_DEPLOY_SMOKE_WEDGE_GATED_BODY="$body_path"
         return 0
     fi
     POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED="$reason"
@@ -2996,14 +2967,18 @@ _post_deploy_smoke_wedge_gate() {
 # four-site table at the top of this section for the gate's own bootstrap and
 # the skip-state parser, which are deliberate exceptions. It asserts rather
 # than re-derives: the gate already ran in the parent shell, so all this can do
-# is refuse a body that is not the one just cleared.
+# is refuse content that is not the body instance just cleared.
 _post_deploy_smoke_wedge_jq() {
     local body_path="$1"
     local filter="$2"
-    if [ "$body_path" != "$POST_DEPLOY_SMOKE_WEDGE_GATED_BODY" ]; then
+    local body
+    if ! body=$(cat "$body_path" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"); then
         return 1
     fi
-    jq -r "$filter" "$body_path" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
+    if [ "$body" != "$POST_DEPLOY_SMOKE_WEDGE_GATED_BODY" ]; then
+        return 1
+    fi
+    printf '%s' "$body" | jq -r "$filter" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
 }
 
 # Fetch /api/health/detail into $1 and gate it. Distinct return codes so each
@@ -3045,7 +3020,7 @@ _post_deploy_smoke_wedge_state_write() {
         rm -f "$tmp" 2>/dev/null || true
         return 1
     fi
-    if ! mv -f "$tmp" "$dest" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+    if ! mv -fh "$tmp" "$dest" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"; then
         rm -f "$tmp" 2>/dev/null || true
         return 1
     fi
@@ -3111,7 +3086,9 @@ _post_deploy_smoke_wedge_corrupt_tally_read() {
 }
 
 # Returns 0 when the skip was recorded below the limit, 1 when the smoke must
-# fail (limit reached, unwritable state, or a repeated unreadable state).
+# fail (limit reached, unwritable state, or a repeated unreadable state). The
+# normal deploy path is serialized by the release deploy lock; this read/modify/
+# write has no separate lock if callers bypass it or choose different lock files.
 _post_deploy_smoke_wedge_skip_state_bump() {
     local reason="$1"
     local count corrupt
@@ -3135,7 +3112,9 @@ _post_deploy_smoke_wedge_skip_state_bump() {
             "relay wedge skip accounting: skip state unreadable, recovering from 0" || return 1
         count=0
     fi
-    count=$((count + 1))
+    if [ "$count" -lt "$POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS" ]; then
+        count=$((count + 1))
+    fi
     # A lost increment is a lost skip, and a skip that is never counted can
     # never reach the limit. One write failure fails the smoke.
     if ! _post_deploy_smoke_wedge_state_write \
@@ -3183,10 +3162,10 @@ _post_deploy_smoke_wedge_skip() {
 
 _post_deploy_smoke_wedge_markers_from_file() {
     local health_detail_path="$1"
-    # Reuse the health/detail markers consumed by the relay E2E validator:
-    # explicit non-healthy relay_stall_state, ownerless/detached inflight,
-    # desync, stale thread proof, or stale watcher attachment. Ordinary active
-    # turns and queues are deliberately not classified as wedges.
+    # A non-healthy relay_stall_state alone is not a wedge: foreground streams
+    # and explicit background work are normal busy states. relay_owner_kind is
+    # not on this wire surface, so ownerless inflight is also out of scope here.
+    # Keep only evidence the serialized mailbox actually supplies.
     _post_deploy_smoke_wedge_jq "$health_detail_path" '
         [
           .degraded_reasons[]?
@@ -3198,15 +3177,9 @@ _post_deploy_smoke_wedge_markers_from_file() {
           | . as $mailbox
           | (($mailbox.relay_stall_state // "healthy") | ascii_downcase) as $stall
           | select(
-              ($stall != "" and $stall != "healthy")
-              or ($mailbox.relay_health.desynced == true)
+              ($mailbox.relay_health.desynced == true)
               or ($mailbox.relay_health.stale_thread_proof == true)
               or ($mailbox.relay_health.watcher_attached_stale == true)
-              or (
-                $mailbox.inflight_state_present == true
-                and (($mailbox.relay_owner_kind // "none") | ascii_downcase) as $owner
-                | ($owner == "" or $owner == "none" or $owner == "unknown")
-              )
               or (
                 $mailbox.inflight_state_present == true
                 and $mailbox.watcher_attached == false
@@ -3224,9 +3197,9 @@ _post_deploy_smoke_wedge_markers_from_file() {
 # and prints something that is not what it evaluated. Without it, any such
 # output is simply != "true" and the caller silently reads "not recovered",
 # which decays into a skip for a body nobody parsed. Scope: this runs inside
-# `$( )`, so it cannot publish a gate trip; the gate's own self-test is what
-# catches an inconsistent jq up front, and this is the residual guard for a jq
-# that passes the self-test and still garbles a real body.
+# `$( )`, so it cannot publish a gate trip. This narrows per-call jq risk for
+# fully_recovered only. A jq that passes the fixed self-test and later suppresses
+# marker output with rc=0 can still manufacture a clean marker verdict.
 _post_deploy_smoke_fully_recovered_from_file() {
     local health_path="$1"
     local state

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -2892,7 +2892,6 @@ _post_deploy_smoke_wedge_gate_state() {
 #
 #   consumer (function : field touched)          required shape  gate clause
 #   ------------------------------------------   --------------  -----------------
-#   all consumers : the body itself              object          type == "object"
 #   _markers_from_file : .degraded_reasons[]?    array           (.degraded_reasons|type)
 #   _markers_from_file : .mailboxes[]? and the mailbox fields below
 #                                                    array        (.mailboxes|type)
@@ -2934,8 +2933,7 @@ _post_deploy_smoke_wedge_gate_body() {
         return 1
     fi
     printf '%s' "$POST_DEPLOY_SMOKE_WEDGE_GATED_BODY" | jq -e '
-        (type == "object")
-        and ((.mailboxes | type) == "array")
+        ((.mailboxes | type) == "array")
         and ((.degraded_reasons | type) == "array")
         and ((.fully_recovered | type) == "boolean")
     ' >/dev/null 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
@@ -2954,7 +2952,7 @@ _post_deploy_smoke_wedge_gate() {
     elif ! _post_deploy_smoke_wedge_gate_state; then
         reason="skip state ${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE} is not a readable/writable regular file"
     elif ! _post_deploy_smoke_wedge_gate_body "$body_path"; then
-        reason="/api/health/detail body unavailable, or not an object carrying a mailboxes array, a degraded_reasons array, and a boolean fully_recovered"
+        reason="/api/health/detail body unavailable, or not carrying a mailboxes array, a degraded_reasons array, and a boolean fully_recovered"
     else
         return 0
     fi

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -2750,13 +2750,12 @@ _post_deploy_smoke_probe_apis() {
 
 # jq floor plus a semantic self-test.
 #
-# Floor. A dependency measured on this box 2026-08-08: the official
-# jq-1.6 darwin binary read {"channel_id":1234567890123456789} back as
-# 1234567890123456800, while jq-1.7.1-apple preserved the literal. channel_id
-# is a Rust u64 (src/services/discord/health/snapshot.rs:340) that the marker
-# strings interpolate verbatim, so on 1.6 a wedge marker would name the wrong
-# channel. Missing/old/unparseable jq versions fail closed; a patch suffix such
-# as the measured `jq-1.7.1-apple` is accepted.
+# Floor. jq versions that store JSON numbers as doubles lose integer precision
+# above 2^53. channel_id is a Rust u64
+# (src/services/discord/health/snapshot.rs:340) that the marker strings
+# interpolate verbatim, so an imprecise parser can name the wrong channel.
+# Missing/old/unparseable jq versions fail closed; a patch suffix such as
+# `jq-1.7.1-apple` is accepted.
 #
 # Self-test. A version string is a claim, not behaviour. A jq that exits 0
 # while printing garbage passes every version check, and downstream that garbage
@@ -3160,10 +3159,11 @@ _post_deploy_smoke_wedge_skip() {
 
 _post_deploy_smoke_wedge_markers_from_file() {
     local health_detail_path="$1"
-    # A non-healthy relay_stall_state alone is not a wedge: foreground streams
-    # and explicit background work are normal busy states. relay_owner_kind is
-    # not on this wire surface, so ownerless inflight is also out of scope here.
-    # Keep only evidence the serialized mailbox actually supplies.
+    # Foreground streams and explicit background work are normal busy states.
+    # The three non-busy stall states below are wedge evidence in their own
+    # right; stale_thread_proof is covered by its dedicated boolean clause.
+    # relay_owner_kind is not on this wire surface, so ownerless inflight is
+    # out of scope here. Keep only evidence the serialized mailbox supplies.
     _post_deploy_smoke_wedge_jq "$health_detail_path" '
         [
           .degraded_reasons[]?
@@ -3175,7 +3175,10 @@ _post_deploy_smoke_wedge_markers_from_file() {
           | . as $mailbox
           | (($mailbox.relay_stall_state // "healthy") | ascii_downcase) as $stall
           | select(
-              ($mailbox.relay_health.desynced == true)
+              ($stall == "orphan_pending_token")
+              or ($stall == "queue_blocked")
+              or ($stall == "tmux_alive_relay_dead")
+              or ($mailbox.relay_health.desynced == true)
               or ($mailbox.relay_health.stale_thread_proof == true)
               or ($mailbox.relay_health.watcher_attached_stale == true)
               or (

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -2741,18 +2741,52 @@ _post_deploy_smoke_probe_apis() {
 # shell. Called from inside a command substitution it could not publish
 # POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED or append to POST_DEPLOY_SMOKE_FAILURES.
 # So it runs where a body ARRIVES (entry + _post_deploy_smoke_wedge_fetch_
-# health_detail), and _post_deploy_smoke_wedge_jq — the sole jq reader for this
-# subsystem — refuses to parse any body the gate has not just cleared. That
-# refusal is what makes a removed gate call observable rather than silent.
+# health_detail), and _post_deploy_smoke_wedge_jq — the sole jq reader of
+# /api/health/detail BODIES — refuses to parse any body the gate has not just
+# cleared. That refusal is what makes a removed gate call observable rather
+# than silent.
+#
+# "Sole reader" is scoped to bodies deliberately: counted 2026-08-08, this
+# subsystem invokes jq five times across four functions, and three of those
+# functions are intentionally NOT routed through _post_deploy_smoke_wedge_jq.
+#   _post_deploy_smoke_wedge_gate_jq     two invocations, `jq --version` and the
+#       semantic self-test. The gate's own bootstrap; it necessarily runs before
+#       any body has been cleared.
+#   _post_deploy_smoke_wedge_gate_body   the gate's own schema assertion. It is
+#       what clears a body, so it cannot require a cleared body.
+#   _post_deploy_smoke_wedge_jq          every read of a cleared health body.
+#   _post_deploy_smoke_wedge_state_read  parses the local skip-state file, not
+#       a health body — a different trust domain with its own range checks.
+#
+# One more literal correction: the entry point does judge one thing before the
+# gate runs. An absent or empty POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY is failed
+# outright in _post_deploy_smoke_check_wedges. That is the only pre-gate
+# judgement, and it is unconditionally a FAILURE, never a skip.
 
-# jq floor. Below 1.7 the wedge filters have never been exercised here, and an
-# unexercised parser that yields a clean verdict is exactly what this gate
-# exists to prevent. A missing jq, a nonzero `jq --version`, and version
-# strings whose major/minor are not plain integers (jq-1.8pre, jq-1.7rc1) all
-# fail closed. A suffixed PATCH field is accepted: the release box measured
-# 2026-08-08 reports `jq-1.7.1-apple`, which is 1.7 with a vendor tag.
+# jq floor plus a semantic self-test.
+#
+# Floor. Below 1.7 the wedge filters have never been exercised here, and the
+# floor covers a dependency measured on this box 2026-08-08: the official
+# jq-1.6 darwin binary read {"channel_id":1234567890123456789} back as
+# 1234567890123456800, while jq-1.7.1-apple preserved the literal. channel_id
+# is a Rust u64 (src/services/discord/health/snapshot.rs:340) that the marker
+# strings interpolate verbatim, so on 1.6 a wedge marker would name the wrong
+# channel. A missing jq, a nonzero `jq --version`, and version strings whose
+# major/minor are not plain integers (jq-1.8pre, jq-1.7rc1) all fail closed. A
+# suffixed PATCH field is accepted: the release box measured 2026-08-08 reports
+# `jq-1.7.1-apple`, which is 1.7 with a vendor tag.
+#
+# Self-test. A version string is a claim, not behaviour. A jq that exits 0
+# while printing garbage passes every version check, and downstream that garbage
+# reads as "fully_recovered is not true" — a skip for a body nobody parsed. So
+# the gate also pushes one fixed body through the exact constructs the wedge
+# filters use — object indexing, array typing, ascii_downcase, test(...;"i"),
+# `//` defaulting, string interpolation via join — and demands the exact
+# expected output. What this does NOT do: it does not prove the filters below
+# are correct, only that this jq evaluates their building blocks the way the
+# filters assume.
 _post_deploy_smoke_wedge_gate_jq() {
-    local raw version rest major minor
+    local raw version rest major minor probe
     if [ "$POST_DEPLOY_SMOKE_WEDGE_GATE_JQ_OK" = "1" ]; then
         return 0
     fi
@@ -2775,24 +2809,84 @@ _post_deploy_smoke_wedge_gate_jq() {
     case "$major" in ''|*[!0-9]*) return 1 ;; esac
     case "$minor" in ''|*[!0-9]*) return 1 ;; esac
     if [ "$major" -gt 1 ] || { [ "$major" -eq 1 ] && [ "$minor" -ge 7 ]; }; then
-        POST_DEPLOY_SMOKE_WEDGE_GATE_JQ_OK=1
-        return 0
+        :
+    else
+        return 1
     fi
-    return 1
+    if ! probe=$(printf '%s' \
+        '{"mailboxes":[{"relay_stall_state":"STALLED"}],"degraded_reasons":["Relay Wedge"],"fully_recovered":true}' \
+        | jq -r '
+            [ (.fully_recovered | tostring),
+              (.mailboxes | type),
+              (.mailboxes[0].relay_stall_state | ascii_downcase),
+              (.degraded_reasons[] | strings | select(test("relay.*wedge"; "i"))),
+              (.mailboxes[0].absent_field // "dflt")
+            ] | join("|")
+        ' 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"); then
+        return 1
+    fi
+    if [ "$probe" != "true|array|stalled|Relay Wedge|dflt" ]; then
+        return 1
+    fi
+    POST_DEPLOY_SMOKE_WEDGE_GATE_JQ_OK=1
+    return 0
+}
+
+# Shape AND range. `case` proves a value is digits; it does not prove this shell
+# can compare or increment it, and every defect that reached this gate was a
+# range defect, not a shape defect.
+#
+# The bound is not a chosen constant — it is this shell's own, asked rather than
+# hardcoded, so it belongs to whichever bash actually runs the deploy. The one
+# comparison below does both jobs at once, and each half is load-bearing.
+# Measured on bash 3.2.57(1)-release (arm64-apple-darwin26) 2026-08-08:
+#
+#   value                                  $((value + 1))          [ … -gt value ]
+#   9223372036854775806 (2^63-2)           9223372036854775807     rc=0  accepted
+#   9223372036854775807 (2^63-1)           -9223372036854775808    rc=1  rejected
+#   9223372036854775808 (2^63)             -9223372036854775807    rc=2  rejected
+#   999…999 (36 digits)                    -5527149226598858752    rc=2  rejected
+#
+# Note the middle column: `$(( ))` never errors, it wraps silently, so the
+# increment alone proves nothing. It is feeding the RAW value back to `[` as the
+# right-hand operand that rejects the out-of-range ones — `[` refuses to parse
+# them ("integer expression expected", rc=2) — while the `-gt` itself rejects
+# 2^63-1, the one in-range value that wraps when the skip counter increments it.
+_post_deploy_smoke_wedge_usable_int() {
+    local value="$1"
+    case "$value" in ''|*[!0-9]*) return 1 ;; esac
+    [ "$((value + 1))" -gt "$value" ] 2>/dev/null || return 1
+    return 0
 }
 
 # The knobs must be usable arithmetic before anything loops or compares on
-# them: a non-numeric recovery deadline would spin the wait loop forever.
+# them. A non-numeric recovery deadline would spin the wait loop forever; so
+# would an out-of-range one, because every `-ge` against it errors and the loop
+# treats the error as "deadline not reached yet".
+#
+# What this does NOT do: it bounds representability, not wall-clock. A deadline
+# of 10^12 seconds is in range, compares correctly, and still outlasts the
+# deploy. That is an operator-set absurdity, not a shell defect.
 _post_deploy_smoke_wedge_gate_config() {
-    case "$POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS" in ''|*[!0-9]*) return 1 ;; esac
-    case "$POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS" in ''|*[!0-9]*) return 1 ;; esac
+    _post_deploy_smoke_wedge_usable_int "$POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS" || return 1
+    _post_deploy_smoke_wedge_usable_int "$POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS" || return 1
     [ "$POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS" -ge 1 ]
 }
 
 # Losing a skip increment is itself a failure, so writability is a
 # precondition, not something discovered at write time. This is the only place
-# the destination shape is judged: a symlink or non-regular destination is
-# rejected here and the atomic replace below trusts that verdict.
+# the destination's OWN shape is judged: a symlink or non-regular destination
+# is rejected here, and _post_deploy_smoke_wedge_state_write's `mv -f` replaces
+# that path by rename, which cannot follow a symlink into somewhere else.
+#
+# The probe path is predictable (`.probe.$$`), so writing it is not enough:
+# a pre-planted symlink there would truncate whatever it points at while
+# reporting a perfectly writable directory. Unlink first — that removes the
+# symlink, never its target — then create under `set -C`, which makes bash open
+# with O_CREAT|O_EXCL and fail on anything that already exists, dangling
+# symlinks included. Verified on this box 2026-08-08: plain `>` through a
+# symlink truncated the target and returned 0; the same redirection under
+# `set -C` refused with "cannot overwrite existing file".
 _post_deploy_smoke_wedge_gate_state() {
     local dir probe
     if [ "$POST_DEPLOY_SMOKE_WEDGE_GATE_STATE_OK" = "1" ]; then
@@ -2809,9 +2903,10 @@ _post_deploy_smoke_wedge_gate_state() {
         [ -w "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ] || return 1
     fi
     probe="${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.probe.$$"
+    rm -f "$probe" 2>/dev/null || return 1
     # Subshell: a failing `>` redirection reports on the shell's own stderr,
-    # which the command's 2> cannot reach.
-    ( printf '' > "$probe" ) 2>/dev/null || return 1
+    # which the command's 2> cannot reach. `set -C` is scoped to it too.
+    ( set -C; printf '' > "$probe" ) 2>/dev/null || return 1
     rm -f "$probe" 2>/dev/null || return 1
     POST_DEPLOY_SMOKE_WEDGE_GATE_STATE_OK=1
     return 0
@@ -2819,14 +2914,59 @@ _post_deploy_smoke_wedge_gate_state() {
 
 # Top-level schema. `.mailboxes[]?` swallows every non-array shape silently —
 # absent, null, string, number, object — and a swallowed shape yields "no
-# markers", i.e. a clean verdict for a body that was never read.
+# markers", i.e. a clean verdict for a body that was never read. The same is
+# true of `.degraded_reasons[]?`, and a non-boolean `.fully_recovered` reads as
+# "not recovered" and decays into a skip.
+#
+# A gate that checks less than its consumers require reproduces exactly that
+# defect one field over, so the clauses below are derived from an exhaustive
+# enumeration of what reads a cleared body. Every consumption site of
+# POST_DEPLOY_SMOKE_WEDGE_GATED_BODY, and the clause that covers it:
+#
+#   consumer (function : field touched)          required shape  gate clause
+#   ------------------------------------------   --------------  -----------------
+#   all consumers : the body itself              object          type == "object"
+#   _markers_from_file : .degraded_reasons[]?    array           (.degraded_reasons|type)
+#   _markers_from_file : .mailboxes[]?           array           (.mailboxes|type)
+#   _fully_recovered_from_file : .fully_recovered boolean        (.fully_recovered|type)
+#
+# That is the whole set: _post_deploy_smoke_wedge_markers_from_file and
+# _post_deploy_smoke_fully_recovered_from_file are the only two callers of
+# _post_deploy_smoke_wedge_jq, and _post_deploy_smoke_wedge_jq is the only
+# reader of a cleared body.
+#
+# What this gate does NOT assert, and why that is still fail-closed: the shapes
+# INSIDE .mailboxes[] (.relay_stall_state, .relay_health.*, .inflight_state_
+# present, .relay_owner_kind). Measured with jq-1.7.1-apple 2026-08-08, every
+# drift there aborts the filter with rc=5 rather than emitting nothing —
+# `{"relay_stall_state":5}` gives "explode input must be a string", a bare
+# string element gives "Cannot index string with string". A nonzero jq is a
+# parse failure at the call site, never a clean verdict, so those fields do not
+# need a top-level clause. Elements of .degraded_reasons are filtered by
+# `strings` on purpose: non-string reasons carry no marker text.
+#
+# Schema provenance, and its one assumption: measured in
+# src/server/routes/health_api.rs, the registry branch always writes
+# `json["fully_recovered"]` as a bool (:355) and `json["degraded_reasons"]` as
+# Value::Array (:359), and `mailboxes` comes from DiscordHealthSnapshot's
+# `Vec<MailboxHealthSnapshot>` (src/services/discord/health/snapshot.rs:180),
+# so all three are unconditional there. This gate therefore presumes the
+# dcserver path — src/cli/dcserver.rs:1486 passes Some(registry). A
+# registry-less node (src/launch.rs:62 passes None) takes the standalone branch
+# at health_api.rs:466, which emits fully_recovered and degraded_reasons but no
+# `mailboxes` key at all; such a node would trip this gate on every deploy. No
+# deploy target runs that way today.
 _post_deploy_smoke_wedge_gate_body() {
     local body_path="$1"
     if [ -z "$body_path" ] || [ ! -s "$body_path" ]; then
         return 1
     fi
-    jq -e '(type == "object") and ((.mailboxes | type) == "array")' \
-        "$body_path" >/dev/null 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
+    jq -e '
+        (type == "object")
+        and ((.mailboxes | type) == "array")
+        and ((.degraded_reasons | type) == "array")
+        and ((.fully_recovered | type) == "boolean")
+    ' "$body_path" >/dev/null 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
 }
 
 _post_deploy_smoke_wedge_gate() {
@@ -2836,13 +2976,13 @@ _post_deploy_smoke_wedge_gate() {
         return 1
     fi
     if ! _post_deploy_smoke_wedge_gate_config; then
-        reason="wedge knobs are not usable integers"
+        reason="wedge knobs are not integers this shell can compare and increment"
     elif ! _post_deploy_smoke_wedge_gate_jq; then
-        reason="jq is absent, unreadable, or older than 1.7"
+        reason="jq is absent, unreadable, older than 1.7, or failed its semantic self-test"
     elif ! _post_deploy_smoke_wedge_gate_state; then
         reason="skip state ${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE} is not a readable/writable regular file"
     elif ! _post_deploy_smoke_wedge_gate_body "$body_path"; then
-        reason="/api/health/detail body unavailable or not an object with a mailboxes array"
+        reason="/api/health/detail body unavailable, or not an object carrying a mailboxes array, a degraded_reasons array, and a boolean fully_recovered"
     else
         POST_DEPLOY_SMOKE_WEDGE_GATED_BODY="$body_path"
         return 0
@@ -2852,9 +2992,11 @@ _post_deploy_smoke_wedge_gate() {
     return 1
 }
 
-# Sole jq reader for the wedge subsystem. It asserts rather than re-derives:
-# the gate already ran in the parent shell, so all this can do is refuse a body
-# that is not the one just cleared.
+# Sole jq reader of /api/health/detail bodies — not of jq as such; see the
+# four-site table at the top of this section for the gate's own bootstrap and
+# the skip-state parser, which are deliberate exceptions. It asserts rather
+# than re-derives: the gate already ran in the parent shell, so all this can do
+# is refuse a body that is not the one just cleared.
 _post_deploy_smoke_wedge_jq() {
     local body_path="$1"
     local filter="$2"
@@ -2885,11 +3027,21 @@ _post_deploy_smoke_wedge_fetch_health_detail() {
 # ── #5244 S1': skip accounting ───────────────────────────────────────────────
 # Atomic replace. A truncated in-place overwrite would read back as corruption
 # on the next deploy and cost a real skip increment.
+#
+# `.tmp.$$` is as predictable as the gate's probe and needs the same treatment:
+# without it, a symlink planted there is written THROUGH (truncating an
+# unrelated file) and then `mv`d onto the destination, which leaves the state
+# file itself a symlink — the gate's regular-file verdict silently undone by
+# the write it was supposed to protect. Unlink then create under `set -C`
+# (O_CREAT|O_EXCL). The unlink also clears a `.tmp.<pid>` left behind by a
+# crashed deploy that happened to reuse this pid, which would otherwise make
+# the exclusive create fail forever.
 _post_deploy_smoke_wedge_state_write() {
     local content="$1"
     local dest="$2"
     local tmp="${dest}.tmp.$$"
-    if ! ( printf '%s\n' "$content" > "$tmp" ) 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+    rm -f "$tmp" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE" || return 1
+    if ! ( set -C; printf '%s\n' "$content" > "$tmp" ) 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"; then
         rm -f "$tmp" 2>/dev/null || true
         return 1
     fi
@@ -2902,6 +3054,13 @@ _post_deploy_smoke_wedge_state_write() {
 
 # stdout: the stored count. Returns 1 when the file exists but cannot be
 # believed — the caller turns that into the corrupt tally, never into 0.
+#
+# Range is part of "believed". A schema-valid count outside bash's integer
+# range is not a smaller problem than a garbage one: the caller immediately
+# evaluates `count + 1`, and 9223372036854775807 + 1 wraps to
+# -9223372036854775808 (measured here 2026-08-08), which compares below every
+# threshold. A state that has already blown past the limit would come back
+# reading as brand new. Out of range is corruption, not zero.
 _post_deploy_smoke_wedge_state_read() {
     local raw value
     if [ ! -e "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ]; then
@@ -2919,15 +3078,23 @@ _post_deploy_smoke_wedge_state_read() {
     ' 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"); then
         return 1
     fi
-    case "$value" in ''|*[!0-9]*) return 1 ;; esac
+    _post_deploy_smoke_wedge_usable_int "$value" || return 1
     printf '%s\n' "$value"
     return 0
 }
 
 # A corrupted count file cannot record how many deploys in a row it has been
 # corrupt, so the streak lives in a sibling. Without it, permanent corruption
-# restarts at 0 every deploy and the threshold is never reached. The sibling is
-# plaintext and its own corruption degrades to 0 — bounded, and noted.
+# restarts at 0 every deploy and the threshold is never reached.
+#
+# The sibling is plaintext, and an unreadable or out-of-range sibling degrades
+# to 0. Scope of that concession, stated precisely because the weaker version
+# of this sentence under-reported the defence that exists: the caller
+# immediately writes the incremented value back with the same atomic replace,
+# so a sibling corrupted once is repaired on that very deploy and the streak
+# resumes — measured cost is at most one deploy of streak. It is only unbounded
+# against something that re-corrupts or deletes the sibling on EVERY deploy,
+# which is also the only case where the tally never reaches 2.
 _post_deploy_smoke_wedge_corrupt_tally_read() {
     local raw
     if ! raw=$(cat "${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.corrupt" 2>/dev/null); then
@@ -2935,7 +3102,10 @@ _post_deploy_smoke_wedge_corrupt_tally_read() {
         return 0
     fi
     raw="${raw%%$'\n'*}"
-    case "$raw" in ''|*[!0-9]*) printf '0\n'; return 0 ;; esac
+    if ! _post_deploy_smoke_wedge_usable_int "$raw"; then
+        printf '0\n'
+        return 0
+    fi
     printf '%s\n' "$raw"
     return 0
 }
@@ -3048,15 +3218,31 @@ _post_deploy_smoke_wedge_markers_from_file() {
     '
 }
 
+# The gate has already asserted .fully_recovered is a boolean, so the filter's
+# own type check is belt-and-braces — and so is the output check below. It
+# catches the one thing neither the gate nor the filter can: a jq that exits 0
+# and prints something that is not what it evaluated. Without it, any such
+# output is simply != "true" and the caller silently reads "not recovered",
+# which decays into a skip for a body nobody parsed. Scope: this runs inside
+# `$( )`, so it cannot publish a gate trip; the gate's own self-test is what
+# catches an inconsistent jq up front, and this is the residual guard for a jq
+# that passes the self-test and still garbles a real body.
 _post_deploy_smoke_fully_recovered_from_file() {
     local health_path="$1"
-    _post_deploy_smoke_wedge_jq "$health_path" '
+    local state
+    if ! state=$(_post_deploy_smoke_wedge_jq "$health_path" '
         if (.fully_recovered | type) == "boolean" then
             .fully_recovered
         else
             error("fully_recovered is not boolean")
         end
-    '
+    '); then
+        return 1
+    fi
+    case "$state" in
+        true|false) printf '%s\n' "$state" ;;
+        *) return 1 ;;
+    esac
 }
 
 # #5244 S2. Poll until startup recovery finishes or the deadline expires. The

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -91,6 +91,19 @@ fi
 #   AGENTDESK_POST_DEPLOY_SMOKE_WARN_LIMIT  fail-closed WARN count considered
 #                                          abnormal (default: 5 in the bounded
 #                                          sample; one WARN never flags).
+#   AGENTDESK_POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS
+#                                          how long the relay wedge check waits
+#                                          for startup recovery to finish before
+#                                          giving up and recording a skip
+#                                          (default: 90 seconds, polled every 5).
+#   AGENTDESK_POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS
+#                                          consecutive deploys the relay wedge
+#                                          check may skip before the smoke fails
+#                                          (default: 3). The count lives in
+#                                          $ADK_REL/runtime and is node-local:
+#                                          --all-nodes runs this same script on
+#                                          each peer, so peers are covered, but
+#                                          each keeps its own counter.
 #   AGENTDESK_POST_DEPLOY_SMOKE_CREATE_ISSUE
 #                                          default: off. Set to literal
 #                                          "confirmed" only when an operator
@@ -1170,6 +1183,8 @@ _deploy_peer_env_prelude() {
         AGENTDESK_DEPLOY_RUNAWAY_CPU_RATIO \
         AGENTDESK_DEPLOY_RUNAWAY_MIN_ELAPSED \
         AGENTDESK_DEPLOY_TEST_MODE \
+        AGENTDESK_POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS \
+        AGENTDESK_POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS \
         AGENTDESK_REL_PORT \
         AGENTDESK_REPORT_CHANNEL_ID \
         AGENTDESK_REPORT_PROVIDER \
@@ -2638,6 +2653,23 @@ POST_DEPLOY_SMOKE_CORE_API_ENDPOINTS=(
 POST_DEPLOY_SMOKE_LOG_LINES="${AGENTDESK_POST_DEPLOY_SMOKE_LOG_LINES:-500}"
 POST_DEPLOY_SMOKE_WARN_LIMIT="${AGENTDESK_POST_DEPLOY_SMOKE_WARN_LIMIT:-5}"
 POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS=4
+# #5244 S2: a single sample taken moments after the restart reports
+# fully_recovered=false on a perfectly healthy node, so the wedge check used to
+# skip on every deploy. Wait for recovery instead; only an expired deadline is
+# a skip.
+POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS="${AGENTDESK_POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS:-90}"
+POST_DEPLOY_SMOKE_WEDGE_RECOVERY_POLL_SECS=5
+# #5244 S1': a skip is not a pass. Consecutive skips are counted across deploys
+# in $ADK_REL/runtime and fail the smoke once they reach this limit.
+POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS="${AGENTDESK_POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS:-3}"
+POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE="$ADK_REL/runtime/post_deploy_smoke_wedge_skips.json"
+# Set by the single gate; consumed by _post_deploy_smoke_check_wedges.
+POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED=""
+POST_DEPLOY_SMOKE_WEDGE_GATED_BODY=""
+POST_DEPLOY_SMOKE_WEDGE_GATE_JQ_OK=""
+POST_DEPLOY_SMOKE_WEDGE_GATE_STATE_OK=""
+POST_DEPLOY_SMOKE_WEDGE_RECOVERY_BODY=""
+POST_DEPLOY_SMOKE_WEDGE_RECOVERY_REASON=""
 POST_DEPLOY_SMOKE_RELAY_CELL="${AGENTDESK_POST_DEPLOY_SMOKE_RELAY_CELL:-claude-tui}"
 POST_DEPLOY_SMOKE_CREATE_ISSUE="${AGENTDESK_POST_DEPLOY_SMOKE_CREATE_ISSUE:-off}"
 POST_DEPLOY_SMOKE_STAMP="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || printf 'unknown-%s' "$$")"
@@ -2696,13 +2728,296 @@ _post_deploy_smoke_probe_apis() {
     [ "$failed" -eq 0 ]
 }
 
+# ── #5244: the single gate ───────────────────────────────────────────────────
+# Three review rounds produced the same class of defect: some site could not
+# evaluate the relay state, treated that as evaluated, and returned a clean
+# verdict. Patching site by site only exposed the next site. So "cannot
+# evaluate" is decided in ONE function, _post_deploy_smoke_wedge_gate, and its
+# verdict is enforced in ONE place, the exit assertion of
+# _post_deploy_smoke_check_wedges. A tripped gate is an accounting FAILURE, not
+# a skip.
+#
+# Cross-shell note that shapes this structure: the gate must run in the parent
+# shell. Called from inside a command substitution it could not publish
+# POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED or append to POST_DEPLOY_SMOKE_FAILURES.
+# So it runs where a body ARRIVES (entry + _post_deploy_smoke_wedge_fetch_
+# health_detail), and _post_deploy_smoke_wedge_jq — the sole jq reader for this
+# subsystem — refuses to parse any body the gate has not just cleared. That
+# refusal is what makes a removed gate call observable rather than silent.
+
+# jq floor. Below 1.7 the wedge filters have never been exercised here, and an
+# unexercised parser that yields a clean verdict is exactly what this gate
+# exists to prevent. A missing jq, a nonzero `jq --version`, and version
+# strings whose major/minor are not plain integers (jq-1.8pre, jq-1.7rc1) all
+# fail closed. A suffixed PATCH field is accepted: the release box measured
+# 2026-08-08 reports `jq-1.7.1-apple`, which is 1.7 with a vendor tag.
+_post_deploy_smoke_wedge_gate_jq() {
+    local raw version rest major minor
+    if [ "$POST_DEPLOY_SMOKE_WEDGE_GATE_JQ_OK" = "1" ]; then
+        return 0
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        return 1
+    fi
+    if ! raw=$(jq --version 2>/dev/null); then
+        return 1
+    fi
+    case "$raw" in
+        jq-*) version="${raw#jq-}" ;;
+        *) return 1 ;;
+    esac
+    major="${version%%.*}"
+    rest="${version#*.}"
+    if [ "$rest" = "$version" ]; then
+        return 1
+    fi
+    minor="${rest%%.*}"
+    case "$major" in ''|*[!0-9]*) return 1 ;; esac
+    case "$minor" in ''|*[!0-9]*) return 1 ;; esac
+    if [ "$major" -gt 1 ] || { [ "$major" -eq 1 ] && [ "$minor" -ge 7 ]; }; then
+        POST_DEPLOY_SMOKE_WEDGE_GATE_JQ_OK=1
+        return 0
+    fi
+    return 1
+}
+
+# The knobs must be usable arithmetic before anything loops or compares on
+# them: a non-numeric recovery deadline would spin the wait loop forever.
+_post_deploy_smoke_wedge_gate_config() {
+    case "$POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS" in ''|*[!0-9]*) return 1 ;; esac
+    case "$POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS" in ''|*[!0-9]*) return 1 ;; esac
+    [ "$POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS" -ge 1 ]
+}
+
+# Losing a skip increment is itself a failure, so writability is a
+# precondition, not something discovered at write time. This is the only place
+# the destination shape is judged: a symlink or non-regular destination is
+# rejected here and the atomic replace below trusts that verdict.
+_post_deploy_smoke_wedge_gate_state() {
+    local dir probe
+    if [ "$POST_DEPLOY_SMOKE_WEDGE_GATE_STATE_OK" = "1" ]; then
+        return 0
+    fi
+    dir=$(dirname "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE")
+    mkdir -p "$dir" 2>/dev/null || return 1
+    if [ -L "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ]; then
+        return 1
+    fi
+    if [ -e "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ]; then
+        [ -f "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ] || return 1
+        [ -r "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ] || return 1
+        [ -w "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ] || return 1
+    fi
+    probe="${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.probe.$$"
+    # Subshell: a failing `>` redirection reports on the shell's own stderr,
+    # which the command's 2> cannot reach.
+    ( printf '' > "$probe" ) 2>/dev/null || return 1
+    rm -f "$probe" 2>/dev/null || return 1
+    POST_DEPLOY_SMOKE_WEDGE_GATE_STATE_OK=1
+    return 0
+}
+
+# Top-level schema. `.mailboxes[]?` swallows every non-array shape silently —
+# absent, null, string, number, object — and a swallowed shape yields "no
+# markers", i.e. a clean verdict for a body that was never read.
+_post_deploy_smoke_wedge_gate_body() {
+    local body_path="$1"
+    if [ -z "$body_path" ] || [ ! -s "$body_path" ]; then
+        return 1
+    fi
+    jq -e '(type == "object") and ((.mailboxes | type) == "array")' \
+        "$body_path" >/dev/null 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
+}
+
+_post_deploy_smoke_wedge_gate() {
+    local body_path="$1"
+    local reason=""
+    if [ -n "$POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED" ]; then
+        return 1
+    fi
+    if ! _post_deploy_smoke_wedge_gate_config; then
+        reason="wedge knobs are not usable integers"
+    elif ! _post_deploy_smoke_wedge_gate_jq; then
+        reason="jq is absent, unreadable, or older than 1.7"
+    elif ! _post_deploy_smoke_wedge_gate_state; then
+        reason="skip state ${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE} is not a readable/writable regular file"
+    elif ! _post_deploy_smoke_wedge_gate_body "$body_path"; then
+        reason="/api/health/detail body unavailable or not an object with a mailboxes array"
+    else
+        POST_DEPLOY_SMOKE_WEDGE_GATED_BODY="$body_path"
+        return 0
+    fi
+    POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED="$reason"
+    _post_deploy_smoke_fail "relay wedge check unevaluable: ${reason}" || true
+    return 1
+}
+
+# Sole jq reader for the wedge subsystem. It asserts rather than re-derives:
+# the gate already ran in the parent shell, so all this can do is refuse a body
+# that is not the one just cleared.
+_post_deploy_smoke_wedge_jq() {
+    local body_path="$1"
+    local filter="$2"
+    if [ "$body_path" != "$POST_DEPLOY_SMOKE_WEDGE_GATED_BODY" ]; then
+        return 1
+    fi
+    jq -r "$filter" "$body_path" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
+}
+
+# Fetch /api/health/detail into $1 and gate it. Distinct return codes so each
+# caller keeps its own skip reason: 0 evaluable, 1 fetch failed, 2 body empty,
+# 3 gate tripped (already recorded as a FAILURE — must not become a skip).
+_post_deploy_smoke_wedge_fetch_health_detail() {
+    local dest="$1"
+    if ! curl -fsS --connect-timeout 2 --max-time 15 \
+        -H "Origin: http://${ADK_DEFAULT_LOOPBACK}:${REL_PORT}" \
+        -o "$dest" \
+        "http://${ADK_DEFAULT_LOOPBACK}:${REL_PORT}/api/health/detail"; then
+        return 1
+    fi
+    if [ ! -s "$dest" ]; then
+        return 2
+    fi
+    _post_deploy_smoke_wedge_gate "$dest" || return 3
+    return 0
+}
+
+# ── #5244 S1': skip accounting ───────────────────────────────────────────────
+# Atomic replace. A truncated in-place overwrite would read back as corruption
+# on the next deploy and cost a real skip increment.
+_post_deploy_smoke_wedge_state_write() {
+    local content="$1"
+    local dest="$2"
+    local tmp="${dest}.tmp.$$"
+    if ! ( printf '%s\n' "$content" > "$tmp" ) 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+        rm -f "$tmp" 2>/dev/null || true
+        return 1
+    fi
+    if ! mv -f "$tmp" "$dest" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+        rm -f "$tmp" 2>/dev/null || true
+        return 1
+    fi
+    return 0
+}
+
+# stdout: the stored count. Returns 1 when the file exists but cannot be
+# believed — the caller turns that into the corrupt tally, never into 0.
+_post_deploy_smoke_wedge_state_read() {
+    local raw value
+    if [ ! -e "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ]; then
+        printf '0\n'
+        return 0
+    fi
+    if ! raw=$(cat "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"); then
+        return 1
+    fi
+    if ! value=$(printf '%s' "$raw" | jq -r '
+        if (type == "object") and ((.consecutive_skips | type) == "number")
+        then .consecutive_skips
+        else error("consecutive_skips missing or not a number")
+        end
+    ' 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"); then
+        return 1
+    fi
+    case "$value" in ''|*[!0-9]*) return 1 ;; esac
+    printf '%s\n' "$value"
+    return 0
+}
+
+# A corrupted count file cannot record how many deploys in a row it has been
+# corrupt, so the streak lives in a sibling. Without it, permanent corruption
+# restarts at 0 every deploy and the threshold is never reached. The sibling is
+# plaintext and its own corruption degrades to 0 — bounded, and noted.
+_post_deploy_smoke_wedge_corrupt_tally_read() {
+    local raw
+    if ! raw=$(cat "${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.corrupt" 2>/dev/null); then
+        printf '0\n'
+        return 0
+    fi
+    raw="${raw%%$'\n'*}"
+    case "$raw" in ''|*[!0-9]*) printf '0\n'; return 0 ;; esac
+    printf '%s\n' "$raw"
+    return 0
+}
+
+# Returns 0 when the skip was recorded below the limit, 1 when the smoke must
+# fail (limit reached, unwritable state, or a repeated unreadable state).
+_post_deploy_smoke_wedge_skip_state_bump() {
+    local reason="$1"
+    local count corrupt
+    if count=$(_post_deploy_smoke_wedge_state_read); then
+        rm -f "${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.corrupt" 2>/dev/null || true
+    else
+        corrupt=$(_post_deploy_smoke_wedge_corrupt_tally_read)
+        corrupt=$((corrupt + 1))
+        if ! _post_deploy_smoke_wedge_state_write \
+            "$corrupt" "${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.corrupt"; then
+            _post_deploy_smoke_fail \
+                "relay wedge skip accounting: corrupt-streak write failed" || true
+            return 1
+        fi
+        if [ "$corrupt" -ge 2 ]; then
+            _post_deploy_smoke_fail \
+                "relay wedge skip accounting: skip state unreadable on ${corrupt} consecutive deploys" || true
+            return 1
+        fi
+        _post_deploy_smoke_note \
+            "relay wedge skip accounting: skip state unreadable, recovering from 0" || return 1
+        count=0
+    fi
+    count=$((count + 1))
+    # A lost increment is a lost skip, and a skip that is never counted can
+    # never reach the limit. One write failure fails the smoke.
+    if ! _post_deploy_smoke_wedge_state_write \
+        "{\"consecutive_skips\": ${count}}" "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"; then
+        _post_deploy_smoke_fail \
+            "relay wedge skip accounting: state write failed, skip ${count} would be lost" || true
+        return 1
+    fi
+    if [ "$count" -ge "$POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS" ]; then
+        _post_deploy_smoke_fail \
+            "relay wedge check skipped on ${count} consecutive deploys (limit ${POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS}); latest reason: ${reason}" || true
+        return 1
+    fi
+    _post_deploy_smoke_note \
+        "relay wedge skip accounting: consecutive_skips=${count}/${POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS}" || return 1
+    return 0
+}
+
+# Reset ONLY from an evidence-based terminal verdict: markers absent, markers
+# cleared after settle, or a persistent marker confirmed. Resetting anywhere
+# else — in particular on a skip path — makes a recurring late skip unable to
+# accumulate to the limit, which was the r1 defect.
+_post_deploy_smoke_wedge_skip_state_reset() {
+    if [ ! -e "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ] \
+      && [ ! -e "${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.corrupt" ]; then
+        return 0
+    fi
+    if ! _post_deploy_smoke_wedge_state_write \
+        '{"consecutive_skips": 0}' "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"; then
+        _post_deploy_smoke_fail \
+            "relay wedge skip accounting: reset write failed" || true
+        return 1
+    fi
+    rm -f "${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.corrupt" 2>/dev/null || true
+    return 0
+}
+
+# The only way to record a skip. Returns 0 when the wedge check may end
+# quietly, 1 when the consecutive-skip limit turns this deploy's smoke red.
+_post_deploy_smoke_wedge_skip() {
+    local reason="$1"
+    _post_deploy_smoke_note "relay wedge=skipped: ${reason}" || return 1
+    _post_deploy_smoke_wedge_skip_state_bump "$reason"
+}
+
 _post_deploy_smoke_wedge_markers_from_file() {
     local health_detail_path="$1"
     # Reuse the health/detail markers consumed by the relay E2E validator:
     # explicit non-healthy relay_stall_state, ownerless/detached inflight,
     # desync, stale thread proof, or stale watcher attachment. Ordinary active
     # turns and queues are deliberately not classified as wedges.
-    jq -r '
+    _post_deploy_smoke_wedge_jq "$health_detail_path" '
         [
           .degraded_reasons[]?
           | strings
@@ -2730,49 +3045,79 @@ _post_deploy_smoke_wedge_markers_from_file() {
           | "mailbox provider=\($mailbox.provider // "unknown") channel=\($mailbox.channel_id // "unknown") stall=\($stall)"
         ]
         | .[]
-    ' "$health_detail_path" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
+    '
 }
 
 _post_deploy_smoke_fully_recovered_from_file() {
     local health_path="$1"
-    jq -r '
+    _post_deploy_smoke_wedge_jq "$health_path" '
         if (.fully_recovered | type) == "boolean" then
             .fully_recovered
         else
             error("fully_recovered is not boolean")
         end
-    ' "$health_path" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
+    '
 }
 
-_post_deploy_smoke_check_wedges() {
-    local fully_recovered wedge_markers wedge_markers_resampled persistent_markers wedge_summary
-    local resample_path="$POST_DEPLOY_SMOKE_TMP_DIR/api_health_detail_resample.json"
-    if [ -z "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY" ] \
-      || [ ! -s "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY" ]; then
-        _post_deploy_smoke_fail "relay wedge check: /api/health/detail body unavailable" || true
-        return 1
-    fi
+# #5244 S2. Poll until startup recovery finishes or the deadline expires. The
+# body whose fully_recovered=true was observed is published in
+# POST_DEPLOY_SMOKE_WEDGE_RECOVERY_BODY (already gated); the skip reason for an
+# expired deadline is left in POST_DEPLOY_SMOKE_WEDGE_RECOVERY_REASON.
+_post_deploy_smoke_wedge_await_recovery() {
+    local poll_path="$POST_DEPLOY_SMOKE_TMP_DIR/api_health_detail_recovery.json"
+    local waited=0
+    local state rc
+    POST_DEPLOY_SMOKE_WEDGE_RECOVERY_BODY="$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+    POST_DEPLOY_SMOKE_WEDGE_RECOVERY_REASON="startup recovery state unavailable"
+    while :; do
+        if state=$(
+            _post_deploy_smoke_fully_recovered_from_file "$POST_DEPLOY_SMOKE_WEDGE_RECOVERY_BODY"
+        ); then
+            if [ "$state" = "true" ]; then
+                return 0
+            fi
+            POST_DEPLOY_SMOKE_WEDGE_RECOVERY_REASON="startup recovery in progress"
+        else
+            POST_DEPLOY_SMOKE_WEDGE_RECOVERY_REASON="startup recovery state unavailable"
+        fi
+        if [ "$waited" -ge "$POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS" ]; then
+            return 1
+        fi
+        sleep "$POST_DEPLOY_SMOKE_WEDGE_RECOVERY_POLL_SECS"
+        waited=$((waited + POST_DEPLOY_SMOKE_WEDGE_RECOVERY_POLL_SECS))
+        rc=0
+        _post_deploy_smoke_wedge_fetch_health_detail "$poll_path" || rc=$?
+        if [ "$rc" -eq 3 ]; then
+            # Gate tripped: already a recorded FAILURE, so stop waiting. The
+            # exit assertion in _post_deploy_smoke_check_wedges converts it.
+            return 1
+        fi
+        if [ "$rc" -ne 0 ]; then
+            POST_DEPLOY_SMOKE_WEDGE_RECOVERY_REASON="startup recovery resample unavailable"
+            continue
+        fi
+        POST_DEPLOY_SMOKE_WEDGE_RECOVERY_BODY="$poll_path"
+    done
+}
 
-    if ! fully_recovered=$(
-        _post_deploy_smoke_fully_recovered_from_file "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
-    ); then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: startup recovery state unavailable" || return 1
-        return 0
-    fi
-    if [ "$fully_recovered" = "false" ]; then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: startup recovery in progress" || return 1
+_post_deploy_smoke_check_wedges_inner() {
+    local fully_recovered wedge_markers wedge_markers_resampled persistent_markers wedge_summary
+    local rc
+    local resample_path="$POST_DEPLOY_SMOKE_TMP_DIR/api_health_detail_resample.json"
+
+    if ! _post_deploy_smoke_wedge_await_recovery; then
+        _post_deploy_smoke_wedge_skip "$POST_DEPLOY_SMOKE_WEDGE_RECOVERY_REASON" || return 1
         return 0
     fi
 
     if ! wedge_markers=$(
-        _post_deploy_smoke_wedge_markers_from_file "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+        _post_deploy_smoke_wedge_markers_from_file "$POST_DEPLOY_SMOKE_WEDGE_RECOVERY_BODY"
     ); then
         _post_deploy_smoke_fail "relay wedge check: health/detail JSON could not be parsed" || true
         return 1
     fi
     if [ -z "$wedge_markers" ]; then
+        _post_deploy_smoke_wedge_skip_state_reset || return 1
         _post_deploy_smoke_note "relay wedge markers=absent" || return 1
         return 0
     fi
@@ -2781,44 +3126,41 @@ _post_deploy_smoke_check_wedges() {
         "relay wedge marker observed; settling ${POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS}s before resample" \
         || return 1
     sleep "$POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS"
-    if ! curl -fsS --connect-timeout 2 --max-time 15 \
-        -H "Origin: http://${ADK_DEFAULT_LOOPBACK}:${REL_PORT}" \
-        -o "$resample_path" \
-        "http://${ADK_DEFAULT_LOOPBACK}:${REL_PORT}/api/health/detail"; then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle resample unavailable" || return 1
+    rc=0
+    _post_deploy_smoke_wedge_fetch_health_detail "$resample_path" || rc=$?
+    if [ "$rc" -eq 1 ]; then
+        _post_deploy_smoke_wedge_skip "settle resample unavailable" || return 1
         return 0
     fi
-    if [ ! -s "$resample_path" ]; then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle resample body empty" || return 1
+    if [ "$rc" -eq 2 ]; then
+        _post_deploy_smoke_wedge_skip "settle resample body empty" || return 1
         return 0
+    fi
+    if [ "$rc" -ne 0 ]; then
+        return 1
     fi
     if ! fully_recovered=$(_post_deploy_smoke_fully_recovered_from_file "$resample_path"); then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle recovery state unavailable" || return 1
+        _post_deploy_smoke_wedge_skip "settle recovery state unavailable" || return 1
         return 0
     fi
     if [ "$fully_recovered" = "false" ]; then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: startup recovery in progress" || return 1
+        _post_deploy_smoke_wedge_skip "startup recovery in progress" || return 1
         return 0
     fi
     if ! wedge_markers_resampled=$(
         _post_deploy_smoke_wedge_markers_from_file "$resample_path"
     ); then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle resample JSON could not be parsed" || return 1
+        _post_deploy_smoke_wedge_skip "settle resample JSON could not be parsed" || return 1
         return 0
     fi
     if ! persistent_markers=$(comm -12 \
         <(printf '%s\n' "$wedge_markers" | LC_ALL=C sort -u) \
         <(printf '%s\n' "$wedge_markers_resampled" | LC_ALL=C sort -u)); then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle resample comparison failed" || return 1
+        _post_deploy_smoke_wedge_skip "settle resample comparison failed" || return 1
         return 0
     fi
     if [ -z "$persistent_markers" ]; then
+        _post_deploy_smoke_wedge_skip_state_reset || return 1
         _post_deploy_smoke_note \
             "relay wedge markers=cleared after ${POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS}s settle" \
             || return 1
@@ -2826,10 +3168,38 @@ _post_deploy_smoke_check_wedges() {
     fi
 
     wedge_summary="${persistent_markers//$'\n'/; }"
+    _post_deploy_smoke_wedge_skip_state_reset || return 1
     _post_deploy_smoke_fail \
         "relay wedge marker persisted after ${POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS}s settle: ${wedge_summary}" \
         || true
     return 1
+}
+
+# ★ #5244: the single gate, both halves.
+#   entry     — nothing evaluates until the preconditions hold, and the primary
+#               body is registered as the one _post_deploy_smoke_wedge_jq may read
+#   exit      — whatever the body decided, clean verdict OR skip, a gate that
+#               tripped anywhere during the run makes this nonzero
+# What this does NOT do: it does not un-count a skip that was recorded before a
+# later gate trip. That inflated count can only make a FUTURE deploy fail
+# sooner, never pass — and this deploy already fails.
+_post_deploy_smoke_check_wedges() {
+    local rc=0
+    POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED=""
+    POST_DEPLOY_SMOKE_WEDGE_GATE_JQ_OK=""
+    POST_DEPLOY_SMOKE_WEDGE_GATE_STATE_OK=""
+    POST_DEPLOY_SMOKE_WEDGE_GATED_BODY=""
+    if [ -z "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY" ] \
+      || [ ! -s "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY" ]; then
+        _post_deploy_smoke_fail "relay wedge check: /api/health/detail body unavailable" || true
+        return 1
+    fi
+    _post_deploy_smoke_wedge_gate "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY" || return 1
+    _post_deploy_smoke_check_wedges_inner || rc=$?
+    if [ -n "$POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED" ]; then
+        return 1
+    fi
+    return "$rc"
 }
 
 _post_deploy_smoke_check_fail_closed_warn_rate() {

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -3017,6 +3017,7 @@ _post_deploy_smoke_wedge_state_write() {
         rm -f "$tmp" 2>/dev/null || true
         return 1
     fi
+    # GNU mv rejects -h; BSD mv -h supplies the destination-symlink defense above.
     if ! mv -fh "$tmp" "$dest" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"; then
         rm -f "$tmp" 2>/dev/null || true
         return 1

--- a/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
+++ b/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+# Regression suite for #5244 (PR-A): the post-deploy relay wedge check must not
+# report a pass for a check it never performed.
+#
+# Two behaviours are pinned here.
+#
+#   S1' skip accounting — a skip is recorded, not swallowed. Consecutive skips
+#       accumulate across deploys in $ADK_REL/runtime and, at the limit, return
+#       nonzero all the way out through _run_post_deploy_functional_smoke. The
+#       accumulation is what the repeated-deploy tests below exercise: a call
+#       counter cannot see a streak that resets itself.
+#
+#   The single gate — "cannot evaluate" is decided in one function and enforced
+#       in one place. Three earlier rounds each patched one site and exposed the
+#       next, so these tests drive the WHOLE _post_deploy_smoke_check_wedges
+#       under a stubbed PATH rather than calling helpers directly: a gate that
+#       only protects the helper it lives in is precisely the defect.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPLOY_SH="$REPO_ROOT/scripts/deploy-release.sh"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agentdesk-wedge-skip-test.XXXXXX")
+# `set -u` aborts mid-suite report rc=0 through some `|| rc=$?` contexts, which
+# would read as a pass. Only the completion flag can make this exit 0.
+SUITE_COMPLETED=0
+cleanup() {
+    local rc=$?
+    rm -rf "$TMP_ROOT"
+    if [ "$SUITE_COMPLETED" -ne 1 ] && [ "$rc" -eq 0 ]; then
+        echo "suite aborted before completing" >&2
+        exit 1
+    fi
+    exit "$rc"
+}
+trap cleanup EXIT
+
+extract_function() {
+    local function_name="$1"
+    awk -v start="^${function_name}[(][)] [{]$" '
+        $0 ~ start { printing = 1 }
+        printing { print }
+        printing && /^}$/ { exit }
+    ' "$DEPLOY_SH"
+}
+
+for fn in \
+    _post_deploy_smoke_note \
+    _post_deploy_smoke_fail \
+    _post_deploy_smoke_wedge_gate_jq \
+    _post_deploy_smoke_wedge_gate_config \
+    _post_deploy_smoke_wedge_gate_state \
+    _post_deploy_smoke_wedge_gate_body \
+    _post_deploy_smoke_wedge_gate \
+    _post_deploy_smoke_wedge_jq \
+    _post_deploy_smoke_wedge_fetch_health_detail \
+    _post_deploy_smoke_wedge_state_write \
+    _post_deploy_smoke_wedge_state_read \
+    _post_deploy_smoke_wedge_corrupt_tally_read \
+    _post_deploy_smoke_wedge_skip_state_bump \
+    _post_deploy_smoke_wedge_skip_state_reset \
+    _post_deploy_smoke_wedge_skip \
+    _post_deploy_smoke_wedge_markers_from_file \
+    _post_deploy_smoke_fully_recovered_from_file \
+    _post_deploy_smoke_wedge_await_recovery \
+    _post_deploy_smoke_check_wedges_inner \
+    _post_deploy_smoke_check_wedges \
+    _run_post_deploy_functional_smoke
+do
+    body=$(extract_function "$fn")
+    if [ -z "$body" ]; then
+        echo "harness: could not extract $fn from $DEPLOY_SH" >&2
+        exit 1
+    fi
+    eval "$body"
+done
+
+# The three sibling checks are out of scope; stub them so the end-to-end
+# propagation assertion isolates the wedge check's return value.
+_post_deploy_smoke_probe_apis() { return 0; }
+_post_deploy_smoke_check_fail_closed_warn_rate() { return 0; }
+_post_deploy_smoke_check_relay_round_trip() { return 0; }
+
+REL_PORT=65535
+ADK_DEFAULT_LOOPBACK="127.0.0.1"
+STUB_STATE="$TMP_ROOT/stub"
+REAL_JQ="$(command -v jq)"
+mkdir -p "$STUB_STATE"
+export STUB_STATE REL_PORT ADK_DEFAULT_LOOPBACK
+
+# curl stub: `mode` selects fetch failure / empty body / a canned body.
+STUB_BIN="$TMP_ROOT/bin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/curl" <<'STUB'
+#!/usr/bin/env bash
+dest=""
+prev=""
+for arg in "$@"; do
+    if [ "$prev" = "-o" ]; then dest="$arg"; fi
+    prev="$arg"
+done
+case "$(cat "$STUB_STATE/curl.mode" 2>/dev/null || printf 'fail')" in
+    empty) : > "$dest" ;;
+    body)  cat "$STUB_STATE/curl.body" > "$dest" ;;
+    *)     exit 22 ;;
+esac
+STUB
+# jq stub: reports whatever version the test asks for and logs that the gate
+# actually consulted it, then delegates every real filter to the real jq.
+cat > "$STUB_BIN/jq" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "--version" ]; then
+    printf 'x\n' >> "\$STUB_STATE/jq.version.calls"
+    cat "\$STUB_STATE/jq.version"
+    exit 0
+fi
+exec "$REAL_JQ" "\$@"
+STUB
+chmod +x "$STUB_BIN/curl" "$STUB_BIN/jq"
+PATH="$STUB_BIN:$PATH"
+
+# A PATH with the externals the wedge path needs but deliberately no jq.
+NOJQ_BIN="$TMP_ROOT/nojq"
+mkdir -p "$NOJQ_BIN"
+for tool in cat mv rm mkdir dirname sleep comm sort mktemp hostname date; do
+    ln -sf "$(command -v "$tool")" "$NOJQ_BIN/$tool"
+done
+ln -sf "$STUB_BIN/curl" "$NOJQ_BIN/curl"
+
+CLEAN_BODY='{"fully_recovered": true, "mailboxes": []}'
+WEDGED_BODY='{"fully_recovered": true, "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"stalled"}]}'
+UNRECOVERED_BODY='{"fully_recovered": false, "mailboxes": []}'
+
+failures=0
+fail_test() {
+    echo "FAIL: $1" >&2
+    failures=$((failures + 1))
+}
+pass_test() { echo "ok: $1"; }
+check_rc() { # want, got, label
+    if [ "$2" -eq "$1" ]; then pass_test "$3"; else fail_test "$3 (want rc=$1, got rc=$2)"; fi
+}
+
+# Fresh per-test world: empty runtime state, empty evidence, chosen bodies.
+setup_case() {
+    ADK_REL="$TMP_ROOT/release"
+    rm -rf "$ADK_REL"
+    mkdir -p "$ADK_REL/logs" "$ADK_REL/runtime"
+    POST_DEPLOY_SMOKE_EVIDENCE="$ADK_REL/logs/evidence.log"
+    : > "$POST_DEPLOY_SMOKE_EVIDENCE"
+    POST_DEPLOY_SMOKE_TMP_DIR="$TMP_ROOT/smoke-tmp"
+    rm -rf "$POST_DEPLOY_SMOKE_TMP_DIR"
+    mkdir -p "$POST_DEPLOY_SMOKE_TMP_DIR"
+    POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$TMP_ROOT/health-detail.json"
+    POST_DEPLOY_SMOKE_STAMP="test-stamp"
+    POST_DEPLOY_SMOKE_FAILURES=()
+    POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS=0
+    POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS=0
+    POST_DEPLOY_SMOKE_WEDGE_RECOVERY_POLL_SECS=1
+    POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS=3
+    POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE="$ADK_REL/runtime/post_deploy_smoke_wedge_skips.json"
+    POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED=""
+    POST_DEPLOY_SMOKE_WEDGE_GATED_BODY=""
+    POST_DEPLOY_SMOKE_WEDGE_GATE_JQ_OK=""
+    POST_DEPLOY_SMOKE_WEDGE_GATE_STATE_OK=""
+    POST_DEPLOY_SMOKE_WEDGE_RECOVERY_BODY=""
+    POST_DEPLOY_SMOKE_WEDGE_RECOVERY_REASON=""
+    printf 'jq-1.7.1-apple\n' > "$STUB_STATE/jq.version"
+    : > "$STUB_STATE/jq.version.calls"
+    printf 'fail\n' > "$STUB_STATE/curl.mode"
+    # The production functions arrive through eval, so the linter cannot see
+    # that they consume these globals; exporting them states the contract.
+    export POST_DEPLOY_SMOKE_STAMP POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS
+    export POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS POST_DEPLOY_SMOKE_WEDGE_RECOVERY_POLL_SECS
+    export POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE
+    export POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED POST_DEPLOY_SMOKE_WEDGE_GATED_BODY
+    export POST_DEPLOY_SMOKE_WEDGE_GATE_JQ_OK POST_DEPLOY_SMOKE_WEDGE_GATE_STATE_OK
+    export POST_DEPLOY_SMOKE_WEDGE_RECOVERY_BODY POST_DEPLOY_SMOKE_WEDGE_RECOVERY_REASON
+    export POST_DEPLOY_SMOKE_EVIDENCE POST_DEPLOY_SMOKE_TMP_DIR
+    export POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY ADK_REL
+}
+stored_count() {
+    if [ -f "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ]; then
+        "$REAL_JQ" -r '.consecutive_skips' "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" 2>/dev/null || printf 'unreadable'
+    else
+        printf 'absent'
+    fi
+}
+# Runs the WHOLE gated check in this shell — not a subshell — so the sticky
+# gate flag and POST_DEPLOY_SMOKE_FAILURES it publishes stay observable. The
+# rc lands in RUN_CHECK_RC; the operator notes go to the evidence file anyway.
+RUN_CHECK_RC=0
+run_check() {
+    RUN_CHECK_RC=0
+    _post_deploy_smoke_check_wedges > /dev/null || RUN_CHECK_RC=$?
+}
+
+# ── S1': one skip is counted, not swallowed ─────────────────────────────────
+setup_case
+printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+run_check; check_rc 0 "$RUN_CHECK_RC" "single late skip keeps the smoke green"
+if [ "$(stored_count)" = "1" ]; then
+    pass_test "single late skip recorded consecutive_skips=1"
+else
+    fail_test "single late skip recorded consecutive_skips=$(stored_count), want 1"
+fi
+
+# ── S1': consecutive skips accumulate across deploys and reach the limit ─────
+# The decisive test for reset placement. A reset on any skip path — the r1
+# defect — makes this streak restart every deploy and never reach the limit.
+setup_case
+printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+run_check; check_rc 0 "$RUN_CHECK_RC" "repeated deploy 1/3 stays green"
+run_check; check_rc 0 "$RUN_CHECK_RC" "repeated deploy 2/3 stays green"
+run_check
+check_rc 1 "$RUN_CHECK_RC" "repeated deploy 3/3 reaches the consecutive-skip limit"
+if printf '%s\n' "${POST_DEPLOY_SMOKE_FAILURES[@]:-}" | grep -q 'skipped on 3 consecutive deploys'; then
+    pass_test "limit breach recorded as a smoke FAILURE"
+else
+    fail_test "limit breach did not record a smoke FAILURE"
+fi
+
+# ── S1': the limit propagates out of _run_post_deploy_functional_smoke ───────
+# #5244's first fix direction: the runner must not print "passed" over this.
+setup_case
+printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+_post_deploy_smoke_wedge_state_write '{"consecutive_skips": 2}' "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
+smoke_rc=0
+_run_post_deploy_functional_smoke || smoke_rc=$?
+check_rc 1 "$smoke_rc" "consecutive-skip limit fails _run_post_deploy_functional_smoke"
+
+# ── Reset happens only on an evidence-based terminal verdict ─────────────────
+setup_case
+printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+run_check
+printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+run_check; check_rc 0 "$RUN_CHECK_RC" "markers-absent verdict is a pass"
+if [ "$(stored_count)" = "0" ]; then
+    pass_test "markers-absent verdict resets the skip streak"
+else
+    fail_test "markers-absent verdict left consecutive_skips=$(stored_count), want 0"
+fi
+
+# A clean first deploy must not invent a skip.
+setup_case
+printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+run_check
+if [ "$(stored_count)" = "absent" ]; then
+    pass_test "clean verdict records no skip"
+else
+    fail_test "clean verdict recorded consecutive_skips=$(stored_count), want no state file"
+fi
+
+# Markers that clear during settle are also an evidence-based verdict.
+setup_case
+printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+_post_deploy_smoke_wedge_state_write '{"consecutive_skips": 2}' "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
+printf 'body\n' > "$STUB_STATE/curl.mode"
+printf '%s\n' "$CLEAN_BODY" > "$STUB_STATE/curl.body"
+run_check; check_rc 0 "$RUN_CHECK_RC" "markers cleared after settle is a pass"
+if [ "$(stored_count)" = "0" ]; then
+    pass_test "markers-cleared verdict resets the skip streak"
+else
+    fail_test "markers-cleared verdict left consecutive_skips=$(stored_count), want 0"
+fi
+
+# A persistent marker is still a failure, and still an evidence-based verdict.
+setup_case
+printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+printf 'body\n' > "$STUB_STATE/curl.mode"
+printf '%s\n' "$WEDGED_BODY" > "$STUB_STATE/curl.body"
+run_check; check_rc 1 "$RUN_CHECK_RC" "persistent marker fails the wedge check"
+
+# ── S2: bounded wait for startup recovery ───────────────────────────────────
+setup_case
+POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS=4
+POST_DEPLOY_SMOKE_WEDGE_RECOVERY_POLL_SECS=1
+printf '%s\n' "$UNRECOVERED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+printf 'body\n' > "$STUB_STATE/curl.mode"
+printf '%s\n' "$CLEAN_BODY" > "$STUB_STATE/curl.body"
+run_check; check_rc 0 "$RUN_CHECK_RC" "recovery that lands inside the deadline reaches a verdict"
+if [ "$(stored_count)" = "absent" ]; then
+    pass_test "waited-out recovery records no skip"
+else
+    fail_test "waited-out recovery recorded consecutive_skips=$(stored_count), want none"
+fi
+
+setup_case
+POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS=2
+POST_DEPLOY_SMOKE_WEDGE_RECOVERY_POLL_SECS=1
+printf '%s\n' "$UNRECOVERED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+printf 'body\n' > "$STUB_STATE/curl.mode"
+printf '%s\n' "$UNRECOVERED_BODY" > "$STUB_STATE/curl.body"
+run_check; check_rc 0 "$RUN_CHECK_RC" "recovery deadline expiry is a skip, not a pass"
+if [ "$(stored_count)" = "1" ]; then
+    pass_test "recovery deadline expiry is counted as a skip"
+else
+    fail_test "recovery deadline expiry recorded consecutive_skips=$(stored_count), want 1"
+fi
+
+# ── The single gate: jq ─────────────────────────────────────────────────────
+setup_case
+printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+nojq_rc=0
+PATH="$NOJQ_BIN" _post_deploy_smoke_check_wedges || nojq_rc=$?
+check_rc 1 "$nojq_rc" "absent jq fails the check instead of yielding a clean verdict"
+if [ "$(stored_count)" = "absent" ]; then
+    pass_test "absent jq is an accounting failure, not a skip"
+else
+    fail_test "absent jq recorded consecutive_skips=$(stored_count), want no skip"
+fi
+
+for bad_version in jq-1.6 jq-1.8pre jq-1.7rc1 jq-1 not-jq ''; do
+    setup_case
+    printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+    printf '%s\n' "$bad_version" > "$STUB_STATE/jq.version"
+    run_check; check_rc 1 "$RUN_CHECK_RC" "jq version '${bad_version:-<empty>}' fails closed"
+    if [ -s "$STUB_STATE/jq.version.calls" ]; then
+        pass_test "jq --version was actually consulted for '${bad_version:-<empty>}'"
+    else
+        fail_test "jq --version was never called for '${bad_version:-<empty>}'"
+    fi
+done
+
+for good_version in jq-1.7 jq-1.7.1 jq-1.7.1-apple jq-2.0; do
+    setup_case
+    printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+    printf '%s\n' "$good_version" > "$STUB_STATE/jq.version"
+    run_check; check_rc 0 "$RUN_CHECK_RC" "jq version '$good_version' is accepted"
+done
+
+# ── The single gate: health/detail schema ───────────────────────────────────
+# Every one of these shapes makes `.mailboxes[]?` emit nothing, which reads as
+# "no wedge markers" — a clean verdict for a body that was never understood.
+while IFS= read -r shape; do
+    setup_case
+    printf '%s\n' "$shape" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+    run_check; check_rc 1 "$RUN_CHECK_RC" "top-level shape $shape is unevaluable"
+done <<'SHAPES'
+{"fully_recovered": true}
+{"fully_recovered": true, "mailboxes": null}
+{"fully_recovered": true, "mailboxes": "none"}
+{"fully_recovered": true, "mailboxes": 0}
+{"fully_recovered": true, "mailboxes": {}}
+[null]
+["mailboxes"]
+"a string body"
+17
+SHAPES
+
+# The resample body is gated too. Before this PR a schema-broken resample
+# produced zero markers, which `comm -12` read as "markers cleared".
+setup_case
+printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+printf 'body\n' > "$STUB_STATE/curl.mode"
+printf '%s\n' '{"fully_recovered": true, "mailboxes": "none"}' > "$STUB_STATE/curl.body"
+run_check; check_rc 1 "$RUN_CHECK_RC" "schema-broken settle resample is unevaluable, not cleared"
+
+# ── The single gate: skip-state I/O ─────────────────────────────────────────
+setup_case
+printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+ln -sf /dev/null "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
+run_check; check_rc 1 "$RUN_CHECK_RC" "symlinked skip state is unevaluable"
+
+setup_case
+printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+chmod 500 "$ADK_REL/runtime"
+run_check; readonly_rc="$RUN_CHECK_RC"
+chmod 700 "$ADK_REL/runtime"
+check_rc 1 "$readonly_rc" "unwritable skip-state directory is unevaluable"
+
+# A write that fails when the skip is being recorded fails the smoke on the
+# FIRST occurrence: losing the increment is losing the skip, and an uncounted
+# skip can never reach the limit. Driven past the gate deliberately — the
+# scenario is a write that fails after the destination was judged usable.
+setup_case
+POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE="$ADK_REL/runtime/nested/state.json"
+mkdir -p "$ADK_REL/runtime/nested"
+chmod 500 "$ADK_REL/runtime/nested"
+write_rc=0
+_post_deploy_smoke_wedge_skip "settle resample unavailable" > /dev/null 2>&1 || write_rc=$?
+chmod 700 "$ADK_REL/runtime/nested"
+check_rc 1 "$write_rc" "a failed skip-state write fails the smoke on the first occurrence"
+if printf '%s\n' "${POST_DEPLOY_SMOKE_FAILURES[@]:-}" | grep -q 'skip .* would be lost'; then
+    pass_test "the lost skip increment is recorded as a smoke FAILURE"
+else
+    fail_test "the lost skip increment was not recorded as a smoke FAILURE"
+fi
+
+# ── Corrupt skip state: recover once, fail on the streak ────────────────────
+setup_case
+printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+printf 'not json at all\n' > "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
+run_check; check_rc 0 "$RUN_CHECK_RC" "one unreadable skip state recovers from 0"
+if grep -q 'skip state unreadable, recovering from 0' "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+    pass_test "the recovery from a corrupt skip state is noted"
+else
+    fail_test "the recovery from a corrupt skip state was silent"
+fi
+if [ "$(cat "${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.corrupt" 2>/dev/null || printf 'absent')" = "1" ]; then
+    pass_test "the corrupt streak is tallied in the sibling file"
+else
+    fail_test "the corrupt streak was not tallied in the sibling file"
+fi
+# Second consecutive deploy with an unreadable state: the streak survives in
+# the sibling, so the limit is reachable even when the count file never is.
+printf 'not json at all\n' > "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
+run_check; check_rc 1 "$RUN_CHECK_RC" "a second consecutive unreadable skip state fails the smoke"
+
+# ── Migration ratchet, not an eternal invariant ─────────────────────────────
+# 7 = the 8 wedge skip branches on main minus the two first-sample recovery
+# branches, which S2 merged into one bounded wait, plus nothing new. A genuine
+# refactor may change this number; change it deliberately and say why.
+skip_sites=$(grep -c '_post_deploy_smoke_wedge_skip "' "$DEPLOY_SH" || true)
+if [ "$skip_sites" -eq 7 ]; then
+    pass_test "all wedge skip branches go through the accounting helper (7 sites)"
+else
+    fail_test "wedge skip helper call sites = $skip_sites, ratchet expects 7"
+fi
+
+SUITE_COMPLETED=1
+if [ "$failures" -eq 0 ]; then
+    echo "wedge skip accounting + single gate tests passed"
+else
+    echo "$failures assertion(s) failed" >&2
+    exit 1
+fi

--- a/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
+++ b/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
@@ -18,6 +18,28 @@
 
 set -euo pipefail
 
+# This is diagnostic only: all verdicts below run through the hermetic jq
+# fixture, not this host binary. Keep it before PATH is replaced by the fixture.
+HOST_JQ_RAW="<absent>"
+HOST_JQ_MAJOR="<unparsed>"
+HOST_JQ_MINOR="<unparsed>"
+if command -v jq >/dev/null 2>&1; then
+    HOST_JQ_RAW=$(jq --version 2>&1 || true)
+    HOST_JQ_RAW="${HOST_JQ_RAW%%$'\n'*}"
+    case "$HOST_JQ_RAW" in
+        jq-*)
+            host_jq_version="${HOST_JQ_RAW#jq-}"
+            HOST_JQ_MAJOR="${host_jq_version%%.*}"
+            host_jq_rest="${host_jq_version#*.}"
+            if [ "$host_jq_rest" != "$host_jq_version" ]; then
+                HOST_JQ_MINOR="${host_jq_rest%%.*}"
+            fi
+            ;;
+    esac
+fi
+printf 'harness jq diagnostic: jq --version=%s parsed_major=%s parsed_minor=%s\n' \
+    "$HOST_JQ_RAW" "$HOST_JQ_MAJOR" "$HOST_JQ_MINOR"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEPLOY_SH="${DEPLOY_SH_OVERRIDE:-$REPO_ROOT/scripts/deploy-release.sh}"
@@ -89,7 +111,6 @@ _post_deploy_smoke_check_relay_round_trip() { return 0; }
 REL_PORT=65535
 ADK_DEFAULT_LOOPBACK="127.0.0.1"
 STUB_STATE="$TMP_ROOT/stub"
-REAL_JQ="$(command -v jq)"
 mkdir -p "$STUB_STATE"
 export STUB_STATE REL_PORT ADK_DEFAULT_LOOPBACK
 
@@ -123,47 +144,157 @@ case "$(cat "$STUB_STATE/curl.mode" 2>/dev/null || printf 'fail')" in
     *)     exit 22 ;;
 esac
 STUB
-# jq stub: reports whatever version the test asks for and logs that the gate
-# actually consulted it, then delegates every real filter to the real jq —
-# unless jq.garbage is set, in which case every filter exits 0 with output that
-# has nothing to do with the input. That is the shape a version check cannot
-# see: an honest --version in front of a parser that answers nonsense.
-cat > "$STUB_BIN/jq" <<STUB
-#!/usr/bin/env bash
-if [ "\$1" = "--version" ]; then
-    printf 'x\n' >> "\$STUB_STATE/jq.version.calls"
-    cat "\$STUB_STATE/jq.version"
-    exit 0
-fi
-if [ -f "\$STUB_STATE/jq.garbage" ]; then
-    printf 'garbage-but-rc-zero\n'
-    exit 0
-fi
-if [ -f "\$STUB_STATE/jq.markersuppress" ]; then
-    for arg in "\$@"; do
-        case "\$arg" in *degraded_reason=*) exit 0 ;; esac
-    done
-fi
-# jq.boolgarble: honest everywhere including the gate's self-test, then garbage
-# from the SECOND fully_recovered read onwards. That filter is the only one
-# carrying this error message, so this reaches _post_deploy_smoke_fully_
-# recovered_from_file and nothing else.
-for arg in "\$@"; do
-    case "\$arg" in
-        *"is not boolean"*)
-            n=\$(cat "\$STUB_STATE/jq.boolgarble.calls" 2>/dev/null || printf 0)
-            n=\$((n + 1))
-            printf '%s\n' "\$n" > "\$STUB_STATE/jq.boolgarble.calls"
-            if [ -f "\$STUB_STATE/jq.boolgarble" ] && [ "\$n" -ge 2 ]; then
-                printf 'garbage-but-rc-zero\n'
-                exit 0
-            fi
-            ;;
-    esac
-done
-exec "$REAL_JQ" "\$@"
+# Hermetic jq fixture. It implements exactly the five filters extracted above,
+# including lossless JSON integers, instead of claiming 1.7 and delegating the
+# actual verdict to the host jq. A real deploy on a node with jq older than 1.7
+# trips the wedge gate and makes this smoke red; deploy-release remains
+# fail-open, so the release continues while the smoke produces alert noise.
+cat > "$STUB_BIN/jq" <<'STUB'
+#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+
+state_dir = os.environ["STUB_STATE"]
+args = sys.argv[1:]
+
+if args == ["--version"]:
+    with open(os.path.join(state_dir, "jq.version.calls"), "a", encoding="utf-8") as stream:
+        stream.write("x\n")
+    with open(os.path.join(state_dir, "jq.version"), encoding="utf-8") as stream:
+        sys.stdout.write(stream.read())
+    raise SystemExit(0)
+
+if os.path.exists(os.path.join(state_dir, "jq.garbage")):
+    print("garbage-but-rc-zero")
+    raise SystemExit(0)
+
+if len(args) < 2 or args[0] not in ("-e", "-r"):
+    print("fixture jq: unsupported arguments", file=sys.stderr)
+    raise SystemExit(2)
+
+mode, jq_filter = args[0], args[1]
+if os.path.exists(os.path.join(state_dir, "jq.markersuppress")) \
+        and "degraded_reason=" in jq_filter:
+    raise SystemExit(0)
+
+if "is not boolean" in jq_filter:
+    calls_path = os.path.join(state_dir, "jq.boolgarble.calls")
+    try:
+        with open(calls_path, encoding="utf-8") as stream:
+            calls = int(stream.read())
+    except (FileNotFoundError, ValueError):
+        calls = 0
+    calls += 1
+    with open(calls_path, "w", encoding="utf-8") as stream:
+        stream.write(f"{calls}\n")
+    if os.path.exists(os.path.join(state_dir, "jq.boolgarble")) and calls >= 2:
+        print("garbage-but-rc-zero")
+        raise SystemExit(0)
+
+try:
+    if len(args) == 3:
+        with open(args[2], encoding="utf-8") as stream:
+            value = json.load(stream)
+    elif len(args) == 2:
+        value = json.load(sys.stdin)
+    else:
+        raise ValueError("unsupported input arguments")
+except (OSError, ValueError, json.JSONDecodeError) as error:
+    print(f"fixture jq: {error}", file=sys.stderr)
+    raise SystemExit(4)
+
+def emit(item):
+    if item is True:
+        print("true")
+    elif item is False:
+        print("false")
+    elif item is None:
+        print("null")
+    else:
+        print(item)
+
+def default(item, fallback):
+    return fallback if item is None or item is False else item
+
+try:
+    if "join(\"|\")" in jq_filter:
+        mailboxes = value["mailboxes"]
+        reasons = value["degraded_reasons"]
+        recovered = value["fully_recovered"]
+        stall = mailboxes[0]["relay_stall_state"].lower()
+        matched = [reason for reason in reasons if isinstance(reason, str)
+                   and re.search(r"relay.*wedge", reason, re.IGNORECASE)]
+        fields = [str(recovered).lower(), "array", stall]
+        fields.extend(matched)
+        fields.append(default(mailboxes[0].get("absent_field"), "dflt"))
+        emit("|".join(fields))
+    elif "((.mailboxes | type) == \"array\")" in jq_filter:
+        valid = (isinstance(value, dict)
+                 and isinstance(value.get("mailboxes"), list)
+                 and isinstance(value.get("degraded_reasons"), list)
+                 and isinstance(value.get("fully_recovered"), bool))
+        emit(valid)
+        if mode == "-e" and not valid:
+            raise SystemExit(1)
+    elif "consecutive_skips missing or not a number" in jq_filter:
+        count = value.get("consecutive_skips") if isinstance(value, dict) else None
+        if isinstance(count, bool) or not isinstance(count, (int, float)):
+            raise ValueError("consecutive_skips missing or not a number")
+        emit(count)
+    elif jq_filter.strip() == ".consecutive_skips":
+        emit(value["consecutive_skips"])
+    elif "degraded_reason=" in jq_filter:
+        marker_pattern = re.compile(
+            r"relay.*(wedge|dead|stall|stuck)|(wedge|dead|stall|stuck).*relay",
+            re.IGNORECASE,
+        )
+        for reason in value["degraded_reasons"]:
+            if isinstance(reason, str) and marker_pattern.search(reason):
+                emit("degraded_reason=" + reason)
+        for mailbox in value["mailboxes"]:
+            stall = default(mailbox.get("relay_stall_state"), "healthy")
+            if not isinstance(stall, str):
+                raise ValueError("relay_stall_state is not a string")
+            stall = stall.lower()
+            relay_health = mailbox.get("relay_health") or {}
+            marked = (stall in ("orphan_pending_token", "queue_blocked", "tmux_alive_relay_dead")
+                      or relay_health.get("desynced") is True
+                      or relay_health.get("stale_thread_proof") is True
+                      or relay_health.get("watcher_attached_stale") is True
+                      or (mailbox.get("inflight_state_present") is True
+                          and mailbox.get("watcher_attached") is False))
+            if marked:
+                provider = default(mailbox.get("provider"), "unknown")
+                channel = default(mailbox.get("channel_id"), "unknown")
+                emit(f"mailbox provider={provider} channel={channel} stall={stall}")
+    elif "fully_recovered is not boolean" in jq_filter:
+        recovered = value.get("fully_recovered") if isinstance(value, dict) else None
+        if not isinstance(recovered, bool):
+            raise ValueError("fully_recovered is not boolean")
+        emit(recovered)
+    else:
+        raise ValueError("unsupported filter")
+except (KeyError, TypeError, ValueError) as error:
+    print(f"fixture jq: {error}", file=sys.stderr)
+    raise SystemExit(5)
 STUB
-chmod +x "$STUB_BIN/curl" "$STUB_BIN/jq"
+
+# Production targets BSD mv's `-h` destination-symlink protection. Python's
+# os.replace supplies the same atomic, no-follow replacement to this harness on
+# both BSD and GNU hosts, so GNU option parsing cannot decide the test verdict.
+cat > "$STUB_BIN/mv" <<'STUB'
+#!/usr/bin/env python3
+import os
+import sys
+
+if len(sys.argv) != 4 or sys.argv[1] != "-fh":
+    print("fixture mv: expected 'mv -fh SOURCE DEST'", file=sys.stderr)
+    raise SystemExit(2)
+os.replace(sys.argv[2], sys.argv[3])
+STUB
+chmod +x "$STUB_BIN/curl" "$STUB_BIN/jq" "$STUB_BIN/mv"
 PATH="$STUB_BIN:$PATH"
 
 # A PATH with the externals the wedge path needs but deliberately no jq.
@@ -183,8 +314,19 @@ OWNERLESS_BODY='{"fully_recovered": true, "degraded_reasons": [], "mailboxes": [
 UNRECOVERED_BODY='{"fully_recovered": false, "mailboxes": [], "degraded_reasons": []}'
 
 failures=0
+report_case_diagnostics() {
+    printf 'diagnostic: POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED=%s\n' \
+        "${POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED:-<unset>}" >&2
+    if [ -n "${POST_DEPLOY_SMOKE_EVIDENCE:-}" ] \
+      && [ -s "$POST_DEPLOY_SMOKE_EVIDENCE" ]; then
+        sed 's/^/diagnostic evidence: /' "$POST_DEPLOY_SMOKE_EVIDENCE" >&2
+    else
+        echo 'diagnostic evidence: <empty>' >&2
+    fi
+}
 fail_test() {
     echo "ASSERT-FAIL: $1" >&2
+    report_case_diagnostics
     failures=$((failures + 1))
 }
 pass_test() { echo "ok: $1"; }
@@ -236,7 +378,7 @@ setup_case() {
 }
 stored_count() {
     if [ -f "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ]; then
-        "$REAL_JQ" -r '.consecutive_skips' "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" 2>/dev/null || printf 'unreadable'
+        jq -r '.consecutive_skips' "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" 2>/dev/null || printf 'unreadable'
     else
         printf 'absent'
     fi
@@ -455,6 +597,16 @@ for bad_version in jq-1.6 jq-1.8pre jq-1.7rc1 jq-1 not-jq ''; do
     else
         fail_test "jq --version was never called for '${bad_version:-<empty>}'"
     fi
+    if [ "$bad_version" = "jq-1.6" ]; then
+        if [ -n "$POST_DEPLOY_SMOKE_WEDGE_GATE_FAILED" ] \
+          && [ "$(stored_count)" = "absent" ] \
+          && printf '%s\n' "${POST_DEPLOY_SMOKE_FAILURES[@]:-}" \
+             | grep -q 'relay wedge check unevaluable'; then
+            pass_test "jq 1.6 is a gate-trip accounting failure, not a skip"
+        else
+            fail_test "jq 1.6 did not take the gate-trip accounting-failure branch"
+        fi
+    fi
 done
 
 for good_version in jq-1.7 jq-1.7.1 jq-1.7.1-apple jq-2.0; do
@@ -463,6 +615,21 @@ for good_version in jq-1.7 jq-1.7.1 jq-1.7.1-apple jq-2.0; do
     printf '%s\n' "$good_version" > "$STUB_STATE/jq.version"
     run_check; check_rc 0 "$RUN_CHECK_RC" "jq version '$good_version' is accepted"
 done
+
+# jq 1.7's numeric representation is load-bearing for unquoted u64 channel_id
+# values interpolated into marker strings. The hermetic fixture must prove the
+# exact decimal survives, not merely print a qualifying version string.
+setup_case
+SNOWFLAKE_WEDGED_BODY='{"fully_recovered":true,"degraded_reasons":[],"mailboxes":[{"provider":"claude","channel_id":1234567890123456789,"relay_stall_state":"tmux_alive_relay_dead","relay_health":{"desynced":true}}]}'
+printf '%s\n' "$SNOWFLAKE_WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+printf 'body\n' > "$STUB_STATE/curl.mode"
+printf '%s\n' "$SNOWFLAKE_WEDGED_BODY" > "$STUB_STATE/curl.body"
+run_check; check_rc 1 "$RUN_CHECK_RC" "jq 1.7 fixture keeps a persistent u64-channel marker red"
+if grep -q 'channel=1234567890123456789' "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+    pass_test "jq 1.7 fixture preserves the u64 channel_id exactly"
+else
+    fail_test "jq 1.7 fixture changed the u64 channel_id marker"
+fi
 
 # ── The single gate: health/detail schema ───────────────────────────────────
 # The gate must assert the WHOLE contract its consumers read, not one field of

--- a/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
+++ b/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
@@ -308,12 +308,13 @@ fi
 
 # relay_stall_state is classified by an explicit allowlist. Drive the complete
 # check so each normal state must reach markers=absent and each abnormal state
-# must persist its own marker after resampling. Other marker fields are false,
-# which prevents those clauses from hiding a missing stall-state comparison.
-while read -r stall expected_rc; do
+# must persist its own marker after resampling. stale_thread_proof is serialized
+# with its matching boolean; all other marker fields are false, so every row
+# exercises only the production evidence associated with that classified state.
+while read -r stall stale_thread_proof expected_rc; do
     setup_case
     body=$(printf '%s\n' \
-        "{\"fully_recovered\":true,\"degraded_reasons\":[],\"mailboxes\":[{\"provider\":\"claude\",\"channel_id\":\"c1\",\"relay_stall_state\":\"$stall\",\"inflight_state_present\":false,\"watcher_attached\":true,\"relay_health\":{\"desynced\":false,\"stale_thread_proof\":false,\"watcher_attached_stale\":false}}]}")
+        "{\"fully_recovered\":true,\"degraded_reasons\":[],\"mailboxes\":[{\"provider\":\"claude\",\"channel_id\":\"c1\",\"relay_stall_state\":\"$stall\",\"inflight_state_present\":false,\"watcher_attached\":true,\"relay_health\":{\"desynced\":false,\"stale_thread_proof\":$stale_thread_proof,\"watcher_attached_stale\":false}}]}")
     printf '%s\n' "$body" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
     printf 'body\n' > "$STUB_STATE/curl.mode"
     printf '%s\n' "$body" > "$STUB_STATE/curl.body"
@@ -330,13 +331,34 @@ while read -r stall expected_rc; do
         fail_test "relay stall state $stall did not persist its marker"
     fi
 done <<'STALL_STATES'
-healthy 0
-active_foreground_stream 0
-explicit_background_work 0
-orphan_pending_token 1
-queue_blocked 1
-tmux_alive_relay_dead 1
+healthy false 0
+active_foreground_stream false 0
+explicit_background_work false 0
+orphan_pending_token false 1
+queue_blocked false 1
+tmux_alive_relay_dead false 1
+stale_thread_proof true 1
 STALL_STATES
+
+# Pin each boolean marker independently with a healthy stall state and every
+# sibling marker false. This keeps one clause from hiding the removal of
+# another clause from the production filter.
+while IFS='|' read -r marker body; do
+    setup_case
+    printf '%s\n' "$body" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+    printf 'body\n' > "$STUB_STATE/curl.mode"
+    printf '%s\n' "$body" > "$STUB_STATE/curl.body"
+    run_check; check_rc 1 "$RUN_CHECK_RC" "$marker marker verdict"
+    if grep -q 'relay wedge marker persisted.*stall=healthy' "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+        pass_test "$marker emits its own marker"
+    else
+        fail_test "$marker did not persist its own marker"
+    fi
+done <<'BOOLEAN_MARKERS'
+desynced|{"fully_recovered":true,"degraded_reasons":[],"mailboxes":[{"provider":"claude","channel_id":"c1","relay_stall_state":"healthy","inflight_state_present":false,"watcher_attached":true,"relay_health":{"desynced":true,"stale_thread_proof":false,"watcher_attached_stale":false}}]}
+watcher_attached_stale|{"fully_recovered":true,"degraded_reasons":[],"mailboxes":[{"provider":"claude","channel_id":"c1","relay_stall_state":"healthy","inflight_state_present":false,"watcher_attached":true,"relay_health":{"desynced":false,"stale_thread_proof":false,"watcher_attached_stale":true}}]}
+inflight_without_watcher|{"fully_recovered":true,"degraded_reasons":[],"mailboxes":[{"provider":"claude","channel_id":"c1","relay_stall_state":"healthy","inflight_state_present":true,"watcher_attached":false,"relay_health":{"desynced":false,"stale_thread_proof":false,"watcher_attached_stale":false}}]}
+BOOLEAN_MARKERS
 
 setup_case
 printf '%s\n' "$OWNERLESS_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"

--- a/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
+++ b/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
@@ -76,6 +76,9 @@ do
     eval "$body"
 done
 
+# NOTE: production _post_deploy_smoke_fail prints lines beginning "FAIL:" as
+# ordinary fixture output. Assertion failures here are marked ASSERT-FAIL.
+
 # The three sibling checks are out of scope; stub them so the end-to-end
 # propagation assertion isolates the wedge check's return value.
 _post_deploy_smoke_probe_apis() { return 0; }
@@ -134,7 +137,7 @@ UNRECOVERED_BODY='{"fully_recovered": false, "mailboxes": []}'
 
 failures=0
 fail_test() {
-    echo "FAIL: $1" >&2
+    echo "ASSERT-FAIL: $1" >&2
     failures=$((failures + 1))
 }
 pass_test() { echo "ok: $1"; }
@@ -356,6 +359,29 @@ printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
 printf 'body\n' > "$STUB_STATE/curl.mode"
 printf '%s\n' '{"fully_recovered": true, "mailboxes": "none"}' > "$STUB_STATE/curl.body"
 run_check; check_rc 1 "$RUN_CHECK_RC" "schema-broken settle resample is unevaluable, not cleared"
+
+# A gate that trips DURING the recovery wait is the case only the exit
+# assertion can catch: the wait gives up, the caller records a skip, and the
+# body of the check therefore returns 0. Nothing but the assertion in
+# _post_deploy_smoke_check_wedges turns that back into a failure.
+setup_case
+POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS=4
+POST_DEPLOY_SMOKE_WEDGE_RECOVERY_POLL_SECS=1
+printf '%s\n' "$UNRECOVERED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+printf 'body\n' > "$STUB_STATE/curl.mode"
+printf '%s\n' '{"fully_recovered": true, "mailboxes": 7}' > "$STUB_STATE/curl.body"
+run_check; check_rc 1 "$RUN_CHECK_RC" "a gate tripped inside the recovery wait cannot end as a skip"
+
+# The sole jq reader refuses a body the gate has not just cleared. This is the
+# coupling that makes every gate call site load-bearing: a future site that
+# fetches a body and forgets to gate it degrades to a visible refusal instead
+# of silently parsing an unvalidated body.
+setup_case
+printf '%s\n' "$WEDGED_BODY" > "$TMP_ROOT/ungated.json"
+POST_DEPLOY_SMOKE_WEDGE_GATED_BODY="$TMP_ROOT/some-other-body.json"
+ungated_rc=0
+_post_deploy_smoke_wedge_markers_from_file "$TMP_ROOT/ungated.json" > /dev/null 2>&1 || ungated_rc=$?
+check_rc 1 "$ungated_rc" "an ungated body is refused by the sole jq reader"
 
 # ── The single gate: skip-state I/O ─────────────────────────────────────────
 setup_case

--- a/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
+++ b/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
@@ -18,8 +18,9 @@
 
 set -euo pipefail
 
-# This is diagnostic only: all verdicts below run through the hermetic jq
-# fixture, not this host binary. Keep it before PATH is replaced by the fixture.
+# This is diagnostic only. The fixture spoofs selected --version and fault
+# cases, but delegates normal production filters to this binary. Record it
+# before PATH is replaced by the fixture.
 HOST_JQ_RAW="<absent>"
 HOST_JQ_MAJOR="<unparsed>"
 HOST_JQ_MINOR="<unparsed>"
@@ -111,6 +112,7 @@ _post_deploy_smoke_check_relay_round_trip() { return 0; }
 REL_PORT=65535
 ADK_DEFAULT_LOOPBACK="127.0.0.1"
 STUB_STATE="$TMP_ROOT/stub"
+REAL_JQ="$(command -v jq)"
 mkdir -p "$STUB_STATE"
 export STUB_STATE REL_PORT ADK_DEFAULT_LOOPBACK
 
@@ -144,141 +146,45 @@ case "$(cat "$STUB_STATE/curl.mode" 2>/dev/null || printf 'fail')" in
     *)     exit 22 ;;
 esac
 STUB
-# Hermetic jq fixture. It implements exactly the five filters extracted above,
-# including lossless JSON integers, instead of claiming 1.7 and delegating the
-# actual verdict to the host jq. A real deploy on a node with jq older than 1.7
-# trips the wedge gate and makes this smoke red; deploy-release remains
-# fail-open, so the release continues while the smoke produces alert noise.
-cat > "$STUB_BIN/jq" <<'STUB'
-#!/usr/bin/env python3
-import json
-import os
-import re
-import sys
-
-state_dir = os.environ["STUB_STATE"]
-args = sys.argv[1:]
-
-if args == ["--version"]:
-    with open(os.path.join(state_dir, "jq.version.calls"), "a", encoding="utf-8") as stream:
-        stream.write("x\n")
-    with open(os.path.join(state_dir, "jq.version"), encoding="utf-8") as stream:
-        sys.stdout.write(stream.read())
-    raise SystemExit(0)
-
-if os.path.exists(os.path.join(state_dir, "jq.garbage")):
-    print("garbage-but-rc-zero")
-    raise SystemExit(0)
-
-if len(args) < 2 or args[0] not in ("-e", "-r"):
-    print("fixture jq: unsupported arguments", file=sys.stderr)
-    raise SystemExit(2)
-
-mode, jq_filter = args[0], args[1]
-if os.path.exists(os.path.join(state_dir, "jq.markersuppress")) \
-        and "degraded_reason=" in jq_filter:
-    raise SystemExit(0)
-
-if "is not boolean" in jq_filter:
-    calls_path = os.path.join(state_dir, "jq.boolgarble.calls")
-    try:
-        with open(calls_path, encoding="utf-8") as stream:
-            calls = int(stream.read())
-    except (FileNotFoundError, ValueError):
-        calls = 0
-    calls += 1
-    with open(calls_path, "w", encoding="utf-8") as stream:
-        stream.write(f"{calls}\n")
-    if os.path.exists(os.path.join(state_dir, "jq.boolgarble")) and calls >= 2:
-        print("garbage-but-rc-zero")
-        raise SystemExit(0)
-
-try:
-    if len(args) == 3:
-        with open(args[2], encoding="utf-8") as stream:
-            value = json.load(stream)
-    elif len(args) == 2:
-        value = json.load(sys.stdin)
-    else:
-        raise ValueError("unsupported input arguments")
-except (OSError, ValueError, json.JSONDecodeError) as error:
-    print(f"fixture jq: {error}", file=sys.stderr)
-    raise SystemExit(4)
-
-def emit(item):
-    if item is True:
-        print("true")
-    elif item is False:
-        print("false")
-    elif item is None:
-        print("null")
-    else:
-        print(item)
-
-def default(item, fallback):
-    return fallback if item is None or item is False else item
-
-try:
-    if "join(\"|\")" in jq_filter:
-        mailboxes = value["mailboxes"]
-        reasons = value["degraded_reasons"]
-        recovered = value["fully_recovered"]
-        stall = mailboxes[0]["relay_stall_state"].lower()
-        matched = [reason for reason in reasons if isinstance(reason, str)
-                   and re.search(r"relay.*wedge", reason, re.IGNORECASE)]
-        fields = [str(recovered).lower(), "array", stall]
-        fields.extend(matched)
-        fields.append(default(mailboxes[0].get("absent_field"), "dflt"))
-        emit("|".join(fields))
-    elif "((.mailboxes | type) == \"array\")" in jq_filter:
-        valid = (isinstance(value, dict)
-                 and isinstance(value.get("mailboxes"), list)
-                 and isinstance(value.get("degraded_reasons"), list)
-                 and isinstance(value.get("fully_recovered"), bool))
-        emit(valid)
-        if mode == "-e" and not valid:
-            raise SystemExit(1)
-    elif "consecutive_skips missing or not a number" in jq_filter:
-        count = value.get("consecutive_skips") if isinstance(value, dict) else None
-        if isinstance(count, bool) or not isinstance(count, (int, float)):
-            raise ValueError("consecutive_skips missing or not a number")
-        emit(count)
-    elif jq_filter.strip() == ".consecutive_skips":
-        emit(value["consecutive_skips"])
-    elif "degraded_reason=" in jq_filter:
-        marker_pattern = re.compile(
-            r"relay.*(wedge|dead|stall|stuck)|(wedge|dead|stall|stuck).*relay",
-            re.IGNORECASE,
-        )
-        for reason in value["degraded_reasons"]:
-            if isinstance(reason, str) and marker_pattern.search(reason):
-                emit("degraded_reason=" + reason)
-        for mailbox in value["mailboxes"]:
-            stall = default(mailbox.get("relay_stall_state"), "healthy")
-            if not isinstance(stall, str):
-                raise ValueError("relay_stall_state is not a string")
-            stall = stall.lower()
-            relay_health = mailbox.get("relay_health") or {}
-            marked = (stall in ("orphan_pending_token", "queue_blocked", "tmux_alive_relay_dead")
-                      or relay_health.get("desynced") is True
-                      or relay_health.get("stale_thread_proof") is True
-                      or relay_health.get("watcher_attached_stale") is True
-                      or (mailbox.get("inflight_state_present") is True
-                          and mailbox.get("watcher_attached") is False))
-            if marked:
-                provider = default(mailbox.get("provider"), "unknown")
-                channel = default(mailbox.get("channel_id"), "unknown")
-                emit(f"mailbox provider={provider} channel={channel} stall={stall}")
-    elif "fully_recovered is not boolean" in jq_filter:
-        recovered = value.get("fully_recovered") if isinstance(value, dict) else None
-        if not isinstance(recovered, bool):
-            raise ValueError("fully_recovered is not boolean")
-        emit(recovered)
-    else:
-        raise ValueError("unsupported filter")
-except (KeyError, TypeError, ValueError) as error:
-    print(f"fixture jq: {error}", file=sys.stderr)
-    raise SystemExit(5)
+# jq stub: reports whatever version the test asks for and logs that the gate
+# actually consulted it, then delegates every real filter to the real jq —
+# unless jq.garbage is set, in which case every filter exits 0 with output that
+# has nothing to do with the input. That is the shape a version check cannot
+# see: an honest --version in front of a parser that answers nonsense.
+cat > "$STUB_BIN/jq" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "--version" ]; then
+    printf 'x\n' >> "\$STUB_STATE/jq.version.calls"
+    cat "\$STUB_STATE/jq.version"
+    exit 0
+fi
+if [ -f "\$STUB_STATE/jq.garbage" ]; then
+    printf 'garbage-but-rc-zero\n'
+    exit 0
+fi
+if [ -f "\$STUB_STATE/jq.markersuppress" ]; then
+    for arg in "\$@"; do
+        case "\$arg" in *degraded_reason=*) exit 0 ;; esac
+    done
+fi
+# jq.boolgarble: honest everywhere including the gate's self-test, then garbage
+# from the SECOND fully_recovered read onwards. That filter is the only one
+# carrying this error message, so this reaches _post_deploy_smoke_fully_
+# recovered_from_file and nothing else.
+for arg in "\$@"; do
+    case "\$arg" in
+        *"is not boolean"*)
+            n=\$(cat "\$STUB_STATE/jq.boolgarble.calls" 2>/dev/null || printf 0)
+            n=\$((n + 1))
+            printf '%s\n' "\$n" > "\$STUB_STATE/jq.boolgarble.calls"
+            if [ -f "\$STUB_STATE/jq.boolgarble" ] && [ "\$n" -ge 2 ]; then
+                printf 'garbage-but-rc-zero\n'
+                exit 0
+            fi
+            ;;
+    esac
+done
+exec "$REAL_JQ" "\$@"
 STUB
 
 # Production targets BSD mv's `-h` destination-symlink protection. Python's
@@ -502,6 +408,19 @@ watcher_attached_stale|{"fully_recovered":true,"degraded_reasons":[],"mailboxes"
 inflight_without_watcher|{"fully_recovered":true,"degraded_reasons":[],"mailboxes":[{"provider":"claude","channel_id":"c1","relay_stall_state":"healthy","inflight_state_present":true,"watcher_attached":false,"relay_health":{"desynced":false,"stale_thread_proof":false,"watcher_attached_stale":false}}]}
 BOOLEAN_MARKERS
 
+# Pin the degraded-reason regex with no mailbox that could supply a marker.
+setup_case
+DEGRADED_REASON_BODY='{"fully_recovered":true,"degraded_reasons":["relay stuck"],"mailboxes":[]}'
+printf '%s\n' "$DEGRADED_REASON_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+printf 'body\n' > "$STUB_STATE/curl.mode"
+printf '%s\n' "$DEGRADED_REASON_BODY" > "$STUB_STATE/curl.body"
+run_check; check_rc 1 "$RUN_CHECK_RC" "degraded relay reason marker verdict"
+if grep -q 'relay wedge marker persisted.*degraded_reason=relay stuck' "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+    pass_test "degraded relay reason emits its own marker"
+else
+    fail_test "degraded relay reason did not persist its own marker"
+fi
+
 setup_case
 printf '%s\n' "$OWNERLESS_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
 run_check; check_rc 0 "$RUN_CHECK_RC" "missing relay_owner_kind is not ownerless wedge evidence"
@@ -617,18 +536,18 @@ for good_version in jq-1.7 jq-1.7.1 jq-1.7.1-apple jq-2.0; do
 done
 
 # jq 1.7's numeric representation is load-bearing for unquoted u64 channel_id
-# values interpolated into marker strings. The hermetic fixture must prove the
-# exact decimal survives, not merely print a qualifying version string.
+# values interpolated into marker strings. Run the production marker filter and
+# require the exact decimal, not merely a qualifying version string.
 setup_case
 SNOWFLAKE_WEDGED_BODY='{"fully_recovered":true,"degraded_reasons":[],"mailboxes":[{"provider":"claude","channel_id":1234567890123456789,"relay_stall_state":"tmux_alive_relay_dead","relay_health":{"desynced":true}}]}'
 printf '%s\n' "$SNOWFLAKE_WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
 printf 'body\n' > "$STUB_STATE/curl.mode"
 printf '%s\n' "$SNOWFLAKE_WEDGED_BODY" > "$STUB_STATE/curl.body"
-run_check; check_rc 1 "$RUN_CHECK_RC" "jq 1.7 fixture keeps a persistent u64-channel marker red"
+run_check; check_rc 1 "$RUN_CHECK_RC" "production jq filter keeps a persistent u64-channel marker red"
 if grep -q 'channel=1234567890123456789' "$POST_DEPLOY_SMOKE_EVIDENCE"; then
-    pass_test "jq 1.7 fixture preserves the u64 channel_id exactly"
+    pass_test "production jq filter preserves the u64 channel_id exactly"
 else
-    fail_test "jq 1.7 fixture changed the u64 channel_id marker"
+    fail_test "production jq filter changed the u64 channel_id marker"
 fi
 
 # ── The single gate: health/detail schema ───────────────────────────────────

--- a/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
+++ b/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
@@ -179,7 +179,7 @@ ln -sf "$STUB_BIN/curl" "$NOJQ_BIN/curl"
 # what the gate now demands.
 CLEAN_BODY='{"fully_recovered": true, "mailboxes": [], "degraded_reasons": []}'
 WEDGED_BODY='{"fully_recovered": true, "degraded_reasons": [], "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"tmux_alive_relay_dead","relay_health":{"desynced":true}}]}'
-ACTIVE_BODY='{"fully_recovered": true, "degraded_reasons": [], "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"active_foreground_stream","inflight_state_present":true,"watcher_attached":true,"relay_health":{"desynced":false,"stale_thread_proof":false,"watcher_attached_stale":false}}]}'
+ACTIVE_BODY='{"fully_recovered": true, "degraded_reasons": [], "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"active_foreground_stream","inflight_state_present":false,"watcher_attached":true,"relay_health":{"desynced":false,"stale_thread_proof":false,"watcher_attached_stale":false}}]}'
 OWNERLESS_BODY='{"fully_recovered": true, "degraded_reasons": [], "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"healthy","inflight_state_present":true,"watcher_attached":true,"relay_health":{"desynced":false,"stale_thread_proof":false,"watcher_attached_stale":false}}]}'
 UNRECOVERED_BODY='{"fully_recovered": false, "mailboxes": [], "degraded_reasons": []}'
 
@@ -432,7 +432,6 @@ done
 #
 #   consumer : field                              broken by rows tagged
 #   -------------------------------------------   ---------------------
-#   all consumers : the body is an object          [object]
 #   _markers_from_file : .mailboxes[]?             [mailboxes]
 #   _markers_from_file : .degraded_reasons[]?      [degraded_reasons]
 #   _fully_recovered_from_file : .fully_recovered  [fully_recovered]

--- a/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
+++ b/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-DEPLOY_SH="$REPO_ROOT/scripts/deploy-release.sh"
+DEPLOY_SH="${DEPLOY_SH_OVERRIDE:-$REPO_ROOT/scripts/deploy-release.sh}"
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agentdesk-wedge-skip-test.XXXXXX")
 # `set -u` aborts mid-suite report rc=0 through some `|| rc=$?` contexts, which
 # would read as a pass. Only the completion flag can make this exit 0.
@@ -107,6 +107,19 @@ done
 case "$(cat "$STUB_STATE/curl.mode" 2>/dev/null || printf 'fail')" in
     empty) : > "$dest" ;;
     body)  cat "$STUB_STATE/curl.body" > "$dest" ;;
+    sequence_partial_fail)
+        calls=$(cat "$STUB_STATE/curl.calls" 2>/dev/null || printf 0)
+        calls=$((calls + 1))
+        printf '%s\n' "$calls" > "$STUB_STATE/curl.calls"
+        [ -f "$STUB_STATE/curl.body.$calls" ] || exit 22
+        cat "$STUB_STATE/curl.body.$calls" > "$dest"
+        [ "$calls" -ne 2 ] || exit 22
+        ;;
+    swap_state_dir)
+        cat "$STUB_STATE/curl.body" > "$dest"
+        rm -f "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
+        ln -s "$SYMLINK_TARGET_DIR" "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
+        ;;
     *)     exit 22 ;;
 esac
 STUB
@@ -125,6 +138,11 @@ fi
 if [ -f "\$STUB_STATE/jq.garbage" ]; then
     printf 'garbage-but-rc-zero\n'
     exit 0
+fi
+if [ -f "\$STUB_STATE/jq.markersuppress" ]; then
+    for arg in "\$@"; do
+        case "\$arg" in *degraded_reason=*) exit 0 ;; esac
+    done
 fi
 # jq.boolgarble: honest everywhere including the gate's self-test, then garbage
 # from the SECOND fully_recovered read onwards. That filter is the only one
@@ -160,7 +178,9 @@ ln -sf "$STUB_BIN/curl" "$NOJQ_BIN/curl"
 # array, boolean fully_recovered — because that is what the server emits and
 # what the gate now demands.
 CLEAN_BODY='{"fully_recovered": true, "mailboxes": [], "degraded_reasons": []}'
-WEDGED_BODY='{"fully_recovered": true, "degraded_reasons": [], "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"stalled"}]}'
+WEDGED_BODY='{"fully_recovered": true, "degraded_reasons": [], "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"tmux_alive_relay_dead","relay_health":{"desynced":true}}]}'
+ACTIVE_BODY='{"fully_recovered": true, "degraded_reasons": [], "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"active_foreground_stream","inflight_state_present":true,"watcher_attached":true,"relay_health":{"desynced":false,"stale_thread_proof":false,"watcher_attached_stale":false}}]}'
+OWNERLESS_BODY='{"fully_recovered": true, "degraded_reasons": [], "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"healthy","inflight_state_present":true,"watcher_attached":true,"relay_health":{"desynced":false,"stale_thread_proof":false,"watcher_attached_stale":false}}]}'
 UNRECOVERED_BODY='{"fully_recovered": false, "mailboxes": [], "degraded_reasons": []}'
 
 failures=0
@@ -199,8 +219,9 @@ setup_case() {
     POST_DEPLOY_SMOKE_WEDGE_RECOVERY_REASON=""
     printf 'jq-1.7.1-apple\n' > "$STUB_STATE/jq.version"
     : > "$STUB_STATE/jq.version.calls"
-    rm -f "$STUB_STATE/jq.garbage" "$STUB_STATE/jq.boolgarble"
+    rm -f "$STUB_STATE/jq.garbage" "$STUB_STATE/jq.boolgarble" "$STUB_STATE/jq.markersuppress"
     printf '0\n' > "$STUB_STATE/jq.boolgarble.calls"
+    printf '0\n' > "$STUB_STATE/curl.calls"
     printf 'fail\n' > "$STUB_STATE/curl.mode"
     # The production functions arrive through eval, so the linter cannot see
     # that they consume these globals; exporting them states the contract.
@@ -212,6 +233,7 @@ setup_case() {
     export POST_DEPLOY_SMOKE_WEDGE_RECOVERY_BODY POST_DEPLOY_SMOKE_WEDGE_RECOVERY_REASON
     export POST_DEPLOY_SMOKE_EVIDENCE POST_DEPLOY_SMOKE_TMP_DIR
     export POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY ADK_REL
+    export STUB_STATE
 }
 stored_count() {
     if [ -f "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ]; then
@@ -285,6 +307,27 @@ else
     fail_test "clean verdict recorded consecutive_skips=$(stored_count), want no state file"
 fi
 
+# Normal busy states are not wedge evidence. active_foreground_stream is a
+# healthy live turn, and relay_owner_kind is absent from the mailbox wire type,
+# so neither condition may manufacture a marker by itself.
+setup_case
+printf '%s\n' "$ACTIVE_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+run_check; check_rc 0 "$RUN_CHECK_RC" "an active foreground stream is not a relay wedge"
+if [ "$(stored_count)" = "absent" ]; then
+    pass_test "an active foreground stream reaches a clean marker verdict"
+else
+    fail_test "an active foreground stream changed skip accounting"
+fi
+
+setup_case
+printf '%s\n' "$OWNERLESS_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+run_check; check_rc 0 "$RUN_CHECK_RC" "missing relay_owner_kind is not ownerless wedge evidence"
+if [ "$(stored_count)" = "absent" ]; then
+    pass_test "wire-level owner absence reaches a clean marker verdict"
+else
+    fail_test "wire-level owner absence changed skip accounting"
+fi
+
 # Markers that clear during settle are also an evidence-based verdict.
 setup_case
 printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
@@ -330,6 +373,23 @@ if [ "$(stored_count)" = "1" ]; then
     pass_test "recovery deadline expiry is counted as a skip"
 else
     fail_test "recovery deadline expiry recorded consecutive_skips=$(stored_count), want 1"
+fi
+
+# A failed curl may still replace its -o file. The same recovery path is reused,
+# so path identity would bless those new bytes with the previous poll's gate.
+# Content identity must refuse them and account the unevaluable wait as a skip.
+setup_case
+POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS=2
+POST_DEPLOY_SMOKE_WEDGE_RECOVERY_POLL_SECS=1
+printf '%s\n' "$UNRECOVERED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+printf 'sequence_partial_fail\n' > "$STUB_STATE/curl.mode"
+printf '%s\n' "$UNRECOVERED_BODY" > "$STUB_STATE/curl.body.1"
+printf '%s\n' "$CLEAN_BODY" > "$STUB_STATE/curl.body.2"
+run_check; check_rc 0 "$RUN_CHECK_RC" "an un-gated replacement body cannot become a clean verdict"
+if [ "$(stored_count)" = "1" ]; then
+    pass_test "a failed fetch that replaced a gated path is accounted as a skip"
+else
+    fail_test "a failed fetch that replaced a gated path left consecutive_skips=$(stored_count), want 1"
 fi
 
 # ── The single gate: jq ─────────────────────────────────────────────────────
@@ -533,6 +593,19 @@ POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS=9223372036854775806
 printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
 run_check; check_rc 0 "$RUN_CHECK_RC" "the largest non-wrapping skip limit is accepted"
 
+# Leading zeroes are decimal operator spelling, not an octal knob.
+setup_case
+POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS=010
+POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS=010
+printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+run_check; check_rc 0 "$RUN_CHECK_RC" "leading-zero integer knobs are normalized as decimal"
+if [ "$POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS" = 10 ] \
+  && [ "$POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS" = 10 ]; then
+    pass_test "leading-zero wedge knobs are stored in decimal form"
+else
+    fail_test "leading-zero wedge knobs were not normalized"
+fi
+
 # ── A stored count outside bash's range is corruption, not zero ─────────────
 # Schema-valid and believable-looking, but `count + 1` wraps to a negative that
 # compares below every threshold — a state that had blown past the limit would
@@ -554,6 +627,23 @@ else
 fi
 printf '{"consecutive_skips": 99999999999999999999}\n' > "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
 run_check; check_rc 1 "$RUN_CHECK_RC" "a second out-of-range stored count fails the smoke"
+
+# Once the configured limit has been reached, later skips remain red. Saturate
+# at the limit instead of writing the next integer and reclassifying it as
+# corruption on the following deploy.
+setup_case
+POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS=9223372036854775806
+printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+_post_deploy_smoke_wedge_state_write \
+    '{"consecutive_skips": 9223372036854775806}' "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
+run_check; check_rc 1 "$RUN_CHECK_RC" "a skip at the maximum limit remains red"
+run_check; check_rc 1 "$RUN_CHECK_RC" "the next skip after the maximum limit remains red"
+if [ "$(stored_count)" = 9223372036854775806 ] \
+  && [ ! -e "${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.corrupt" ]; then
+    pass_test "the reached limit stays monotonic without corruption recovery"
+else
+    fail_test "the reached limit escaped through corruption recovery"
+fi
 
 # ── The single gate: skip-state I/O ─────────────────────────────────────────
 setup_case
@@ -597,6 +687,26 @@ if [ "$(stored_count)" = "1" ]; then
     pass_test "the skip was still recorded while refusing the planted temp symlink"
 else
     fail_test "the planted temp symlink cost the skip increment (count=$(stored_count))"
+fi
+
+# BSD mv follows a destination symlink to a directory unless -h is used. Swap
+# that symlink after the gate and verify the atomic replacement neither follows
+# it nor overwrites the attacker's same-basename sibling.
+setup_case
+printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+SYMLINK_TARGET_DIR="$ADK_REL/runtime/attacker-dir"
+mkdir -p "$SYMLINK_TARGET_DIR"
+victim="$SYMLINK_TARGET_DIR/$(basename "${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.tmp.$$")"
+printf 'victim-contents-must-survive\n' > "$victim"
+export SYMLINK_TARGET_DIR
+printf 'swap_state_dir\n' > "$STUB_STATE/curl.mode"
+printf '%s\n' "$WEDGED_BODY" > "$STUB_STATE/curl.body"
+run_check; check_rc 1 "$RUN_CHECK_RC" "a persistent marker still fails after a destination symlink swap"
+if [ ! -L "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ] \
+  && [ "$(cat "$victim")" = "victim-contents-must-survive" ]; then
+    pass_test "the atomic replace does not follow a directory symlink destination"
+else
+    fail_test "the atomic replace followed a directory symlink destination"
 fi
 
 setup_case

--- a/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
+++ b/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
@@ -179,7 +179,6 @@ ln -sf "$STUB_BIN/curl" "$NOJQ_BIN/curl"
 # what the gate now demands.
 CLEAN_BODY='{"fully_recovered": true, "mailboxes": [], "degraded_reasons": []}'
 WEDGED_BODY='{"fully_recovered": true, "degraded_reasons": [], "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"tmux_alive_relay_dead","relay_health":{"desynced":true}}]}'
-ACTIVE_BODY='{"fully_recovered": true, "degraded_reasons": [], "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"active_foreground_stream","inflight_state_present":false,"watcher_attached":true,"relay_health":{"desynced":false,"stale_thread_proof":false,"watcher_attached_stale":false}}]}'
 OWNERLESS_BODY='{"fully_recovered": true, "degraded_reasons": [], "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"healthy","inflight_state_present":true,"watcher_attached":true,"relay_health":{"desynced":false,"stale_thread_proof":false,"watcher_attached_stale":false}}]}'
 UNRECOVERED_BODY='{"fully_recovered": false, "mailboxes": [], "degraded_reasons": []}'
 
@@ -307,17 +306,37 @@ else
     fail_test "clean verdict recorded consecutive_skips=$(stored_count), want no state file"
 fi
 
-# Normal busy states are not wedge evidence. active_foreground_stream is a
-# healthy live turn, and relay_owner_kind is absent from the mailbox wire type,
-# so neither condition may manufacture a marker by itself.
-setup_case
-printf '%s\n' "$ACTIVE_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
-run_check; check_rc 0 "$RUN_CHECK_RC" "an active foreground stream is not a relay wedge"
-if [ "$(stored_count)" = "absent" ]; then
-    pass_test "an active foreground stream reaches a clean marker verdict"
-else
-    fail_test "an active foreground stream changed skip accounting"
-fi
+# relay_stall_state is classified by an explicit allowlist. Drive the complete
+# check so each normal state must reach markers=absent and each abnormal state
+# must persist its own marker after resampling. Other marker fields are false,
+# which prevents those clauses from hiding a missing stall-state comparison.
+while read -r stall expected_rc; do
+    setup_case
+    body=$(printf '%s\n' \
+        "{\"fully_recovered\":true,\"degraded_reasons\":[],\"mailboxes\":[{\"provider\":\"claude\",\"channel_id\":\"c1\",\"relay_stall_state\":\"$stall\",\"inflight_state_present\":false,\"watcher_attached\":true,\"relay_health\":{\"desynced\":false,\"stale_thread_proof\":false,\"watcher_attached_stale\":false}}]}")
+    printf '%s\n' "$body" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+    printf 'body\n' > "$STUB_STATE/curl.mode"
+    printf '%s\n' "$body" > "$STUB_STATE/curl.body"
+    run_check; check_rc "$expected_rc" "$RUN_CHECK_RC" "relay stall state $stall marker verdict"
+    if [ "$expected_rc" -eq 0 ]; then
+        if grep -q 'relay wedge markers=absent' "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+            pass_test "relay stall state $stall emits no marker"
+        else
+            fail_test "relay stall state $stall did not reach markers=absent"
+        fi
+    elif grep -q "relay wedge marker persisted.*stall=$stall" "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+        pass_test "relay stall state $stall emits a marker"
+    else
+        fail_test "relay stall state $stall did not persist its marker"
+    fi
+done <<'STALL_STATES'
+healthy 0
+active_foreground_stream 0
+explicit_background_work 0
+orphan_pending_token 1
+queue_blocked 1
+tmux_alive_relay_dead 1
+STALL_STATES
 
 setup_case
 printf '%s\n' "$OWNERLESS_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
@@ -647,7 +666,8 @@ fi
 # ── The single gate: skip-state I/O ─────────────────────────────────────────
 setup_case
 printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
-ln -sf /dev/null "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
+printf '{"consecutive_skips": 0}\n' > "$ADK_REL/runtime/symlink-target.json"
+ln -sf "$ADK_REL/runtime/symlink-target.json" "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
 run_check; check_rc 1 "$RUN_CHECK_RC" "symlinked skip state is unevaluable"
 
 # ── Predictable scratch paths are not writable handles ──────────────────────

--- a/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
+++ b/tests/test_deploy_smoke_wedge_skip_accounting_5244.sh
@@ -48,6 +48,7 @@ extract_function() {
 for fn in \
     _post_deploy_smoke_note \
     _post_deploy_smoke_fail \
+    _post_deploy_smoke_wedge_usable_int \
     _post_deploy_smoke_wedge_gate_jq \
     _post_deploy_smoke_wedge_gate_config \
     _post_deploy_smoke_wedge_gate_state \
@@ -110,7 +111,10 @@ case "$(cat "$STUB_STATE/curl.mode" 2>/dev/null || printf 'fail')" in
 esac
 STUB
 # jq stub: reports whatever version the test asks for and logs that the gate
-# actually consulted it, then delegates every real filter to the real jq.
+# actually consulted it, then delegates every real filter to the real jq —
+# unless jq.garbage is set, in which case every filter exits 0 with output that
+# has nothing to do with the input. That is the shape a version check cannot
+# see: an honest --version in front of a parser that answers nonsense.
 cat > "$STUB_BIN/jq" <<STUB
 #!/usr/bin/env bash
 if [ "\$1" = "--version" ]; then
@@ -118,6 +122,27 @@ if [ "\$1" = "--version" ]; then
     cat "\$STUB_STATE/jq.version"
     exit 0
 fi
+if [ -f "\$STUB_STATE/jq.garbage" ]; then
+    printf 'garbage-but-rc-zero\n'
+    exit 0
+fi
+# jq.boolgarble: honest everywhere including the gate's self-test, then garbage
+# from the SECOND fully_recovered read onwards. That filter is the only one
+# carrying this error message, so this reaches _post_deploy_smoke_fully_
+# recovered_from_file and nothing else.
+for arg in "\$@"; do
+    case "\$arg" in
+        *"is not boolean"*)
+            n=\$(cat "\$STUB_STATE/jq.boolgarble.calls" 2>/dev/null || printf 0)
+            n=\$((n + 1))
+            printf '%s\n' "\$n" > "\$STUB_STATE/jq.boolgarble.calls"
+            if [ -f "\$STUB_STATE/jq.boolgarble" ] && [ "\$n" -ge 2 ]; then
+                printf 'garbage-but-rc-zero\n'
+                exit 0
+            fi
+            ;;
+    esac
+done
 exec "$REAL_JQ" "\$@"
 STUB
 chmod +x "$STUB_BIN/curl" "$STUB_BIN/jq"
@@ -131,9 +156,12 @@ for tool in cat mv rm mkdir dirname sleep comm sort mktemp hostname date; do
 done
 ln -sf "$STUB_BIN/curl" "$NOJQ_BIN/curl"
 
-CLEAN_BODY='{"fully_recovered": true, "mailboxes": []}'
-WEDGED_BODY='{"fully_recovered": true, "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"stalled"}]}'
-UNRECOVERED_BODY='{"fully_recovered": false, "mailboxes": []}'
+# Fixtures carry the whole gated contract — mailboxes array, degraded_reasons
+# array, boolean fully_recovered — because that is what the server emits and
+# what the gate now demands.
+CLEAN_BODY='{"fully_recovered": true, "mailboxes": [], "degraded_reasons": []}'
+WEDGED_BODY='{"fully_recovered": true, "degraded_reasons": [], "mailboxes": [{"provider":"claude","channel_id":"c1","relay_stall_state":"stalled"}]}'
+UNRECOVERED_BODY='{"fully_recovered": false, "mailboxes": [], "degraded_reasons": []}'
 
 failures=0
 fail_test() {
@@ -171,6 +199,8 @@ setup_case() {
     POST_DEPLOY_SMOKE_WEDGE_RECOVERY_REASON=""
     printf 'jq-1.7.1-apple\n' > "$STUB_STATE/jq.version"
     : > "$STUB_STATE/jq.version.calls"
+    rm -f "$STUB_STATE/jq.garbage" "$STUB_STATE/jq.boolgarble"
+    printf '0\n' > "$STUB_STATE/jq.boolgarble.calls"
     printf 'fail\n' > "$STUB_STATE/curl.mode"
     # The production functions arrive through eval, so the linter cannot see
     # that they consume these globals; exporting them states the contract.
@@ -334,31 +364,118 @@ for good_version in jq-1.7 jq-1.7.1 jq-1.7.1-apple jq-2.0; do
 done
 
 # ── The single gate: health/detail schema ───────────────────────────────────
-# Every one of these shapes makes `.mailboxes[]?` emit nothing, which reads as
-# "no wedge markers" — a clean verdict for a body that was never understood.
+# The gate must assert the WHOLE contract its consumers read, not one field of
+# it. A gate narrower than its consumers is the same defect one field over, so
+# the shapes below are organised as a 1:1 contrast with the consumption sites:
+# each row breaks exactly one consumed field and nothing else, and every row
+# must be unevaluable.
+#
+#   consumer : field                              broken by rows tagged
+#   -------------------------------------------   ---------------------
+#   all consumers : the body is an object          [object]
+#   _markers_from_file : .mailboxes[]?             [mailboxes]
+#   _markers_from_file : .degraded_reasons[]?      [degraded_reasons]
+#   _fully_recovered_from_file : .fully_recovered  [fully_recovered]
+#
+# If a consumer is added that reads a fifth thing, this table gains a row and
+# the gate gains a clause. Drift between the two columns IS the defect.
 while IFS= read -r shape; do
     setup_case
     printf '%s\n' "$shape" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
     run_check; check_rc 1 "$RUN_CHECK_RC" "top-level shape $shape is unevaluable"
 done <<'SHAPES'
-{"fully_recovered": true}
-{"fully_recovered": true, "mailboxes": null}
-{"fully_recovered": true, "mailboxes": "none"}
-{"fully_recovered": true, "mailboxes": 0}
-{"fully_recovered": true, "mailboxes": {}}
+{"fully_recovered": true, "degraded_reasons": []}
+{"fully_recovered": true, "degraded_reasons": [], "mailboxes": null}
+{"fully_recovered": true, "degraded_reasons": [], "mailboxes": "none"}
+{"fully_recovered": true, "degraded_reasons": [], "mailboxes": 0}
+{"fully_recovered": true, "degraded_reasons": [], "mailboxes": {}}
+{"fully_recovered": true, "mailboxes": []}
+{"fully_recovered": true, "mailboxes": [], "degraded_reasons": null}
+{"fully_recovered": true, "mailboxes": [], "degraded_reasons": "relay wedge"}
+{"fully_recovered": true, "mailboxes": [], "degraded_reasons": {}}
+{"mailboxes": [], "degraded_reasons": []}
+{"fully_recovered": null, "mailboxes": [], "degraded_reasons": []}
+{"fully_recovered": "true", "mailboxes": [], "degraded_reasons": []}
+{"fully_recovered": 1, "mailboxes": [], "degraded_reasons": []}
 [null]
 ["mailboxes"]
 "a string body"
 17
 SHAPES
 
-# The resample body is gated too. Before this PR a schema-broken resample
-# produced zero markers, which `comm -12` read as "markers cleared".
+# The resample body is gated too, on every clause. Before this PR a
+# schema-broken resample produced zero markers, which `comm -12` read as
+# "markers cleared".
+for broken_resample in \
+    '{"fully_recovered": true, "degraded_reasons": [], "mailboxes": "none"}' \
+    '{"fully_recovered": true, "mailboxes": [], "degraded_reasons": "none"}' \
+    '{"fully_recovered": "yes", "mailboxes": [], "degraded_reasons": []}'
+do
+    setup_case
+    printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+    printf 'body\n' > "$STUB_STATE/curl.mode"
+    printf '%s\n' "$broken_resample" > "$STUB_STATE/curl.body"
+    run_check
+    check_rc 1 "$RUN_CHECK_RC" "schema-broken settle resample $broken_resample is unevaluable, not cleared"
+done
+
+# A recovery POLL body that breaks the contract is the case leg B reproduced as
+# a green skip: the wait could not read fully_recovered, gave up at the
+# deadline, and called that "recovery state unavailable". It is a gate trip.
+for broken_poll in \
+    '{"mailboxes": [], "degraded_reasons": []}' \
+    '{"fully_recovered": "yes", "mailboxes": [], "degraded_reasons": []}' \
+    '{"fully_recovered": true, "mailboxes": [], "degraded_reasons": "wedge"}'
+do
+    setup_case
+    POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS=2
+    POST_DEPLOY_SMOKE_WEDGE_RECOVERY_POLL_SECS=1
+    printf '%s\n' "$UNRECOVERED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+    printf 'body\n' > "$STUB_STATE/curl.mode"
+    printf '%s\n' "$broken_poll" > "$STUB_STATE/curl.body"
+    run_check
+    check_rc 1 "$RUN_CHECK_RC" "schema-broken recovery poll $broken_poll is a gate trip, not a skip"
+done
+
+# ── The single gate: jq that exits 0 and lies ───────────────────────────────
+# The version gate proves a claim about jq, not a behaviour. Only the gate's
+# semantic self-test separates a working parser from one that returns success
+# with unrelated output — and that output otherwise reads as "not recovered",
+# i.e. a skip for a body nobody parsed.
+setup_case
+printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+: > "$STUB_STATE/jq.garbage"
+run_check; garbage_rc="$RUN_CHECK_RC"
+rm -f "$STUB_STATE/jq.garbage"
+check_rc 1 "$garbage_rc" "a jq that exits 0 with garbage output is unevaluable"
+if [ "$(stored_count)" = "absent" ]; then
+    pass_test "a lying jq is an accounting failure, not a skip"
+else
+    fail_test "a lying jq recorded consecutive_skips=$(stored_count), want no skip"
+fi
+
+# The self-test cannot cover a jq that answers honestly once and then garbles a
+# real body, so the reader checks its own output too. Isolating that guard takes
+# the settle path: the recovery read is honest (so the wait completes and the
+# markers are real), the settle read is garbage. Without the reader's true/false
+# check that garbage merely fails `= "false"`, the check walks on to compare
+# markers, finds them cleared, and RESETS the streak — a clean verdict derived
+# from a recovery state nobody read. With it, the deploy skips, and from a
+# streak of 2 that skip is the third, which is red.
 setup_case
 printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
 printf 'body\n' > "$STUB_STATE/curl.mode"
-printf '%s\n' '{"fully_recovered": true, "mailboxes": "none"}' > "$STUB_STATE/curl.body"
-run_check; check_rc 1 "$RUN_CHECK_RC" "schema-broken settle resample is unevaluable, not cleared"
+printf '%s\n' "$CLEAN_BODY" > "$STUB_STATE/curl.body"
+_post_deploy_smoke_wedge_state_write '{"consecutive_skips": 2}' "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
+: > "$STUB_STATE/jq.boolgarble"
+run_check; boolgarble_rc="$RUN_CHECK_RC"
+rm -f "$STUB_STATE/jq.boolgarble"
+check_rc 1 "$boolgarble_rc" "a garbled settle recovery state cannot become a cleared verdict"
+if [ "$(stored_count)" = "3" ]; then
+    pass_test "a garbled settle recovery state is skipped, not reset"
+else
+    fail_test "a garbled settle recovery state left consecutive_skips=$(stored_count), want 3"
+fi
 
 # A gate that trips DURING the recovery wait is the case only the exit
 # assertion can catch: the wait gives up, the caller records a skip, and the
@@ -383,11 +500,104 @@ ungated_rc=0
 _post_deploy_smoke_wedge_markers_from_file "$TMP_ROOT/ungated.json" > /dev/null 2>&1 || ungated_rc=$?
 check_rc 1 "$ungated_rc" "an ungated body is refused by the sole jq reader"
 
+# ── The single gate: knobs bash can actually compare ────────────────────────
+# A digit-only wait outside bash's integer range passes a shape check and then
+# makes every `-ge` in the wait loop error out. The loop reads that error as
+# "deadline not reached", so the bounded wait stops being bounded. The stub
+# curl counter proves the gate stops it BEFORE the first poll rather than
+# merely surviving it.
+for huge_knob in 9223372036854775808 99999999999999999999 999999999999999999999999999999999999; do
+    setup_case
+    POST_DEPLOY_SMOKE_WEDGE_RECOVERY_WAIT_SECS="$huge_knob"
+    POST_DEPLOY_SMOKE_WEDGE_RECOVERY_POLL_SECS=1
+    printf '%s\n' "$UNRECOVERED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+    printf 'body\n' > "$STUB_STATE/curl.mode"
+    printf '%s\n' "$CLEAN_BODY" > "$STUB_STATE/curl.body"
+    printf '0\n' > "$STUB_STATE/curl.calls"
+    run_check
+    check_rc 1 "$RUN_CHECK_RC" "out-of-range recovery wait '$huge_knob' is unevaluable"
+    if [ "$(cat "$STUB_STATE/curl.calls")" = "0" ]; then
+        pass_test "out-of-range wait '$huge_knob' never entered the poll loop"
+    else
+        fail_test "out-of-range wait '$huge_knob' polled $(cat "$STUB_STATE/curl.calls") time(s)"
+    fi
+done
+# 2^63-1 is comparable but wraps to a negative on the +1 the counter performs,
+# so the gate rejects it too; 2^63-2 is the largest knob that survives both.
+setup_case
+POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS=9223372036854775807
+printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+run_check; check_rc 1 "$RUN_CHECK_RC" "a skip limit that wraps when incremented is unevaluable"
+setup_case
+POST_DEPLOY_SMOKE_WEDGE_MAX_CONSECUTIVE_SKIPS=9223372036854775806
+printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+run_check; check_rc 0 "$RUN_CHECK_RC" "the largest non-wrapping skip limit is accepted"
+
+# ── A stored count outside bash's range is corruption, not zero ─────────────
+# Schema-valid and believable-looking, but `count + 1` wraps to a negative that
+# compares below every threshold — a state that had blown past the limit would
+# come back reading as brand new. It must land in the corrupt tally instead, so
+# a second consecutive occurrence turns the smoke red.
+setup_case
+printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+printf '{"consecutive_skips": 9223372036854775807}\n' > "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
+run_check; check_rc 0 "$RUN_CHECK_RC" "an out-of-range stored count recovers from 0 once"
+if [ "$(cat "${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.corrupt" 2>/dev/null || printf 'absent')" = "1" ]; then
+    pass_test "an out-of-range stored count is tallied as corruption"
+else
+    fail_test "an out-of-range stored count was not tallied as corruption"
+fi
+if [ "$(stored_count)" = "1" ]; then
+    pass_test "an out-of-range stored count does not wrap into the counter"
+else
+    fail_test "an out-of-range stored count left consecutive_skips=$(stored_count), want 1"
+fi
+printf '{"consecutive_skips": 99999999999999999999}\n' > "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
+run_check; check_rc 1 "$RUN_CHECK_RC" "a second out-of-range stored count fails the smoke"
+
 # ── The single gate: skip-state I/O ─────────────────────────────────────────
 setup_case
 printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
 ln -sf /dev/null "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
 run_check; check_rc 1 "$RUN_CHECK_RC" "symlinked skip state is unevaluable"
+
+# ── Predictable scratch paths are not writable handles ──────────────────────
+# `.probe.$$` and `.tmp.$$` are guessable. A symlink planted at either is
+# written THROUGH by a plain redirection: the whole checker returns 0 while an
+# unrelated file is truncated, and in the `.tmp` case the atomic replace then
+# renames the symlink onto the state path, quietly undoing the gate's own
+# regular-file verdict. Exclusive creation is what makes the gate's claim true.
+setup_case
+printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+printf 'victim-contents-must-survive\n' > "$ADK_REL/runtime/victim"
+ln -sf "$ADK_REL/runtime/victim" "${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.probe.$$"
+run_check
+if [ "$(cat "$ADK_REL/runtime/victim")" = "victim-contents-must-survive" ]; then
+    pass_test "the gate's writability probe does not truncate a planted symlink target"
+else
+    fail_test "the gate's writability probe truncated the planted symlink target"
+fi
+
+setup_case
+printf '%s\n' "$WEDGED_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
+printf 'victim-contents-must-survive\n' > "$ADK_REL/runtime/victim"
+ln -sf "$ADK_REL/runtime/victim" "${POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE}.tmp.$$"
+run_check
+if [ "$(cat "$ADK_REL/runtime/victim")" = "victim-contents-must-survive" ]; then
+    pass_test "the atomic replace does not write through a planted temp symlink"
+else
+    fail_test "the atomic replace wrote the skip state through a planted temp symlink"
+fi
+if [ ! -L "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE" ]; then
+    pass_test "the skip state is still a regular file after the atomic replace"
+else
+    fail_test "the atomic replace turned the skip state into a symlink"
+fi
+if [ "$(stored_count)" = "1" ]; then
+    pass_test "the skip was still recorded while refusing the planted temp symlink"
+else
+    fail_test "the planted temp symlink cost the skip increment (count=$(stored_count))"
+fi
 
 setup_case
 printf '%s\n' "$CLEAN_BODY" > "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
@@ -435,9 +645,12 @@ printf 'not json at all\n' > "$POST_DEPLOY_SMOKE_WEDGE_SKIP_STATE"
 run_check; check_rc 1 "$RUN_CHECK_RC" "a second consecutive unreadable skip state fails the smoke"
 
 # ── Migration ratchet, not an eternal invariant ─────────────────────────────
-# 7 = the 8 wedge skip branches on main minus the two first-sample recovery
-# branches, which S2 merged into one bounded wait, plus nothing new. A genuine
-# refactor may change this number; change it deliberately and say why.
+# 7 = 8 - 2 + 1. main had 8 wedge skip branches; S2 replaced the two
+# first-sample recovery branches with one bounded wait (-2) and that merged
+# wait still ends in a skip of its own when the deadline expires (+1). Counting
+# call sites proves every skip goes through the accounting helper, not that
+# every branch that ought to skip does. A genuine refactor may change this
+# number; change it deliberately and say why.
 skip_sites=$(grep -c '_post_deploy_smoke_wedge_skip "' "$DEPLOY_SH" || true)
 if [ "$skip_sites" -eq 7 ]; then
     pass_test "all wedge skip branches go through the accounting helper (7 sites)"


### PR DESCRIPTION
## 무엇을 고치는가

post-deploy 기능 스모크의 **릴레이 wedge 검사가 "평가할 수 없음"을 조용한 skip 으로 처리**해서,
한 번도 실제로 평가되지 않은 채 배포가 계속 green 이 됐다 (#5244).

이 PR 은 두 가지만 담는다:
1. **S1′ skip 연속 회계** — skip 을 연속 카운트해 임계(기본 3) 도달 시 스모크를 red 로.
2. **S2 복구 대기** — 재시작 직후 `fully_recovered=false` 구간을 bounded 대기로 넘겨,
   정상적인 첫 턴을 wedge 로 오인하지 않게.

**durable 축은 의도적으로 제외했다** — `delivered_frontier` / `discord_delivery_records` /
`watcher_owner_channel_id` 는 한 줄도 건드리지 않는다. 그 축이 왜 지금 쓸 수 없는지는
#5263 · #5264 · #5265 에 실측으로 등재했다.

## 설계의 핵심 — 단일 관문

`_post_deploy_smoke_check_wedges` **진입부에서 한 번** 전제조건을 집행하고,
**관문 실패는 skip 이 아니라 회계 실패**로 보낸다.

- 관문: jq 존재 · 버전 ≥1.7 · 노브 정수성 · 상태 파일 I/O · body 최상위 스키마
- **sole reader** 가 방금 게이트를 통과한 body 외에는 파싱을 거부
- **종료 단언** 이 실행 중 어디서든 트립한 관문을 nonzero 로 전환
- 소비 사이트 ↔ 게이트 절 **1:1 대조표**를 코드 주석에 남겼고,
  **이 게이트가 assert 하지 않는 것**도 그 옆에 정확히 선언했다

왜 이 형태인가: 앞선 발산 브랜치가 3라운드 동안 **같은 부류의 결함**(평가 못한 것을 평가한 것처럼 처리)을
매번 다른 사이트에서 냈다. 사이트마다 손으로 막는 대신 관문을 하나로 모았다.

## 탐지 범위를 좁혔다 (정직한 축소)

`relay_stall_state` 는 7종인데 정상이 셋(`healthy` / `active_foreground_stream` / `explicit_background_work`)이다.
기존 필터는 그 문자열만으로 wedge 를 판정해서 **라이브 턴 동반 배포마다 거짓 FAIL** 을 냈다
(에이전트 주도 배포의 기본형이다). 그래서 이상 상태만 **화이트리스트**로 좁혔다:
`orphan_pending_token` / `queue_blocked` / `tmux_alive_relay_dead`.

`relay_owner_kind` 기반 ownerless 절은 **서버가 그 필드를 직렬화하지 않아** 구조적으로 발화 불가라 제거했다.
그렇게 잃은 검출력은 셸에서 회수할 수 없다 — **#5265** 에 후속으로 등재했다.

## 검증

- 뮤테이션 **20/20 KILLED, 생존 0**. 전부 stub PATH 아래 `_post_deploy_smoke_check_wedges` **전체 구동**
- 마커 절 4개(`desynced` / `stale_thread_proof` / `watcher_attached_stale` / `inflight && !watcher`)를
  각각 무력화하면 **각각 rc=1** 로 죽는다 (r4 에서는 지워도 통과했다 — r5 가 고정)
- 게이트: `standby_gate_5026` / `warn_scope_4511` / `restart_drain_helpers` / `rollback_health_4348` /
  `python3 -m unittest tests.test_pg_tunnel` / 신규 스위트 — 전부 rc=0
- `TEST_LANE_BASELINE_REF=759e9f4b0… bash scripts/ci-script-checks.sh` → **rc=0, 배너 49**
- `shellcheck -S warning` 두 파일 0경고
- 라이브 `/api/health/detail` 로 필터 실행 → **마커 0건** (정상 채널을 wedge 로 부르지 않는다)

## 리뷰

교차모델 적대 리뷰 5라운드. 최종 두 leg **`VERDICT: CLEAN`**.
발산 브랜치(`+733 → +1249 → +1470`)는 폐기하고 `origin/main` 위에 최소집합으로 재구성했으며,
재구성 이후 프로덕션 표면은 **단조 축소**했다 (`+863 → +1261 → +576/−49 → +578/−48`).
마지막 라운드는 **프로덕션 0줄 변경**(테스트 전용)이다.

## 남긴 한계 (주석에 그대로 적혀 있다)

- `.mailboxes[]` **내부** 형태 드리프트는 게이트가 assert 하지 않는다. 일부는 jq rc=5 로 닫히지만
  부재·null·false·문자열화된 boolean 은 조용히 default 로 흡수된다
- 관문이 늦게 트립하면 그 전에 기록된 skip 증가분은 되돌리지 않는다
  (부풀린 카운트는 *나중* 배포를 더 일찍 실패시킬 뿐 통과시키지는 않는다)
- 외부에서 state 파일이 1회 손상되면 임계 도달 후에도 약 2 deploy 가 green 으로 돌아온다
  (`repeated unreadable state` 로 선언돼 있고 포화가 자기유발 경로는 막는다)

fixes #5244
