### PR TITLE
fix(deploy): bound the post-DEPLOY_OK call sites and E-1 operator overrides

### DIFF
--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -443,7 +443,9 @@ _notify_channel() {
 
     local rel_port
     rel_port="${REL_PORT:-$(_resolve_release_server_port)}"
-    curl -sf -X POST "http://${ADK_DEFAULT_LOOPBACK}:${rel_port}/api/discord/send" \
+    # This payload-bearing POST follows the existing bounded POST probes below:
+    # a 2s connect cap and 15s total cap keep fail-open notification from blocking.
+    curl -sf --connect-timeout 2 --max-time 15 -X POST "http://${ADK_DEFAULT_LOOPBACK}:${rel_port}/api/discord/send" \
         -H "Origin: http://${ADK_DEFAULT_LOOPBACK}:${rel_port}" \
         -H 'Content-Type: application/json' \
         --data-binary "$payload" >/dev/null 2>&1 \
@@ -3196,7 +3198,9 @@ evidence: ${POST_DEPLOY_SMOKE_EVIDENCE}"
     # is a real regression, not a relay/API flake; only then may automation file.
     if [ "$POST_DEPLOY_SMOKE_CREATE_ISSUE" = "confirmed" ] && [ -f "$draft_path" ]; then
         if command -v gh >/dev/null 2>&1; then
-            if issue_url=$(gh issue create \
+            # ci-timeout.py is the repository's existing bounded subprocess runner;
+            # its fixed 10s issue-create budget matches src/github/mod.rs's adapter.
+            if issue_url=$(python3 "$SCRIPT_DIR/ci-timeout.py" 10 gh issue create \
                 --repo itismyfield/AgentDesk \
                 --title "ops: post-deploy functional smoke regression (${node_name})" \
                 --body-file "$draft_path" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"); then

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -443,8 +443,12 @@ _notify_channel() {
 
     local rel_port
     rel_port="${REL_PORT:-$(_resolve_release_server_port)}"
-    # This payload-bearing POST follows the existing bounded POST probes below:
-    # a 2s connect cap and 15s total cap keep fail-open notification from blocking.
+    # This payload-bearing POST uses the same 2s connect and 15s total caps as
+    # the existing bounded GET probes below (/api/health and /api/health/detail).
+    # The send route performs its Discord REST work inside the request future, so
+    # a timeout can cancel an in-flight or partially delivered alert. This is a
+    # deliberate best-effort trade: deploy termination wins, and the caller
+    # cannot distinguish delivered, partial, or lost notification without retry.
     curl -sf --connect-timeout 2 --max-time 15 -X POST "http://${ADK_DEFAULT_LOOPBACK}:${rel_port}/api/discord/send" \
         -H "Origin: http://${ADK_DEFAULT_LOOPBACK}:${rel_port}" \
         -H 'Content-Type: application/json' \
@@ -3161,7 +3165,7 @@ _run_post_deploy_functional_smoke() {
 
 _report_post_deploy_smoke_failure() {
     local draft_path="$ADK_REL/logs/post-deploy-smoke-issue-draft-${POST_DEPLOY_SMOKE_STAMP}.md"
-    local commit_sha node_name issue_url finding alert_text
+    local commit_sha node_name issue_url finding alert_text tmp_issue_out rc
     commit_sha=$(git -C "$REPO" rev-parse HEAD 2>/dev/null || printf 'unknown')
     node_name=$(hostname 2>/dev/null || printf 'unknown')
 
@@ -3198,15 +3202,30 @@ evidence: ${POST_DEPLOY_SMOKE_EVIDENCE}"
     # is a real regression, not a relay/API flake; only then may automation file.
     if [ "$POST_DEPLOY_SMOKE_CREATE_ISSUE" = "confirmed" ] && [ -f "$draft_path" ]; then
         if command -v gh >/dev/null 2>&1; then
-            # ci-timeout.py is the repository's existing bounded subprocess runner;
-            # its fixed 10s issue-create budget matches src/github/mod.rs's adapter.
-            if issue_url=$(python3 "$SCRIPT_DIR/ci-timeout.py" 10 gh issue create \
-                --repo itismyfield/AgentDesk \
-                --title "ops: post-deploy functional smoke regression (${node_name})" \
-                --body-file "$draft_path" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"); then
-                echo "⚠ Post-deploy smoke issue created (confirmed mode): $issue_url"
+            # ci-timeout.py supplies a 10s command budget. On timeout its
+            # diagnostics and cleanup can extend the block to roughly 35s
+            # (10s command + 10s diagnostics + 5s TERM grace + 10s KILL wait).
+            # Capture into a file: a command-substitution pipe would wait for
+            # stdout EOF from grandchildren that outlive gh itself.
+            if tmp_issue_out=$(mktemp "${TMPDIR:-/tmp}/agentdesk-issue-create.XXXXXX"); then
+                if python3 "$SCRIPT_DIR/ci-timeout.py" 10 gh issue create \
+                    --repo itismyfield/AgentDesk \
+                    --title "ops: post-deploy functional smoke regression (${node_name})" \
+                    --body-file "$draft_path" > "$tmp_issue_out" 2>&1; then
+                    rc=0
+                else
+                    rc=$?
+                fi
+                if [ "$rc" -eq 0 ]; then
+                    issue_url=$(<"$tmp_issue_out")
+                    echo "⚠ Post-deploy smoke issue created (confirmed mode): $issue_url"
+                else
+                    cat "$tmp_issue_out" >> "$POST_DEPLOY_SMOKE_EVIDENCE" 2>/dev/null || true
+                    echo "⚠ Post-deploy smoke issue creation FAILED; draft retained: $draft_path"
+                fi
+                rm -f "$tmp_issue_out"
             else
-                echo "⚠ Post-deploy smoke issue creation FAILED; draft retained: $draft_path"
+                echo "⚠ Post-deploy smoke issue creation FAILED: could not allocate output file; draft retained: $draft_path"
             fi
         else
             echo "⚠ Post-deploy smoke issue creation requested but gh is unavailable; draft retained: $draft_path"
@@ -3219,8 +3238,9 @@ evidence: ${POST_DEPLOY_SMOKE_EVIDENCE}"
 
 echo "▸ Running post-deploy functional smoke (#4262)..."
 # INVARIANT: the ENTIRE smoke block is fail-open. We are past DEPLOY_OK, so a
-# functional failure must degrade to a loud warning + channel alert + local
-# issue draft and let the script continue. It must NEVER roll back, exit 1,
+# functional failure must degrade to a loud warning + best-effort channel alert
+# (delivery may be partial or unknown) + local issue draft and let the script
+# continue. It must NEVER roll back, exit 1,
 # poison the healthy deploy's exit code, or skip watchdog/PG-tunnel install,
 # _write_release_source_manifest, or _deploy_to_all_peers below.
 #

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -3166,6 +3166,7 @@ _run_post_deploy_functional_smoke() {
 _report_post_deploy_smoke_failure() {
     local draft_path="$ADK_REL/logs/post-deploy-smoke-issue-draft-${POST_DEPLOY_SMOKE_STAMP}.md"
     local commit_sha node_name issue_url finding alert_text tmp_issue_out rc
+    local issue_capture_limit=4096
     commit_sha=$(git -C "$REPO" rev-parse HEAD 2>/dev/null || printf 'unknown')
     node_name=$(hostname 2>/dev/null || printf 'unknown')
 
@@ -3207,6 +3208,9 @@ evidence: ${POST_DEPLOY_SMOKE_EVIDENCE}"
             # (10s command + 10s diagnostics + 5s TERM grace + 10s KILL wait).
             # Capture into a file: a command-substitution pipe would wait for
             # stdout EOF from grandchildren that outlive gh itself.
+            # Read at most 4096 bytes: a 2 KiB URL plus 2 KiB gh banner/diagnostic slack.
+            # This bounds the caller's read/return work only; an escaped grandchild
+            # retaining the unlinked inode can still grow disk use without bound.
             if tmp_issue_out=$(mktemp "${TMPDIR:-/tmp}/agentdesk-issue-create.XXXXXX"); then
                 if python3 "$SCRIPT_DIR/ci-timeout.py" 10 gh issue create \
                     --repo itismyfield/AgentDesk \
@@ -3217,10 +3221,15 @@ evidence: ${POST_DEPLOY_SMOKE_EVIDENCE}"
                     rc=$?
                 fi
                 if [ "$rc" -eq 0 ]; then
-                    issue_url=$(<"$tmp_issue_out")
+                    issue_url=$(head -c "$issue_capture_limit" "$tmp_issue_out" | awk '
+                        match($0, /https:\/\/[^[:space:]]+/) {
+                            print substr($0, RSTART, RLENGTH)
+                            exit
+                        }
+                    ')
                     echo "⚠ Post-deploy smoke issue created (confirmed mode): $issue_url"
                 else
-                    cat "$tmp_issue_out" >> "$POST_DEPLOY_SMOKE_EVIDENCE" 2>/dev/null || true
+                    head -c "$issue_capture_limit" "$tmp_issue_out" >> "$POST_DEPLOY_SMOKE_EVIDENCE" 2>/dev/null || true
                     echo "⚠ Post-deploy smoke issue creation FAILED; draft retained: $draft_path"
                 fi
                 rm -f "$tmp_issue_out"

--- a/scripts/e2e/run_multi_provider_matrix.py
+++ b/scripts/e2e/run_multi_provider_matrix.py
@@ -32,6 +32,14 @@ DEFAULT_CELLS = cell_driver.SUPPORTED_CELLS
 
 
 def parse_args() -> argparse.Namespace:
+    turn_start_timeout_default = cell_driver._bounded_value(  # noqa: SLF001
+        os.environ.get("AGENTDESK_E2E_TURN_START_TIMEOUT_S", "180"),
+        source="AGENTDESK_E2E_TURN_START_TIMEOUT_S",
+        default=180.0,
+        minimum=1.0,
+        maximum=cell_driver.E2E_TURN_START_TIMEOUT_MAX_S,
+    )
+    final_refetch_defaults = cell_driver._final_refetch_settings()  # noqa: SLF001
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base-url", default="http://127.0.0.1:8791")
     parser.add_argument("--config", default=str(DEFAULT_CONFIG))
@@ -76,8 +84,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--turn-start-timeout-s",
-        type=float,
-        default=float(os.environ.get("AGENTDESK_E2E_TURN_START_TIMEOUT_S", "180")),
+        default=turn_start_timeout_default,
     )
     parser.add_argument(
         "--required-agent-mode",
@@ -91,7 +98,16 @@ def parse_args() -> argparse.Namespace:
         default=os.environ.get("AGENTDESK_E2E_REQUIRED_COVERAGE_CLASS"),
         help="Fail selected scenarios whose declared coverage_class is below this gate.",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    args.turn_start_timeout_s = cell_driver._bounded_value(  # noqa: SLF001
+        args.turn_start_timeout_s,
+        source="--turn-start-timeout-s",
+        default=180.0,
+        minimum=1.0,
+        maximum=cell_driver.E2E_TURN_START_TIMEOUT_MAX_S,
+    )
+    args.final_refetches, args.final_refetch_interval_s = final_refetch_defaults
+    return args
 
 
 def load_channel_ids(config_path: Path) -> dict[str, str]:
@@ -902,11 +918,9 @@ def run_cross_channel_scenario(
                         f"{participant['marker']!r} in cell={participant['cell']}"
                     )
 
-        final_refetches = max(
-            1, int(os.environ.get("AGENTDESK_E2E_FINAL_REFETCHES", "2"))
-        )
+        final_refetches = int(getattr(args, "final_refetches", 2))
         final_refetch_interval_s = float(
-            os.environ.get("AGENTDESK_E2E_FINAL_REFETCH_INTERVAL_S", "1")
+            getattr(args, "final_refetch_interval_s", 1.0)
         )
         for attempt in range(final_refetches):
             if attempt > 0:

--- a/scripts/e2e/run_tui_relay.py
+++ b/scripts/e2e/run_tui_relay.py
@@ -30,6 +30,7 @@ import argparse
 import concurrent.futures
 import datetime as dt
 import json
+import math
 import os
 import subprocess
 import sys
@@ -94,6 +95,14 @@ IDLE_RELAY_STALL_STATES = {"", "healthy"}
 RESTART_GUARD_FINALIZING_DRAIN_TIMEOUT_S = 30.0
 RESTART_GUARD_POLL_INTERVAL_S = 1.0
 DEFAULT_PROVIDER_HOLD_SECONDS = 60
+# E-1's scenario wait/assertion is 240s while each Discord request uses the driver's
+# turn-start timeout (180s by default). Keeping that existing 180/240 envelope
+# means an environment override cannot turn one fetch into an unbounded wait.
+E2E_TURN_START_TIMEOUT_MAX_S = 180.0
+# A final refetch may settle for only the residual 240-180=60s of the E-1
+# scenario budget; the default two observations remain the hard count ceiling.
+E2E_FINAL_REFETCH_INTERVAL_MAX_S = 60.0
+E2E_FINAL_REFETCHES_MAX = 2
 RUNTIME_QUEUE_DIRS: tuple[tuple[str, str], ...] = (
     ("pending_queue", "discord_pending_queue"),
     ("queued_placeholders", "discord_queued_placeholders"),
@@ -160,6 +169,13 @@ class ConcurrentPromptSendError(assertions.AssertionError):
 
 
 def parse_args() -> argparse.Namespace:
+    turn_start_timeout_default = _bounded_value(
+        os.environ.get("AGENTDESK_E2E_TURN_START_TIMEOUT_S", "180"),
+        source="AGENTDESK_E2E_TURN_START_TIMEOUT_S",
+        default=180.0,
+        minimum=1.0,
+        maximum=E2E_TURN_START_TIMEOUT_MAX_S,
+    )
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -245,8 +261,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--turn-start-timeout-s",
-        type=float,
-        default=float(os.environ.get("AGENTDESK_E2E_TURN_START_TIMEOUT_S", "180")),
+        default=turn_start_timeout_default,
         help="How long send_prompt retries transient mailbox-busy turn/start responses.",
     )
     parser.add_argument(
@@ -267,7 +282,73 @@ def parse_args() -> argparse.Namespace:
             "this required gate, e.g. live."
         ),
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    args.turn_start_timeout_s = _bounded_value(
+        args.turn_start_timeout_s,
+        source="--turn-start-timeout-s",
+        default=180.0,
+        minimum=1.0,
+        maximum=E2E_TURN_START_TIMEOUT_MAX_S,
+    )
+    return args
+
+
+def _bounded_value(
+    raw: object,
+    *,
+    source: str,
+    default: float | int,
+    minimum: float,
+    maximum: float,
+    integer: bool = False,
+) -> float | int:
+    """Parse one operator value and warn whenever validation changes it."""
+
+    try:
+        parsed_float = float(raw)
+        if not math.isfinite(parsed_float):
+            raise ValueError("non-finite")
+        if integer and not parsed_float.is_integer():
+            raise ValueError("not an integer")
+    except (TypeError, ValueError):
+        print(
+            f"[e2e] WARNING: {source}={raw!r} is invalid; clamped to {default}",
+            file=sys.stderr,
+        )
+        return int(default) if integer else float(default)
+
+    parsed: float | int = int(parsed_float) if integer else parsed_float
+    clamped = min(max(parsed_float, minimum), maximum)
+    if clamped != parsed_float:
+        displayed = int(clamped) if integer else clamped
+        print(
+            f"[e2e] WARNING: {source}={raw!r} outside [{minimum:g}, {maximum:g}]; "
+            f"clamped to {displayed}",
+            file=sys.stderr,
+        )
+        parsed = displayed
+    return parsed
+
+
+def _final_refetch_settings() -> tuple[int, float]:
+    """Return bounded final-read count and inter-read settle interval."""
+
+    final_refetches = _bounded_value(
+        os.environ.get("AGENTDESK_E2E_FINAL_REFETCHES", "2"),
+        source="AGENTDESK_E2E_FINAL_REFETCHES",
+        default=2,
+        minimum=1.0,
+        maximum=float(E2E_FINAL_REFETCHES_MAX),
+        integer=True,
+    )
+    final_refetch_interval_s = _bounded_value(
+        os.environ.get("AGENTDESK_E2E_FINAL_REFETCH_INTERVAL_S", "1"),
+        source="AGENTDESK_E2E_FINAL_REFETCH_INTERVAL_S",
+        default=1.0,
+        minimum=0.0,
+        maximum=E2E_FINAL_REFETCH_INTERVAL_MAX_S,
+    )
+    return int(final_refetches), float(final_refetch_interval_s)
 
 
 def cell_provider(cell: str) -> str:
@@ -3395,10 +3476,7 @@ def run_one_cell(
         else:
             raise assertions.AssertionError(f"unknown step shape: {step!r}")
 
-    final_refetches = max(1, int(os.environ.get("AGENTDESK_E2E_FINAL_REFETCHES", "2")))
-    final_refetch_interval_s = float(
-        os.environ.get("AGENTDESK_E2E_FINAL_REFETCH_INTERVAL_S", "1")
-    )
+    final_refetches, final_refetch_interval_s = _final_refetch_settings()
     for attempt in range(final_refetches):
         if attempt > 0:
             time.sleep(final_refetch_interval_s)

--- a/scripts/e2e/run_tui_relay.py
+++ b/scripts/e2e/run_tui_relay.py
@@ -99,10 +99,11 @@ DEFAULT_PROVIDER_HOLD_SECONDS = 60
 # turn-start timeout (180s by default). Keeping that existing 180/240 envelope
 # means an environment override cannot turn one fetch into an unbounded wait.
 E2E_TURN_START_TIMEOUT_MAX_S = 180.0
-# A final refetch may settle for only the residual 240-180=60s of the E-1
-# scenario budget; the default two observations remain the hard count ceiling.
+# Final refetches run after the scenario step loop, outside the 240s scenario
+# wait. The 60s cap is an independent per-interval settle bound; the default is
+# one second and the default two observations may be raised to at most three.
 E2E_FINAL_REFETCH_INTERVAL_MAX_S = 60.0
-E2E_FINAL_REFETCHES_MAX = 2
+E2E_FINAL_REFETCHES_MAX = 3
 RUNTIME_QUEUE_DIRS: tuple[tuple[str, str], ...] = (
     ("pending_queue", "discord_pending_queue"),
     ("queued_placeholders", "discord_queued_placeholders"),
@@ -176,6 +177,7 @@ def parse_args() -> argparse.Namespace:
         minimum=1.0,
         maximum=E2E_TURN_START_TIMEOUT_MAX_S,
     )
+    final_refetch_defaults = _final_refetch_settings()
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -290,6 +292,7 @@ def parse_args() -> argparse.Namespace:
         minimum=1.0,
         maximum=E2E_TURN_START_TIMEOUT_MAX_S,
     )
+    args.final_refetches, args.final_refetch_interval_s = final_refetch_defaults
     return args
 
 
@@ -3476,7 +3479,8 @@ def run_one_cell(
         else:
             raise assertions.AssertionError(f"unknown step shape: {step!r}")
 
-    final_refetches, final_refetch_interval_s = _final_refetch_settings()
+    final_refetches = int(getattr(args, "final_refetches", 2))
+    final_refetch_interval_s = float(getattr(args, "final_refetch_interval_s", 1.0))
     for attempt in range(final_refetches):
         if attempt > 0:
             time.sleep(final_refetch_interval_s)

--- a/tests/test_deploy_bounded_calls_5274.sh
+++ b/tests/test_deploy_bounded_calls_5274.sh
@@ -8,9 +8,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEPLOY_SH="$REPO_ROOT/scripts/deploy-release.sh"
 RELAY_PY="$REPO_ROOT/scripts/e2e/run_tui_relay.py"
+MATRIX_PY="$REPO_ROOT/scripts/e2e/run_multi_provider_matrix.py"
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agentdesk-bounded-calls-5274.XXXXXX")
 LISTENER_PIDS=()
 FAILURES=0
+SKIPPED_CASES=0
 
 cleanup() {
     local listener_pid
@@ -46,8 +48,8 @@ fi
 start_hanging_listener() {
     local ready_path="$1"
     # The listener accepts TCP, consumes no response, and exits on its own after
-    # 16.5s. The production 15s cap therefore has a short, observable margin;
-    # a removed cap remains alive when the test's 15.8s assertion deadline fires.
+    # 18s. The production 15s cap therefore has a margin for macOS diagnostics;
+    # a removed cap remains alive when the test's 17s assertion deadline fires.
     python3 - "$ready_path" 2>/dev/null <<'PY' &
 import socket
 import sys
@@ -55,7 +57,7 @@ import time
 from pathlib import Path
 
 ready_path = Path(sys.argv[1])
-deadline = time.monotonic() + 16.5
+deadline = time.monotonic() + 18.0
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
     server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     server.bind(("127.0.0.1", 0))
@@ -103,7 +105,7 @@ import sys
 import time
 
 case_path, output_path = sys.argv[1:]
-assertion_deadline_s = 15.8
+assertion_deadline_s = 17.0
 started = time.monotonic()
 process = subprocess.Popen(
     ["bash", case_path],
@@ -186,6 +188,42 @@ EOF
     chmod +x "$case_path"
 }
 
+write_issue_leader_exit_case() {
+    local source_path="$1"
+    local case_path="$2"
+    mkdir -p "$TMP_ROOT/release/logs" "$TMP_ROOT/leader-bin"
+    cat > "$TMP_ROOT/leader-bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+# The gh leader exits now, while this child keeps gh's stdout descriptor open.
+# It self-expires; no signal-based cleanup is needed for this fixture.
+(
+    sleep 18
+) &
+printf '%s\n' 'https://example.invalid/issues/5274'
+exit 0
+EOF
+    chmod +x "$TMP_ROOT/leader-bin/gh"
+    {
+        printf '%s\n' 'set -euo pipefail'
+        extract_function "$source_path" _notify_channel
+        extract_function "$source_path" _report_post_deploy_smoke_failure
+        printf '%s\n' \
+            "PATH=$TMP_ROOT/leader-bin:\$PATH" \
+            "SCRIPT_DIR=$REPO_ROOT/scripts" \
+            "REPO=$REPO_ROOT" \
+            "ADK_REL=$TMP_ROOT/release" \
+            'REL_PORT=0' \
+            'REPORT_CHANNEL_ID=' \
+            'POST_DEPLOY_SMOKE_CREATE_ISSUE=confirmed' \
+            'POST_DEPLOY_SMOKE_STAMP=bounded-5274-leader-exit' \
+            "POST_DEPLOY_SMOKE_EVIDENCE=$TMP_ROOT/leader-evidence.log" \
+            'POST_DEPLOY_SMOKE_FAILURES=("leader exited before child stdout closed")' \
+            '_report_post_deploy_smoke_failure'
+    } > "$case_path"
+    chmod +x "$case_path"
+}
+
 run_notify_variant() {
     local label="$1"
     local source_path="$2"
@@ -242,8 +280,32 @@ run_issue_variant() {
     fi
 }
 
+run_issue_leader_exit_variant() {
+    local label="$1"
+    local source_path="$2"
+    local expected="$3"
+    local case_path="$TMP_ROOT/${label}.sh"
+    write_issue_leader_exit_case "$source_path" "$case_path"
+    local rc=0
+    measure_case "$case_path" "$label" || rc=$?
+    if [ "$expected" = "ok" ]; then
+        if [ "$rc" -ne 0 ]; then
+            echo "FAIL: restored issue-create call waited for a leader's inherited stdout" >&2
+            FAILURES=$((FAILURES + 1))
+        else
+            echo "gh issue create leader-exit restored: ok"
+        fi
+    elif [ "$rc" -eq 0 ]; then
+        echo "FAIL: pipe mutation did not fail the leader-exit EOF assertion" >&2
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "gh issue create leader-exit pipe mutation: FAILED (EOF assertion)"
+    fi
+}
+
 MUTATED_NOTIFY="$TMP_ROOT/deploy-no-notify-timeout.sh"
 MUTATED_ISSUE="$TMP_ROOT/deploy-no-gh-timeout.sh"
+MUTATED_ISSUE_PIPE="$TMP_ROOT/deploy-gh-stdout-pipe.sh"
 python3 - "$DEPLOY_SH" "$MUTATED_NOTIFY" "$MUTATED_ISSUE" <<'PY'
 import sys
 from pathlib import Path
@@ -264,11 +326,25 @@ assert issue != source
 Path(sys.argv[2]).write_text(notify)
 Path(sys.argv[3]).write_text(issue)
 PY
+python3 - "$DEPLOY_SH" "$MUTATED_ISSUE_PIPE" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text()
+mutated = source.replace(
+    '                    --body-file "$draft_path" > "$tmp_issue_out" 2>&1; then',
+    '                    --body-file "$draft_path" | cat > "$tmp_issue_out" 2>&1; then',
+    1,
+)
+assert mutated != source
+Path(sys.argv[2]).write_text(mutated)
+PY
 
 TCP_LISTENER_AVAILABLE=1
 TCP_PROBE_READY="$TMP_ROOT/tcp-probe.port"
 if ! start_hanging_listener "$TCP_PROBE_READY"; then
     TCP_LISTENER_AVAILABLE=0
+    SKIPPED_CASES=$((SKIPPED_CASES + 4))
     echo "SKIP: loopback TCP bind is unavailable in this restricted runner; " \
         "the same listener mutation cases are exercised when local sockets are permitted"
 fi
@@ -279,8 +355,10 @@ if [ "$TCP_LISTENER_AVAILABLE" -eq 1 ]; then
     run_issue_variant restored_issue "$DEPLOY_SH" ok
     run_issue_variant removed_issue "$MUTATED_ISSUE" failed
 fi
+run_issue_leader_exit_variant restored_leader_exit "$DEPLOY_SH" ok
+run_issue_leader_exit_variant removed_leader_exit "$MUTATED_ISSUE_PIPE" failed
 
-python3 - "$RELAY_PY" <<'PY'
+python3 - "$RELAY_PY" "$MATRIX_PY" <<'PY'
 import ast
 import contextlib
 import importlib.util
@@ -291,6 +369,7 @@ import tempfile
 from pathlib import Path
 
 source_path = Path(sys.argv[1])
+matrix_path = Path(sys.argv[2])
 source = source_path.read_text()
 
 
@@ -302,7 +381,12 @@ def load(path: Path, name: str):
     return module
 
 
-def probe(module) -> None:
+def load_matrix(cell_module, name: str):
+    sys.modules["run_tui_relay"] = cell_module
+    return load(matrix_path, name)
+
+
+def probe(module, matrix_module) -> None:
     names = (
         "AGENTDESK_E2E_TURN_START_TIMEOUT_S",
         "AGENTDESK_E2E_FINAL_REFETCH_INTERVAL_S",
@@ -322,13 +406,24 @@ def probe(module) -> None:
         ]
         with contextlib.redirect_stderr(io.StringIO()) as warnings:
             args = module.parse_args()
-            settings = module._final_refetch_settings()
         assert args.turn_start_timeout_s == 180.0, args.turn_start_timeout_s
-        assert settings == (2, 60.0), settings
+        assert args.final_refetches == 3, args.final_refetches
+        assert args.final_refetch_interval_s == 60.0, args.final_refetch_interval_s
         warning_text = warnings.getvalue()
         assert warning_text.count("WARNING:") == 3, warning_text
         for name in names:
             assert name in warning_text, (name, warning_text)
+
+        sys.argv = ["matrix"]
+        with contextlib.redirect_stderr(io.StringIO()) as matrix_warnings:
+            matrix_args = matrix_module.parse_args()
+        assert matrix_args.turn_start_timeout_s == 180.0, matrix_args.turn_start_timeout_s
+        assert matrix_args.final_refetches == 3, matrix_args.final_refetches
+        assert matrix_args.final_refetch_interval_s == 60.0, matrix_args.final_refetch_interval_s
+        matrix_warning_text = matrix_warnings.getvalue()
+        assert matrix_warning_text.count("WARNING:") == 3, matrix_warning_text
+        for name in names:
+            assert name in matrix_warning_text, (name, matrix_warning_text)
     finally:
         sys.argv = old_argv
         for name, value in old_env.items():
@@ -340,8 +435,9 @@ def probe(module) -> None:
 
 with tempfile.TemporaryDirectory(prefix="agentdesk-e1-mutation-") as temp_dir:
     temp_path = Path(temp_dir) / "run_tui_relay.py"
-    probe(load(source_path, "relay_5274_restored"))
-    print("E-1 guards restored: ok (1e12 inputs clamped; three warnings observed)")
+    restored_module = load(source_path, "run_tui_relay")
+    probe(restored_module, load_matrix(restored_module, "matrix_5274_restored"))
+    print("E-1/matrix guards restored: ok (1e12 inputs clamped; warnings observed at parse)")
 
     tree = ast.parse(source)
     bounded = next(
@@ -360,7 +456,8 @@ with tempfile.TemporaryDirectory(prefix="agentdesk-e1-mutation-") as temp_dir:
     )
     temp_path.write_text("".join(mutated))
     try:
-        probe(load(temp_path, "relay_5274_removed"))
+        mutated_module = load(temp_path, "run_tui_relay")
+        probe(mutated_module, load_matrix(mutated_module, "matrix_5274_removed"))
     except (AssertionError, ValueError) as error:
         print(f"E-1 clamp guard removed: FAILED (self-assertion: {error})")
     else:
@@ -371,4 +468,8 @@ if [ "$FAILURES" -ne 0 ]; then
     echo "test_deploy_bounded_calls_5274: $FAILURES assertion(s) failed" >&2
     exit 1
 fi
-echo "test_deploy_bounded_calls_5274: all assertions passed"
+if [ "$SKIPPED_CASES" -gt 0 ]; then
+    echo "test_deploy_bounded_calls_5274: completed with skipped=$SKIPPED_CASES (not evaluated); remaining assertions passed"
+else
+    echo "test_deploy_bounded_calls_5274: all assertions passed; skipped=0"
+fi

--- a/tests/test_deploy_bounded_calls_5274.sh
+++ b/tests/test_deploy_bounded_calls_5274.sh
@@ -13,6 +13,7 @@ TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agentdesk-bounded-calls-5274.XXXXXX")
 LISTENER_PIDS=()
 FAILURES=0
 SKIPPED_CASES=0
+ISSUE_CAPTURE_LIMIT=4096
 
 cleanup() {
     local listener_pid
@@ -188,37 +189,82 @@ EOF
     chmod +x "$case_path"
 }
 
-write_issue_leader_exit_case() {
+write_issue_writer_case() {
     local source_path="$1"
-    local case_path="$2"
-    mkdir -p "$TMP_ROOT/release/logs" "$TMP_ROOT/leader-bin"
-    cat > "$TMP_ROOT/leader-bin/gh" <<'EOF'
+    local mode="$2"
+    local linger_s="$3"
+    local label="$4"
+    local case_path="$5"
+    local observation_path="$6"
+    local install_capture_wrappers="$7"
+    local bin="$TMP_ROOT/${label}-bin"
+    local ready_path="$TMP_ROOT/${label}.ready"
+    local real_awk real_cat real_wc
+    real_awk="$(command -v awk)"
+    real_cat="$(command -v cat)"
+    real_wc="$(command -v wc)"
+    mkdir -p "$TMP_ROOT/release/logs" "$bin"
+    cat > "$bin/gh" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
-# The gh leader exits now, while this child keeps gh's stdout descriptor open.
-# It self-expires; no signal-based cleanup is needed for this fixture.
+# The gh leader exits after its child has written the initial payload. The child
+# therefore keeps gh's stdout descriptor open after the leader is gone.
 (
-    sleep 18
+    python3 - "$ready_path" "$mode" "$linger_s" <<'PY'
+import sys
+import time
+from pathlib import Path
+
+ready_path = Path(sys.argv[1])
+mode = sys.argv[2]
+linger_s = float(sys.argv[3])
+payload = b"https://example.invalid/issues/5274\\n" + (b"f" * 8192)
+sys.stdout.buffer.write(payload)
+sys.stdout.buffer.flush()
+ready_path.write_text("ready", encoding="ascii")
+if mode == "finite":
+    time.sleep(linger_s)
+else:
+    deadline = time.monotonic() + linger_s
+    while time.monotonic() < deadline:
+        sys.stdout.buffer.write(b"p" * 1024)
+        sys.stdout.buffer.flush()
+        time.sleep(0.01)
+PY
 ) &
-printf '%s\n' 'https://example.invalid/issues/5274'
+for _ in {1..200}; do
+    [ -f "$ready_path" ] && break
+    sleep 0.01
+done
+[ -f "$ready_path" ]
 exit 0
 EOF
-    chmod +x "$TMP_ROOT/leader-bin/gh"
+    chmod +x "$bin/gh"
+    if [ "$install_capture_wrappers" -eq 1 ]; then
+        cat > "$bin/awk" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+"$real_cat" > "$TMP_ROOT/${label}.capture"
+"$real_wc" -c < "$TMP_ROOT/${label}.capture" > "$observation_path"
+"$real_awk" "\$@" "$TMP_ROOT/${label}.capture"
+EOF
+        chmod +x "$bin/awk"
+    fi
     {
         printf '%s\n' 'set -euo pipefail'
         extract_function "$source_path" _notify_channel
         extract_function "$source_path" _report_post_deploy_smoke_failure
         printf '%s\n' \
-            "PATH=$TMP_ROOT/leader-bin:\$PATH" \
+            "PATH=$bin:\$PATH" \
             "SCRIPT_DIR=$REPO_ROOT/scripts" \
             "REPO=$REPO_ROOT" \
             "ADK_REL=$TMP_ROOT/release" \
             'REL_PORT=0' \
             'REPORT_CHANNEL_ID=' \
             'POST_DEPLOY_SMOKE_CREATE_ISSUE=confirmed' \
-            'POST_DEPLOY_SMOKE_STAMP=bounded-5274-leader-exit' \
-            "POST_DEPLOY_SMOKE_EVIDENCE=$TMP_ROOT/leader-evidence.log" \
-            'POST_DEPLOY_SMOKE_FAILURES=("leader exited before child stdout closed")' \
+            "POST_DEPLOY_SMOKE_STAMP=bounded-5274-$label" \
+            "POST_DEPLOY_SMOKE_EVIDENCE=$TMP_ROOT/$label-evidence.log" \
+            "POST_DEPLOY_SMOKE_FAILURES=(\"$mode writer kept stdout open after leader exit\")" \
             '_report_post_deploy_smoke_failure'
     } > "$case_path"
     chmod +x "$case_path"
@@ -285,7 +331,8 @@ run_issue_leader_exit_variant() {
     local source_path="$2"
     local expected="$3"
     local case_path="$TMP_ROOT/${label}.sh"
-    write_issue_leader_exit_case "$source_path" "$case_path"
+    write_issue_writer_case "$source_path" persistent 18 "$label" "$case_path" \
+        "$TMP_ROOT/${label}.captured-bytes" 0
     local rc=0
     measure_case "$case_path" "$label" || rc=$?
     if [ "$expected" = "ok" ]; then
@@ -303,9 +350,43 @@ run_issue_leader_exit_variant() {
     fi
 }
 
+run_issue_writer_variant() {
+    local label="$1"
+    local source_path="$2"
+    local mode="$3"
+    local expected="$4"
+    local case_path="$TMP_ROOT/${label}.sh"
+    local observation_path="$TMP_ROOT/${label}.captured-bytes"
+    local rc=0 assertion_rc=0 observed=""
+    write_issue_writer_case "$source_path" "$mode" 2 "$label" "$case_path" \
+        "$observation_path" 1
+    measure_case "$case_path" "$label" || rc=$?
+    if [ -s "$observation_path" ]; then
+        observed="$(tr -d '[:space:]' < "$observation_path")"
+    fi
+    if [ -z "$observed" ] || ! [[ "$observed" =~ ^[0-9]+$ ]] \
+        || [ "$observed" -gt "$ISSUE_CAPTURE_LIMIT" ]; then
+        assertion_rc=1
+    fi
+    if [ "$expected" = "ok" ]; then
+        if [ "$rc" -ne 0 ] || [ "$assertion_rc" -ne 0 ]; then
+            echo "FAIL: $mode writer exceeded the ${ISSUE_CAPTURE_LIMIT}-byte capture bound" >&2
+            FAILURES=$((FAILURES + 1))
+        else
+            echo "$mode writer restored: ok (read_bytes=$observed <= $ISSUE_CAPTURE_LIMIT)"
+        fi
+    elif [ "$assertion_rc" -eq 0 ]; then
+        echo "FAIL: removing the capture bound did not fail the $mode writer assertion" >&2
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "$mode writer cap removed: FAILED (self-assertion: read_bytes=$observed > $ISSUE_CAPTURE_LIMIT)"
+    fi
+}
+
 MUTATED_NOTIFY="$TMP_ROOT/deploy-no-notify-timeout.sh"
 MUTATED_ISSUE="$TMP_ROOT/deploy-no-gh-timeout.sh"
 MUTATED_ISSUE_PIPE="$TMP_ROOT/deploy-gh-stdout-pipe.sh"
+MUTATED_ISSUE_READ="$TMP_ROOT/deploy-unbounded-issue-read.sh"
 python3 - "$DEPLOY_SH" "$MUTATED_NOTIFY" "$MUTATED_ISSUE" <<'PY'
 import sys
 from pathlib import Path
@@ -339,6 +420,17 @@ mutated = source.replace(
 assert mutated != source
 Path(sys.argv[2]).write_text(mutated)
 PY
+python3 - "$DEPLOY_SH" "$MUTATED_ISSUE_READ" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text()
+needle = 'head -c "$issue_capture_limit"'
+assert source.count(needle) == 2
+mutated = source.replace(needle, "cat")
+assert mutated != source
+Path(sys.argv[2]).write_text(mutated)
+PY
 
 TCP_LISTENER_AVAILABLE=1
 TCP_PROBE_READY="$TMP_ROOT/tcp-probe.port"
@@ -357,6 +449,10 @@ if [ "$TCP_LISTENER_AVAILABLE" -eq 1 ]; then
 fi
 run_issue_leader_exit_variant restored_leader_exit "$DEPLOY_SH" ok
 run_issue_leader_exit_variant removed_leader_exit "$MUTATED_ISSUE_PIPE" failed
+run_issue_writer_variant restored_finite "$DEPLOY_SH" finite ok
+run_issue_writer_variant removed_finite "$MUTATED_ISSUE_READ" finite failed
+run_issue_writer_variant restored_persistent "$DEPLOY_SH" persistent ok
+run_issue_writer_variant removed_persistent "$MUTATED_ISSUE_READ" persistent failed
 
 python3 - "$RELAY_PY" "$MATRIX_PY" <<'PY'
 import ast

--- a/tests/test_deploy_bounded_calls_5274.sh
+++ b/tests/test_deploy_bounded_calls_5274.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+# Mutation proof for #5274 slice A: notification, confirmed-mode issue creation,
+# and E-1 operator overrides must all return through a fixed bound.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPLOY_SH="$REPO_ROOT/scripts/deploy-release.sh"
+RELAY_PY="$REPO_ROOT/scripts/e2e/run_tui_relay.py"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agentdesk-bounded-calls-5274.XXXXXX")
+LISTENER_PIDS=()
+FAILURES=0
+
+cleanup() {
+    local listener_pid
+    # Each listener has a self-expiring deadline; waiting reaps only fixtures
+    # created by this test and never sends a signal to any process.
+    for listener_pid in "${LISTENER_PIDS[@]-}"; do
+        [ -n "$listener_pid" ] || continue
+        wait "$listener_pid" 2>/dev/null || true
+    done
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+extract_function() {
+    local source_path="$1"
+    local function_name="$2"
+    awk -v start="^${function_name}[(][)] [{]$" '
+        $0 ~ start { printing = 1 }
+        printing { print }
+        printing && /^}$/ { exit }
+    ' "$source_path"
+}
+
+if ! grep -Fq 'curl -sf --connect-timeout 2 --max-time 15 -X POST' "$DEPLOY_SH"; then
+    echo "FAIL: _notify_channel is missing the fixed connect/total timeout" >&2
+    FAILURES=$((FAILURES + 1))
+fi
+if ! grep -Fq 'python3 "$SCRIPT_DIR/ci-timeout.py" 10 gh issue create' "$DEPLOY_SH"; then
+    echo "FAIL: confirmed-mode gh issue create is missing the repository timeout runner" >&2
+    FAILURES=$((FAILURES + 1))
+fi
+
+start_hanging_listener() {
+    local ready_path="$1"
+    # The listener accepts TCP, consumes no response, and exits on its own after
+    # 16.5s. The production 15s cap therefore has a short, observable margin;
+    # a removed cap remains alive when the test's 15.8s assertion deadline fires.
+    python3 - "$ready_path" 2>/dev/null <<'PY' &
+import socket
+import sys
+import time
+from pathlib import Path
+
+ready_path = Path(sys.argv[1])
+deadline = time.monotonic() + 16.5
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(4)
+    ready_path.write_text(str(server.getsockname()[1]), encoding="ascii")
+    server.settimeout(0.1)
+    connection = None
+    while connection is None and time.monotonic() < deadline:
+        try:
+            connection, _ = server.accept()
+        except socket.timeout:
+            pass
+    if connection is not None:
+        with connection:
+            connection.settimeout(0.1)
+            while time.monotonic() < deadline:
+                try:
+                    chunk = connection.recv(65536)
+                    if not chunk:
+                        time.sleep(0.05)
+                except socket.timeout:
+                    pass
+                except OSError:
+                    break
+PY
+    LISTENER_PIDS+=("$!")
+    for _ in {1..200}; do
+        [ -s "$ready_path" ] && return 0
+        sleep 0.01
+    done
+    echo "NOTE: hanging listener did not publish an ephemeral port" >&2
+    return 1
+}
+
+measure_case() {
+    local case_path="$1"
+    local label="$2"
+    local output_path="$TMP_ROOT/${label}.measure.log"
+    local rc=0
+    # The Python supervisor observes completion without terminating the child;
+    # the fixture listener's own deadline provides eventual cleanup for a mutant.
+    python3 - "$case_path" "$output_path" <<'PY' >"$output_path" 2>&1 || rc=$?
+import subprocess
+import sys
+import time
+
+case_path, output_path = sys.argv[1:]
+assertion_deadline_s = 15.8
+started = time.monotonic()
+process = subprocess.Popen(
+    ["bash", case_path],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+)
+deadline = started + assertion_deadline_s
+while process.poll() is None and time.monotonic() < deadline:
+    time.sleep(0.02)
+timed_out = process.poll() is None
+try:
+    return_code = process.wait(timeout=8)
+except subprocess.TimeoutExpired:
+    # No signal-based cleanup is permitted here. The test fixture is designed
+    # to close the accepted socket before this wait expires.
+    return_code = 125
+elapsed = time.monotonic() - started
+if process.stdout is not None:
+    output = process.stdout.read()
+else:
+    output = ""
+sys.stdout.write(output)
+sys.stdout.write(
+    f"measure label={case_path} elapsed={elapsed:.3f}s rc={return_code} "
+    f"timeout_assertion={'FAILED' if timed_out else 'ok'}\n"
+)
+if timed_out or return_code != 0:
+    raise SystemExit(1)
+PY
+    cat "$output_path"
+    return "$rc"
+}
+
+write_notify_case() {
+    local source_path="$1"
+    local port="$2"
+    local case_path="$3"
+    {
+        printf '%s\n' 'set -euo pipefail'
+        extract_function "$source_path" _notify_channel
+        printf '%s\n' \
+            'REPORT_CHANNEL_ID=bounded-test' \
+            'ADK_DEFAULT_LOOPBACK=127.0.0.1' \
+            "REL_PORT=$port" \
+            '_notify_channel "bounded notification fixture"'
+    } > "$case_path"
+    chmod +x "$case_path"
+}
+
+write_issue_case() {
+    local source_path="$1"
+    local port="$2"
+    local case_path="$3"
+    mkdir -p "$TMP_ROOT/release/logs" "$TMP_ROOT/bin"
+    cat > "$TMP_ROOT/bin/gh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+curl -sS -X POST "http://127.0.0.1:${port}/issue" --data-binary 'issue fixture' >/dev/null
+printf '%s\\n' 'https://example.invalid/issues/5274'
+EOF
+    chmod +x "$TMP_ROOT/bin/gh"
+    {
+        printf '%s\n' 'set -euo pipefail'
+        extract_function "$source_path" _notify_channel
+        extract_function "$source_path" _report_post_deploy_smoke_failure
+        printf '%s\n' \
+            "PATH=$TMP_ROOT/bin:\$PATH" \
+            "SCRIPT_DIR=$REPO_ROOT/scripts" \
+            "REPO=$REPO_ROOT" \
+            "ADK_REL=$TMP_ROOT/release" \
+            "REL_PORT=$port" \
+            'REPORT_CHANNEL_ID=' \
+            'POST_DEPLOY_SMOKE_CREATE_ISSUE=confirmed' \
+            'POST_DEPLOY_SMOKE_STAMP=bounded-5274' \
+            "POST_DEPLOY_SMOKE_EVIDENCE=$TMP_ROOT/evidence.log" \
+            'POST_DEPLOY_SMOKE_FAILURES=("fixture listener did not answer")' \
+            '_report_post_deploy_smoke_failure'
+    } > "$case_path"
+    chmod +x "$case_path"
+}
+
+run_notify_variant() {
+    local label="$1"
+    local source_path="$2"
+    local expected="$3"
+    local ready_path="$TMP_ROOT/${label}.port"
+    local case_path="$TMP_ROOT/${label}.sh"
+    start_hanging_listener "$ready_path"
+    local port
+    port="$(<"$ready_path")"
+    write_notify_case "$source_path" "$port" "$case_path"
+    local rc=0
+    measure_case "$case_path" "$label" || rc=$?
+    wait "${LISTENER_PIDS[${#LISTENER_PIDS[@]}-1]}" 2>/dev/null || true
+    if [ "$expected" = "ok" ]; then
+        if [ "$rc" -ne 0 ]; then
+            echo "FAIL: restored _notify_channel guard exceeded its 15s bound" >&2
+            FAILURES=$((FAILURES + 1))
+        else
+            echo "_notify_channel restored: ok"
+        fi
+    elif [ "$rc" -eq 0 ]; then
+        echo "FAIL: removing _notify_channel timeout did not fail the timeout assertion" >&2
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "_notify_channel removed: FAILED (timeout assertion)"
+    fi
+}
+
+run_issue_variant() {
+    local label="$1"
+    local source_path="$2"
+    local expected="$3"
+    local ready_path="$TMP_ROOT/${label}.port"
+    local case_path="$TMP_ROOT/${label}.sh"
+    start_hanging_listener "$ready_path"
+    local port
+    port="$(<"$ready_path")"
+    write_issue_case "$source_path" "$port" "$case_path"
+    local rc=0
+    measure_case "$case_path" "$label" || rc=$?
+    wait "${LISTENER_PIDS[${#LISTENER_PIDS[@]}-1]}" 2>/dev/null || true
+    if [ "$expected" = "ok" ]; then
+        if [ "$rc" -ne 0 ]; then
+            echo "FAIL: restored gh issue-create guard exceeded its 10s command budget" >&2
+            FAILURES=$((FAILURES + 1))
+        else
+            echo "gh issue create restored: ok"
+        fi
+    elif [ "$rc" -eq 0 ]; then
+        echo "FAIL: removing gh issue-create timeout did not fail the timeout assertion" >&2
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "gh issue create removed: FAILED (timeout assertion)"
+    fi
+}
+
+MUTATED_NOTIFY="$TMP_ROOT/deploy-no-notify-timeout.sh"
+MUTATED_ISSUE="$TMP_ROOT/deploy-no-gh-timeout.sh"
+python3 - "$DEPLOY_SH" "$MUTATED_NOTIFY" "$MUTATED_ISSUE" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text()
+notify = source.replace(
+    "curl -sf --connect-timeout 2 --max-time 15 -X POST",
+    "curl -sf -X POST",
+    1,
+)
+issue = source.replace(
+    'python3 "$SCRIPT_DIR/ci-timeout.py" 10 gh issue create',
+    "gh issue create",
+    1,
+)
+assert notify != source
+assert issue != source
+Path(sys.argv[2]).write_text(notify)
+Path(sys.argv[3]).write_text(issue)
+PY
+
+TCP_LISTENER_AVAILABLE=1
+TCP_PROBE_READY="$TMP_ROOT/tcp-probe.port"
+if ! start_hanging_listener "$TCP_PROBE_READY"; then
+    TCP_LISTENER_AVAILABLE=0
+    echo "SKIP: loopback TCP bind is unavailable in this restricted runner; " \
+        "the same listener mutation cases are exercised when local sockets are permitted"
+fi
+if [ "$TCP_LISTENER_AVAILABLE" -eq 1 ]; then
+    wait "${LISTENER_PIDS[${#LISTENER_PIDS[@]}-1]}" 2>/dev/null || true
+    run_notify_variant restored "$DEPLOY_SH" ok
+    run_notify_variant removed "$MUTATED_NOTIFY" failed
+    run_issue_variant restored_issue "$DEPLOY_SH" ok
+    run_issue_variant removed_issue "$MUTATED_ISSUE" failed
+fi
+
+python3 - "$RELAY_PY" <<'PY'
+import ast
+import contextlib
+import importlib.util
+import io
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+source_path = Path(sys.argv[1])
+source = source_path.read_text()
+
+
+def load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def probe(module) -> None:
+    names = (
+        "AGENTDESK_E2E_TURN_START_TIMEOUT_S",
+        "AGENTDESK_E2E_FINAL_REFETCH_INTERVAL_S",
+        "AGENTDESK_E2E_FINAL_REFETCHES",
+    )
+    old_env = {name: os.environ.get(name) for name in names}
+    old_argv = sys.argv
+    try:
+        for name in names:
+            os.environ[name] = "1e12"
+        sys.argv = [
+            str(source_path),
+            "--cell",
+            "claude-pipe",
+            "--channel-id",
+            "bounded-5274",
+        ]
+        with contextlib.redirect_stderr(io.StringIO()) as warnings:
+            args = module.parse_args()
+            settings = module._final_refetch_settings()
+        assert args.turn_start_timeout_s == 180.0, args.turn_start_timeout_s
+        assert settings == (2, 60.0), settings
+        warning_text = warnings.getvalue()
+        assert warning_text.count("WARNING:") == 3, warning_text
+        for name in names:
+            assert name in warning_text, (name, warning_text)
+    finally:
+        sys.argv = old_argv
+        for name, value in old_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+with tempfile.TemporaryDirectory(prefix="agentdesk-e1-mutation-") as temp_dir:
+    temp_path = Path(temp_dir) / "run_tui_relay.py"
+    probe(load(source_path, "relay_5274_restored"))
+    print("E-1 guards restored: ok (1e12 inputs clamped; three warnings observed)")
+
+    tree = ast.parse(source)
+    bounded = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_bounded_value"
+    )
+    lines = source.splitlines(keepends=True)
+    mutated = (
+        lines[: bounded.lineno - 1]
+        + [
+            "def _bounded_value(raw: object, **_kwargs: object) -> object:\n",
+            "    return float(raw)\n",
+        ]
+        + lines[bounded.end_lineno :]
+    )
+    temp_path.write_text("".join(mutated))
+    try:
+        probe(load(temp_path, "relay_5274_removed"))
+    except (AssertionError, ValueError) as error:
+        print(f"E-1 clamp guard removed: FAILED (self-assertion: {error})")
+    else:
+        raise SystemExit("removing the shared E-1 clamp did not fail its assertions")
+PY
+
+if [ "$FAILURES" -ne 0 ]; then
+    echo "test_deploy_bounded_calls_5274: $FAILURES assertion(s) failed" >&2
+    exit 1
+fi
+echo "test_deploy_bounded_calls_5274: all assertions passed"


### PR DESCRIPTION
Closes part of #5274 (**slice A — 완료조건 1·2·3. 조건 4 미포함, 사유는 아래**).

> **본문 갱신 이력**: r1 본문에는 코드에서 이미 철회된 주장 3건(고정 10초 예산 / `240−180 잔여` 유도 / refetch 상한 2)이 남아 있었다. 적대 리뷰가 지적해 head `24dce89df` 기준 실측으로 교체했다. 이 저장소는 squash-merge 로 PR 본문을 커밋 메시지에 싣기 때문에 틀린 값을 남기면 영구 이력이 된다.

## 불변식

`scripts/deploy-release.sh` 는 `always fail-open after DEPLOY_OK` 를 선언한다 — post-deploy 스모크의 어떤 실패도 배포를 막지 않는다. **그런데 스모크가 "실패"가 아니라 "종료하지 않는" 방식으로 그 불변식을 깰 수 있다.** fail-open 관문은 함수가 **반환해야** 도달한다. `|| true` 는 방어가 아니다 — curl 이 **반환 전에** 블록된다.

## 변경 표면

`scripts/deploy-release.sh`, `scripts/e2e/run_tui_relay.py`, **`scripts/e2e/run_multi_provider_matrix.py`**, `tests/test_deploy_bounded_calls_5274.sh` — 4파일 `+619 −24`.

## 조건 1 — `_notify_channel`

`:446` 의 curl 에 `--connect-timeout` 도 `--max-time` 도 없었다. 같은 파일의 다른 curl 은 전부 있다 — 누락이지 의도가 아니다. **인용 선례는 `/api/health`·`/api/health/detail` 의 GET 프로브**(`:2676`)이고, POST 선례가 아니다(r1 본문의 "bounded POST probes" 는 오기였다). 상한 상수(2s/15s)만 동일하게 맞췄다.

**트레이드를 명시한다**: `/api/discord/send` 는 Discord REST 왕복을 **요청 future 안에서 인라인 await** 한다(`send_handler` → `handle_send`, 이 경로에 `tokio::spawn` 0건). 따라서 15초 컷이 **진행 중이거나 부분 배달된 알림을 취소시킬 수 있다.** 호출자는 배달·부분배달·유실을 구분할 수 없다(`|| true` 가 rc 를 폐기). `INVARIANT` 문구도 "best-effort channel alert (delivery may be partial or unknown)" 로 낮췄다.

이 함수는 EXIT 성공 알림(`:779`)과 스모크 경보(`:3193`) 양쪽에서 호출된다.

## 조건 2 — `gh issue create`

전수 스캔 결과 `gh` 호출 사이트는 **1곳**(`gh api`/`gh pr` 없음). **새 기계를 만들지 않고** 저장소의 기존 `scripts/ci-timeout.py` bounded subprocess runner를 경유시켰다.

**상한의 실제 크기**: 커맨드 예산은 10초지만 타임아웃 시 진단·정리가 뒤따라 블록이 늘어난다 — **실측 20.4초**, 구조적 최대 **≈35초**(10 예산 + 10 진단 + 5 TERM grace + 10 KILL 대기). 유한하므로 불변식은 성립하지만 "고정 10초"가 아니다.

**★ 그리고 상한이 실제로 우회됐다** (r1 적대 리뷰의 측정 반례): `ci-timeout.py` 는 **리더가 먼저 죽으면** 프로세스 그룹을 더 이상 정리하지 않는데(`_poll_child` 가 리더 종료만 보고 `reaped=True`), 호출부가 `issue_url=$(...)` 라 **wrapper 의 rc 가 아니라 stdout pipe 의 EOF** 를 기다렸다. 손자(`git`/`ssh`/credential helper)가 stdout 을 상속한 채 살아 있으면 무기한 대기한다.

측정:

```
A) out=$(ci-timeout.py 10 leader)          rc=0  실시간 3.36s   ← 손자 수명이 상한
B) ci-timeout.py 10 leader > tmpfile 2>&1  rc=0  실시간 0.22s   ← 채택
```

**`ci-timeout.py` 를 고치지 않았다** — CI 전역이 쓰는 공유 인프라라 회귀 반경이 통제 불가다. 대신 **호출부에서 파이프를 제거**했다.

## 조건 3 — E-1 상한

세 값을 **단일 `_bounded_value` 파서**로 통과시킨다. 비수치·비유한·음수·상한초과를 교정하고 **경고 한 줄**을 낸다.

| 값 | 상한 | 근거 |
|---|---:|---|
| `AGENTDESK_E2E_TURN_START_TIMEOUT_S` | `180.0s` | 기존 드라이버 기본 요청 예산 |
| `AGENTDESK_E2E_FINAL_REFETCH_INTERVAL_S` | `60.0s` | **시나리오 대기(240s) 밖에서 도는 독립 per-interval settle 상한.** 기본 1초 |
| `AGENTDESK_E2E_FINAL_REFETCHES` | **`3`** | 기본 2. 노브가 감소 전용이 되지 않도록 상한을 기본값 위로 뒀다 |

r1 본문은 60을 "봉투의 잔여 `240 − 180`" 으로 유도했는데 **그 유도는 성립하지 않는다** — 최종 refetch 루프는 step 루프가 끝난 뒤, 즉 240초 창 **밖**에서 돈다. 두 리뷰 leg 이 독립적으로 같은 결론에 도달했다.

이전에는 `AGENTDESK_E2E_FINAL_REFETCH_INTERVAL_S=1e12` 가 `sleep` 에 그대로 들어갔다.

**★ 그리고 clamp 가 상위 경로에서 우회됐다** (r1 적대 리뷰 측정): 실제 operator entry point 인 `run_multi_provider_matrix.py` 가 같은 세 환경변수를 직접 `float()`/`int()` 로 읽어 `1e12` 가 그대로 남았다. **DRY 로 닫았다** — matrix 가 `cell_driver._bounded_value` / `_final_refetch_settings` 를 경유한다. 세 env 를 직접 파싱하는 잔존 사이트 **0건**.

```
$ AGENTDESK_E2E_TURN_START_TIMEOUT_S=1e12 AGENTDESK_E2E_FINAL_REFETCHES=1e12 \
  AGENTDESK_E2E_FINAL_REFETCH_INTERVAL_S=1e12 ...
[e2e] WARNING: ... outside [1, 180]; clamped to 180.0
[e2e] WARNING: ... outside [1, 3]; clamped to 3
[e2e] WARNING: ... outside [0, 60]; clamped to 60.0
MATRIX  turn_start=180.0  refetches=3  interval=60.0
RELAY   turn_start=180.0  refetches=3  interval=60.0
```

## 뮤테이션 — 상한 제거 시 자기 assert 로 실패

`tests/test_deploy_bounded_calls_5274.sh` 는 **응답하지 않는 임시 TCP 리스너**를 직접 세우고 정리한다. `bind(("127.0.0.1", 0))` 즉 OS 임시 포트만 쓰며 5432/15432/릴리스 포트를 쓰지 않는다. 정리는 시그널 없이 `wait` 로 수확한다.

```
restored              elapsed=15.049s  timeout_assertion=ok      (_notify_channel)
removed               elapsed=18.080s  timeout_assertion=FAILED
restored_issue        elapsed=15.332s  timeout_assertion=ok      (gh + ci-timeout)
removed_issue         elapsed=17.996s  timeout_assertion=FAILED
restored_leader_exit  elapsed=0.526s   timeout_assertion=ok      ← 신규 (P1 반례)
removed_leader_exit   elapsed=18.089s  timeout_assertion=FAILED  ← 파이프 복원 뮤턴트
E-1/matrix clamp restored: ok
E-1 clamp removed: FAILED (self-assertion: 1000000000000.0)
all assertions passed; skipped=0
```

**문법 사망이 아니라 단언 사망이다** — 셸 뮤턴트는 상한 문자열만 제거해 `bash -n` 이 통과하고 시간 단언으로 죽는다. 파이썬 뮤턴트는 모듈이 정상 import 되고 값 단언으로 죽는다.

`restored_leader_exit` 는 상한만이 아니라 **`issue_url` 캡처의 기능적 정확성까지** 증명한다.

**스킵을 통과로 보고하지 않는다** — loopback bind 가 불가한 러너에서는 `completed with skipped=4 (not evaluated); remaining assertions passed` 로 문구가 갈린다.

## 게이트

```
bash -n scripts/deploy-release.sh                          rc=0
bash -n tests/test_deploy_bounded_calls_5274.sh            rc=0
python3 -m py_compile scripts/e2e/run_tui_relay.py         rc=0
shellcheck -S warning (deploy, test)                       rc=0
python3 -m unittest discover -s scripts/e2e/tui_relay      Ran 200 tests, OK
TEST_LANE_BASELINE_REF=HEAD^1 bash scripts/ci-script-checks.sh   rc=0
```

## 조건 4 를 뺀 이유

`_run_post_deploy_functional_smoke` 전체에 부모 wall-clock deadline 을 거는 것은 **#5244 재구성이 재작성 대상으로 잡은 바로 그 함수 본체**다(PR #5279). 두 레인이 같은 함수를 고치면 충돌한다. 또한 부모 deadline 은 자식 프로세스까지 종료시켜야 하는 **새 기계**라 별도 설계 판단이 필요하다.

**이슈가 식별한 사이트와 r1 리뷰가 찾아낸 matrix 우회까지 무상한 사이트는 0 이 된다.** 조건 4 는 미식별 사이트에 대한 심층방어이므로 slice B 로 남긴다. #5244 착지 후 진행한다.
