### PR TITLE
fix(discord): confine readoption marker authority to the turn it describes (#5242)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -677,6 +677,7 @@ src/
 │   │   │   ├── jsonl_extract.rs
 │   │   │   ├── manual_rebind_output_path.rs
 │   │   │   ├── manual_rebind_override.rs
+│   │   │   ├── mint_gate.rs
 │   │   │   ├── output_path_detect.rs
 │   │   │   ├── phase_policy.rs
 │   │   │   ├── rebind_runtime.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -127,6 +127,25 @@ time for diagnostics; neither is a stored approval value.
 
 ## Surface Map (by feature)
 
+### `recovery_marker_authority`
+
+- invariant: re-adoption evidence describes only its recorded turn
+  `T=(owner, effective finalizer id)`. Mailbox disposition may consume it only
+  when the evidence proves the disposition target is exactly T. The present-row
+  path enforces raw `user_msg_id == active_user_message_id`; the absent-row
+  ledger independently requires exact owner+id+finished.
+- restore-site four-value policy:
+
+  | production site | `WillSpawn` | `NoOutputPath` | `IncumbentReuse` | `Unknown` |
+  |---|---|---|---|---|
+  | `restore_inflight.rs` restart-report loop | watcher start exists, no reusable incumbent | `restart_report_watcher_start == None` for every runtime | healthy same-path incumbent | unreachable; no later rollout resolver |
+  | `restore_inflight.rs` ordinary loop | path exists, no reusable incumbent | missing non-Codex path; refuse mint and DLQ loss observation | refuse mint, never DLQ; incumbent remains the consumer | missing Codex path; later rollout resolver may install watcher |
+  | `watchers/lifecycle/restore.rs` startup restore | excluded from this gate | excluded | excluded | excluded |
+
+  Startup restore is excluded because it enqueues `PendingWatcher` regardless
+  of reregister result, so refusal cannot prove consumer absence. Episode
+  handoff preserves its guarded direct entry outside these three loop rows.
+
 ### `provider_output_guard`
 
 - canonical_modules:

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -143,9 +143,19 @@ time for diagnostics; neither is a stored approval value.
   | `watchers/lifecycle/restore.rs` startup restore | excluded from this gate | excluded | excluded | excluded |
 
   The gate suppresses mailbox-token mint only. Refusal still runs finalizer
-  reseeding and the identity-guarded readoption write, including consumption of
-  an outgoing `restart_mode`. This PR does not promote refusal to a DLQ fact;
-  the existing #4380 DLQ remains limited to durable marker-write failure.
+  reseeding and attempts the identity-guarded readoption write. When that write
+  succeeds, the store sets `readopted_from_inflight` and clears `restart_mode`;
+  those writes do not prove that a watcher, mailbox token, or pending consumer
+  was installed.
+
+  Residual on the successful-write path: if no consumer is actually installed,
+  undelivered output remains without a durable DLQ copy. The #4380 predicate
+  requires `!readopted_from_inflight`, so the successful marker write makes it
+  false and the DLQ does not fire. The refusal WARN cannot distinguish a safe
+  refusal (another consumer exists or will be installed) from real no-consumer
+  loss, is not a loss-confirmation signal, and does not preserve the undelivered
+  body. This residual is limited to successful marker writes; marker-write
+  failure remains covered by the existing #4380 DLQ backstop.
 
   Refusal is not proof that this process has no consumer. In the ordinary path,
   only the generic branch inserts `recovering_channels`; the ordinary branch
@@ -155,11 +165,12 @@ time for diagnostics; neither is a stored approval value.
   excluded from the gate. Episode handoff preserves its guarded direct entry
   outside these three loop rows.
 
-  Review-coordinate corrections against the r1 snapshot: unconditional
-  `pending.push` is `watchers/lifecycle/restore.rs:516`; the
-  `find_watcher_by_tmux_session` call is `claims.rs:345`, while the actual
-  `ReuseExisting` return is `claims.rs:417`; the W1c marker block spans
-  `restore_inflight.rs:2207-2211`.
+  Review coordinates use symbols, not mutable line numbers: startup restore's
+  unconditional enqueue is `pending.push(PendingWatcher { .. })` in
+  `restore_tmux_watchers`; incumbent lookup and reuse are the
+  `find_watcher_by_tmux_session` call and `WatcherClaimAction::ReuseExisting`
+  return in `claim_watcher`; the W1c marker site is the
+  `readopt_marker_eligible_real_user` guard block in `restore_inflight_turns`.
 
   G2 also reseeds the recovered finalizer ledger when mint returns false. This
   is inert for queue admission by itself because `claim_queue_eligible()` still

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -138,13 +138,32 @@ time for diagnostics; neither is a stored approval value.
 
   | production site | `WillSpawn` | `NoOutputPath` | `IncumbentReuse` | `Unknown` |
   |---|---|---|---|---|
-  | `restore_inflight.rs` restart-report loop | watcher start exists, no reusable incumbent | `restart_report_watcher_start == None` for every runtime | healthy same-path incumbent | unreachable; no later rollout resolver |
-  | `restore_inflight.rs` ordinary loop | path exists, no reusable incumbent | missing non-Codex path; refuse mint and DLQ loss observation | refuse mint, never DLQ; incumbent remains the consumer | missing Codex path; later rollout resolver may install watcher |
+  | `restore_inflight.rs` restart-report loop | watcher start exists, no reusable incumbent | `restart_report_watcher_start == None` for every runtime; refuse mint only | healthy same-path incumbent; refuse mint only | unreachable; no later rollout resolver |
+  | `restore_inflight.rs` ordinary loop | path exists, no reusable incumbent | missing non-Codex path; refuse mint only | healthy same-path incumbent; refuse mint only | missing Codex path; later rollout resolver may install watcher |
   | `watchers/lifecycle/restore.rs` startup restore | excluded from this gate | excluded | excluded | excluded |
 
-  Startup restore is excluded because it enqueues `PendingWatcher` regardless
-  of reregister result, so refusal cannot prove consumer absence. Episode
-  handoff preserves its guarded direct entry outside these three loop rows.
+  The gate suppresses mailbox-token mint only. Refusal still runs finalizer
+  reseeding and the identity-guarded readoption write, including consumption of
+  an outgoing `restart_mode`. This PR does not promote refusal to a DLQ fact;
+  the existing #4380 DLQ remains limited to durable marker-write failure.
+
+  Refusal is not proof that this process has no consumer. In the ordinary path,
+  only the generic branch inserts `recovering_channels`; the ordinary branch
+  continues before that insert. Startup then runs `restore_tmux_watchers`, whose
+  scan re-registers the row and unconditionally enqueues `PendingWatcher` before
+  its later `recovery_handled` check. The startup-restore site is therefore also
+  excluded from the gate. Episode handoff preserves its guarded direct entry
+  outside these three loop rows.
+
+  Review-coordinate corrections against the r1 snapshot: unconditional
+  `pending.push` is `watchers/lifecycle/restore.rs:516`; the
+  `find_watcher_by_tmux_session` call is `claims.rs:345`, while the actual
+  `ReuseExisting` return is `claims.rs:417`; the W1c marker block spans
+  `restore_inflight.rs:2207-2211`.
+
+  G2 also reseeds the recovered finalizer ledger when mint returns false. This
+  is inert for queue admission by itself because `claim_queue_eligible()` still
+  requires `mailbox_released`.
 
 ### `provider_output_guard`
 

--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -3660,6 +3660,7 @@ services::discord::recovery_engine::manual_rebind_override::tests::health_rebind
 services::discord::recovery_engine::manual_rebind_override::tests::health_rebind_override_rejects_missing_and_non_regular_paths
 services::discord::recovery_engine::manual_rebind_override::tests::health_rebind_override_rejects_non_uuid_session_id
 services::discord::recovery_engine::manual_rebind_override::tests::health_rebind_override_rejects_symlink_escape_from_allowed_root
+services::discord::recovery_engine::mint_gate::tests::four_value_watcher_install_policy_is_exact
 services::discord::recovery_engine::phase_policy::tests::orphaned_synthetic_watcher_row_adoption_quadrants
 services::discord::recovery_engine::phase_policy::tests::ownerless_live_inflight_with_partial_response_can_reattach_watcher
 services::discord::recovery_engine::phase_policy::tests::planned_restart_ownerless_live_inflight_with_restore_anchor_can_reattach_watcher
@@ -3703,9 +3704,9 @@ services::discord::recovery_engine::recovery_two_message_panel::tests::replaceme
 services::discord::recovery_engine::recovery_two_message_panel::tests::replacement_owner_survives_recovery_send_race
 services::discord::recovery_engine::recovery_two_message_panel::tests::restart_reanchors_stranded_panel_and_persists_new_epoch
 services::discord::recovery_engine::recovery_two_message_panel::tests::restart_recreates_missing_panel_without_duplicate_old_delete
-services::discord::recovery_engine::restore_inflight::tests::generic_recovery_consumes_restart_before_runtime_ready_and_persists_runtime_stamp
+services::discord::recovery_engine::restore_inflight::tests::generic_recovery_clears_restart_mode_before_runtime_ready_and_persists_runtime_stamp
 services::discord::recovery_engine::restore_inflight::tests::ordinary_restore_same_and_cross_channel_incumbents_refuse_mint
-services::discord::recovery_engine::restore_inflight::tests::restart_report_refusal_consumes_restart_authority_without_minting
+services::discord::recovery_engine::restore_inflight::tests::restart_report_refusal_writes_readoption_marker_without_minting
 services::discord::recovery_engine::restore_inflight::tests::restore_claude_tui_without_runtime_output_uses_tmux_fallback_path
 services::discord::recovery_engine::restore_inflight::tests::restore_rollout_output_path_patch_preserves_concurrent_relay_fields
 services::discord::recovery_engine::routing_orphan::tests::orphan_with_probe_error_is_preserved_while_dead_pane_is_cleaned

--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -3597,7 +3597,6 @@ services::discord::recovery_engine::crash_resume_guard::tests::committed_turn_is
 services::discord::recovery_engine::crash_resume_guard::tests::crash_readopt_real_user_live_turn_matches_the_black_hole_shape
 services::discord::recovery_engine::crash_resume_guard::tests::crash_real_user_missing_marker_dead_letters
 services::discord::recovery_engine::crash_resume_guard::tests::marker_present_is_a_no_op
-services::discord::recovery_engine::crash_resume_guard::tests::no_output_path_dead_letters_even_with_a_premarked_row
 services::discord::recovery_engine::crash_resume_guard::tests::planned_restart_missing_marker_does_not_dead_letter
 services::discord::recovery_engine::crash_resume_guard::tests::real_owner_id0_missing_marker_does_not_dead_letter
 services::discord::recovery_engine::crash_resume_guard::tests::rebind_origin_turn_is_owned_by_the_rebind_api
@@ -3705,9 +3704,8 @@ services::discord::recovery_engine::recovery_two_message_panel::tests::replaceme
 services::discord::recovery_engine::recovery_two_message_panel::tests::restart_reanchors_stranded_panel_and_persists_new_epoch
 services::discord::recovery_engine::recovery_two_message_panel::tests::restart_recreates_missing_panel_without_duplicate_old_delete
 services::discord::recovery_engine::restore_inflight::tests::generic_recovery_consumes_restart_before_runtime_ready_and_persists_runtime_stamp
-services::discord::recovery_engine::restore_inflight::tests::ordinary_restore_incumbents_same_and_intended_cross_channel_never_dead_letter
-services::discord::recovery_engine::restore_inflight::tests::ordinary_restore_no_output_outer_guard_dead_letters_premarked_row
-services::discord::recovery_engine::restore_inflight::tests::restart_report_missing_start_outer_guard_refuses_mailbox_mint
+services::discord::recovery_engine::restore_inflight::tests::ordinary_restore_same_and_cross_channel_incumbents_refuse_mint
+services::discord::recovery_engine::restore_inflight::tests::restart_report_refusal_consumes_restart_authority_without_minting
 services::discord::recovery_engine::restore_inflight::tests::restore_claude_tui_without_runtime_output_uses_tmux_fallback_path
 services::discord::recovery_engine::restore_inflight::tests::restore_rollout_output_path_patch_preserves_concurrent_relay_fields
 services::discord::recovery_engine::routing_orphan::tests::orphan_with_probe_error_is_preserved_while_dead_pane_is_cleaned

--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -3597,6 +3597,7 @@ services::discord::recovery_engine::crash_resume_guard::tests::committed_turn_is
 services::discord::recovery_engine::crash_resume_guard::tests::crash_readopt_real_user_live_turn_matches_the_black_hole_shape
 services::discord::recovery_engine::crash_resume_guard::tests::crash_real_user_missing_marker_dead_letters
 services::discord::recovery_engine::crash_resume_guard::tests::marker_present_is_a_no_op
+services::discord::recovery_engine::crash_resume_guard::tests::no_output_path_dead_letters_even_with_a_premarked_row
 services::discord::recovery_engine::crash_resume_guard::tests::planned_restart_missing_marker_does_not_dead_letter
 services::discord::recovery_engine::crash_resume_guard::tests::real_owner_id0_missing_marker_does_not_dead_letter
 services::discord::recovery_engine::crash_resume_guard::tests::rebind_origin_turn_is_owned_by_the_rebind_api
@@ -3704,6 +3705,9 @@ services::discord::recovery_engine::recovery_two_message_panel::tests::replaceme
 services::discord::recovery_engine::recovery_two_message_panel::tests::restart_reanchors_stranded_panel_and_persists_new_epoch
 services::discord::recovery_engine::recovery_two_message_panel::tests::restart_recreates_missing_panel_without_duplicate_old_delete
 services::discord::recovery_engine::restore_inflight::tests::generic_recovery_consumes_restart_before_runtime_ready_and_persists_runtime_stamp
+services::discord::recovery_engine::restore_inflight::tests::ordinary_restore_incumbents_same_and_intended_cross_channel_never_dead_letter
+services::discord::recovery_engine::restore_inflight::tests::ordinary_restore_no_output_outer_guard_dead_letters_premarked_row
+services::discord::recovery_engine::restore_inflight::tests::restart_report_missing_start_outer_guard_refuses_mailbox_mint
 services::discord::recovery_engine::restore_inflight::tests::restore_claude_tui_without_runtime_output_uses_tmux_fallback_path
 services::discord::recovery_engine::restore_inflight::tests::restore_rollout_output_path_patch_preserves_concurrent_relay_fields
 services::discord::recovery_engine::routing_orphan::tests::orphan_with_probe_error_is_preserved_while_dead_pane_is_cleaned
@@ -5227,6 +5231,8 @@ services::discord::tui_prompt_relay::synthetic_start::tests::path_b_absent_row_i
 services::discord::tui_prompt_relay::synthetic_start::tests::path_b_absent_row_ledger_different_user_msg_id_is_never_stolen
 services::discord::tui_prompt_relay::synthetic_start::tests::path_b_absent_row_ledger_live_not_finished_is_never_stolen
 services::discord::tui_prompt_relay::synthetic_start::tests::path_b_absent_row_not_in_ledger_is_never_reclaimed
+services::discord::tui_prompt_relay::synthetic_start::tests::premarked_x_after_refusal_does_not_cancel_aged_live_successor_y
+services::discord::tui_prompt_relay::synthetic_start::tests::queue_persistence_refusal_still_records_readoption
 services::discord::tui_prompt_relay::synthetic_start::tests::readopted_from_inflight_id0_row_is_never_reclaimed
 services::discord::tui_prompt_relay::synthetic_start::tests::readopted_from_inflight_real_owner_committed_row_reclaims_for_starved_synthetic
 services::discord::tui_prompt_relay::synthetic_start::tests::readopted_from_inflight_real_owner_live_turn_is_never_stolen
@@ -5237,6 +5243,7 @@ services::discord::tui_prompt_relay::synthetic_start::tests::stale_synthetic_own
 services::discord::tui_prompt_relay::synthetic_start::tests::stale_synthetic_owner_replaced_requires_same_tmux_session
 services::discord::tui_prompt_relay::synthetic_start::tests::synthetic_finish_routes_release_through_finalizer
 services::discord::tui_prompt_relay::synthetic_start::tests::synthetic_finish_session_key_mismatch_preserves_newer_turn
+services::discord::tui_prompt_relay::synthetic_start::tests::token_race_marks_x_but_preserves_aged_live_y
 services::discord::tui_prompt_relay::synthetic_start::tests::young_rowless_synthetic_owner_is_not_reclaimed
 services::discord::tui_prompt_relay::tests::abort_cleanup_records_marker_and_keeps_hourglass
 services::discord::tui_prompt_relay::tests::bridge_adapter_inflight_marks_external_input_as_bridge_owned

--- a/src/db/relay_dead_letter.rs
+++ b/src/db/relay_dead_letter.rs
@@ -29,9 +29,10 @@ pub(crate) const KIND_QUEUE_OVERFLOW: &str = "queue_overflow";
 /// #4380: a crash restart re-adopted a still-live real-user bridge turn, but the
 /// `readopted_from_inflight` relay-resume marker did not durably persist, so the
 /// recovered watcher will yield to the dead bridge and silently drop the turn's
-/// remaining output. Recording the undelivered body here ends the 30-minute silent
-/// wedge (the recurring `.stuck-manual-*` hand-recovery) with an observable,
-/// recoverable row. The root fix (watcher-yield escape hatch) resumes relay on the
+/// remaining output. The body is only the best-effort tail through the durable
+/// frontier; output never persisted before bridge death is unavailable. Recording
+/// it ends the silent wedge with observable loss evidence, not loss restoration.
+/// The root fix (watcher-yield escape hatch) resumes relay on the
 /// normal path; this KIND only fires on the marker-write-failure residual.
 ///
 /// Declared unconditionally like the sibling `KIND_*` discriminators (a DB `kind`

--- a/src/services/discord/inflight/model.rs
+++ b/src/services/discord/inflight/model.rs
@@ -393,8 +393,8 @@ pub(in crate::services::discord) struct InflightTurnState {
     /// no-op check. Mailbox disposition has two evidence paths: the present-row
     /// classifier enforces raw owner+id equality, while the absent-row in-memory
     /// ledger already enforces owner+id+finished. Crash resume is self-referential
-    /// to this row; DLQ authority is additionally restricted by the typed watcher
-    /// outlook. The marker alone never authorizes reclaim.
+    /// to this row; the crash DLQ backstop fires only when this durable marker
+    /// write failed. Mint refusal is not DLQ authority; the marker alone never authorizes reclaim.
     ///
     /// NOTE (#4370/#4810): this marker is written through the NARROW adoption patch
     /// `mark_readopted_from_inflight_if_identity_unchanged`

--- a/src/services/discord/inflight/model.rs
+++ b/src/services/discord/inflight/model.rs
@@ -382,15 +382,19 @@ pub(in crate::services::discord) struct InflightTurnState {
     /// `✅`/footer + analytics/transcript must STILL fire — reusing
     /// `relay_ownership_only` would wrongly mute the very prose this fix protects.
     ///
-    /// This marker therefore feeds EXACTLY ONE guard: TUI-direct synthetic
-    /// `stale_reclaim` eligibility for a PRESENT row. It lets a later starved
-    /// injection / task-notification synthetic turn reclaim the mailbox of a
-    /// re-adopted real-user owner once that owner is stale
-    /// (`terminal_delivery_committed`) — closing the #4018 regression on the
-    /// restart-resume path, where the synthetic-owner-only reclaim could never
-    /// free a real-user mailbox (#4370). It NEVER by itself triggers a reclaim; a
-    /// live, progressing re-adopted turn (matching `user_msg_id`, not committed)
-    /// still yields reclaim-reason `None`.
+    /// INV: re-adoption evidence is a statement about the turn
+    /// T=(owner, effective finalizer id) that recorded it. A mailbox disposition
+    /// may consume that evidence only when the evidence itself proves that the
+    /// disposition target is exactly T. Evidence residue is harmless; allowing it
+    /// to authorize disposition of another turn is the defect.
+    ///
+    /// There are four direct consumers: present-row stale-reclaim eligibility,
+    /// crash relay-resume, crash DLQ/backstop policy, and the lock-held persist
+    /// no-op check. Mailbox disposition has two evidence paths: the present-row
+    /// classifier enforces raw owner+id equality, while the absent-row in-memory
+    /// ledger already enforces owner+id+finished. Crash resume is self-referential
+    /// to this row; DLQ authority is additionally restricted by the typed watcher
+    /// outlook. The marker alone never authorizes reclaim.
     ///
     /// NOTE (#4370/#4810): this marker is written through the NARROW adoption patch
     /// `mark_readopted_from_inflight_if_identity_unchanged`

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -437,15 +437,7 @@ fn recovery_mint_outlook(
     let incumbent = path_exists
         .then(|| {
             tmux_session_name.and_then(|name| {
-                let owner = shared.tmux_watchers.owner_channel_for_tmux_session(name)?;
-                let entry = shared.tmux_watchers.by_tmux_session.get(name)?;
-                Some((
-                    owner,
-                    entry.heartbeat_stale()
-                        || entry.cancel.load(std::sync::atomic::Ordering::Relaxed),
-                    entry.paused.load(std::sync::atomic::Ordering::Relaxed),
-                    entry.output_path.clone(),
-                ))
+                super::tmux::find_watcher_by_tmux_session(&shared.tmux_watchers, name)
             })
         })
         .flatten();

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -434,6 +434,7 @@ fn recovery_mint_outlook(
     output_path: &str,
     path_exists: bool,
 ) -> mint_gate::WatcherInstallOutlook {
+    #[cfg(unix)]
     let incumbent = path_exists
         .then(|| {
             tmux_session_name.and_then(|name| {
@@ -441,6 +442,10 @@ fn recovery_mint_outlook(
             })
         })
         .flatten();
+    #[cfg(not(unix))]
+    let incumbent: Option<(ChannelId, bool, bool, String)> = None;
+    #[cfg(not(unix))]
+    let _ = (shared, tmux_session_name);
     mint_gate::watcher_install_outlook(
         path_exists,
         state.runtime_kind,

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -84,6 +84,8 @@ mod unix_journal;
 // module. The entry point is re-exported below so external call sites
 // (`watchers::lifecycle`, `manual_rebind`, the restart-path reattach calls) stay
 // byte-identical.
+#[path = "recovery_engine/mint_gate.rs"]
+pub(in crate::services::discord) mod mint_gate;
 #[path = "recovery_engine/runtime.rs"]
 mod runtime;
 // #3834 r2: behavior-preserving extraction of the terminal recovery delivery /
@@ -194,6 +196,9 @@ pub(in crate::services::discord) use self::restore_inflight::{
 };
 use self::restore_persist_outcome::{RestorePersistOutcome, restore_codex_rollout_output_path};
 pub(super) use self::runtime::reregister_active_turn_from_inflight;
+pub(in crate::services::discord) use self::runtime::reregister_active_turn_from_inflight_with_outlook;
+#[cfg(test)]
+pub(crate) use self::runtime::{BeforeMailboxClaimBarrier, install_before_mailbox_claim_barrier};
 pub(in crate::services::discord) use self::terminal_text_idempotency::RecoveryDeliveryContext;
 use self::tmux_probe::tmux_session_alive_with_retry;
 // #3479: re-import the analytics + transcript helpers so root call sites stay
@@ -420,6 +425,38 @@ fn emit_recovery_quality_event(
             }),
         },
     );
+}
+
+fn recovery_mint_outlook(
+    shared: &Arc<SharedData>,
+    state: &inflight::InflightTurnState,
+    tmux_session_name: Option<&str>,
+    output_path: &str,
+    path_exists: bool,
+) -> mint_gate::WatcherInstallOutlook {
+    let incumbent = path_exists
+        .then(|| {
+            tmux_session_name.and_then(|name| {
+                let owner = shared.tmux_watchers.owner_channel_for_tmux_session(name)?;
+                let entry = shared.tmux_watchers.by_tmux_session.get(name)?;
+                Some((
+                    owner,
+                    entry.heartbeat_stale()
+                        || entry.cancel.load(std::sync::atomic::Ordering::Relaxed),
+                    entry.paused.load(std::sync::atomic::Ordering::Relaxed),
+                    entry.output_path.clone(),
+                ))
+            })
+        })
+        .flatten();
+    mint_gate::watcher_install_outlook(
+        path_exists,
+        state.runtime_kind,
+        incumbent
+            .as_ref()
+            .map(|(owner, cancelled, paused, path)| (*owner, *cancelled, *paused, path.as_str())),
+        output_path,
+    )
 }
 
 /// #896: Outcome of a successful [`rebind_inflight_for_channel`] call.

--- a/src/services/discord/recovery_engine/crash_resume_guard.rs
+++ b/src/services/discord/recovery_engine/crash_resume_guard.rs
@@ -23,11 +23,10 @@
 //! text-chars) — the seed always clamps the offset, so it never zeroes the delta.
 //!
 //! Backstop (NOT a substitute for the fix): if the marker write did not durably
-//! persist (`IoError`), or the typed watcher outlook proves there is no output
-//! path, the recovered watcher cannot relay, so
+//! persist (`IoError`) the recovered watcher still yields, so
 //! [`guard_readopt_relay_resume_or_dead_letter`] dead-letters the undelivered body
 //! (`KIND_READOPT_RELAY_STUCK`) with a WARN, turning a silent 30-minute wedge into
-//! an observable loss record; it cannot reconstruct output never persisted.
+//! an observable, recoverable row.
 //!
 //! Lives under `recovery_engine` (a non-giant) so declaring it never re-inflates
 //! the `discord/mod.rs` giant; the yield-gate predicate is re-exported at
@@ -97,35 +96,33 @@ pub(in crate::services::discord) fn crash_readopt_live_relay_resume_required(
 }
 
 /// Pure DLQ-fire decision for the #4380 backstop, extracted so it is unit-testable
-/// WITHOUT Postgres. Within the crash black-hole shape, `NoOutputPath` fires
-/// regardless of marker, `IncumbentReuse` never fires, and spawn-capable outlooks
-/// fire only when the marker write failed. Planned restarts and id-0 rows remain
-/// excluded before outlook is considered.
+/// WITHOUT Postgres (the sink `record_detached` needs a live pool). Fires iff the
+/// reloaded row is still the crash black-hole shape
+/// ([`crash_readopt_real_user_live_turn`]) AND lacks the `readopted_from_inflight`
+/// marker — i.e. the resume guard could not be armed (the marker WRITE failed with
+/// IoError), so the recovered watcher WILL yield to the dead bridge. The shape
+/// already excludes planned restarts and id-0 rows, so a marker that is absent
+/// BY DESIGN (never eligible) can never trip this.
 pub(in crate::services::discord) fn readopt_relay_black_hole_dead_letter_required(
     state: &InflightTurnState,
-    outlook: super::mint_gate::WatcherInstallOutlook,
 ) -> bool {
-    crash_readopt_real_user_live_turn(state)
-        && match outlook {
-            super::mint_gate::WatcherInstallOutlook::NoOutputPath => true,
-            super::mint_gate::WatcherInstallOutlook::IncumbentReuse { .. } => false,
-            super::mint_gate::WatcherInstallOutlook::WillSpawn
-            | super::mint_gate::WatcherInstallOutlook::Unknown => !state.readopted_from_inflight,
-        }
+    crash_readopt_real_user_live_turn(state) && !state.readopted_from_inflight
 }
 
-/// #4380/#5242 backstop: WARN + durable dead-letter for a re-adopted real-user
-/// turn whose typed outlook proves relay cannot resume. Fire-and-forget: the DLQ
-/// insert rides a detached task (`record_detached`), never blocking recovery.
+/// #4380 backstop: WARN + durable dead-letter for a re-adopted real-user live turn
+/// whose relay-resume guard could NOT be armed (the `readopted_from_inflight`
+/// marker did not durably persist), so the recovered watcher will yield to the dead
+/// bridge and silently drop the remaining output. Fire-and-forget: the DLQ insert
+/// rides a detached task (`record_detached`), never blocking recovery.
 pub(in crate::services::discord) fn record_readopt_relay_black_hole_dead_letter(
     pool: Option<&PgPool>,
     channel_id: ChannelId,
     state: &InflightTurnState,
     reason: &str,
 ) {
-    // This is only the best-effort tail through the last durably persisted
-    // frontier. Bytes produced immediately before bridge death but never persisted
-    // cannot be reconstructed here; DLQ makes loss observable, not recoverable.
+    // The undelivered body is `full_response[response_sent_offset..]`; fall back to
+    // the whole body if the (clamped) offset is somehow out of bounds so the DLQ
+    // never loses content to a slice panic.
     let undelivered = state
         .full_response
         .get(state.response_sent_offset..)
@@ -153,45 +150,32 @@ pub(in crate::services::discord) fn record_readopt_relay_black_hole_dead_letter(
 }
 
 /// #4380 backstop entry point, called from the crash-recovery re-adopt path right
-/// after typed re-registration. Reloads the durable row and applies the pure
-/// marker+outlook decision above, returning whether a record was requested.
+/// after `reregister_active_turn_from_inflight` (which stamps the marker). Reloads
+/// the durable row and, iff it is still an at-risk re-adopted real-user live turn
+/// that LACKS the `readopted_from_inflight` marker (marker write failed), records a
+/// dead letter. On the normal path the marker is present, so this is a no-op.
 pub(in crate::services::discord) fn guard_readopt_relay_resume_or_dead_letter(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: ChannelId,
-    outlook: super::mint_gate::WatcherInstallOutlook,
-) -> bool {
+) {
     let Some(reloaded) =
         crate::services::discord::inflight::load_inflight_state(provider, channel_id.get())
     else {
-        return false;
+        return;
     };
-    if readopt_relay_black_hole_dead_letter_required(&reloaded, outlook) {
-        let episode = reloaded
-            .turn_nonce
-            .as_deref()
-            .unwrap_or("legacy-no-turn-nonce");
-        let reason = if outlook.requires_marker_independent_dead_letter() {
-            format!("watcher outlook has no output path; recovery_episode={episode} (#5242)")
-        } else {
-            format!(
-                "readopted_from_inflight marker did not persist; recovery_episode={episode} (#4380)"
-            )
-        };
+    if readopt_relay_black_hole_dead_letter_required(&reloaded) {
         record_readopt_relay_black_hole_dead_letter(
             shared.pg_pool.as_ref(),
             channel_id,
             &reloaded,
-            &reason,
+            "readopted_from_inflight marker did not persist; recovered watcher will yield to the dead bridge (#4380)",
         );
-        return true;
     }
-    false
 }
 
 #[cfg(test)]
 mod tests {
-    use super::super::mint_gate::WatcherInstallOutlook;
     use super::*;
     use crate::services::agent_protocol::RuntimeHandoffKind;
 
@@ -333,10 +317,7 @@ mod tests {
             state.readopted_from_inflight = false;
             state.set_restart_mode(crate::services::discord::InflightRestartMode::DrainRestart);
             assert!(
-                !readopt_relay_black_hole_dead_letter_required(
-                    &state,
-                    WatcherInstallOutlook::WillSpawn,
-                ),
+                !readopt_relay_black_hole_dead_letter_required(&state),
                 "a planned-restart row is resumed by the restart_mode escape hatch, not black-holed"
             );
         });
@@ -353,10 +334,7 @@ mod tests {
             state.readopted_from_inflight = false;
             state.user_msg_id = 0;
             assert!(
-                !readopt_relay_black_hole_dead_letter_required(
-                    &state,
-                    WatcherInstallOutlook::WillSpawn,
-                ),
+                !readopt_relay_black_hole_dead_letter_required(&state),
                 "id-0 rows are never marker-eligible; an absent marker is by-design, not a failed write"
             );
         });
@@ -370,10 +348,7 @@ mod tests {
         with_readopted_crash_turn(|mut state| {
             state.readopted_from_inflight = false;
             assert!(
-                readopt_relay_black_hole_dead_letter_required(
-                    &state,
-                    WatcherInstallOutlook::WillSpawn,
-                ),
+                readopt_relay_black_hole_dead_letter_required(&state),
                 "a crash re-adopt whose marker failed to persist is the real black-hole → must DLQ"
             );
         });
@@ -385,23 +360,9 @@ mod tests {
     fn marker_present_is_a_no_op() {
         with_readopted_crash_turn(|state| {
             assert!(
-                !readopt_relay_black_hole_dead_letter_required(
-                    &state,
-                    WatcherInstallOutlook::WillSpawn,
-                ),
+                !readopt_relay_black_hole_dead_letter_required(&state),
                 "when the marker persisted the resume guard is armed → no dead-letter"
             );
-        });
-    }
-
-    #[test]
-    fn no_output_path_dead_letters_even_with_a_premarked_row() {
-        with_readopted_crash_turn(|state| {
-            assert!(state.readopted_from_inflight);
-            assert!(readopt_relay_black_hole_dead_letter_required(
-                &state,
-                WatcherInstallOutlook::NoOutputPath,
-            ));
         });
     }
 }

--- a/src/services/discord/recovery_engine/crash_resume_guard.rs
+++ b/src/services/discord/recovery_engine/crash_resume_guard.rs
@@ -23,10 +23,11 @@
 //! text-chars) — the seed always clamps the offset, so it never zeroes the delta.
 //!
 //! Backstop (NOT a substitute for the fix): if the marker write did not durably
-//! persist (`IoError`) the recovered watcher still yields, so
+//! persist (`IoError`), or the typed watcher outlook proves there is no output
+//! path, the recovered watcher cannot relay, so
 //! [`guard_readopt_relay_resume_or_dead_letter`] dead-letters the undelivered body
 //! (`KIND_READOPT_RELAY_STUCK`) with a WARN, turning a silent 30-minute wedge into
-//! an observable, recoverable row.
+//! an observable loss record; it cannot reconstruct output never persisted.
 //!
 //! Lives under `recovery_engine` (a non-giant) so declaring it never re-inflates
 //! the `discord/mod.rs` giant; the yield-gate predicate is re-exported at
@@ -96,33 +97,35 @@ pub(in crate::services::discord) fn crash_readopt_live_relay_resume_required(
 }
 
 /// Pure DLQ-fire decision for the #4380 backstop, extracted so it is unit-testable
-/// WITHOUT Postgres (the sink `record_detached` needs a live pool). Fires iff the
-/// reloaded row is still the crash black-hole shape
-/// ([`crash_readopt_real_user_live_turn`]) AND lacks the `readopted_from_inflight`
-/// marker — i.e. the resume guard could not be armed (the marker WRITE failed with
-/// IoError), so the recovered watcher WILL yield to the dead bridge. The shape
-/// already excludes planned restarts and id-0 rows, so a marker that is absent
-/// BY DESIGN (never eligible) can never trip this.
+/// WITHOUT Postgres. Within the crash black-hole shape, `NoOutputPath` fires
+/// regardless of marker, `IncumbentReuse` never fires, and spawn-capable outlooks
+/// fire only when the marker write failed. Planned restarts and id-0 rows remain
+/// excluded before outlook is considered.
 pub(in crate::services::discord) fn readopt_relay_black_hole_dead_letter_required(
     state: &InflightTurnState,
+    outlook: super::mint_gate::WatcherInstallOutlook,
 ) -> bool {
-    crash_readopt_real_user_live_turn(state) && !state.readopted_from_inflight
+    crash_readopt_real_user_live_turn(state)
+        && match outlook {
+            super::mint_gate::WatcherInstallOutlook::NoOutputPath => true,
+            super::mint_gate::WatcherInstallOutlook::IncumbentReuse { .. } => false,
+            super::mint_gate::WatcherInstallOutlook::WillSpawn
+            | super::mint_gate::WatcherInstallOutlook::Unknown => !state.readopted_from_inflight,
+        }
 }
 
-/// #4380 backstop: WARN + durable dead-letter for a re-adopted real-user live turn
-/// whose relay-resume guard could NOT be armed (the `readopted_from_inflight`
-/// marker did not durably persist), so the recovered watcher will yield to the dead
-/// bridge and silently drop the remaining output. Fire-and-forget: the DLQ insert
-/// rides a detached task (`record_detached`), never blocking recovery.
+/// #4380/#5242 backstop: WARN + durable dead-letter for a re-adopted real-user
+/// turn whose typed outlook proves relay cannot resume. Fire-and-forget: the DLQ
+/// insert rides a detached task (`record_detached`), never blocking recovery.
 pub(in crate::services::discord) fn record_readopt_relay_black_hole_dead_letter(
     pool: Option<&PgPool>,
     channel_id: ChannelId,
     state: &InflightTurnState,
     reason: &str,
 ) {
-    // The undelivered body is `full_response[response_sent_offset..]`; fall back to
-    // the whole body if the (clamped) offset is somehow out of bounds so the DLQ
-    // never loses content to a slice panic.
+    // This is only the best-effort tail through the last durably persisted
+    // frontier. Bytes produced immediately before bridge death but never persisted
+    // cannot be reconstructed here; DLQ makes loss observable, not recoverable.
     let undelivered = state
         .full_response
         .get(state.response_sent_offset..)
@@ -150,32 +153,45 @@ pub(in crate::services::discord) fn record_readopt_relay_black_hole_dead_letter(
 }
 
 /// #4380 backstop entry point, called from the crash-recovery re-adopt path right
-/// after `reregister_active_turn_from_inflight` (which stamps the marker). Reloads
-/// the durable row and, iff it is still an at-risk re-adopted real-user live turn
-/// that LACKS the `readopted_from_inflight` marker (marker write failed), records a
-/// dead letter. On the normal path the marker is present, so this is a no-op.
+/// after typed re-registration. Reloads the durable row and applies the pure
+/// marker+outlook decision above, returning whether a record was requested.
 pub(in crate::services::discord) fn guard_readopt_relay_resume_or_dead_letter(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: ChannelId,
-) {
+    outlook: super::mint_gate::WatcherInstallOutlook,
+) -> bool {
     let Some(reloaded) =
         crate::services::discord::inflight::load_inflight_state(provider, channel_id.get())
     else {
-        return;
+        return false;
     };
-    if readopt_relay_black_hole_dead_letter_required(&reloaded) {
+    if readopt_relay_black_hole_dead_letter_required(&reloaded, outlook) {
+        let episode = reloaded
+            .turn_nonce
+            .as_deref()
+            .unwrap_or("legacy-no-turn-nonce");
+        let reason = if outlook.requires_marker_independent_dead_letter() {
+            format!("watcher outlook has no output path; recovery_episode={episode} (#5242)")
+        } else {
+            format!(
+                "readopted_from_inflight marker did not persist; recovery_episode={episode} (#4380)"
+            )
+        };
         record_readopt_relay_black_hole_dead_letter(
             shared.pg_pool.as_ref(),
             channel_id,
             &reloaded,
-            "readopted_from_inflight marker did not persist; recovered watcher will yield to the dead bridge (#4380)",
+            &reason,
         );
+        return true;
     }
+    false
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::mint_gate::WatcherInstallOutlook;
     use super::*;
     use crate::services::agent_protocol::RuntimeHandoffKind;
 
@@ -317,7 +333,10 @@ mod tests {
             state.readopted_from_inflight = false;
             state.set_restart_mode(crate::services::discord::InflightRestartMode::DrainRestart);
             assert!(
-                !readopt_relay_black_hole_dead_letter_required(&state),
+                !readopt_relay_black_hole_dead_letter_required(
+                    &state,
+                    WatcherInstallOutlook::WillSpawn,
+                ),
                 "a planned-restart row is resumed by the restart_mode escape hatch, not black-holed"
             );
         });
@@ -334,7 +353,10 @@ mod tests {
             state.readopted_from_inflight = false;
             state.user_msg_id = 0;
             assert!(
-                !readopt_relay_black_hole_dead_letter_required(&state),
+                !readopt_relay_black_hole_dead_letter_required(
+                    &state,
+                    WatcherInstallOutlook::WillSpawn,
+                ),
                 "id-0 rows are never marker-eligible; an absent marker is by-design, not a failed write"
             );
         });
@@ -348,7 +370,10 @@ mod tests {
         with_readopted_crash_turn(|mut state| {
             state.readopted_from_inflight = false;
             assert!(
-                readopt_relay_black_hole_dead_letter_required(&state),
+                readopt_relay_black_hole_dead_letter_required(
+                    &state,
+                    WatcherInstallOutlook::WillSpawn,
+                ),
                 "a crash re-adopt whose marker failed to persist is the real black-hole → must DLQ"
             );
         });
@@ -360,9 +385,23 @@ mod tests {
     fn marker_present_is_a_no_op() {
         with_readopted_crash_turn(|state| {
             assert!(
-                !readopt_relay_black_hole_dead_letter_required(&state),
+                !readopt_relay_black_hole_dead_letter_required(
+                    &state,
+                    WatcherInstallOutlook::WillSpawn,
+                ),
                 "when the marker persisted the resume guard is armed → no dead-letter"
             );
+        });
+    }
+
+    #[test]
+    fn no_output_path_dead_letters_even_with_a_premarked_row() {
+        with_readopted_crash_turn(|state| {
+            assert!(state.readopted_from_inflight);
+            assert!(readopt_relay_black_hole_dead_letter_required(
+                &state,
+                WatcherInstallOutlook::NoOutputPath,
+            ));
         });
     }
 }

--- a/src/services/discord/recovery_engine/mint_gate.rs
+++ b/src/services/discord/recovery_engine/mint_gate.rs
@@ -27,12 +27,6 @@ impl WatcherInstallOutlook {
             Self::WillSpawn | Self::Unknown => None,
         }
     }
-
-    /// Only a missing output path proves that this recovery has no relay
-    /// consumer. Reusing a live incumbent is a mint refusal, but not relay loss.
-    pub(super) fn requires_marker_independent_dead_letter(self) -> bool {
-        matches!(self, Self::NoOutputPath)
-    }
 }
 
 pub(super) fn watcher_install_outlook(

--- a/src/services/discord/recovery_engine/mint_gate.rs
+++ b/src/services/discord/recovery_engine/mint_gate.rs
@@ -51,3 +51,116 @@ pub(super) fn watcher_install_outlook(
     }
     WatcherInstallOutlook::WillSpawn
 }
+
+pub(super) async fn reregister_active_turn_for_output_path(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    state: &inflight::InflightTurnState,
+    tmux_session_name: &str,
+    output_path: &str,
+) -> (bool, WatcherInstallOutlook) {
+    let path_exists = std::fs::metadata(output_path).is_ok();
+    let outlook = super::recovery_mint_outlook(
+        shared,
+        state,
+        Some(tmux_session_name),
+        output_path,
+        path_exists,
+    );
+    // Refusal suppresses only token mint. Runtime recovery still reseeds the
+    // finalizer and attempts the readoption marker write.
+    let started = if !outlook.allows_mint() {
+        super::reregister_active_turn_from_inflight_with_outlook(shared, state, outlook).await
+    } else {
+        super::reregister_active_turn_from_inflight(shared, state).await
+    };
+    #[cfg(unix)]
+    super::guard_readopt_relay_resume_or_dead_letter(shared, provider, channel_id);
+    (started, outlook)
+}
+
+pub(super) async fn reregister_active_turn_for_restart_report(
+    shared: &Arc<SharedData>,
+    state: &inflight::InflightTurnState,
+    tmux_session_name: Option<&str>,
+    watcher_start: Option<&(String, u64, u64, bool)>,
+) -> (bool, WatcherInstallOutlook) {
+    let outlook = watcher_start.map_or(WatcherInstallOutlook::NoOutputPath, |(output_path, ..)| {
+        super::recovery_mint_outlook(shared, state, tmux_session_name, output_path, true)
+    });
+    // Site-specific outer guard; `&& false` is a required mutation target.
+    let started = if !outlook.allows_mint() {
+        super::reregister_active_turn_from_inflight_with_outlook(shared, state, outlook).await
+    } else {
+        super::reregister_active_turn_from_inflight(shared, state).await
+    };
+    (started, outlook)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn four_value_watcher_install_policy_is_exact() {
+        let owner = ChannelId::new(5_242_701);
+        let cases = [
+            (
+                "missing Codex path remains unresolved",
+                false,
+                Some(RuntimeHandoffKind::CodexTui),
+                None,
+                WatcherInstallOutlook::Unknown,
+            ),
+            (
+                "missing non-Codex path refuses mint",
+                false,
+                Some(RuntimeHandoffKind::ClaudeTui),
+                None,
+                WatcherInstallOutlook::NoOutputPath,
+            ),
+            (
+                "healthy same-path incumbent is reused",
+                true,
+                Some(RuntimeHandoffKind::ClaudeTui),
+                Some((owner, false, false, "/tmp/requested.jsonl")),
+                WatcherInstallOutlook::IncumbentReuse { owner },
+            ),
+            (
+                "different-path incumbent cannot be reused",
+                true,
+                Some(RuntimeHandoffKind::ClaudeTui),
+                Some((owner, false, false, "/tmp/other.jsonl")),
+                WatcherInstallOutlook::WillSpawn,
+            ),
+            (
+                "cancelled same-path incumbent is replaced",
+                true,
+                Some(RuntimeHandoffKind::ClaudeTui),
+                Some((owner, true, false, "/tmp/requested.jsonl")),
+                WatcherInstallOutlook::WillSpawn,
+            ),
+            (
+                "present path without incumbent spawns",
+                true,
+                Some(RuntimeHandoffKind::CodexTui),
+                None,
+                WatcherInstallOutlook::WillSpawn,
+            ),
+        ];
+
+        for (name, path_exists, runtime_kind, incumbent, expected) in cases {
+            assert_eq!(
+                watcher_install_outlook(
+                    path_exists,
+                    runtime_kind,
+                    incumbent,
+                    "/tmp/requested.jsonl",
+                ),
+                expected,
+                "{name}"
+            );
+        }
+    }
+}

--- a/src/services/discord/recovery_engine/mint_gate.rs
+++ b/src/services/discord/recovery_engine/mint_gate.rs
@@ -1,0 +1,59 @@
+//! Read-only recovery watcher-install outlook.
+//!
+//! Callers supply one filesystem observation and one watcher-registry observation.
+//! This module only classifies those values; it neither claims a watcher nor mints
+//! a mailbox token. Registry references are reduced to owned scalar values before
+//! any later `.await`, so no DashMap shard guard crosses an await point.
+
+use super::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) enum WatcherInstallOutlook {
+    WillSpawn,
+    NoOutputPath,
+    IncumbentReuse { owner: ChannelId },
+    Unknown,
+}
+
+impl WatcherInstallOutlook {
+    pub(super) fn allows_mint(self) -> bool {
+        matches!(self, Self::WillSpawn | Self::Unknown)
+    }
+
+    pub(super) fn refusal(self) -> Option<(&'static str, Option<ChannelId>)> {
+        match self {
+            Self::NoOutputPath => Some(("no_output_path", None)),
+            Self::IncumbentReuse { owner } => Some(("incumbent_reuse", Some(owner))),
+            Self::WillSpawn | Self::Unknown => None,
+        }
+    }
+
+    /// Only a missing output path proves that this recovery has no relay
+    /// consumer. Reusing a live incumbent is a mint refusal, but not relay loss.
+    pub(super) fn requires_marker_independent_dead_letter(self) -> bool {
+        matches!(self, Self::NoOutputPath)
+    }
+}
+
+pub(super) fn watcher_install_outlook(
+    path_exists: bool,
+    runtime_kind: Option<RuntimeHandoffKind>,
+    incumbent: Option<(ChannelId, bool, bool, &str)>,
+    requested_path: &str,
+) -> WatcherInstallOutlook {
+    if !path_exists {
+        return if runtime_kind == Some(RuntimeHandoffKind::CodexTui) {
+            WatcherInstallOutlook::Unknown
+        } else {
+            WatcherInstallOutlook::NoOutputPath
+        };
+    }
+    if let Some((owner, cancelled, paused, existing_path)) = incumbent
+        && !cancelled
+        && !paused
+        && existing_path == requested_path
+    {
+        return WatcherInstallOutlook::IncumbentReuse { owner };
+    }
+    WatcherInstallOutlook::WillSpawn
+}

--- a/src/services/discord/recovery_engine/restore_inflight.rs
+++ b/src/services/discord/recovery_engine/restore_inflight.rs
@@ -28,55 +28,6 @@ fn recovery_output_path_with_tmux_fallback(
         .or_else(|| (!fallback_output.is_empty()).then_some(fallback_output))
 }
 
-async fn reregister_active_turn_for_output_path(
-    shared: &Arc<SharedData>,
-    provider: &ProviderKind,
-    channel_id: ChannelId,
-    state: &inflight::InflightTurnState,
-    tmux_session_name: &str,
-    output_path: &str,
-) -> (bool, mint_gate::WatcherInstallOutlook) {
-    let path_exists = std::fs::metadata(output_path).is_ok();
-    let outlook = recovery_mint_outlook(
-        shared,
-        state,
-        Some(tmux_session_name),
-        output_path,
-        path_exists,
-    );
-    // Keep the refusal as an outer production guard. It suppresses token mint
-    // only; the runtime entry still transfers marker/restart authority below.
-    let started = if !outlook.allows_mint() {
-        reregister_active_turn_from_inflight_with_outlook(shared, state, outlook).await
-    } else {
-        reregister_active_turn_from_inflight(shared, state).await
-    };
-    #[cfg(unix)]
-    super::guard_readopt_relay_resume_or_dead_letter(shared, provider, channel_id);
-    (started, outlook)
-}
-
-async fn reregister_active_turn_for_restart_report(
-    shared: &Arc<SharedData>,
-    state: &inflight::InflightTurnState,
-    tmux_session_name: Option<&str>,
-    watcher_start: Option<&(String, u64, u64, bool)>,
-) -> (bool, mint_gate::WatcherInstallOutlook) {
-    let outlook = watcher_start.map_or(
-        mint_gate::WatcherInstallOutlook::NoOutputPath,
-        |(output_path, ..)| {
-            recovery_mint_outlook(shared, state, tmux_session_name, output_path, true)
-        },
-    );
-    // Site-specific outer guard; `&& false` is a required mutation target.
-    let started = if !outlook.allows_mint() {
-        reregister_active_turn_from_inflight_with_outlook(shared, state, outlook).await
-    } else {
-        reregister_active_turn_from_inflight(shared, state).await
-    };
-    (started, outlook)
-}
-
 pub(in crate::services::discord) async fn finish_recovered_turn_mailbox(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
@@ -759,15 +710,12 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                     http, shared, provider, &mut state,
                 )
                 .await;
-                // Restart-report policy: `Some(start)` is WillSpawn or
-                // IncumbentReuse. `None` is NoOutputPath for every runtime;
-                // Unknown is unreachable because this site has no later Codex
-                // rollout fallback.
+                // Classify restart-report watcher installation before token mint.
                 let watcher_start = tmux_name.as_deref().and_then(|tmux_session_name| {
                     restart_report_watcher_start(tmux_session_name, &state)
                 });
                 let (finish_mailbox_on_completion, _outlook) =
-                    reregister_active_turn_for_restart_report(
+                    mint_gate::reregister_active_turn_for_restart_report(
                         shared,
                         &state,
                         tmux_name.as_deref(),
@@ -1938,21 +1886,18 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                 http, shared, provider, &mut state,
             )
             .await;
-            // Ordinary restore policy: missing non-Codex is NoOutputPath;
-            // missing CodexTui is Unknown because the resolver below may find the
-            // rollout; a healthy same-path incumbent is IncumbentReuse; every
-            // other present-path shape is WillSpawn. The outlook suppresses only
-            // mailbox token mint; marker/restart-authority transfer and the
-            // existing marker-write-failure DLQ backstop still run.
-            let (finish_mailbox_on_completion, _outlook) = reregister_active_turn_for_output_path(
-                shared,
-                provider,
-                channel_id,
-                &state,
-                &tmux_session_name,
-                &output_path,
-            )
-            .await;
+            // Classify watcher installation before token mint; the marker-write
+            // failure DLQ backstop still runs after the recovery call.
+            let (finish_mailbox_on_completion, _outlook) =
+                mint_gate::reregister_active_turn_for_output_path(
+                    shared,
+                    provider,
+                    channel_id,
+                    &state,
+                    &tmux_session_name,
+                    &output_path,
+                )
+                .await;
 
             let output_path = match restore_codex_rollout_output_path(provider, &state, output_path)
             {
@@ -2197,8 +2142,8 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
         )
         .await;
 
-        // Consume outgoing planned-restart authority (identity-guarded readoption)
-        // before the reader publishes RuntimeReady; failed adoption stays fail-closed.
+        // Write readoption state (including clearing `restart_mode`) before the
+        // reader publishes RuntimeReady; a failed write stays fail-closed.
         if super::runtime::readopt_marker_eligible_real_user(&state) {
             let _ = super::runtime::mark_readopted_from_inflight(
                 shared, provider, channel_id, &state, true,
@@ -2444,7 +2389,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn restart_report_refusal_consumes_restart_authority_without_minting() {
+    async fn restart_report_refusal_writes_readoption_marker_without_minting() {
         let root = tempfile::tempdir().expect("runtime root");
         let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let shared = super::super::make_shared_data_for_tests();
@@ -2459,9 +2404,10 @@ mod tests {
                 .into_owned(),
         );
         state.set_restart_mode(InflightRestartMode::DrainRestart);
+        state.set_relay_owner_kind(RelayOwnerKind::Watcher);
         inflight::save_inflight_state(&state).expect("seed planned-restart row");
 
-        let (started, outlook) = super::reregister_active_turn_for_restart_report(
+        let (started, outlook) = super::mint_gate::reregister_active_turn_for_restart_report(
             &shared,
             &state,
             state.tmux_session_name.as_deref(),
@@ -2477,6 +2423,13 @@ mod tests {
             "MUTATION GUARD: restart-report NoOutputPath outer guard must refuse mailbox mint"
         );
         assert!(
+            shared
+                .turn_finalizer
+                .has_live_watcher_pending(channel_id, shared.restart.current_generation)
+                .await,
+            "M3b: started=false must still enqueue the recovered finalizer Start entry"
+        );
+        assert!(
             super::super::mailbox_snapshot(&shared, channel_id)
                 .await
                 .cancel_token
@@ -2490,7 +2443,7 @@ mod tests {
         );
         assert_eq!(
             persisted.restart_mode, None,
-            "mint refusal must not cancel planned-restart authority transfer"
+            "a successful readoption write must clear the planned-restart marker"
         );
         assert!(persisted.readopted_from_inflight);
     }
@@ -2521,7 +2474,7 @@ mod tests {
             inflight::save_inflight_state(&state).expect("seed crash row");
             install_live_watcher(&shared, owner, &tmux, output.to_str().expect("UTF-8 path"));
 
-            let (started, outlook) = super::reregister_active_turn_for_output_path(
+            let (started, outlook) = super::mint_gate::reregister_active_turn_for_output_path(
                 &shared,
                 &provider,
                 channel_id,
@@ -2574,13 +2527,13 @@ mod tests {
                 .expect("readopted durable row")
                 .restart_mode
                 .is_none(),
-            "the generic recovery handoff must observe consumed restart authority"
+            "the generic recovery handoff must observe cleared restart_mode"
         );
         outcome
     }
 
     #[test]
-    fn generic_recovery_consumes_restart_before_runtime_ready_and_persists_runtime_stamp() {
+    fn generic_recovery_clears_restart_mode_before_runtime_ready_and_persists_runtime_stamp() {
         let _guard = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let root = tempfile::tempdir().expect("runtime root");
         let _env = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
@@ -2631,7 +2584,7 @@ mod tests {
                 "test::generic_recovery_runtime_ready",
             ),
             GuardedSaveOutcome::Saved,
-            "runtime stamp must succeed only after generic recovery consumes restart authority"
+            "runtime stamp must succeed only after generic recovery clears restart_mode"
         );
 
         let persisted = inflight::load_inflight_state(&provider, channel_id)

--- a/src/services/discord/recovery_engine/restore_inflight.rs
+++ b/src/services/discord/recovery_engine/restore_inflight.rs
@@ -28,6 +28,59 @@ fn recovery_output_path_with_tmux_fallback(
         .or_else(|| (!fallback_output.is_empty()).then_some(fallback_output))
 }
 
+async fn reregister_active_turn_for_output_path(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    state: &inflight::InflightTurnState,
+    tmux_session_name: &str,
+    output_path: &str,
+) -> (bool, mint_gate::WatcherInstallOutlook, bool) {
+    let path_exists = std::fs::metadata(output_path).is_ok();
+    let outlook = recovery_mint_outlook(
+        shared,
+        state,
+        Some(tmux_session_name),
+        output_path,
+        path_exists,
+    );
+    // Keep the refusal as an outer production guard. Mutation tests replace this
+    // condition with `&& false`; the missing-path integration test must then see
+    // the legacy entry mint a token and fail on its own assertion.
+    let started = if !outlook.allows_mint() {
+        reregister_active_turn_from_inflight_with_outlook(shared, state, outlook).await
+    } else {
+        reregister_active_turn_from_inflight(shared, state).await
+    };
+    #[cfg(unix)]
+    let dead_lettered =
+        super::guard_readopt_relay_resume_or_dead_letter(shared, provider, channel_id, outlook);
+    #[cfg(not(unix))]
+    let dead_lettered = false;
+    (started, outlook, dead_lettered)
+}
+
+async fn reregister_active_turn_for_restart_report(
+    shared: &Arc<SharedData>,
+    state: &inflight::InflightTurnState,
+    tmux_session_name: Option<&str>,
+    watcher_start: Option<&(String, u64, u64, bool)>,
+) -> (bool, mint_gate::WatcherInstallOutlook) {
+    let outlook = watcher_start.map_or(
+        mint_gate::WatcherInstallOutlook::NoOutputPath,
+        |(output_path, ..)| {
+            recovery_mint_outlook(shared, state, tmux_session_name, output_path, true)
+        },
+    );
+    // Site-specific outer guard; `&& false` is a required mutation target.
+    let started = if !outlook.allows_mint() {
+        reregister_active_turn_from_inflight_with_outlook(shared, state, outlook).await
+    } else {
+        reregister_active_turn_from_inflight(shared, state).await
+    };
+    (started, outlook)
+}
+
 pub(in crate::services::discord) async fn finish_recovered_turn_mailbox(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
@@ -710,15 +763,28 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                     http, shared, provider, &mut state,
                 )
                 .await;
-                let finish_mailbox_on_completion =
-                    reregister_active_turn_from_inflight(shared, &state).await;
+                // Restart-report policy: `Some(start)` is WillSpawn or
+                // IncumbentReuse. `None` is NoOutputPath for every runtime;
+                // Unknown is unreachable because this site has no later Codex
+                // rollout fallback.
+                let watcher_start = tmux_name.as_deref().and_then(|tmux_session_name| {
+                    restart_report_watcher_start(tmux_session_name, &state)
+                });
+                let (finish_mailbox_on_completion, _outlook) =
+                    reregister_active_turn_for_restart_report(
+                        shared,
+                        &state,
+                        tmux_name.as_deref(),
+                        watcher_start.as_ref(),
+                    )
+                    .await;
 
                 // Spawn the tmux watcher immediately rather than deferring to
                 // restore_tmux_watchers(): the "watcher will adopt" approach raced
                 // — the session could die in the ~50s gap and lose the response.
                 if let Some(ref tmux_session_name) = tmux_name {
                     if let Some((output_path, initial_offset, current_len, truncated)) =
-                        restart_report_watcher_start(tmux_session_name, &state)
+                        watcher_start
                     {
                         let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                         let paused = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -1876,18 +1942,22 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                 http, shared, provider, &mut state,
             )
             .await;
-            let finish_mailbox_on_completion =
-                reregister_active_turn_from_inflight(shared, &state).await;
-
-            // #4380 backstop: `reregister_active_turn_from_inflight` stamps
-            // `readopted_from_inflight`, which the watcher-yield escape hatch honours
-            // to resume relay for this re-adopted live turn. If that marker did NOT
-            // durably persist (IoError), the recovered watcher will still yield to
-            // the dead bridge and drop the remaining output silently — dead-letter it
-            // so the loss is observable/recoverable instead of a silent wedge. No-op
-            // on the normal path (marker present).
-            #[cfg(unix)]
-            super::guard_readopt_relay_resume_or_dead_letter(shared, provider, channel_id);
+            // Ordinary restore policy: missing non-Codex is NoOutputPath;
+            // missing CodexTui is Unknown because the resolver below may find the
+            // rollout; a healthy same-path incumbent is IncumbentReuse; every
+            // other present-path shape is WillSpawn. The helper also applies the
+            // typed DLQ backstop: NoOutputPath is marker-independent, while
+            // IncumbentReuse is not evidence of relay loss.
+            let (finish_mailbox_on_completion, _outlook, _dead_lettered) =
+                reregister_active_turn_for_output_path(
+                    shared,
+                    provider,
+                    channel_id,
+                    &state,
+                    &tmux_session_name,
+                    &output_path,
+                )
+                .await;
 
             let output_path = match restore_codex_rollout_output_path(provider, &state, output_path)
             {
@@ -2329,6 +2399,181 @@ mod tests {
         self, GuardedSaveOutcome, InflightTurnIdentity, InflightTurnState, RelayOwnerKind,
     };
     use crate::services::provider::ProviderKind;
+
+    fn mint_gate_crash_state(
+        channel_id: serenity::model::id::ChannelId,
+        user_msg_id: u64,
+        tmux_session: &str,
+        output_path: String,
+    ) -> InflightTurnState {
+        let mut state = InflightTurnState::new(
+            ProviderKind::Claude,
+            channel_id.get(),
+            Some("adk-cc".to_string()),
+            5_242_900,
+            user_msg_id,
+            user_msg_id + 1,
+            "recovery mint outlook".to_string(),
+            Some("session-5242".to_string()),
+            Some(tmux_session.to_string()),
+            Some(output_path),
+            None,
+            0,
+        );
+        state.runtime_kind = Some(RuntimeHandoffKind::ClaudeTui);
+        state.set_relay_owner_kind(RelayOwnerKind::None);
+        state
+    }
+
+    fn install_live_watcher(
+        shared: &super::SharedData,
+        owner: serenity::model::id::ChannelId,
+        tmux_session: &str,
+        output_path: &str,
+    ) {
+        shared.tmux_watchers.insert(
+            owner,
+            crate::services::discord::TmuxWatcherHandle {
+                tmux_session_name: tmux_session.to_string(),
+                output_path: output_path.to_string(),
+                paused: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                resume_offset: std::sync::Arc::new(std::sync::Mutex::new(None)),
+                cancel: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                pause_epoch: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                turn_delivered: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                last_heartbeat_ts_ms: std::sync::Arc::new(std::sync::atomic::AtomicI64::new(
+                    crate::services::discord::tmux_watcher_now_ms(),
+                )),
+            },
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ordinary_restore_no_output_outer_guard_dead_letters_premarked_row() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
+        let shared = super::super::make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = serenity::model::id::ChannelId::new(5_242_901);
+        let missing = root.path().join("missing.jsonl");
+        let mut state = mint_gate_crash_state(
+            channel_id,
+            5_242_902,
+            "AgentDesk-claude-5242-no-output",
+            missing.to_string_lossy().into_owned(),
+        );
+        state.readopted_from_inflight = true;
+        inflight::save_inflight_state(&state).expect("seed premarked crash row");
+
+        let (started, outlook, dead_lettered) = super::reregister_active_turn_for_output_path(
+            &shared,
+            &provider,
+            channel_id,
+            &state,
+            state.tmux_session_name.as_deref().expect("tmux"),
+            missing.to_str().expect("UTF-8 path"),
+        )
+        .await;
+        assert!(!started);
+        assert_eq!(
+            outlook,
+            super::mint_gate::WatcherInstallOutlook::NoOutputPath
+        );
+        assert!(
+            dead_lettered,
+            "MUTATION GUARD: the production ordinary-restore outer guard must execute NoOutputPath DLQ"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn restart_report_missing_start_outer_guard_refuses_mailbox_mint() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
+        let shared = super::super::make_shared_data_for_tests();
+        let channel_id = serenity::model::id::ChannelId::new(5_242_905);
+        let state = mint_gate_crash_state(
+            channel_id,
+            5_242_906,
+            "AgentDesk-claude-5242-restart-report",
+            root.path()
+                .join("missing-restart-report.jsonl")
+                .to_string_lossy()
+                .into_owned(),
+        );
+
+        let (started, outlook) = super::reregister_active_turn_for_restart_report(
+            &shared,
+            &state,
+            state.tmux_session_name.as_deref(),
+            None,
+        )
+        .await;
+        assert_eq!(
+            outlook,
+            super::mint_gate::WatcherInstallOutlook::NoOutputPath
+        );
+        assert!(
+            !started,
+            "MUTATION GUARD: restart-report NoOutputPath outer guard must refuse mailbox mint"
+        );
+        assert!(
+            super::super::mailbox_snapshot(&shared, channel_id)
+                .await
+                .cancel_token
+                .is_none()
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ordinary_restore_incumbents_same_and_intended_cross_channel_never_dead_letter() {
+        for cross_channel in [false, true] {
+            let root = tempfile::tempdir().expect("runtime root");
+            let _env = crate::config::set_agentdesk_root_for_test(root.path());
+            let shared = super::super::make_shared_data_for_tests();
+            let provider = ProviderKind::Claude;
+            let channel_id = serenity::model::id::ChannelId::new(5_242_910 + cross_channel as u64);
+            let owner = if cross_channel {
+                serenity::model::id::ChannelId::new(5_242_919)
+            } else {
+                channel_id
+            };
+            let output = root.path().join(format!("incumbent-{cross_channel}.jsonl"));
+            std::fs::write(&output, b"live").expect("output path");
+            let tmux = format!("AgentDesk-claude-5242-incumbent-{cross_channel}");
+            let mut state = mint_gate_crash_state(
+                channel_id,
+                5_242_920 + cross_channel as u64,
+                &tmux,
+                output.to_string_lossy().into_owned(),
+            );
+            state.readopted_from_inflight = false;
+            if cross_channel {
+                state.logical_channel_id = Some(owner.get());
+                state.thread_id = Some(channel_id.get());
+            }
+            inflight::save_inflight_state(&state).expect("seed crash row");
+            install_live_watcher(&shared, owner, &tmux, output.to_str().expect("UTF-8 path"));
+
+            let (started, outlook, dead_lettered) = super::reregister_active_turn_for_output_path(
+                &shared,
+                &provider,
+                channel_id,
+                &state,
+                &tmux,
+                output.to_str().expect("UTF-8 path"),
+            )
+            .await;
+            assert!(!started);
+            assert_eq!(
+                outlook,
+                super::mint_gate::WatcherInstallOutlook::IncumbentReuse { owner }
+            );
+            assert!(
+                !dead_lettered,
+                "MUTATION GUARD: incumbent reuse is not NoOutputPath, including intended thread follow-up reuse"
+            );
+        }
+    }
 
     fn generic_recovery_runtime_ready(
         shared: &std::sync::Arc<super::SharedData>,

--- a/src/services/discord/recovery_engine/restore_inflight.rs
+++ b/src/services/discord/recovery_engine/restore_inflight.rs
@@ -35,7 +35,7 @@ async fn reregister_active_turn_for_output_path(
     state: &inflight::InflightTurnState,
     tmux_session_name: &str,
     output_path: &str,
-) -> (bool, mint_gate::WatcherInstallOutlook, bool) {
+) -> (bool, mint_gate::WatcherInstallOutlook) {
     let path_exists = std::fs::metadata(output_path).is_ok();
     let outlook = recovery_mint_outlook(
         shared,
@@ -44,20 +44,16 @@ async fn reregister_active_turn_for_output_path(
         output_path,
         path_exists,
     );
-    // Keep the refusal as an outer production guard. Mutation tests replace this
-    // condition with `&& false`; the missing-path integration test must then see
-    // the legacy entry mint a token and fail on its own assertion.
+    // Keep the refusal as an outer production guard. It suppresses token mint
+    // only; the runtime entry still transfers marker/restart authority below.
     let started = if !outlook.allows_mint() {
         reregister_active_turn_from_inflight_with_outlook(shared, state, outlook).await
     } else {
         reregister_active_turn_from_inflight(shared, state).await
     };
     #[cfg(unix)]
-    let dead_lettered =
-        super::guard_readopt_relay_resume_or_dead_letter(shared, provider, channel_id, outlook);
-    #[cfg(not(unix))]
-    let dead_lettered = false;
-    (started, outlook, dead_lettered)
+    super::guard_readopt_relay_resume_or_dead_letter(shared, provider, channel_id);
+    (started, outlook)
 }
 
 async fn reregister_active_turn_for_restart_report(
@@ -1945,19 +1941,18 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
             // Ordinary restore policy: missing non-Codex is NoOutputPath;
             // missing CodexTui is Unknown because the resolver below may find the
             // rollout; a healthy same-path incumbent is IncumbentReuse; every
-            // other present-path shape is WillSpawn. The helper also applies the
-            // typed DLQ backstop: NoOutputPath is marker-independent, while
-            // IncumbentReuse is not evidence of relay loss.
-            let (finish_mailbox_on_completion, _outlook, _dead_lettered) =
-                reregister_active_turn_for_output_path(
-                    shared,
-                    provider,
-                    channel_id,
-                    &state,
-                    &tmux_session_name,
-                    &output_path,
-                )
-                .await;
+            // other present-path shape is WillSpawn. The outlook suppresses only
+            // mailbox token mint; marker/restart-authority transfer and the
+            // existing marker-write-failure DLQ backstop still run.
+            let (finish_mailbox_on_completion, _outlook) = reregister_active_turn_for_output_path(
+                shared,
+                provider,
+                channel_id,
+                &state,
+                &tmux_session_name,
+                &output_path,
+            )
+            .await;
 
             let output_path = match restore_codex_rollout_output_path(provider, &state, output_path)
             {
@@ -2449,49 +2444,12 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn ordinary_restore_no_output_outer_guard_dead_letters_premarked_row() {
-        let root = tempfile::tempdir().expect("runtime root");
-        let _env = crate::config::set_agentdesk_root_for_test(root.path());
-        let shared = super::super::make_shared_data_for_tests();
-        let provider = ProviderKind::Claude;
-        let channel_id = serenity::model::id::ChannelId::new(5_242_901);
-        let missing = root.path().join("missing.jsonl");
-        let mut state = mint_gate_crash_state(
-            channel_id,
-            5_242_902,
-            "AgentDesk-claude-5242-no-output",
-            missing.to_string_lossy().into_owned(),
-        );
-        state.readopted_from_inflight = true;
-        inflight::save_inflight_state(&state).expect("seed premarked crash row");
-
-        let (started, outlook, dead_lettered) = super::reregister_active_turn_for_output_path(
-            &shared,
-            &provider,
-            channel_id,
-            &state,
-            state.tmux_session_name.as_deref().expect("tmux"),
-            missing.to_str().expect("UTF-8 path"),
-        )
-        .await;
-        assert!(!started);
-        assert_eq!(
-            outlook,
-            super::mint_gate::WatcherInstallOutlook::NoOutputPath
-        );
-        assert!(
-            dead_lettered,
-            "MUTATION GUARD: the production ordinary-restore outer guard must execute NoOutputPath DLQ"
-        );
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn restart_report_missing_start_outer_guard_refuses_mailbox_mint() {
+    async fn restart_report_refusal_consumes_restart_authority_without_minting() {
         let root = tempfile::tempdir().expect("runtime root");
         let _env = crate::config::set_agentdesk_root_for_test(root.path());
         let shared = super::super::make_shared_data_for_tests();
         let channel_id = serenity::model::id::ChannelId::new(5_242_905);
-        let state = mint_gate_crash_state(
+        let mut state = mint_gate_crash_state(
             channel_id,
             5_242_906,
             "AgentDesk-claude-5242-restart-report",
@@ -2500,6 +2458,8 @@ mod tests {
                 .to_string_lossy()
                 .into_owned(),
         );
+        state.set_restart_mode(InflightRestartMode::DrainRestart);
+        inflight::save_inflight_state(&state).expect("seed planned-restart row");
 
         let (started, outlook) = super::reregister_active_turn_for_restart_report(
             &shared,
@@ -2522,10 +2482,21 @@ mod tests {
                 .cancel_token
                 .is_none()
         );
+        let persisted = inflight::load_inflight_state(&ProviderKind::Claude, channel_id.get())
+            .expect("readopted planned-restart row");
+        eprintln!(
+            "PROBE: started={started} after_refusal_restart_mode={:?} readopted_from_inflight={}",
+            persisted.restart_mode, persisted.readopted_from_inflight
+        );
+        assert_eq!(
+            persisted.restart_mode, None,
+            "mint refusal must not cancel planned-restart authority transfer"
+        );
+        assert!(persisted.readopted_from_inflight);
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn ordinary_restore_incumbents_same_and_intended_cross_channel_never_dead_letter() {
+    async fn ordinary_restore_same_and_cross_channel_incumbents_refuse_mint() {
         for cross_channel in [false, true] {
             let root = tempfile::tempdir().expect("runtime root");
             let _env = crate::config::set_agentdesk_root_for_test(root.path());
@@ -2547,14 +2518,10 @@ mod tests {
                 output.to_string_lossy().into_owned(),
             );
             state.readopted_from_inflight = false;
-            if cross_channel {
-                state.logical_channel_id = Some(owner.get());
-                state.thread_id = Some(channel_id.get());
-            }
             inflight::save_inflight_state(&state).expect("seed crash row");
             install_live_watcher(&shared, owner, &tmux, output.to_str().expect("UTF-8 path"));
 
-            let (started, outlook, dead_lettered) = super::reregister_active_turn_for_output_path(
+            let (started, outlook) = super::reregister_active_turn_for_output_path(
                 &shared,
                 &provider,
                 channel_id,
@@ -2567,10 +2534,6 @@ mod tests {
             assert_eq!(
                 outlook,
                 super::mint_gate::WatcherInstallOutlook::IncumbentReuse { owner }
-            );
-            assert!(
-                !dead_lettered,
-                "MUTATION GUARD: incumbent reuse is not NoOutputPath, including intended thread follow-up reuse"
             );
         }
     }

--- a/src/services/discord/recovery_engine/runtime.rs
+++ b/src/services/discord/recovery_engine/runtime.rs
@@ -19,6 +19,55 @@
 
 use super::*;
 
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct BeforeMailboxClaimBarrier {
+    pub(crate) reached: Arc<tokio::sync::Barrier>,
+    pub(crate) resume: Arc<tokio::sync::Barrier>,
+}
+
+#[cfg(test)]
+fn before_mailbox_claim_barrier_slot()
+-> &'static std::sync::Mutex<Option<BeforeMailboxClaimBarrier>> {
+    static SLOT: std::sync::OnceLock<std::sync::Mutex<Option<BeforeMailboxClaimBarrier>>> =
+        std::sync::OnceLock::new();
+    SLOT.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+#[cfg(test)]
+pub(crate) struct BeforeMailboxClaimBarrierGuard;
+
+#[cfg(test)]
+impl Drop for BeforeMailboxClaimBarrierGuard {
+    fn drop(&mut self) {
+        *before_mailbox_claim_barrier_slot()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = None;
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn install_before_mailbox_claim_barrier(
+    barrier: BeforeMailboxClaimBarrier,
+) -> BeforeMailboxClaimBarrierGuard {
+    *before_mailbox_claim_barrier_slot()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner()) = Some(barrier);
+    BeforeMailboxClaimBarrierGuard
+}
+
+#[cfg(test)]
+async fn await_before_mailbox_claim_barrier() {
+    let barrier = before_mailbox_claim_barrier_slot()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .clone();
+    if let Some(barrier) = barrier {
+        barrier.reached.wait().await;
+        barrier.resume.wait().await;
+    }
+}
+
 /// Recovery re-seeds the persisted terminal owner instead of fabricating a
 /// watcher owner. Ownerless/non-watcher terminal paths do not emit a watcher
 /// projection edge, so they use immediate admission; watcher-owned rows retain
@@ -186,6 +235,7 @@ async fn reregister_active_turn_from_inflight_inner(
     shared: &Arc<SharedData>,
     state: &inflight::InflightTurnState,
     persist_durable_marker: bool,
+    outlook: mint_gate::WatcherInstallOutlook,
 ) -> bool {
     let Some(finalizer_msg_id) =
         super::inflight::opt_message_id(state.effective_finalizer_turn_id())
@@ -280,45 +330,56 @@ async fn reregister_active_turn_from_inflight_inner(
         return false;
     }
 
-    let cancel_token = Arc::new(CancelToken::new());
-    super::ensure_cancel_token_bound_from_inflight_state(
-        &provider,
-        state,
-        &cancel_token,
-        "inflight reregister active turn",
-    );
-
-    let started = super::mailbox_try_start_turn(
-        shared,
-        channel_id,
-        cancel_token,
-        UserId::new(state.request_owner_user_id),
-        finalizer_msg_id,
-    )
-    .await;
-    if started {
-        reseed_recovered_finalizer_ledger(
+    let started = if outlook.allows_mint() {
+        let cancel_token = Arc::new(CancelToken::new());
+        super::ensure_cancel_token_bound_from_inflight_state(
+            &provider,
+            state,
+            &cancel_token,
+            "inflight reregister active turn",
+        );
+        #[cfg(test)]
+        await_before_mailbox_claim_barrier().await;
+        super::mailbox_try_start_turn(
             shared,
             channel_id,
+            cancel_token,
+            UserId::new(state.request_owner_user_id),
+            finalizer_msg_id,
+        )
+        .await
+    } else {
+        let (reason, owner) = outlook
+            .refusal()
+            .expect("non-minting outlook must carry a refusal reason");
+        tracing::warn!(
+            provider = %provider.as_str(),
+            channel_id = channel_id.get(),
+            reason,
+            owner_channel_id = ?owner.map(ChannelId::get),
             finalizer_turn_id,
-            &provider,
-            state.effective_relay_owner_kind(),
+            tmux_session = state.tmux_session_name.as_deref().unwrap_or_default(),
+            "recovery mailbox token mint refused by watcher-install outlook"
         );
-        // #4370: the mailbox now carries a re-adopted-from-inflight REAL user turn
-        // (owner == request_owner_user_id). Record it in the ledger + on-disk
-        // marker so a later starved injection / task-notification synthetic turn
-        // can reclaim this mailbox once the re-adopted turn is stale — without
-        // this, #4018's synthetic-owner-only reclaim can never free it and the
-        // follow-up relay text is silently dropped.
-        if readopted_ledger_record_allowed(state) {
-            mark_readopted_from_inflight(
-                shared,
-                &provider,
-                channel_id,
-                state,
-                persist_durable_marker,
-            );
-        }
+        return false;
+    };
+
+    // #5242 G2: adoption is the fact recorded here, not successful mailbox mint.
+    // `started == false` can mean queue-persistence failure or a real token race.
+    // Unconditional marking is safe ONLY while G1's raw exact-id confinement
+    // remains in `classify_reclaimable_mailbox_owner`: an X marker must never
+    // qualify a different live mailbox turn Y for reclaim. The unconditional
+    // write preserves #4380's marker/ledger defense when persistence rejects the
+    // mailbox claim.
+    reseed_recovered_finalizer_ledger(
+        shared,
+        channel_id,
+        finalizer_turn_id,
+        &provider,
+        state.effective_relay_owner_kind(),
+    );
+    if readopted_ledger_record_allowed(state) {
+        mark_readopted_from_inflight(shared, &provider, channel_id, state, persist_durable_marker);
     }
     started
 }
@@ -327,7 +388,21 @@ pub(in crate::services::discord) async fn reregister_active_turn_from_inflight(
     shared: &Arc<SharedData>,
     state: &inflight::InflightTurnState,
 ) -> bool {
-    reregister_active_turn_from_inflight_inner(shared, state, true).await
+    reregister_active_turn_from_inflight_inner(
+        shared,
+        state,
+        true,
+        mint_gate::WatcherInstallOutlook::WillSpawn,
+    )
+    .await
+}
+
+pub(in crate::services::discord) async fn reregister_active_turn_from_inflight_with_outlook(
+    shared: &Arc<SharedData>,
+    state: &inflight::InflightTurnState,
+    outlook: mint_gate::WatcherInstallOutlook,
+) -> bool {
+    reregister_active_turn_from_inflight_inner(shared, state, true, outlook).await
 }
 
 /// Automatic reattach holds the canonical episode flock across mailbox and
@@ -339,7 +414,13 @@ pub(in crate::services::discord) async fn reregister_active_turn_from_inflight_u
     shared: &Arc<SharedData>,
     state: &inflight::InflightTurnState,
 ) -> bool {
-    reregister_active_turn_from_inflight_inner(shared, state, false).await
+    reregister_active_turn_from_inflight_inner(
+        shared,
+        state,
+        false,
+        mint_gate::WatcherInstallOutlook::WillSpawn,
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/src/services/discord/recovery_engine/runtime.rs
+++ b/src/services/discord/recovery_engine/runtime.rs
@@ -177,8 +177,10 @@ pub(in crate::services::discord) fn readopt_marker_eligible_real_user(
 ///     `mark_readopted_from_inflight_if_identity_unchanged` (NOT a blind whole-row
 ///     save): a concurrently-cleared row is NOT resurrected (`Missing`), and a row
 ///     a newer turn re-owns is NOT clobbered (`IdentityMismatch`). Under the same
-///     canonical lock it also consumes any planned-restart marker, transferring
-///     durable authority to the replacement process before runtime handoff.
+///     canonical lock it also clears any planned-restart marker while setting
+///     `readopted_from_inflight`. A successful write records only that durable
+///     state transition; it does not prove that a watcher, mailbox token, or
+///     pending consumer was installed.
 ///
 /// This does NOT touch the completion lifecycle: the re-adopted turn's own
 /// `✅`/footer + analytics still fire (see the `readopted_from_inflight` field doc
@@ -379,16 +381,17 @@ async fn reregister_active_turn_from_inflight_inner(
         false
     };
 
-    // #5242 G2: adoption is the fact recorded here, not successful mailbox mint.
-    // `started == false` can mean an outlook refusal, queue-persistence failure,
-    // or a real token race. Both finalizer reseeding and marker/ledger recording
-    // therefore run unconditionally. The reseeded entry cannot make a queue claim
-    // eligible by itself because completion admission still requires
-    // `mailbox_released`; unconditional marking is safe ONLY while G1's raw
-    // exact-id confinement remains in `classify_reclaimable_mailbox_owner`: an X
-    // marker must never qualify a different live mailbox turn Y for reclaim. The
-    // durable marker write also consumes an outgoing planned-restart marker,
-    // transferring authority even when the outlook suppresses token mint.
+    // #5242 G2: `started` reports only whether this call minted the mailbox token.
+    // A false value can mean an outlook refusal, queue-persistence failure, or a
+    // real token race. Finalizer reseeding and the readoption write therefore run
+    // unconditionally. The reseeded entry cannot make a queue claim eligible by
+    // itself because completion admission still requires `mailbox_released`;
+    // unconditional marking is safe ONLY while G1's raw exact-id confinement
+    // remains in `classify_reclaimable_mailbox_owner`: an X marker must never
+    // qualify a different live mailbox turn Y for reclaim. On a successful
+    // durable write, the store sets `readopted_from_inflight` and clears
+    // `restart_mode`; neither operation establishes a watcher, mailbox token, or
+    // pending consumer.
     reseed_recovered_finalizer_ledger(
         shared,
         channel_id,

--- a/src/services/discord/recovery_engine/runtime.rs
+++ b/src/services/discord/recovery_engine/runtime.rs
@@ -20,53 +20,68 @@
 use super::*;
 
 #[cfg(test)]
-#[derive(Clone)]
-pub(crate) struct BeforeMailboxClaimBarrier {
-    pub(crate) reached: Arc<tokio::sync::Barrier>,
-    pub(crate) resume: Arc<tokio::sync::Barrier>,
-}
+mod mailbox_claim_barrier {
+    use super::*;
 
-#[cfg(test)]
-fn before_mailbox_claim_barrier_slot()
--> &'static std::sync::Mutex<Option<BeforeMailboxClaimBarrier>> {
-    static SLOT: std::sync::OnceLock<std::sync::Mutex<Option<BeforeMailboxClaimBarrier>>> =
-        std::sync::OnceLock::new();
-    SLOT.get_or_init(|| std::sync::Mutex::new(None))
-}
+    type BarrierKey = (u64, u64);
 
-#[cfg(test)]
-pub(crate) struct BeforeMailboxClaimBarrierGuard;
+    #[derive(Clone)]
+    pub(crate) struct BeforeMailboxClaimBarrier {
+        pub(crate) channel_id: u64,
+        pub(crate) user_msg_id: u64,
+        pub(crate) reached: Arc<tokio::sync::Barrier>,
+        pub(crate) resume: Arc<tokio::sync::Barrier>,
+    }
 
-#[cfg(test)]
-impl Drop for BeforeMailboxClaimBarrierGuard {
-    fn drop(&mut self) {
-        *before_mailbox_claim_barrier_slot()
+    fn barriers()
+    -> &'static std::sync::Mutex<std::collections::HashMap<BarrierKey, BeforeMailboxClaimBarrier>>
+    {
+        static BARRIERS: std::sync::OnceLock<
+            std::sync::Mutex<std::collections::HashMap<BarrierKey, BeforeMailboxClaimBarrier>>,
+        > = std::sync::OnceLock::new();
+        BARRIERS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+    }
+
+    pub(crate) struct BeforeMailboxClaimBarrierGuard(BarrierKey);
+
+    impl Drop for BeforeMailboxClaimBarrierGuard {
+        fn drop(&mut self) {
+            barriers()
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .remove(&self.0);
+        }
+    }
+
+    pub(crate) fn install_before_mailbox_claim_barrier(
+        barrier: BeforeMailboxClaimBarrier,
+    ) -> BeforeMailboxClaimBarrierGuard {
+        let key = (barrier.channel_id, barrier.user_msg_id);
+        let previous = barriers()
             .lock()
-            .unwrap_or_else(|poison| poison.into_inner()) = None;
+            .unwrap_or_else(|poison| poison.into_inner())
+            .insert(key, barrier);
+        assert!(previous.is_none(), "duplicate mailbox-claim test barrier");
+        BeforeMailboxClaimBarrierGuard(key)
+    }
+
+    pub(super) async fn await_before_mailbox_claim_barrier(state: &InflightTurnState) {
+        let barrier = barriers()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .get(&(state.channel_id, state.user_msg_id))
+            .cloned();
+        if let Some(barrier) = barrier {
+            barrier.reached.wait().await;
+            barrier.resume.wait().await;
+        }
     }
 }
 
 #[cfg(test)]
-pub(crate) fn install_before_mailbox_claim_barrier(
-    barrier: BeforeMailboxClaimBarrier,
-) -> BeforeMailboxClaimBarrierGuard {
-    *before_mailbox_claim_barrier_slot()
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner()) = Some(barrier);
-    BeforeMailboxClaimBarrierGuard
-}
-
-#[cfg(test)]
-async fn await_before_mailbox_claim_barrier() {
-    let barrier = before_mailbox_claim_barrier_slot()
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner())
-        .clone();
-    if let Some(barrier) = barrier {
-        barrier.reached.wait().await;
-        barrier.resume.wait().await;
-    }
-}
+pub(crate) use mailbox_claim_barrier::{
+    BeforeMailboxClaimBarrier, install_before_mailbox_claim_barrier,
+};
 
 /// Recovery re-seeds the persisted terminal owner instead of fabricating a
 /// watcher owner. Ownerless/non-watcher terminal paths do not emit a watcher
@@ -339,7 +354,7 @@ async fn reregister_active_turn_from_inflight_inner(
             "inflight reregister active turn",
         );
         #[cfg(test)]
-        await_before_mailbox_claim_barrier().await;
+        mailbox_claim_barrier::await_before_mailbox_claim_barrier(state).await;
         super::mailbox_try_start_turn(
             shared,
             channel_id,
@@ -361,16 +376,19 @@ async fn reregister_active_turn_from_inflight_inner(
             tmux_session = state.tmux_session_name.as_deref().unwrap_or_default(),
             "recovery mailbox token mint refused by watcher-install outlook"
         );
-        return false;
+        false
     };
 
     // #5242 G2: adoption is the fact recorded here, not successful mailbox mint.
-    // `started == false` can mean queue-persistence failure or a real token race.
-    // Unconditional marking is safe ONLY while G1's raw exact-id confinement
-    // remains in `classify_reclaimable_mailbox_owner`: an X marker must never
-    // qualify a different live mailbox turn Y for reclaim. The unconditional
-    // write preserves #4380's marker/ledger defense when persistence rejects the
-    // mailbox claim.
+    // `started == false` can mean an outlook refusal, queue-persistence failure,
+    // or a real token race. Both finalizer reseeding and marker/ledger recording
+    // therefore run unconditionally. The reseeded entry cannot make a queue claim
+    // eligible by itself because completion admission still requires
+    // `mailbox_released`; unconditional marking is safe ONLY while G1's raw
+    // exact-id confinement remains in `classify_reclaimable_mailbox_owner`: an X
+    // marker must never qualify a different live mailbox turn Y for reclaim. The
+    // durable marker write also consumes an outgoing planned-restart marker,
+    // transferring authority even when the outlook suppresses token mint.
     reseed_recovered_finalizer_ledger(
         shared,
         channel_id,

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -73,8 +73,8 @@ pub(in crate::services::discord) use self::watcher_lifecycle::{
     ThreadFollowUpParent, claim_or_replace_watcher, claim_or_replace_watcher_with_thread_parent,
     claim_or_reuse_watcher, claim_or_reuse_watcher_with_thread_parent,
     clear_recovery_handled_channels, fail_dispatch_for_ready_for_input_stall,
-    refresh_session_heartbeat_from_tmux_output, restore_tmux_watchers,
-    session_belongs_to_current_runtime, store_recovery_handled_channels,
+    find_watcher_by_tmux_session, refresh_session_heartbeat_from_tmux_output,
+    restore_tmux_watchers, session_belongs_to_current_runtime, store_recovery_handled_channels,
     thread_follow_up_parent_channel_id, thread_follow_up_parent_from_live,
     try_claim_watcher_with_thread_parent,
 };

--- a/src/services/discord/tui_prompt_relay/synthetic_start.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start.rs
@@ -1119,6 +1119,8 @@ mod tests {
         let resume = Arc::new(tokio::sync::Barrier::new(2));
         let _barrier = crate::services::discord::recovery::install_before_mailbox_claim_barrier(
             crate::services::discord::recovery::BeforeMailboxClaimBarrier {
+                channel_id: channel_id.get(),
+                user_msg_id: x_id.get(),
                 reached: reached.clone(),
                 resume: resume.clone(),
             },

--- a/src/services/discord/tui_prompt_relay/synthetic_start.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start.rs
@@ -1055,6 +1055,186 @@ mod tests {
         );
     }
 
+    /// #5242 T1: a marker recorded for X cannot authorize disposition of an
+    /// aged live successor Y, even when a later NoOutputPath recovery leaves the
+    /// pre-existing X row and marker intact.
+    #[tokio::test(flavor = "current_thread")]
+    async fn premarked_x_after_refusal_does_not_cancel_aged_live_successor_y() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
+        let provider = ProviderKind::Claude;
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let channel_id = ChannelId::new(5_242_320);
+        let tmux = "AgentDesk-claude-5242-premarked";
+        let x_id = MessageId::new(5_242_321);
+        let y_id = MessageId::new(5_242_322);
+
+        let mut x_state = real_user_inflight_state(channel_id, x_id, tmux, false);
+        x_state.readopted_from_inflight = true;
+        inflight::save_inflight_state(&x_state).expect("seed marked X row");
+        assert!(
+            !crate::services::discord::recovery::reregister_active_turn_from_inflight_with_outlook(
+                &shared,
+                &x_state,
+                crate::services::discord::recovery::mint_gate::WatcherInstallOutlook::NoOutputPath,
+            )
+            .await
+        );
+
+        let y_token = seed_real_owner_mailbox(&shared, channel_id, y_id).await;
+        let reclaimed = release_reclaimable_stale_synthetic_mailbox_owner_if_current(
+            &shared,
+            &provider,
+            channel_id,
+            tmux,
+            y_id,
+            Some(real_owner()),
+            ActiveTurnKind::UserOrAgent,
+            old_owner_started_at(),
+            MessageId::new(5_242_323),
+        )
+        .await;
+        assert!(!reclaimed, "X evidence must not qualify Y for reclaim");
+        assert!(!y_token.cancelled.load(Ordering::Relaxed));
+    }
+
+    /// #5242 G2: create a real snapshot-to-claim race. Y wins the mailbox while
+    /// X's recovery is paused after its empty snapshot; X then receives
+    /// `started=false` and is still marked for #4380. G1 must confine that X
+    /// marker so the aged Y token survives stale-reclaim inspection.
+    #[tokio::test(flavor = "current_thread")]
+    async fn token_race_marks_x_but_preserves_aged_live_y() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
+        let provider = ProviderKind::Claude;
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let channel_id = ChannelId::new(5_242_330);
+        let tmux = "AgentDesk-claude-5242-token-race";
+        let x_id = MessageId::new(5_242_331);
+        let y_id = MessageId::new(5_242_332);
+        let x_state = real_user_inflight_state(channel_id, x_id, tmux, false);
+        inflight::save_inflight_state(&x_state).expect("seed X row");
+
+        let reached = Arc::new(tokio::sync::Barrier::new(2));
+        let resume = Arc::new(tokio::sync::Barrier::new(2));
+        let _barrier = crate::services::discord::recovery::install_before_mailbox_claim_barrier(
+            crate::services::discord::recovery::BeforeMailboxClaimBarrier {
+                reached: reached.clone(),
+                resume: resume.clone(),
+            },
+        );
+        let recovery_shared = shared.clone();
+        let recovery_state = x_state.clone();
+        let recovery = tokio::spawn(async move {
+            crate::services::discord::recovery::reregister_active_turn_from_inflight_with_outlook(
+                &recovery_shared,
+                &recovery_state,
+                crate::services::discord::recovery::mint_gate::WatcherInstallOutlook::WillSpawn,
+            )
+            .await
+        });
+
+        reached.wait().await;
+        let y_token = seed_real_owner_mailbox(&shared, channel_id, y_id).await;
+        resume.wait().await;
+        assert!(
+            !recovery.await.expect("recovery task"),
+            "Y must win the token race"
+        );
+        assert!(
+            inflight::load_inflight_state(&provider, channel_id.get())
+                .expect("X row remains")
+                .readopted_from_inflight,
+            "G2 must record adoption even when the real token race returns started=false"
+        );
+
+        let reclaimed = release_reclaimable_stale_synthetic_mailbox_owner_if_current(
+            &shared,
+            &provider,
+            channel_id,
+            tmux,
+            y_id,
+            Some(real_owner()),
+            ActiveTurnKind::UserOrAgent,
+            old_owner_started_at(),
+            MessageId::new(5_242_333),
+        )
+        .await;
+        assert!(!reclaimed, "the X marker must not authorize Y disposition");
+        assert!(!y_token.cancelled.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn queue_persistence_refusal_still_records_readoption() {
+        use crate::services::turn_orchestrator::{Intervention, InterventionMode};
+
+        let root = tempfile::tempdir().expect("runtime root");
+        let _env = crate::config::set_agentdesk_root_for_test(root.path());
+        let provider = ProviderKind::Claude;
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let channel_id = ChannelId::new(5_242_340);
+        let x_id = MessageId::new(5_242_341);
+        let state = real_user_inflight_state(
+            channel_id,
+            x_id,
+            "AgentDesk-claude-5242-queue-failure",
+            false,
+        );
+        inflight::save_inflight_state(&state).expect("seed X row");
+        shared
+            .mailbox(channel_id)
+            .replace_queue(
+                vec![Intervention {
+                    author_id: real_owner(),
+                    author_is_bot: false,
+                    message_id: x_id,
+                    queued_generation: crate::services::discord::runtime_store::process_generation(
+                    ),
+                    source_message_ids: vec![x_id],
+                    source_message_queued_generations: Vec::new(),
+                    source_text_segments: Vec::new(),
+                    text: "queued X".to_string(),
+                    mode: InterventionMode::Soft,
+                    created_at: std::time::Instant::now(),
+                    reply_context: None,
+                    has_reply_boundary: false,
+                    merge_consecutive: false,
+                    pending_uploads: Vec::new(),
+                    voice_announcement: None,
+                }],
+                crate::services::discord::queue_persistence_context(&shared, &provider, channel_id),
+            )
+            .await;
+
+        // Replace the queue directory with a regular file. The real mailbox
+        // actor can purge X in memory but its atomic queue persist must fail.
+        let queue_dir = root
+            .path()
+            .join("runtime/discord_pending_queue")
+            .join(provider.as_str())
+            .join(&shared.token_hash);
+        let backup = queue_dir.with_extension("backup");
+        std::fs::rename(&queue_dir, &backup).expect("move queue dir");
+        std::fs::write(&queue_dir, b"not a directory").expect("block queue dir");
+        let started = crate::services::discord::recovery::reregister_active_turn_from_inflight(
+            &shared, &state,
+        )
+        .await;
+        std::fs::remove_file(&queue_dir).expect("remove blocker");
+        std::fs::rename(&backup, &queue_dir).expect("restore queue dir");
+
+        assert!(
+            !started,
+            "queue persistence failure must refuse the mailbox claim"
+        );
+        assert!(
+            inflight::load_inflight_state(&provider, channel_id.get())
+                .expect("X row")
+                .readopted_from_inflight,
+            "MUTATION GUARD: #4380 requires marking even when started=false"
+        );
+    }
+
     // #4370 (fresh-Claude r3 #1). The mailbox's `active_user_message_id` is the turn's
     // `effective_finalizer_turn_id()`, which equals `user_msg_id` only when that id is
     // NON-zero. An id-0 marked row makes the two diverge, so the reason function would

--- a/src/services/discord/tui_prompt_relay/synthetic_start/stale_reclaim.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start/stale_reclaim.rs
@@ -234,22 +234,12 @@ fn stale_synthetic_mailbox_owner_reclaim_reason(
 ///     defeat the fix — the observed task-notification loss occurred ~79s after
 ///     restart (this present-row `Finalized` shape is what covers the sub-120s
 ///     follow-up loss; see R3-4).
-///   - `OwnerInflightReplaced`  — age `>= 120s` REQUIRED. UNREACHABLE for a
-///     re-adopted real owner, for TWO independent reasons — state both, because an
-///     earlier revision of this note cited only the first and it is NOT the
-///     load-bearing one (fresh-Claude r3 #1):
-///       (a) a superseding turn writes a FRESH row (marker `false`, absent from the
-///           ledger under this id), so `classify_reclaimable_mailbox_owner` returns
-///           `None` before this reason is consulted; and
-///       (b) — the one that actually matters — this reason fires on
-///           `state.user_msg_id != active_user_message_id`, and
-///           `active_user_message_id` IS `effective_finalizer_turn_id()`, which
-///           equals `user_msg_id` whenever that id is non-zero. An id-0 row would
-///           make the two diverge and misfire this reason on a LIVE turn, so id-0
-///           rows are refused at BOTH ends: recovery never records them
-///           (`readopted_ledger_record_allowed`) and `classify_reclaimable_mailbox_owner`
-///           never classifies them.
-///     It stays reachable only for the #4018 synthetic owner.
+///   - `OwnerInflightReplaced` — age `>= 120s` REQUIRED. It remains reachable for
+///     the #4018 synthetic owner. It is structurally unreachable for a real
+///     readopted owner because classification now requires raw
+///     `state.user_msg_id == active_user_message_id`; this reason requires the
+///     exact raw inequality, and the release function passes the same loaded
+///     `state` and the same active id to both checks without re-reading either.
 #[derive(Clone, Copy)]
 enum ReclaimableMailboxOwner {
     /// #4018 — the TUI-direct synthetic relay owner.
@@ -272,8 +262,8 @@ impl ReclaimableMailboxOwner {
 ///   - the synthetic relay owner (#4018), or
 ///   - a real-user turn this process re-adopted from persisted inflight (#4370),
 ///     proven per row shape:
-///       * PRESENT row → the on-disk `readopted_from_inflight` marker AND a request
-///         owner matching the live mailbox owner.
+///       * PRESENT row → the on-disk `readopted_from_inflight` marker, request
+///         owner, and raw user-message id all match the live mailbox owner/id.
 ///       * ABSENT row (Path B) → the in-memory `readopted_mailbox_ledger` records
 ///         THIS `(provider, channel_id)` as re-adopted with the SAME owner, the
 ///         SAME `active_user_message_id`, AND `finished == true` (its terminal
@@ -302,19 +292,18 @@ fn classify_reclaimable_mailbox_owner(
     }
     // A real-user owner: eligibility depends on the row shape.
     //
-    // `user_msg_id != 0` is load-bearing, not cosmetic (fresh-Claude r3 #1). The
-    // mailbox's `active_user_message_id` is the turn's `effective_finalizer_turn_id()`,
-    // which equals `user_msg_id` ONLY when that id is non-zero. For an id-0 row the
-    // two diverge, so `stale_synthetic_mailbox_owner_reclaim_reason` would read
-    // `state.user_msg_id != active_user_message_id` and misfire `OwnerInflightReplaced`
-    // on a turn that is still LIVE — reclaiming it once it aged past 120s. Recovery
-    // already refuses to record such rows (`readopted_ledger_record_allowed`); this is
-    // the matching refusal at the consumption site, so the invariant is enforced at
-    // both ends instead of being assumed.
+    // INV: re-adoption evidence states a fact about the turn T=(owner, effective
+    // finalizer id) that recorded it. A mailbox disposition may consume that
+    // evidence only when the evidence itself proves the disposition target is
+    // exactly T. For PRESENT rows, the raw equality below is the authority gate.
+    // It intentionally complements the reason function's raw `!=`; do not replace
+    // it with `effective_finalizer_turn_id()`. The separate id-0 refusal is also
+    // retained to mirror the write-side eligibility gate.
     match state {
         Some(state) => (state.readopted_from_inflight
             && state.user_msg_id != 0
-            && state.request_owner_user_id == owner.get())
+            && state.request_owner_user_id == owner.get()
+            && state.user_msg_id == active_user_message_id.get())
         .then_some(ReclaimableMailboxOwner::ReadoptedFromInflight),
         None => shared
             .is_readopted_mailbox_owner(

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -79,8 +79,8 @@ pub(super) use self::claims::*;
 pub(in crate::services::discord) use self::claims::{
     ThreadFollowUpParent, claim_or_replace_watcher, claim_or_replace_watcher_with_thread_parent,
     claim_or_reuse_watcher, claim_or_reuse_watcher_with_thread_parent,
-    thread_follow_up_parent_channel_id, thread_follow_up_parent_from_live,
-    try_claim_watcher_with_thread_parent,
+    find_watcher_by_tmux_session, thread_follow_up_parent_channel_id,
+    thread_follow_up_parent_from_live, try_claim_watcher_with_thread_parent,
 };
 
 #[path = "lifecycle/restore.rs"]

--- a/src/services/discord/watchers/lifecycle/restore.rs
+++ b/src/services/discord/watchers/lifecycle/restore.rs
@@ -481,6 +481,10 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
                     );
                     continue;
                 }
+                // #5242: intentionally excluded from the mint gate. This restore
+                // path enqueues `PendingWatcher` below regardless of the mailbox
+                // reregister result, so refusal cannot prove that no relay
+                // consumer will be installed. Preserve legacy mint semantics.
                 let finish_mailbox_on_completion =
                     super::super::super::recovery::reregister_active_turn_from_inflight(
                         &shared, &state,


### PR DESCRIPTION
Closes #5242.

## 불변식과 변경 범위

재채택 증거는 그것이 기록한 턴 `T=(owner, effective finalizer id)`에 대한 진술이다. mailbox 처분은 처분 대상이 정확히 T임을 증거가 담보할 때만 그 증거를 입력으로 삼는다.

- present-row reclaim은 raw `state.user_msg_id == active_user_message_id`를 요구한다. absent-row ledger는 exact owner+id+finished를 요구한다.
- restore의 mailbox-token mint는 `WatcherInstallOutlook::{WillSpawn, NoOutputPath, IncumbentReuse, Unknown}`으로 분류한다. missing Codex path는 later rollout resolver를 위해 `Unknown`, healthy same-path incumbent는 `IncumbentReuse`다.
- mint 결과가 false여도 recovered finalizer `Start` reseed와 identity-guarded readoption write는 실행한다. 성공한 durable write가 보장하는 것은 `readopted_from_inflight` 설정과 `restart_mode` clear뿐이다. watcher, mailbox token, pending consumer 설치를 뜻하지 않는다.
- 순수 판정/호출 helper를 기존 `mint_gate.rs`로 옮겨 `restore_inflight.rs`를 2333 production LoC로 낮췄다. 신규 모듈은 없다.
- 비-Unix에는 tmux watcher가 없으므로 incumbent를 `None`으로 분류한다. 이 cfg가 기존 Windows E0433/E0282 compile failure를 닫는다.

## 성공-write 잔여

consumer가 실제로 설치되지 않은 성공-write 경로에서는 undelivered output이 durable DLQ copy 없이 남을 수 있다. marker write가 성공하면 #4380의 `!readopted_from_inflight` predicate가 false이므로 DLQ는 발화하지 않는다. refusal WARN은 다른 consumer가 존재하는 safe refusal과 real no-consumer loss를 구분하지 못하고, loss 확정 신호가 아니며, body도 보존하지 않는다.

이 선언은 성공-write 경로에 한정한다. marker write 실패 경로의 기존 #4380 DLQ backstop은 유지된다. `origin/main`의 기존 marker-clear 동작과 6단계 반례는 후속 [#5282](https://github.com/itismyfield/AgentDesk/issues/5282)에 기록했다. consumer 설치와 marker clear를 결합하는 계약 변경은 #5242 범위 밖이다.

## 검증

- M3b: `started=false`에서도 recovered finalizer `Start`가 생기는 assert
- M7/M8: same-path incumbent와 missing Codex `Unknown`을 포함한 6-case 4값 표 테스트
- 리포 밖 변이 사본에서 M3b/M7/M8 각각 제거 시 assert FAILED, 원복 시 ok
- `restore_inflight.rs`: 2333 production LoC; maintainability audit rc=0, finding count 0
- production delta: `+186` (r2와 동일), test delta: `+457`; 14 files, `+803/-104`
- fmt, lib check, 지정 recovery tests, inventory freshness/integrity 모두 rc=0

F5 공시: restart-report 사이트의 `restart_report_watcher_start` 호출은 `reregister_*`보다 앞으로 이동했다. 이 함수는 출력 경로 metadata/offset만 읽고, 사이의 marker RMW는 출력 파일을 건드리지 않으므로 더 이른 snapshot은 같거나 더 이른 재전송 경계를 만들 뿐이다. 더 많이 재전송하는 안전한 방향이라는 판정에 동의한다.
