### PR TITLE
docs(#5268): make the #5071 T1 S5b freshness header parseable

### DIFF
--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -1,21 +1,22 @@
 # Discord Outbound Migration — Coverage Map (#1006 v3 / #1280 / #1436 / #1457)
 
-> Last refreshed: 2026-08-08 (#5071 T1 S5b — **on unix**, the recovery /
-> fresh-send / orphan family joined the shadow journal, at the anchor S5a
-> corrected. Its three confirmed-delivery entry points (the leased no-anchor fresh
-> send, the anchored-replace edit-failure fallback, and the same fallback through
-> the turn-output controller) open one obligation immediately before
-> `RecoveryDeliveryContext::record_durable_frontier`, and that funnel returns its
-> own verdict so the obligation settles `C` only when the durable write returned
-> `Ok`; every refusal it already had — no tmux session name, no current
-> generation marker, write error, anchor bind not persisted — settles `U` naming
-> itself. Two ceilings are declared rather than papered over: the obligation opens
-> AFTER transport, because two of the three entry points only learn that they
-> advance the frontier from the edit transport's own answer, so a recovery
-> delivery lost mid-POST leaves no trace; and it emits no `T`, because no receipt
-> is observable on this path and synthesising one from the anchor message id would
-> make `requested == returned` structurally true. The journal stays shadow-only
-> with nothing reading it back, and the recovery path's bypass of the
+> Last refreshed: 2026-08-08 (against #5071 T1 S5b).
+>
+> — **on unix**, the recovery / fresh-send / orphan family joined the shadow
+> journal, at the anchor S5a corrected. Its three confirmed-delivery entry points
+> (the leased no-anchor fresh send, the anchored-replace edit-failure fallback,
+> and the same fallback through the turn-output controller) open one obligation
+> immediately before `RecoveryDeliveryContext::record_durable_frontier`, and that
+> funnel returns its own verdict so the obligation settles `C` only when the
+> durable write returned `Ok`; every refusal it already had — no tmux session
+> name, no current generation marker, write error, anchor bind not persisted —
+> settles `U` naming itself. Two ceilings are declared rather than papered over:
+> the obligation opens AFTER transport, because two of the three entry points only
+> learn that they advance the frontier from the edit transport's own answer, so a
+> recovery delivery lost mid-POST leaves no trace; and it emits no `T`, because no
+> receipt is observable on this path and synthesising one from the anchor message
+> id would make `requested == returned` structurally true. The journal stays
+> shadow-only with nothing reading it back, and the recovery path's bypass of the
 > `shadow_mirror_delivered_frontier` funnel is deliberately still there — S5b
 > measures that bypass, T1 S7 closes it. Off unix this family is uninstrumented:
 > the journal is `#[cfg(unix)]` while `recovery_engine` / `recovery_paths` /
@@ -23,7 +24,7 @@
 > non-unix half is an uninhabited enum. The uninstrumented baseline moves 2 -> 1;
 > the one family still uninstrumented is `pipe stream epoch`, whose own anchor is
 > the open question S5a raised. No delivery behaviour changes, so the coverage
-> rows below are unchanged.)
+> rows below are unchanged.
 
 > Last refreshed: 2026-08-08 (#5071 T1 S5a — the shadow journal's **family map**
 > was corrected; no family gained instrumentation and the uninstrumented baseline


### PR DESCRIPTION
Closes #5268.

`docs/agent-maintenance/discord-outbound-migration.md` 의 `Last refreshed` 헤더가 여러 블록쿼트 줄에 걸쳐 있어 freshness 파서가 인식하지 못했다.

## 무엇을 바꿨나

헤더를 파서가 요구하는 한 줄 형태로 분리하고, 원래 설명 산문은 바로 아래 블록쿼트로 옮겼다. **날짜와 설명 문구는 유지**했다 — 갱신 권위는 #5071 소유 범위에 남는다. 중복 freshness 스텁은 추가하지 않았다(#5242 에서 시도했다가 되돌린 접근).

```
> Last refreshed: 2026-08-08 (against #5071 T1 S5b).
>
> — **on unix**, the recovery / fresh-send / orphan family joined ...
```

## 파서가 실제로 하는 일 (정정)

이 PR 의 초기 본문은 파서가 **"파일당 최상단 헤더 하나"** 를 권위로 삼는다고 썼다. **거짓이다.** `check_agent_maintenance_docs.py::parse_last_refreshed` (`:166-179`) 는 **1~80행 안에서 정규식에 매치되는 첫 헤더**를 권위로 삼는다. 매치되지 않는 헤더는 조용히 건너뛰고 그 아래 헤더로 내려간다.

이 차이가 중요한 이유: 다중행 헤더는 **에러가 아니라 침묵**이다. 더 오래된 아래쪽 헤더가 권위가 되고, 문서는 실제보다 stale 한 상태로 게이트된다.

## 형제 문서에 같은 결함이 살아 있다 (정정)

초기 본문은 다른 가드 문서 헤더가 **"전부 한 물리적 줄"** 이라고 썼다. **이것도 거짓이다.** 실측:

| 문서 | 표시된 최신 헤더 | 실제로 강제되는 헤더 |
|---|---|---|
| `change-surfaces.md:11` | 2026-08-06 (다중행 — 매치 안 됨) | 2026-07-21 |
| `multinode-transition.md:17` | 2026-07-31 (`against` 누락) | 그 아래 |

즉 두 문서가 **지금 stale 헤더로 게이트되고 있다.** 이 PR 은 `discord-outbound-migration.md` 만 고치므로 그 둘은 열린 채로 남는다 — 별도 후속으로 등재한다.

## 문서를 고쳤지 파서를 고치지 않은 이유

파서를 다중행까지 넓히면 지금 조용히 건너뛰고 있는 헤더들이 일제히 정본으로 바뀌어 **기존 finding 이 소리 없이 달라진다.** 그 변화는 이 PR 의 범위를 넘고, 위 형제 문서 2건과 함께 판단해야 한다.

## 검증

| 항목 | 결과 |
|---|---|
| `check_agent_maintenance_docs.py` (strict) | rc=0 — `agent-maintenance freshness check passed` |
| `check_agent_maintenance_docs.py --warning-only --line-count-gate` | rc=0 — 동일 |
| `generate_inventory_docs.py` 후 tracked 산출물 | 전부 unchanged |
| finding diff | 사라진 finding 은 이 헤더 것 **한 건뿐** (strict/CI 양쪽) |
| 산문 무손실 | 리뷰 leg 가 공백·블록쿼트 마커 정규화 후 비교 — 텍스트 동일 |

base 상태는 이 문서의 **헤더 인식 0개**였고, CI 는 `--warning-only` 라 rc=0 이었다(즉 침묵으로 통과 중이었다).

전달 동작 변경 없음 — 커버리지 행은 그대로다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)