### PR TITLE
fix(docs): surface freshness headers the parser silently skips

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -8,14 +8,16 @@
 > [`docs/generated/giant-file-registry.md`](../generated/giant-file-registry.md);
 > the rows below project the operational meaning of each entry.
 >
-> Last refreshed: 2026-08-06 (#5071 T1 S3b — the dead-tmux tail drain in
-> `tmux.rs` (`drain_missing_inflight_dead_tmux_tail_to_eof`) now records itself in
+> Last refreshed: 2026-08-06 (against #5071 T1 S3b).
+>
+> — the dead-tmux tail drain in `tmux.rs`
+> (`drain_missing_inflight_dead_tmux_tail_to_eof`) now records itself in
 > the delivery journal. That arm advances the relay frontier to EOF so it cannot
 > strand behind a dead wrapper, but nothing is posted, so it emits `O`+`S` only —
 > no attempt and no receipt — and is never counted as Delivered. Shadow
 > instrumentation only: the drain's trigger conditions, offset authority and
 > delivery behavior are unchanged, and no new coordinate field or
-> migration-sensitive surface is added).
+> migration-sensitive surface is added.
 >
 > Last refreshed: 2026-07-21 (against #4706 acceptance repair: structural lint allow baseline, giant-registry issue validation, and production-count sync).
 >

--- a/docs/agent-maintenance/index.md
+++ b/docs/agent-maintenance/index.md
@@ -89,7 +89,11 @@ refresh is intentionally anchored to review context instead of a commit, use
 `Last refreshed: <date> (against #<issue> <reason>)`,
 `Last refreshed: <date> (against PR #<num> <reason>)`, or
 `Last refreshed: <date> (manual: <reason>)`; those forms still get date
-freshness checks but skip commit ancestry validation. The gate warns when
+freshness checks but skip commit ancestry validation. The header must occupy one
+physical line; put longer refresh notes in prose below it. Within the first 80
+lines, the first matching header is authoritative: non-matching
+`Last refreshed:` candidates are skipped, and the gate reports any such
+candidate above the authoritative match. The gate warns when
 copied line counts in `change-surfaces.md` drift from
 `docs/generated/module-inventory.md`, and requires the matching maintenance
 page to be touched when guarded code globs change. That touch rule is a

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -14,7 +14,7 @@
 > moving any AgentDesk runtime, worker, dispatch, provider, MCP, merge, or test
 > execution path from one dcserver node to multiple nodes.
 >
-> Last refreshed: 2026-07-31 (PR #5048 stale-route recovery changes).
+> Last refreshed: 2026-07-31 (against PR #5048 stale-route recovery changes).
 >
 > Last refreshed: 2026-07-05 (#4089 — `worker_registry.rs` exposes the local RateLimitSync leader-worker active flag (`rate_limit_sync_active`) so the claude-accounts switch endpoint can report whether the receiving node performs usage collection. Read-only exposure: leader election, lease, and singleton ownership assumptions are unchanged; the Keychain auth switch itself is node-local by design (MVP), so non-leader switches surface `rate_limit_sync_not_active_on_this_node` instead of racing the leader loop.)
 >

--- a/scripts/check_agent_maintenance_docs.py
+++ b/scripts/check_agent_maintenance_docs.py
@@ -45,6 +45,7 @@ LAST_REFRESHED_RE = re.compile(
     r")"
     r"\)\.?\s*$"
 )
+LAST_REFRESHED_PREFIX_RE = re.compile(r"^>\s*Last refreshed:\s*")
 # Module inventory row: | `module` | `path` | <total> | <prod> | <test> | flags |
 MODULE_INVENTORY_ROW_RE = re.compile(
     r"^\|\s*`[^`]+`\s*\|\s*`(?P<path>[^`]+\.rs)`\s*\|"
@@ -179,6 +180,26 @@ def parse_last_refreshed(text: str) -> LastRefreshed | None:
     return None
 
 
+def find_skipped_last_refreshed_lines(
+    text: str, authoritative_line: int
+) -> list[int]:
+    """Return malformed header candidates skipped before the first valid header.
+
+    This deliberately shares the parser's bounded top-matter window and only
+    diagnoses blockquote lines that start with ``Last refreshed:``. Candidates
+    after the authoritative match remain historical prose, and a document with
+    no valid match is handled by the existing missing-header finding.
+    """
+
+    lines = text.splitlines()[:HEADER_SCAN_LINE_LIMIT]
+    return [
+        line_no
+        for line_no, line in enumerate(lines[: authoritative_line - 1], start=1)
+        if LAST_REFRESHED_PREFIX_RE.match(line.strip()) is not None
+        and LAST_REFRESHED_RE.match(line.strip()) is None
+    ]
+
+
 def check_doc_headers(
     repo_root: Path, today: dt.date, freshness_days: int
 ) -> list[Finding]:
@@ -191,7 +212,8 @@ def check_doc_headers(
             )
             continue
 
-        parsed = parse_last_refreshed(path.read_text(encoding="utf-8"))
+        text = path.read_text(encoding="utf-8")
+        parsed = parse_last_refreshed(text)
         if parsed is None:
             findings.append(
                 Finding(
@@ -205,6 +227,20 @@ def check_doc_headers(
                 )
             )
             continue
+
+        for line_no in find_skipped_last_refreshed_lines(text, parsed.line):
+            findings.append(
+                Finding(
+                    "error",
+                    rel_path,
+                    (
+                        "unrecognized Last refreshed header was skipped before "
+                        f"the authoritative header on line {parsed.line}; keep the "
+                        "header on one physical line and use a documented anchor shape."
+                    ),
+                    line_no,
+                )
+            )
 
         if parsed.refreshed_on > today:
             findings.append(

--- a/tests/test_agent_maintenance_docs.py
+++ b/tests/test_agent_maintenance_docs.py
@@ -104,6 +104,63 @@ class LastRefreshedHeaderTest(unittest.TestCase):
 
 
 class HeaderValidationTest(unittest.TestCase):
+    def _write_guarded_docs(self, root: Path, target_body: str) -> None:
+        valid_body = """
+            # Doc
+
+            > Last refreshed: 2026-04-30 (manual: test fixture).
+        """
+        for rel_path in CHECKER.MIGRATION_SENSITIVE_DOCS:
+            body = (
+                target_body
+                if rel_path.endswith("change-surfaces.md")
+                else valid_body
+            )
+            _write(root, rel_path, body)
+
+    def test_errors_on_unrecognized_header_before_authoritative_match(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_guarded_docs(
+                root,
+                """
+                # Doc
+
+                > Last refreshed: 2026-05-01 (against #5270 multiline audit
+                > details continue here).
+
+                > Last refreshed: 2026-04-30 (manual: older valid anchor).
+                """,
+            )
+            findings = CHECKER.check_doc_headers(
+                root, CHECKER.dt.date(2026, 5, 1), CHECKER.DEFAULT_FRESHNESS_DAYS
+            )
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].severity, "error")
+        self.assertEqual(findings[0].line, 3)
+        self.assertIn("was skipped", findings[0].message)
+        self.assertIn("authoritative header on line 6", findings[0].message)
+
+    def test_ignores_unrecognized_header_after_authoritative_match(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_guarded_docs(
+                root,
+                """
+                # Doc
+
+                > Last refreshed: 2026-05-01 (against #5270 valid anchor).
+
+                > Last refreshed: 2026-04-30 (undocumented historical shape).
+                """,
+            )
+            findings = CHECKER.check_doc_headers(
+                root, CHECKER.dt.date(2026, 5, 1), CHECKER.DEFAULT_FRESHNESS_DAYS
+            )
+
+        self.assertEqual(findings, [])
+
     def test_unresolvable_commit_is_warning_in_shallow_checkout(self) -> None:
         commit = "1d165cd3844e94015ab30cda8e4b1bba717f934d"
 


### PR DESCRIPTION
Closes #5270.

## 문제 — 실패가 조용했다

`check_agent_maintenance_docs.py::parse_last_refreshed` 는 **1~80행 안에서 정규식에 매치되는 첫 헤더**를 권위로 삼는다. 매치 실패는 **에러가 아니라 침묵**이고 그대로 아래 헤더로 내려간다.

그래서 최신 헤더가 형식을 어기면 게이트는 통과하는데 **더 오래된 날짜로 게이트된다.** 아무도 모른다.

실측으로 확인된 살아 있는 사이트 2건:

| 문서 | 표시된 최신 헤더 | 실제로 강제되던 헤더 | 어긴 형식 |
|---|---|---|---|
| `change-surfaces.md:11` | 2026-08-06 (#5071 T1 S3b) | **2026-07-21** | 다중행 |
| `multinode-transition.md:17` | 2026-07-31 (PR #5048) | 그 아래 | `against` 누락 |

## 무엇을 바꿨나

**1. 두 사이트의 헤더를 파서가 인식하는 형태로 고쳤다.** 날짜와 설명 문구는 유지 — 갱신 권위는 각 문서의 원 소유 범위에 남는다.

**2. 침묵을 소리로 바꿨다.** `find_skipped_last_refreshed_lines` 는 권위 헤더보다 **위에** 있으면서 `> Last refreshed:` 로 시작하는데 전체 정규식에는 매치되지 않는 줄을 finding 으로 낸다. 사이트 2건만 고치면 세 번째가 또 조용히 생기므로 이쪽이 본체다.

**3. `index.md` 의 Freshness Gate 절에 두 규칙을 명시했다** — 헤더는 **단일 물리 행**이어야 하고, **첫 매치가 권위**다. 이 둘이 안 적혀 있던 것이 재발 원인이다.

## 검증

**긍정 대조 (positive control)** — 고친 헤더를 일부러 다시 다중행으로 되돌리면:

```
broken -> enforced 2026-07-21 line 23
skipped lines: [11]
```

강제 날짜가 조용히 되돌아가고, **동시에 새 검사가 11행을 지목한다.**

수정 후 실제 상태:

```
change-surfaces.md        -> 2026-08-06 line 11  skipped []
multinode-transition.md   -> 2026-07-31 line 17  skipped []
```

| 항목 | 결과 |
|---|---|
| finding diff (base vs HEAD) | **0 bytes** — 새로 생기거나 사라진 finding 없음 |
| strict | rc=1 — PR #5269 소유의 기존 Discord finding 1건뿐 (base 와 동일) |
| CI 형태 (`--warning-only --line-count-gate`) | rc=0 |
| 검사 뮤테이션 | 호출부 제거 시 `AssertionError: 0 != 1` FAILED / 복원 시 OK |
| 전체 테스트 | 32 tests OK |
| `generate_inventory_docs.py` 후 tracked 산출물 | 5개 모두 unchanged |

## 범위 밖

파서를 다중행 파싱까지 확장하는 것은 이번 범위가 아니다. 지금 조용히 건너뛰는 헤더들이 일제히 정본으로 바뀌면 기존 finding 이 한꺼번에 달라지므로, 그건 별도 판단이 필요하다.

`docs/agent-maintenance/discord-outbound-migration.md` 는 PR #5269 소유라 건드리지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)