### PR TITLE
fix(deploy): report post-deploy wedge coverage honestly (#5244)

### DIFF
--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -311,6 +311,10 @@ echo "=== Shell test suites (tests/*.sh) ==="
 # while every required check stayed green. Run them here, in the job that already
 # owns script-level gates.
 SHELL_TESTS_FAILED=0
+required_shell_suites=(tests/test_deploy_smoke_wedge_coverage_5244.sh)
+for required_suite in "${required_shell_suites[@]}"; do
+  [ -f "$required_suite" ] || { echo "✗ required shell suite missing: $required_suite" >&2; SHELL_TESTS_FAILED=1; }
+done
 for shell_test in tests/*.sh; do
   [ -f "$shell_test" ] || continue
   echo "--- $shell_test"

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -2643,6 +2643,8 @@ POST_DEPLOY_SMOKE_LOG_LINES="${AGENTDESK_POST_DEPLOY_SMOKE_LOG_LINES:-500}"
 POST_DEPLOY_SMOKE_WARN_LIMIT="${AGENTDESK_POST_DEPLOY_SMOKE_WARN_LIMIT:-5}"
 POST_DEPLOY_SMOKE_RELAY_CELL="${AGENTDESK_POST_DEPLOY_SMOKE_RELAY_CELL:-claude-tui}"
 POST_DEPLOY_SMOKE_CREATE_ISSUE="${AGENTDESK_POST_DEPLOY_SMOKE_CREATE_ISSUE:-off}"
+# Keep the PID suffix after both date success/failure paths so artifacts from
+# concurrently live deploy shells use distinct smoke paths.
 POST_DEPLOY_SMOKE_STAMP="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || printf 'unknown')-$$"
 POST_DEPLOY_SMOKE_EVIDENCE="$ADK_REL/logs/post-deploy-smoke-${POST_DEPLOY_SMOKE_STAMP}.log"
 POST_DEPLOY_SMOKE_TMP_DIR=""
@@ -2652,6 +2654,7 @@ POST_DEPLOY_SMOKE_SESSIONS_BODY=""
 POST_DEPLOY_SMOKE_FAILURES=()
 
 # >>> BEGIN wedge-check region (#5244) — coverage is report-only and point-in-time
+POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE="evaluated: 0 stall-state marker(s) observed (point-in-time)"
 _post_deploy_smoke_note() {
     local message="$1"
     printf '%s\n' "$message"
@@ -2702,9 +2705,11 @@ _post_deploy_smoke_probe_apis() {
 
 _post_deploy_smoke_wedge_scan_from_file() {
     local health_detail_path="$1"
-    # This is the only health/detail parser. The caller deliberately reports a
-    # broad scan failure because schema, I/O, filter/tool, and signal failures
-    # cannot be distinguished safely at this shell boundary.
+    # This is the only health/detail parser that feeds wedge coverage. The E-1
+    # busy gate at :3024 parses the same body independently. The caller
+    # deliberately reports a broad scan failure because schema, I/O,
+    # filter/tool, and signal failures cannot be distinguished safely at this
+    # shell boundary (jq absence alone has separate vocabulary).
     # The three marker states below are point-in-time Rust-classifier
     # observations. Watchdog auto-recovery may change the next snapshot; this
     # function does not infer persistence or an unresolvable wedge from one.
@@ -2802,20 +2807,21 @@ _post_deploy_smoke_check_wedges() {
         _post_deploy_smoke_wedge_unevaluable "wedge scan output contract violated"
         return 1
     fi
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        _post_deploy_smoke_note "relay wedge observation: ${line#obs=}" || return 1
+    done <<< "$observations"
     if [ "$recovered" = "false" ]; then
         POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not evaluated: startup recovery in progress"
         _post_deploy_smoke_note "relay wedge=${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}" || return 1
         return 0
     fi
-    while IFS= read -r line; do
-        [ -n "$line" ] || continue
-        _post_deploy_smoke_note "relay wedge observation: ${line#obs=}" || return 1
-    done <<< "$observations"
-    POST_DEPLOY_SMOKE_WEDGE_COVERAGE="evaluated: ${marker_count} stall-state marker(s) observed (point-in-time)"
     if [ "$marker_count" = "0" ]; then
+        POST_DEPLOY_SMOKE_WEDGE_COVERAGE="$POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE"
         _post_deploy_smoke_note "relay wedge=${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}" || return 1
         return 0
     fi
+    POST_DEPLOY_SMOKE_WEDGE_COVERAGE="evaluated: ${marker_count} stall-state marker(s) observed (point-in-time)"
     _post_deploy_smoke_fail \
         "relay stall-state marker(s) observed (point-in-time): ${markers//$'\n'/; }" \
         || true
@@ -3220,7 +3226,7 @@ echo "▸ Running post-deploy functional smoke (#4262)..."
 # each fallible step is nevertheless explicitly guarded or carries `|| return`.
 if _run_post_deploy_functional_smoke; then
     case "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE" in
-        "evaluated: 0 stall-state marker(s) observed (point-in-time)")
+        "$POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE")
             echo "✓ Post-deploy functional smoke passed (relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}; evidence: $POST_DEPLOY_SMOKE_EVIDENCE)"
             ;;
         *)

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -103,6 +103,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/_defaults.sh"
 
 ADK_REL="${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}"
+# #5244: the EXIT trap can run before post-deploy smoke initialization. Keep a
+# truthful default so early exits report that the wedge check did not execute.
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
 # The Rust dcserver reads AGENTDESK_DCSERVER_LABEL for the plist Label; honor it first
 # so launchd Label and plist filename never diverge when the operator overrides one side.
 PLIST_REL="${AGENTDESK_DCSERVER_LABEL:-${AGENTDESK_PLIST_REL:-com.agentdesk.release}}"
@@ -764,7 +767,8 @@ _finalize_detached_helper() {
 
     local content
     if [ "$status" -eq 0 ]; then
-        content="✅ release deploy complete"
+        content="✅ release deploy complete
+relay wedge: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE:-not run: wedge check did not execute}"
     else
         content="❌ release deploy failed (exit ${status})
 log: ${DEPLOY_LOG_PATH:-n/a}"
@@ -2637,10 +2641,9 @@ POST_DEPLOY_SMOKE_CORE_API_ENDPOINTS=(
 )
 POST_DEPLOY_SMOKE_LOG_LINES="${AGENTDESK_POST_DEPLOY_SMOKE_LOG_LINES:-500}"
 POST_DEPLOY_SMOKE_WARN_LIMIT="${AGENTDESK_POST_DEPLOY_SMOKE_WARN_LIMIT:-5}"
-POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS=4
 POST_DEPLOY_SMOKE_RELAY_CELL="${AGENTDESK_POST_DEPLOY_SMOKE_RELAY_CELL:-claude-tui}"
 POST_DEPLOY_SMOKE_CREATE_ISSUE="${AGENTDESK_POST_DEPLOY_SMOKE_CREATE_ISSUE:-off}"
-POST_DEPLOY_SMOKE_STAMP="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || printf 'unknown-%s' "$$")"
+POST_DEPLOY_SMOKE_STAMP="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || printf 'unknown')-$$"
 POST_DEPLOY_SMOKE_EVIDENCE="$ADK_REL/logs/post-deploy-smoke-${POST_DEPLOY_SMOKE_STAMP}.log"
 POST_DEPLOY_SMOKE_TMP_DIR=""
 POST_DEPLOY_SMOKE_HEALTH_BODY=""
@@ -2648,6 +2651,7 @@ POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY=""
 POST_DEPLOY_SMOKE_SESSIONS_BODY=""
 POST_DEPLOY_SMOKE_FAILURES=()
 
+# >>> BEGIN wedge-check region (#5244) — coverage is report-only and point-in-time
 _post_deploy_smoke_note() {
     local message="$1"
     printf '%s\n' "$message"
@@ -2696,141 +2700,129 @@ _post_deploy_smoke_probe_apis() {
     [ "$failed" -eq 0 ]
 }
 
-_post_deploy_smoke_wedge_markers_from_file() {
+_post_deploy_smoke_wedge_scan_from_file() {
     local health_detail_path="$1"
-    # Reuse the health/detail markers consumed by the relay E2E validator:
-    # explicit non-healthy relay_stall_state, ownerless/detached inflight,
-    # desync, stale thread proof, or stale watcher attachment. Ordinary active
-    # turns and queues are deliberately not classified as wedges.
+    # This is the only health/detail parser. The caller deliberately reports a
+    # broad scan failure because schema, I/O, filter/tool, and signal failures
+    # cannot be distinguished safely at this shell boundary.
+    # The three marker states below are point-in-time Rust-classifier
+    # observations. Watchdog auto-recovery may change the next snapshot; this
+    # function does not infer persistence or an unresolvable wedge from one.
     jq -r '
-        [
-          .degraded_reasons[]?
-          | strings
-          | select(test("relay.*(wedge|dead|stall|stuck)|(?:wedge|dead|stall|stuck).*relay"; "i"))
-          | "degraded_reason=" + .
-        ] + [
-          .mailboxes[]?
-          | . as $mailbox
-          | (($mailbox.relay_stall_state // "healthy") | ascii_downcase) as $stall
-          | select(
-              ($stall != "" and $stall != "healthy")
-              or ($mailbox.relay_health.desynced == true)
-              or ($mailbox.relay_health.stale_thread_proof == true)
-              or ($mailbox.relay_health.watcher_attached_stale == true)
-              or (
-                $mailbox.inflight_state_present == true
-                and (($mailbox.relay_owner_kind // "none") | ascii_downcase) as $owner
-                | ($owner == "" or $owner == "none" or $owner == "unknown")
-              )
-              or (
-                $mailbox.inflight_state_present == true
-                and $mailbox.watcher_attached == false
-              )
-            )
-          | "mailbox provider=\($mailbox.provider // "unknown") channel=\($mailbox.channel_id // "unknown") stall=\($stall)"
-        ]
-        | .[]
+        def die($message): error("wedge-schema: " + $message);
+        if (type != "object") then die("root is not an object")
+        elif ((.fully_recovered | type) != "boolean") then die("fully_recovered is not boolean")
+        elif ((.mailboxes | type) != "array") then die(".mailboxes is not an array")
+        else
+          ([ .mailboxes[]
+             | if (type != "object") then die("mailbox entry is not an object")
+               elif ((.relay_stall_state | type) != "string") then die("mailbox relay_stall_state is not a string")
+               else { ch: ((.channel_id // "?") | tostring),
+                      pv: ((.provider // "?") | tostring),
+                      s: (.relay_stall_state | ascii_downcase) }
+               end ]) as $mailboxes
+          | ([ $mailboxes[]
+               | select(.s == "tmux_alive_relay_dead"
+                       or .s == "stale_thread_proof"
+                       or .s == "orphan_pending_token")
+               | "marker=stall-state provider=\(.pv) channel=\(.ch) state=\(.s)" ]) as $markers
+          | ([ $mailboxes[] | select(.s == "queue_blocked")
+               | "obs=queue_blocked provider=\(.pv) channel=\(.ch)" ]) as $queue_observations
+          | ([ $mailboxes[]
+               | select(.s | IN("healthy", "active_foreground_stream", "explicit_background_work",
+                               "queue_blocked", "tmux_alive_relay_dead", "stale_thread_proof",
+                               "orphan_pending_token") | not)
+               | "obs=unknown_stall_state provider=\(.pv) channel=\(.ch) stall=\(.s)" ]) as $unknown_observations
+          | ([ "recovered=\(.fully_recovered)",
+               "count=\($markers | length)" ] + $markers
+             + $queue_observations + $unknown_observations)
+          | .[]
+        end
     ' "$health_detail_path" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
 }
 
-_post_deploy_smoke_fully_recovered_from_file() {
-    local health_path="$1"
-    jq -r '
-        if (.fully_recovered | type) == "boolean" then
-            .fully_recovered
-        else
-            error("fully_recovered is not boolean")
-        end
-    ' "$health_path" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
+_post_deploy_smoke_wedge_unevaluable() {
+    POST_DEPLOY_SMOKE_WEDGE_COVERAGE="unevaluable: $1"
+    _post_deploy_smoke_fail "relay wedge check ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}" || true
+    return 1
 }
 
 _post_deploy_smoke_check_wedges() {
-    local fully_recovered wedge_markers wedge_markers_resampled persistent_markers wedge_summary
-    local resample_path="$POST_DEPLOY_SMOKE_TMP_DIR/api_health_detail_resample.json"
+    # There is intentionally no wait, persistent tally, or second marker
+    # sample here. Transient suppression was not retained: the report says what
+    # this snapshot evaluated and does not claim a persistent-wedge proof.
+    local scan_out recovered marker_count markers observations line
     if [ -z "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY" ] \
       || [ ! -s "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY" ]; then
-        _post_deploy_smoke_fail "relay wedge check: /api/health/detail body unavailable" || true
+        _post_deploy_smoke_wedge_unevaluable "/api/health/detail body unavailable"
         return 1
     fi
-
-    if ! fully_recovered=$(
-        _post_deploy_smoke_fully_recovered_from_file "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
-    ); then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: startup recovery state unavailable" || return 1
-        return 0
-    fi
-    if [ "$fully_recovered" = "false" ]; then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: startup recovery in progress" || return 1
-        return 0
-    fi
-
-    if ! wedge_markers=$(
-        _post_deploy_smoke_wedge_markers_from_file "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
-    ); then
-        _post_deploy_smoke_fail "relay wedge check: health/detail JSON could not be parsed" || true
+    if ! command -v jq >/dev/null 2>&1; then
+        _post_deploy_smoke_wedge_unevaluable "jq unavailable"
         return 1
     fi
-    if [ -z "$wedge_markers" ]; then
-        _post_deploy_smoke_note "relay wedge markers=absent" || return 1
+    if ! scan_out=$(_post_deploy_smoke_wedge_scan_from_file \
+        "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"); then
+        _post_deploy_smoke_wedge_unevaluable "health/detail scan failed"
+        return 1
+    fi
+    while IFS= read -r line; do
+        case "$line" in
+            recovered=*|count=*|marker=*|obs=*) : ;;
+            '') : ;;
+            *)
+                _post_deploy_smoke_wedge_unevaluable "wedge scan output contract violated"
+                return 1
+                ;;
+        esac
+    done <<< "$scan_out"
+    recovered=$(printf '%s\n' "$scan_out" | sed -n 's/^recovered=//p')
+    marker_count=$(printf '%s\n' "$scan_out" | sed -n 's/^count=//p')
+    markers=$(printf '%s\n' "$scan_out" | grep '^marker=' || true)
+    observations=$(printf '%s\n' "$scan_out" | grep '^obs=' || true)
+    case "$recovered" in
+        true|false) : ;;
+        *)
+            _post_deploy_smoke_wedge_unevaluable "wedge scan output contract violated"
+            return 1
+            ;;
+    esac
+    # jq length is the canonical producer. This shell guard admits only
+    # decimal digits with no leading zero and never performs arithmetic.
+    case "$marker_count" in
+        0) : ;;
+        ''|*[!0-9]*|0*)
+            _post_deploy_smoke_wedge_unevaluable "wedge scan output contract violated"
+            return 1
+            ;;
+        *) : ;;
+    esac
+    if { [ "$marker_count" = "0" ] && [ -n "$markers" ]; } \
+      || { [ "$marker_count" != "0" ] && [ -z "$markers" ]; }; then
+        _post_deploy_smoke_wedge_unevaluable "wedge scan output contract violated"
+        return 1
+    fi
+    if [ "$recovered" = "false" ]; then
+        POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not evaluated: startup recovery in progress"
+        _post_deploy_smoke_note "relay wedge=${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}" || return 1
         return 0
     fi
-
-    _post_deploy_smoke_note \
-        "relay wedge marker observed; settling ${POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS}s before resample" \
-        || return 1
-    sleep "$POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS"
-    if ! curl -fsS --connect-timeout 2 --max-time 15 \
-        -H "Origin: http://${ADK_DEFAULT_LOOPBACK}:${REL_PORT}" \
-        -o "$resample_path" \
-        "http://${ADK_DEFAULT_LOOPBACK}:${REL_PORT}/api/health/detail"; then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle resample unavailable" || return 1
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        _post_deploy_smoke_note "relay wedge observation: ${line#obs=}" || return 1
+    done <<< "$observations"
+    POST_DEPLOY_SMOKE_WEDGE_COVERAGE="evaluated: ${marker_count} stall-state marker(s) observed (point-in-time)"
+    if [ "$marker_count" = "0" ]; then
+        _post_deploy_smoke_note "relay wedge=${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}" || return 1
         return 0
     fi
-    if [ ! -s "$resample_path" ]; then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle resample body empty" || return 1
-        return 0
-    fi
-    if ! fully_recovered=$(_post_deploy_smoke_fully_recovered_from_file "$resample_path"); then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle recovery state unavailable" || return 1
-        return 0
-    fi
-    if [ "$fully_recovered" = "false" ]; then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: startup recovery in progress" || return 1
-        return 0
-    fi
-    if ! wedge_markers_resampled=$(
-        _post_deploy_smoke_wedge_markers_from_file "$resample_path"
-    ); then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle resample JSON could not be parsed" || return 1
-        return 0
-    fi
-    if ! persistent_markers=$(comm -12 \
-        <(printf '%s\n' "$wedge_markers" | LC_ALL=C sort -u) \
-        <(printf '%s\n' "$wedge_markers_resampled" | LC_ALL=C sort -u)); then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle resample comparison failed" || return 1
-        return 0
-    fi
-    if [ -z "$persistent_markers" ]; then
-        _post_deploy_smoke_note \
-            "relay wedge markers=cleared after ${POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS}s settle" \
-            || return 1
-        return 0
-    fi
-
-    wedge_summary="${persistent_markers//$'\n'/; }"
     _post_deploy_smoke_fail \
-        "relay wedge marker persisted after ${POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS}s settle: ${wedge_summary}" \
+        "relay stall-state marker(s) observed (point-in-time): ${markers//$'\n'/; }" \
         || true
     return 1
 }
+
+# <<< END wedge-check region (#5244)
 
 _post_deploy_smoke_check_fail_closed_warn_rate() {
     local log_path="$POST_DEPLOY_SMOKE_LOG_PATH"
@@ -3170,6 +3162,7 @@ _report_post_deploy_smoke_failure() {
         printf -- '- Commit: `%s`\n' "$commit_sha"
         printf -- '- Port: `%s`\n' "$REL_PORT"
         printf -- '- Evidence: `%s`\n\n' "$POST_DEPLOY_SMOKE_EVIDENCE"
+        printf -- '- Relay wedge coverage: `%s`\n\n' "${POST_DEPLOY_SMOKE_WEDGE_COVERAGE:-not run: wedge check did not execute}"
         printf '## Findings\n\n'
         for finding in "${POST_DEPLOY_SMOKE_FAILURES[@]}"; do
             printf -- '- %s\n' "$finding"
@@ -3186,6 +3179,8 @@ node: ${node_name}
 commit: ${commit_sha}
 draft: ${draft_path}
 evidence: ${POST_DEPLOY_SMOKE_EVIDENCE}"
+    alert_text="${alert_text}
+relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE:-not run: wedge check did not execute}"
     for finding in "${POST_DEPLOY_SMOKE_FAILURES[@]}"; do
         alert_text="${alert_text}
 - ${finding}"
@@ -3213,6 +3208,7 @@ evidence: ${POST_DEPLOY_SMOKE_EVIDENCE}"
     return 0
 }
 
+# >>> BEGIN smoke-disposition region (#5244)
 echo "▸ Running post-deploy functional smoke (#4262)..."
 # INVARIANT: the ENTIRE smoke block is fail-open. We are past DEPLOY_OK, so a
 # functional failure must degrade to a loud warning + channel alert + local
@@ -3223,9 +3219,17 @@ echo "▸ Running post-deploy functional smoke (#4262)..."
 # The smoke function runs from an `if` guard, suspending `set -e` within it;
 # each fallible step is nevertheless explicitly guarded or carries `|| return`.
 if _run_post_deploy_functional_smoke; then
-    echo "✓ Post-deploy functional smoke passed (evidence: $POST_DEPLOY_SMOKE_EVIDENCE)"
+    case "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE" in
+        "evaluated: 0 stall-state marker(s) observed (point-in-time)")
+            echo "✓ Post-deploy functional smoke passed (relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}; evidence: $POST_DEPLOY_SMOKE_EVIDENCE)"
+            ;;
+        *)
+            echo "△ Post-deploy functional smoke completed with coverage gap (relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}; evidence: $POST_DEPLOY_SMOKE_EVIDENCE)"
+            ;;
+    esac
 else
     echo "⚠ POST-DEPLOY FUNCTIONAL SMOKE FAILED — deploy remains healthy (fail-open)"
+    echo "  relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}"
     echo "  evidence: $POST_DEPLOY_SMOKE_EVIDENCE"
     if [ -n "$POST_DEPLOY_SMOKE_TMP_DIR" ]; then
         rm -rf "$POST_DEPLOY_SMOKE_TMP_DIR" 2>/dev/null || true
@@ -3236,6 +3240,7 @@ else
     fi
     _report_post_deploy_smoke_failure || true
 fi
+# <<< END smoke-disposition region (#5244)
 
 # ── Out-of-band relay watchdog (#4381) ────────────────────────────────────────
 # Deliberately OUTSIDE dcserver's launchd job: the watchdog must survive exactly

--- a/tests/test_deploy_smoke_wedge_coverage_5244.sh
+++ b/tests/test_deploy_smoke_wedge_coverage_5244.sh
@@ -27,8 +27,17 @@ if [ -n "$begin_line" ] && [ -n "$end_line" ]; then
     sed -n "$((begin_line + 1)),$((end_line - 1))p" "$DEPLOY_SH" > "$REGION"
 fi
 
+# The wedge region is evaluated in child shells, so an unreviewed source hook
+# could replace its parser without changing the visible coverage assignment.
+if grep -qE '^[[:space:]]*(\.|source)[[:space:]]+' "$REGION"; then
+    fail 'wedge region sources an override'
+    exit 1
+fi
+
 # H2/H7: derive the evaluated function set from the region, then check actual
-# definitions and the whole file's exact-one rule.
+# shell function definitions (canonical `name() {` and `function name {` forms)
+# and the whole file's exact-one rule. CASE_DONE below is only a child-shell
+# completion token; it is not an authenticated function-return witness.
 expected_functions=$(grep -E '^_post_deploy_smoke[a-z_]*\(\)' "$REGION" | sed 's/().*$//' | sort -u)
 if [ -z "$expected_functions" ]; then
     fail 'wedge region yielded no functions'
@@ -38,9 +47,13 @@ else
     [ "$actual_functions" = "$expected_functions" ] || fail "region/function mismatch"
     while IFS= read -r fn; do
         [ -n "$fn" ] || continue
-        definition_count=$(grep -cE "^${fn}\(\)" "$DEPLOY_SH")
-        [ "$definition_count" -eq 1 ] || fail "definition count for $fn is $definition_count"
-        definition_line=$(grep -nE "^${fn}\(\)" "$DEPLOY_SH" | cut -d: -f1)
+        definition_pattern="^[[:space:]]*(function[[:space:]]+)?${fn}[[:space:]]*(\\(\\))?[[:space:]]*\\{"
+        definition_count=$(grep -cE "$definition_pattern" "$DEPLOY_SH")
+        if [ "$definition_count" -ne 1 ]; then
+            fail "definition count for $fn is $definition_count"
+            continue
+        fi
+        definition_line=$(grep -nE "$definition_pattern" "$DEPLOY_SH" | cut -d: -f1)
         [ "$definition_line" -ge "$begin_line" ] && [ "$definition_line" -le "$end_line" ] || fail "$fn is outside the wedge region"
     done <<< "$expected_functions"
 fi
@@ -50,10 +63,13 @@ fi
 smoke_to_report=$(sed -n '/^_run_post_deploy_functional_smoke()/,/^_report_post_deploy_smoke_failure()/p' "$DEPLOY_SH")
 cleanup_to_signal=$(sed -n '/^_cleanup_on_exit()/,/^_handle_cleanup_signal()/p' "$DEPLOY_SH")
 grep -q '_post_deploy_smoke_check_wedges' <<< "$smoke_to_report" || fail 'smoke runner text does not contain check_wedges'
+grep -qE '^[[:space:]]*if ! _post_deploy_smoke_check_wedges; then$' <<< "$smoke_to_report" || fail 'runner wedge check is wrapped in a subshell or pipeline'
 grep -q '_finalize_detached_helper' <<< "$cleanup_to_signal" || fail 'cleanup text does not contain finalizer'
 coverage_decl_line=$(grep -nE '^POST_DEPLOY_SMOKE_WEDGE_COVERAGE=' "$DEPLOY_SH" | head -1 | cut -d: -f1)
 trap_line=$(grep -nF 'trap _cleanup_on_exit EXIT' "$DEPLOY_SH" | head -1 | cut -d: -f1)
 [ -n "$coverage_decl_line" ] && [ -n "$trap_line" ] && [ "$coverage_decl_line" -lt "$trap_line" ] || fail 'coverage declaration is not before EXIT trap'
+exit_trap_count=$(grep -cE '^[[:space:]]*trap[[:space:]]+[^-][^[:space:]]*[[:space:]]+EXIT$' "$DEPLOY_SH" || true)
+[ "$exit_trap_count" -eq 1 ] || fail "expected one installed EXIT trap, got $exit_trap_count"
 while IFS=: read -r assignment_line _; do
     [ -n "$assignment_line" ] || continue
     if [ "$assignment_line" != "$coverage_decl_line" ]; then
@@ -93,9 +109,11 @@ fixture tmux_dead '{"fully_recovered":true,"mailboxes":[{"provider":"claude","ch
 fixture stale_thread '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"stale_thread_proof"}]}'
 fixture orphan_token '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"orphan_pending_token"}]}'
 fixture observations '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"queue_blocked"},{"provider":"claude","channel_id":2,"relay_stall_state":"future_state"}]}'
+fixture recovering_observations '{"fully_recovered":false,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"queue_blocked"},{"provider":"claude","channel_id":2,"relay_stall_state":"future_state"}]}'
 fixture malformed '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":42}]}'
 fixture malformed_json '{broken'
 fixture empty_mailboxes '{"fully_recovered":true,"mailboxes":null}'
+fixture empty_mailboxes_valid '{"fully_recovered":true,"mailboxes":[]}'
 fixture root_scalar '[]'
 fixture recovery_missing '{"mailboxes":[]}'
 fixture mailbox_scalar '{"fully_recovered":true,"mailboxes":["mailbox"]}'
@@ -139,9 +157,11 @@ run_case tmux_alive_relay_dead 1 "$TMP_ROOT/tmux_dead.json" 'evaluated: 1 stall-
 run_case stale_thread_proof 1 "$TMP_ROOT/stale_thread.json" 'evaluated: 1 stall-state marker(s) observed (point-in-time)'
 run_case orphan_pending_token 1 "$TMP_ROOT/orphan_token.json" 'evaluated: 1 stall-state marker(s) observed (point-in-time)'
 run_case observations 0 "$TMP_ROOT/observations.json" 'evaluated: 0 stall-state marker(s) observed (point-in-time)'
+run_case recovering_observations 0 "$TMP_ROOT/recovering_observations.json" 'not evaluated: startup recovery in progress'
 run_case malformed 1 "$TMP_ROOT/malformed.json" 'unevaluable: health/detail scan failed'
 run_case malformed_json 1 "$TMP_ROOT/malformed_json.json" 'unevaluable: health/detail scan failed'
 run_case empty_mailboxes 1 "$TMP_ROOT/empty_mailboxes.json" 'unevaluable: health/detail scan failed'
+run_case empty_mailboxes_valid 0 "$TMP_ROOT/empty_mailboxes_valid.json" 'evaluated: 0 stall-state marker(s) observed (point-in-time)'
 run_case root_scalar 1 "$TMP_ROOT/root_scalar.json" 'unevaluable: health/detail scan failed'
 run_case recovery_missing 1 "$TMP_ROOT/recovery_missing.json" 'unevaluable: health/detail scan failed'
 run_case mailbox_scalar 1 "$TMP_ROOT/mailbox_scalar.json" 'unevaluable: health/detail scan failed'
@@ -225,6 +245,21 @@ CHILD
 grep -q 'relay wedge observation: queue_blocked' <<< "$observation_output" || fail 'queue_blocked was not reported as an observation'
 grep -q 'relay wedge observation: unknown_stall_state' <<< "$observation_output" || fail 'unknown stall was not reported as an observation'
 
+recovery_observation_output=$(bash -s -- "$REGION" "$TMP_ROOT/recovering_observations.json" <<'CHILD'
+set -euo pipefail
+eval "$(<"$1")"
+POST_DEPLOY_SMOKE_EVIDENCE="${TMPDIR:-/tmp}/5244-recovery-observation.evidence"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$2"
+POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+if _post_deploy_smoke_check_wedges; then rc=0; else rc=$?; fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+)
+grep -q 'relay wedge observation: queue_blocked' <<< "$recovery_observation_output" || fail 'recovery queue observation was discarded'
+grep -q 'relay wedge observation: unknown_stall_state' <<< "$recovery_observation_output" || fail 'recovery unknown observation was discarded'
+
 # H3: disposition wording is driven by coverage, while FAIL remains fail-open.
 DISPOSITION="$TMP_ROOT/disposition.sh"
 disposition_begin=$(grep -nF '# >>> BEGIN smoke-disposition region (#5244)' "$DEPLOY_SH" | cut -d: -f1)
@@ -236,6 +271,7 @@ disposition_case() {
     output=$(SMOKE_RC="$smoke_rc" COVERAGE="$coverage" bash -s -- "$DISPOSITION" <<'CHILD'
 set -euo pipefail
 POST_DEPLOY_SMOKE_WEDGE_COVERAGE="$COVERAGE"
+POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE='evaluated: 0 stall-state marker(s) observed (point-in-time)'
 POST_DEPLOY_SMOKE_EVIDENCE=/tmp/5244-disposition.evidence
 POST_DEPLOY_SMOKE_TMP_DIR=""
 POST_DEPLOY_SMOKE_FAILURES=()

--- a/tests/test_deploy_smoke_wedge_coverage_5244.sh
+++ b/tests/test_deploy_smoke_wedge_coverage_5244.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# #5244 is a report-coverage test. It extracts only the sentinel region and
+# never sources deploy-release.sh (which would execute a real deployment).
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEPLOY_SH="${DEPLOY_SH_OVERRIDE:-$ROOT_DIR/scripts/deploy-release.sh}"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agentdesk-wedge-coverage-5244.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+failures=0
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+begin_line=$(grep -nF '# >>> BEGIN wedge-check region (#5244)' "$DEPLOY_SH" | cut -d: -f1)
+end_line=$(grep -nF '# <<< END wedge-check region (#5244)' "$DEPLOY_SH" | cut -d: -f1)
+[ -n "$begin_line" ] || fail 'wedge-check BEGIN sentinel missing'
+[ -n "$end_line" ] || fail 'wedge-check END sentinel missing'
+if [ -n "$begin_line" ] && [ -n "$end_line" ]; then
+    [ "$begin_line" -lt "$end_line" ] || fail 'wedge-check sentinels are reversed'
+fi
+
+REGION="$TMP_ROOT/wedge-region.sh"
+if [ -n "$begin_line" ] && [ -n "$end_line" ]; then
+    sed -n "$((begin_line + 1)),$((end_line - 1))p" "$DEPLOY_SH" > "$REGION"
+fi
+
+# H2/H7: derive the evaluated function set from the region, then check actual
+# definitions and the whole file's exact-one rule.
+expected_functions=$(grep -E '^_post_deploy_smoke[a-z_]*\(\)' "$REGION" | sed 's/().*$//' | sort -u)
+if [ -z "$expected_functions" ]; then
+    fail 'wedge region yielded no functions'
+else
+    eval "$(<"$REGION")"
+    actual_functions=$(declare -F | sed -E 's/^declare -f //' | grep '^_post_deploy_smoke' | sort -u || true)
+    [ "$actual_functions" = "$expected_functions" ] || fail "region/function mismatch"
+    while IFS= read -r fn; do
+        [ -n "$fn" ] || continue
+        definition_count=$(grep -cE "^${fn}\(\)" "$DEPLOY_SH")
+        [ "$definition_count" -eq 1 ] || fail "definition count for $fn is $definition_count"
+        definition_line=$(grep -nE "^${fn}\(\)" "$DEPLOY_SH" | cut -d: -f1)
+        [ "$definition_line" -ge "$begin_line" ] && [ "$definition_line" -le "$end_line" ] || fail "$fn is outside the wedge region"
+    done <<< "$expected_functions"
+fi
+
+# H8 is a text-presence check, not a claim that a runtime call graph was
+# proved. Check both edges, declaration order, and assignment confinement.
+smoke_to_report=$(sed -n '/^_run_post_deploy_functional_smoke()/,/^_report_post_deploy_smoke_failure()/p' "$DEPLOY_SH")
+cleanup_to_signal=$(sed -n '/^_cleanup_on_exit()/,/^_handle_cleanup_signal()/p' "$DEPLOY_SH")
+grep -q '_post_deploy_smoke_check_wedges' <<< "$smoke_to_report" || fail 'smoke runner text does not contain check_wedges'
+grep -q '_finalize_detached_helper' <<< "$cleanup_to_signal" || fail 'cleanup text does not contain finalizer'
+coverage_decl_line=$(grep -nE '^POST_DEPLOY_SMOKE_WEDGE_COVERAGE=' "$DEPLOY_SH" | head -1 | cut -d: -f1)
+trap_line=$(grep -nF 'trap _cleanup_on_exit EXIT' "$DEPLOY_SH" | head -1 | cut -d: -f1)
+[ -n "$coverage_decl_line" ] && [ -n "$trap_line" ] && [ "$coverage_decl_line" -lt "$trap_line" ] || fail 'coverage declaration is not before EXIT trap'
+while IFS=: read -r assignment_line _; do
+    [ -n "$assignment_line" ] || continue
+    if [ "$assignment_line" != "$coverage_decl_line" ]; then
+        [ "$assignment_line" -ge "$begin_line" ] && [ "$assignment_line" -le "$end_line" ] || fail "coverage assignment escaped region at line $assignment_line"
+    fi
+done < <(grep -nE '^[[:space:]]*POST_DEPLOY_SMOKE_WEDGE_COVERAGE=' "$DEPLOY_SH" || true)
+
+scanner_text=$(sed -n '/^_post_deploy_smoke_wedge_scan_from_file()/,/^_post_deploy_smoke_wedge_unevaluable()/p' "$DEPLOY_SH")
+check_text=$(sed -n '/^_post_deploy_smoke_check_wedges()/,/^# <<< END wedge-check region/p' "$DEPLOY_SH")
+grep -qF 'count=\($markers | length)' <<< "$scanner_text" || fail 'count is not produced by jq array length'
+grep -q 'queue_blocked' <<< "$scanner_text" || fail 'queue_blocked observation was removed'
+grep -q 'unknown_stall_state' <<< "$scanner_text" || fail 'unknown stall observation was removed'
+for state in tmux_alive_relay_dead stale_thread_proof orphan_pending_token; do
+    grep -q "$state" <<< "$scanner_text" || fail "marker state $state is not in the classifier filter"
+done
+grep -q 'relay_stall_state.*type' <<< "$scanner_text" || fail 'relay_stall_state type guard is missing'
+! grep -q 'degraded_reasons' <<< "$scanner_text" || fail 'degraded_reasons became a second authority'
+! grep -qE 'desynced|watcher_attached_stale|relay_owner_kind' <<< "$scanner_text" || fail 'input booleans were re-promoted'
+! grep -qE '\b(sleep|curl|comm|sort)\b' <<< "$check_text" || fail 'deleted transient machinery remains in check_wedges'
+! grep -qE 'marker_count.*(\$\(\(|-gt|-ge|-lt|-le)' <<< "$check_text" || fail 'marker count uses shell arithmetic'
+grep -qF 'POST_DEPLOY_SMOKE_STAMP="$(date' "$DEPLOY_SH" || fail 'stamp assignment disappeared'
+grep -qF ')-$$"' "$DEPLOY_SH" || fail 'stamp has no PID suffix'
+for old_name in consecutive_skips WEDGE_SETTLE RECOVERY_WAIT; do
+    ! grep -q "$old_name" "$DEPLOY_SH" || fail "deleted persistent/wait mechanism remains: $old_name"
+done
+
+# Fixtures are wire bodies, not precomputed jq output. Every behavior case is
+# a child shell and must print CASE_DONE after the target function returns.
+fixture() {
+    local name="$1" body="$2"
+    printf '%s\n' "$body" > "$TMP_ROOT/$name.json"
+}
+fixture clean '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"healthy"}]}'
+fixture active_stream '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"active_foreground_stream","relay_health":{"desynced":true,"stale_thread_proof":true,"watcher_attached_stale":true}}]}'
+fixture recovering '{"fully_recovered":false,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"healthy"}]}'
+fixture tmux_dead '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"tmux_alive_relay_dead"}]}'
+fixture stale_thread '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"stale_thread_proof"}]}'
+fixture orphan_token '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"orphan_pending_token"}]}'
+fixture observations '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"queue_blocked"},{"provider":"claude","channel_id":2,"relay_stall_state":"future_state"}]}'
+fixture malformed '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":42}]}'
+fixture malformed_json '{broken'
+fixture empty_mailboxes '{"fully_recovered":true,"mailboxes":null}'
+fixture root_scalar '[]'
+fixture recovery_missing '{"mailboxes":[]}'
+fixture mailbox_scalar '{"fully_recovered":true,"mailboxes":["mailbox"]}'
+fixture mailbox_missing_state '{"fully_recovered":true,"mailboxes":[{"provider":"claude"}]}'
+fixture recovery_string '{"fully_recovered":"yes","mailboxes":[]}'
+
+run_case() {
+    local name="$1" expected_rc="$2" fixture_path="$3" expected_coverage="$4"
+    local output rc case_line coverage_line
+    output=$(bash -s -- "$REGION" "$fixture_path" <<'CHILD'
+set -euo pipefail
+region_path="$1"
+body_path="$2"
+eval "$(<"$region_path")"
+POST_DEPLOY_SMOKE_EVIDENCE="${body_path}.evidence"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$body_path"
+POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+if _post_deploy_smoke_check_wedges; then
+    rc=0
+else
+    rc=$?
+fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+    )
+    case_line=$(grep '^CASE_DONE ' <<< "$output" || true)
+    [ -n "$case_line" ] || { fail "$name: completion token missing"; return; }
+    rc=${case_line#*rc=}
+    rc=${rc%% *}
+    coverage_line=${case_line#*coverage=}
+    [ "$rc" -eq "$expected_rc" ] || fail "$name: expected rc $expected_rc, got $rc"
+    [ "$coverage_line" = "$expected_coverage" ] || fail "$name: expected coverage [$expected_coverage], got [$coverage_line]"
+}
+
+run_case clean 0 "$TMP_ROOT/clean.json" 'evaluated: 0 stall-state marker(s) observed (point-in-time)'
+run_case active_stream 0 "$TMP_ROOT/active_stream.json" 'evaluated: 0 stall-state marker(s) observed (point-in-time)'
+run_case recovering 0 "$TMP_ROOT/recovering.json" 'not evaluated: startup recovery in progress'
+run_case tmux_alive_relay_dead 1 "$TMP_ROOT/tmux_dead.json" 'evaluated: 1 stall-state marker(s) observed (point-in-time)'
+run_case stale_thread_proof 1 "$TMP_ROOT/stale_thread.json" 'evaluated: 1 stall-state marker(s) observed (point-in-time)'
+run_case orphan_pending_token 1 "$TMP_ROOT/orphan_token.json" 'evaluated: 1 stall-state marker(s) observed (point-in-time)'
+run_case observations 0 "$TMP_ROOT/observations.json" 'evaluated: 0 stall-state marker(s) observed (point-in-time)'
+run_case malformed 1 "$TMP_ROOT/malformed.json" 'unevaluable: health/detail scan failed'
+run_case malformed_json 1 "$TMP_ROOT/malformed_json.json" 'unevaluable: health/detail scan failed'
+run_case empty_mailboxes 1 "$TMP_ROOT/empty_mailboxes.json" 'unevaluable: health/detail scan failed'
+run_case root_scalar 1 "$TMP_ROOT/root_scalar.json" 'unevaluable: health/detail scan failed'
+run_case recovery_missing 1 "$TMP_ROOT/recovery_missing.json" 'unevaluable: health/detail scan failed'
+run_case mailbox_scalar 1 "$TMP_ROOT/mailbox_scalar.json" 'unevaluable: health/detail scan failed'
+run_case mailbox_missing_state 1 "$TMP_ROOT/mailbox_missing_state.json" 'unevaluable: health/detail scan failed'
+run_case recovery_string 1 "$TMP_ROOT/recovery_string.json" 'unevaluable: health/detail scan failed'
+
+missing_body_output=$(bash -s -- "$REGION" <<'CHILD'
+set -euo pipefail
+eval "$(<"$1")"
+POST_DEPLOY_SMOKE_EVIDENCE="${TMPDIR:-/tmp}/5244-missing.evidence"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY=""
+POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+if _post_deploy_smoke_check_wedges; then rc=0; else rc=$?; fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+)
+grep -q 'CASE_DONE rc=1 coverage=unevaluable: /api/health/detail body unavailable' <<< "$missing_body_output" || fail 'body-unavailable case did not fail with unevaluable coverage'
+
+# Missing jq is separated by command -v. All other scan failures use the
+# deliberate broad (a) vocabulary. An empty PATH is applied after eval.
+jq_missing_output=$(bash -s -- "$REGION" "$TMP_ROOT/clean.json" <<'CHILD'
+set -euo pipefail
+eval "$(<"$1")"
+POST_DEPLOY_SMOKE_EVIDENCE="${TMPDIR:-/tmp}/5244-jq-missing.evidence"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$2"
+POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+PATH="${TMPDIR:-/tmp}/does-not-contain-jq"
+if _post_deploy_smoke_check_wedges; then rc=0; else rc=$?; fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+)
+grep -q 'CASE_DONE rc=1 coverage=unevaluable: jq unavailable' <<< "$jq_missing_output" || fail 'jq-unavailable case did not use separate vocabulary'
+
+# Contract guard cases: no arithmetic is allowed, and each malformed count is
+# asserted through the function's own return and coverage result.
+run_contract_case() {
+    local label="$1" encoded_count="$2"
+    local output
+    output=$(COUNT_VALUE="$encoded_count" bash -s -- "$REGION" "$TMP_ROOT/clean.json" <<'CHILD'
+set -euo pipefail
+eval "$(<"$1")"
+POST_DEPLOY_SMOKE_EVIDENCE="${TMPDIR:-/tmp}/5244-contract.evidence"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$2"
+POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
+_post_deploy_smoke_wedge_scan_from_file() {
+    printf 'recovered=true\ncount=%s\nmarker=fake\n' "$COUNT_VALUE"
+}
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+if _post_deploy_smoke_check_wedges; then rc=0; else rc=$?; fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+    )
+    grep -q 'CASE_DONE rc=1 coverage=unevaluable: wedge scan output contract violated' <<< "$output" || fail "$label: malformed count was accepted"
+}
+run_contract_case count_10x '10x'
+run_contract_case count_space '10 2'
+run_contract_case count_newline $'10\n2'
+run_contract_case count_08 '08'
+run_contract_case count_negative '-1'
+run_contract_case count_empty ''
+
+# The recovery gate is global: a valid body is reportable as not evaluated,
+# while malformed mailbox evidence remains unevaluable rather than vanishing.
+observation_output=$(bash -s -- "$REGION" "$TMP_ROOT/observations.json" <<'CHILD'
+set -euo pipefail
+eval "$(<"$1")"
+POST_DEPLOY_SMOKE_EVIDENCE="${TMPDIR:-/tmp}/5244-observation.evidence"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$2"
+POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+if _post_deploy_smoke_check_wedges; then rc=0; else rc=$?; fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+)
+grep -q 'relay wedge observation: queue_blocked' <<< "$observation_output" || fail 'queue_blocked was not reported as an observation'
+grep -q 'relay wedge observation: unknown_stall_state' <<< "$observation_output" || fail 'unknown stall was not reported as an observation'
+
+# H3: disposition wording is driven by coverage, while FAIL remains fail-open.
+DISPOSITION="$TMP_ROOT/disposition.sh"
+disposition_begin=$(grep -nF '# >>> BEGIN smoke-disposition region (#5244)' "$DEPLOY_SH" | cut -d: -f1)
+disposition_end=$(grep -nF '# <<< END smoke-disposition region (#5244)' "$DEPLOY_SH" | cut -d: -f1)
+sed -n "$((disposition_begin + 1)),$((disposition_end - 1))p" "$DEPLOY_SH" > "$DISPOSITION"
+disposition_case() {
+    local label="$1" smoke_rc="$2" coverage="$3" expected="$4"
+    local output
+    output=$(SMOKE_RC="$smoke_rc" COVERAGE="$coverage" bash -s -- "$DISPOSITION" <<'CHILD'
+set -euo pipefail
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="$COVERAGE"
+POST_DEPLOY_SMOKE_EVIDENCE=/tmp/5244-disposition.evidence
+POST_DEPLOY_SMOKE_TMP_DIR=""
+POST_DEPLOY_SMOKE_FAILURES=()
+_run_post_deploy_functional_smoke() { return "$SMOKE_RC"; }
+_report_post_deploy_smoke_failure() { printf 'REPORT_CALLED\n'; }
+eval "$(<"$1")"
+printf 'CASE_DONE disposition\n'
+CHILD
+    )
+    grep -q 'CASE_DONE disposition' <<< "$output" || fail "$label: disposition completion token missing"
+    grep -q "$expected" <<< "$output" || fail "$label: expected [$expected]"
+}
+disposition_case evaluated_clean 0 'evaluated: 0 stall-state marker(s) observed (point-in-time)' 'passed (relay wedge coverage:'
+disposition_case coverage_gap 0 'not evaluated: startup recovery in progress' 'completed with coverage gap'
+disposition_case failed 1 'unevaluable: health/detail scan failed' 'REPORT_CALLED'
+
+if [ "$failures" -ne 0 ]; then
+    printf 'test_deploy_smoke_wedge_coverage_5244: %s assertion(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'test_deploy_smoke_wedge_coverage_5244: all assertions passed\n'


### PR DESCRIPTION
Closes #5244. **재구성 브랜치** — 기존 `wt/5244-skip-accounting`(PR #5267)은 폐기하고 읽기만 했다(cherry-pick 없음).

## 재프레이밍 — 탐지 결함이 아니라 **보고 결함**이다

이 스모크는 **DEPLOY_OK 이후에 실행되며 어떤 결과도 배포를 막지 않는다**(fail-open INVARIANT). 즉 유일한 산출물은 **보고**다. 그런데 코드가 "평가 불가"를 알고 있는데 출력은 "통과"라고 말했다.

그리고 #5265 가 확정한 대로 **탐지 자체가 건전하지 않으므로 "wedge 를 정확히 세는 것"은 목적이 될 수 없다.** 건전하지 않은 탐지기에서 남는 것은 정확히 하나 — **커버리지의 정직성**이다.

**세 기계를 전부 삭제했다**: ① wait 루프 ② 영속 tally(`consecutive_skips` + `.corrupt` 형제) ③ 2샘플 marker 교차(`sleep` + 재샘플 + `comm -12`). 남는 것은 **3-값 보고**다: `evaluated` / `not run` / `unevaluable`.

## 설계 적대 리뷰의 GO 조건 4건 (전부 반영)

- **GO-1 — 설계의 주장이 코드로 반증됐다.** 설계는 `tmux_alive_relay_dead` / `stale_thread_proof` / `orphan_pending_token` 세 상태를 "외부 개입 없이 안 풀린다"고 분류하고 1회 샘플을 `WEDGE` 로 승격했다. 그런데 stall watchdog 이 **매 tick 자동 복구를 돌린다** — `relay_dead_reattach::try_apply`(`health/recovery.rs:1728-1739`), `run_orphan_token_auto_heal_pass`(`:2145`), 그리고 `StaleThreadProof` 는 영속 latch 가 아니라 **매 snapshot 재계산**된다(`health/snapshot.rs:317-335`). → **point-in-time stall-state marker** 로 축소했고, 2샘플 삭제로 **포기한 transient 억제 방어를 명시**했다.
- **GO-2 — 한 rc 권위가 서로 다른 실패를 오분류했다.** schema `error()` / 파일 소실 / redirection 실패 / jq filter compile 실패 / 실행파일 고장 / signal·OOM 이 전부 `schema invalid` 가 됐다. 어휘를 `unevaluable: health/detail scan failed` 로 넓히고 보장 범위를 좁혔다(`jq` 부재만 별도 어휘로 분리). 병합 필터가 `fully_recovered=false` 여도 전 mailbox 를 검증해 **무관한 mailbox 하나가 전체를 unevaluable 로** 만드는 결합도 선언했다.
- **GO-3 — "정규식 가드"가 정규식이 아니라 shell glob 이었다.** `case ... [1-9][0-9]*)` 의 마지막 `*` 는 digit 반복이 아니라 임의 suffix라, Bash 3.2 실측에서 `10x` / `10 2` / 개행 포함이 전부 **PASS** 했다. 실제 digit-only + no-leading-zero 검사로 교체했다. **셸 산술은 여전히 0회** — count 는 jq 가 검증된 배열의 `length` 로 canonical decimal 을 내고 셸은 보간만 한다.
- **GO-4 — "Discord 로 확실히 도달" 은 코드가 보장하지 않는다.** `_notify_channel` 은 `REPORT_CHANNEL_ID` 가 비면 즉시 성공 반환하고 curl 실패를 `|| true` 로 삼킨다. 권위를 **"Discord 호출을 best-effort 로 시도"** 로 축소했다. 함수 본체는 **바이트 동일**(#5274 레인 소유, 무침범).

## 뮤테이션

**16/16 KILLED, 문법 사망 0건.** 전부 `bash -n` rc=0 인 상태에서 자기 assert 로 죽는다.

## 예산

| | production | test |
|---|---:|---:|
| 기존 브랜치 | **+579 (net)** | **904** |
| 본 PR | **+9** | **259** |

`deploy-release.sh` +5, `ci-script-checks.sh` +4. production 이 설계 추정(≈ −10)보다 19줄 많고, 보고서가 그 초과를 숨기지 않고 명시한다.

## 이 게이트가 보장하지 않는 것 (10항, 요약)

배포 차단·롤백 / 건전한 wedge 검출(#5265) / durable 축 관측(#5264) / **transient 대 persistent 구분** / 배포 간 누적 상태 / 복구 완료 대기 / wedge 해소 / `relay_owner_kind` ownerless 판정 / **스모크 전체 종료성(#5274 범위)** / `degraded_reasons` 독립 승격.

이 열거가 설계의 본체다 — 지우지 말 것.

리뷰 중: 독립 2 leg.
