### PR TITLE
fix(db): enforce PostgreSQL fixture target authority (#5229 slice A)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -119,6 +119,7 @@ src/
 │   ├── cancel_tombstones.rs
 │   ├── dispatch_semaphores.rs
 │   ├── dispatched_sessions.rs
+│   ├── fixture_target.rs
 │   ├── idempotency.rs
 │   ├── intake_outbox.rs
 │   ├── kanban.rs

--- a/docs/auto-queue-preflight.md
+++ b/docs/auto-queue-preflight.md
@@ -76,5 +76,8 @@ without a visible reason, diagnostics that omit correlation ids, or any default
 sandbox mutation of production cards, PR/branch tracking, live sessions,
 dispatch delivery, channel messages, or worktree/branch context.
 
-Requirements: the same local PostgreSQL test environment used by the repo's
-Postgres-backed tests (`POSTGRES_TEST_DATABASE_URL_BASE` or `PG*` variables).
+Requirements: explicitly set `POSTGRES_TEST_DATABASE_URL_BASE` to the same local
+PostgreSQL test server used by the repo's Postgres-backed tests. Its URL
+authority must include both host and port. `PG*` variables may still supply
+credentials or fixture database names, but they do not select or authorize a
+fixture server on their own.

--- a/docs/auto-queue-preflight.md
+++ b/docs/auto-queue-preflight.md
@@ -76,8 +76,8 @@ without a visible reason, diagnostics that omit correlation ids, or any default
 sandbox mutation of production cards, PR/branch tracking, live sessions,
 dispatch delivery, channel messages, or worktree/branch context.
 
-Requirements: explicitly set `POSTGRES_TEST_DATABASE_URL_BASE` to the same local
-PostgreSQL test server used by the repo's Postgres-backed tests. Its URL
-authority must include both host and port. `PG*` variables may still supply
-credentials or fixture database names, but they do not select or authorize a
-fixture server on their own.
+Requirements: set `POSTGRES_TEST_DATABASE_URL_BASE` to the local test server URL
+with an explicit TCP host and port. For Config fixtures, its `sslmode` must match
+the Config-derived options; when `PGSSLMODE` is unset, omit it or use `prefer`.
+`PG*` variables may supply credentials or database names, but do not authorize
+a server alone.

--- a/docs/ci/release-gates.md
+++ b/docs/ci/release-gates.md
@@ -359,7 +359,7 @@ high_risk_recovery: # ci-pr.yml only additions
 
 ### Pool sizing
 
-- pool=1 은 공용 상수 `TEST_POSTGRES_POOL_MAX_CONNECTIONS`(`src/db/postgres.rs:1174`)가 강제한다. 단일 connection 이므로 startup reconcile 이 runtime pool 을 점유한 채 끝나면 곧바로 pool timeout 으로 드러난다.
+- pool=1 은 `src/db/postgres.rs`의 공용 상수 `TEST_POSTGRES_POOL_MAX_CONNECTIONS`가 강제한다. 단일 connection 이므로 startup reconcile 이 runtime pool 을 점유한 채 끝나면 곧바로 pool timeout 으로 드러난다.
 - ⚠️ 이전 판이 인용하던 `pg_recovery_test_config` 와 `scenario_969_pg_boot_reconcile_uses_startup_pool_without_pool_timeout_logs` 는 **코드에 존재하지 않는다**(`git grep` 0건). 이 문서에 심볼을 적을 때는 실재를 확인하고 적는다.
 
 ## 5. Triage 분류 규약

--- a/justfile
+++ b/justfile
@@ -149,7 +149,7 @@ test-non-pg:
 # are intentionally excluded; add a separate PG lane command if either gains PG coverage.
 # The fixture server must be explicit; PG* variables alone are not authorization.
 test-postgres:
-    @test -n "$${POSTGRES_TEST_DATABASE_URL_BASE:-}" || (echo "POSTGRES_TEST_DATABASE_URL_BASE must name the dedicated PostgreSQL test server with an explicit host and port" >&2; exit 1)
+    @test -n "${POSTGRES_TEST_DATABASE_URL_BASE:-}" || (echo "POSTGRES_TEST_DATABASE_URL_BASE must name the dedicated PostgreSQL test server with an explicit host and port" >&2; exit 1)
     cargo test --lib -- _pg pg_ postgres --nocapture --test-threads=1
 
 check: fmt-check lint cargo-check test

--- a/justfile
+++ b/justfile
@@ -147,7 +147,9 @@ test-non-pg:
 
 # PostgreSQL tests belong in the library harness. Integration and doctest targets
 # are intentionally excluded; add a separate PG lane command if either gains PG coverage.
+# The fixture server must be explicit; PG* variables alone are not authorization.
 test-postgres:
+    @test -n "$${POSTGRES_TEST_DATABASE_URL_BASE:-}" || (echo "POSTGRES_TEST_DATABASE_URL_BASE must name the dedicated PostgreSQL test server with an explicit host and port" >&2; exit 1)
     cargo test --lib -- _pg pg_ postgres --nocapture --test-threads=1
 
 check: fmt-check lint cargo-check test

--- a/scripts/ci/non-pg-test-filter.sh
+++ b/scripts/ci/non-pg-test-filter.sh
@@ -17,7 +17,7 @@ done
 unset index
 readonly -a PG_INCLUDE_ARGS
 
-# The broad substring filter also matches these 15 source-verified library
+# The broad substring filter also matches these 14 source-verified library
 # tests even though their bodies do not connect to PostgreSQL. Replay all of
 # them in the full non-PG sweeps to preserve their macOS/Windows coverage.
 NON_PG_FILTER_FALSE_POSITIVES=(
@@ -32,7 +32,6 @@ NON_PG_FILTER_FALSE_POSITIVES=(
   db::postgres::tests::clamp_foreground_reserve_always_leaves_a_background_slot
   db::postgres::tests::runtime_pool_settings_enable_dead_peer_detection
   db::postgres::tests::startup_pool_settings_raise_pool_size_and_acquire_timeout
-  db::postgres::tests::test_database_server_identity_normalizes_loopback_aliases_without_collisions
   reconcile::dispatch_delivery_reconcile_tests::dispatch_delivery_reconcile_classifies_rows_without_postgres
   services::discord::turn_bridge::completion_guard::completion_postgres::runtime_completion_policy_tests::runtime_auto_queue_terminal_sync_matches_dispatch_completion_policy
   services::observability::cancellation_observability_tests::turn_cancelled_emit_records_normalized_payload_without_pg

--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -360,6 +360,13 @@ db::dispatches::metadata::tests::parse_pg_dispatch_context_ignores_empty_context
 db::dispatches::metadata::tests::parse_pg_dispatch_context_rejects_malformed_json
 db::dispatches::metadata::tests::parse_pg_dispatch_context_rejects_non_object_context
 db::dispatches::outbox::delivery::tests::old_owner_completion_after_stale_reclaim_is_noop_pg
+db::fixture_target::tests::config_representation_rejects_socket_transport
+db::fixture_target::tests::endpoint_enumeration_matrix_has_no_ambient_authority
+db::fixture_target::tests::explicit_authority_fields_are_required
+db::fixture_target::tests::loopback_aliases_normalize_without_collisions
+db::fixture_target::tests::mismatch_is_always_a_hard_failure
+db::fixture_target::tests::socket_transport_precedes_host_transport
+db::fixture_target::tests::tls_routing_is_part_of_identity
 db::idempotency::tests::fingerprint_differs_when_body_changes
 db::idempotency::tests::fingerprint_differs_when_path_changes
 db::idempotency::tests::fingerprint_handles_non_json_body
@@ -435,7 +442,6 @@ db::postgres::tests::require_pg_guard_preserves_errors_when_ci_lane_does_not_req
 db::postgres::tests::runtime_pool_settings_enable_dead_peer_detection
 db::postgres::tests::startup_pool_settings_raise_pool_size_and_acquire_timeout
 db::postgres::tests::sync_agents_writes_and_preserves_preferred_intake_node_labels
-db::postgres::tests::test_database_server_identity_normalizes_loopback_aliases_without_collisions
 db::postgres::tests::worker_node_reseed_does_not_clobber_shared_agent_roster
 db::prompt_manifests::tests::manifest_storage_stats_counts_utf8_bytes_not_chars_pg
 db::prompt_manifests::tests::prompt_manifest_apply_retention_trims_old_full_content_pg

--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -361,12 +361,14 @@ db::dispatches::metadata::tests::parse_pg_dispatch_context_rejects_malformed_jso
 db::dispatches::metadata::tests::parse_pg_dispatch_context_rejects_non_object_context
 db::dispatches::outbox::delivery::tests::old_owner_completion_after_stale_reclaim_is_noop_pg
 db::fixture_target::tests::config_representation_rejects_socket_transport
+db::fixture_target::tests::configured_target_rejects_changed_host
+db::fixture_target::tests::configured_target_rejects_changed_port
 db::fixture_target::tests::endpoint_enumeration_matrix_has_no_ambient_authority
 db::fixture_target::tests::explicit_authority_fields_are_required
 db::fixture_target::tests::loopback_aliases_normalize_without_collisions
-db::fixture_target::tests::mismatch_is_always_a_hard_failure
 db::fixture_target::tests::socket_transport_precedes_host_transport
 db::fixture_target::tests::tls_routing_is_part_of_identity
+db::fixture_target::tests::unconfigured_target_is_rejected_without_panicking
 db::idempotency::tests::fingerprint_differs_when_body_changes
 db::idempotency::tests::fingerprint_differs_when_path_changes
 db::idempotency::tests::fingerprint_handles_non_json_body

--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -365,7 +365,7 @@ db::fixture_target::tests::configured_target_rejects_changed_host
 db::fixture_target::tests::configured_target_rejects_changed_port
 db::fixture_target::tests::endpoint_enumeration_matrix_has_no_ambient_authority
 db::fixture_target::tests::explicit_authority_fields_are_required
-db::fixture_target::tests::loopback_aliases_normalize_without_collisions
+db::fixture_target::tests::loopback_aliases_share_a_label_but_raw_host_discriminates
 db::fixture_target::tests::socket_transport_precedes_host_transport
 db::fixture_target::tests::tls_routing_is_part_of_identity
 db::fixture_target::tests::unconfigured_target_is_rejected_without_panicking

--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -365,7 +365,7 @@ db::fixture_target::tests::configured_target_rejects_changed_host
 db::fixture_target::tests::configured_target_rejects_changed_port
 db::fixture_target::tests::endpoint_enumeration_matrix_has_no_ambient_authority
 db::fixture_target::tests::explicit_authority_fields_are_required
-db::fixture_target::tests::loopback_aliases_share_a_label_but_raw_host_discriminates
+db::fixture_target::tests::raw_tcp_hosts_discriminate
 db::fixture_target::tests::socket_transport_precedes_host_transport
 db::fixture_target::tests::tls_routing_is_part_of_identity
 db::fixture_target::tests::unconfigured_target_is_rejected_without_panicking
@@ -425,6 +425,7 @@ db::postgres::tests::core_status_constraints_reject_invalid_values_and_allow_val
 db::postgres::tests::deploy_gate_constraint_allows_supported_legacy_values_and_rejects_deploy_gate
 db::postgres::tests::deploy_gate_constraint_migration_blocks_existing_deploy_gate_rows
 db::postgres::tests::deploy_gate_constraint_serializes_concurrent_legacy_writer
+db::postgres::tests::ownership_registry_key_matches_between_admin_url_and_config_options
 db::postgres::tests::postgres_advisory_lock_lease_allows_only_one_live_holder
 db::postgres::tests::postgres_advisory_lock_lease_does_not_exhaust_shared_pool
 db::postgres::tests::postgres_advisory_lock_lease_releases_on_drop_across_separate_pools

--- a/src/db/fixture_target.rs
+++ b/src/db/fixture_target.rs
@@ -8,7 +8,6 @@
 //! peer.
 
 use std::fmt;
-use std::net::IpAddr;
 use std::str::FromStr;
 
 use sqlx::postgres::{PgConnectOptions, PgSslMode};
@@ -24,7 +23,7 @@ pub(super) struct ParsedFixtureUrl {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum FixtureTransport {
     Socket(String),
-    Tcp(String),
+    Tcp,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -42,7 +41,6 @@ struct FixtureIdentity {
     transport: FixtureTransport,
     port: u16,
     routing_host: String,
-    tcp_connect_host: Option<String>,
     tls_mode: TlsMode,
 }
 
@@ -50,40 +48,9 @@ impl fmt::Display for FixtureIdentity {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             formatter,
-            "{:?}:{};route={};tcp-host={:?};tls={:?}",
-            self.transport, self.port, self.routing_host, self.tcp_connect_host, self.tls_mode
+            "{:?}:{};route={};tls={:?}",
+            self.transport, self.port, self.routing_host, self.tls_mode
         )
-    }
-}
-
-fn normalized_host(host: &str) -> String {
-    let host = host.trim();
-    // Strip a DNS-style trailing dot before removing IPv6 brackets so both
-    // `[::1]` and `[::1].` reach the same canonical parser input. Preserve
-    // Unix-socket paths verbatim below; a path is not a DNS host name.
-    let host_for_ip_or_hostname = host.trim_end_matches('.');
-    let unbracketed_host = host_for_ip_or_hostname
-        .strip_prefix('[')
-        .and_then(|value| value.strip_suffix(']'))
-        .unwrap_or(host_for_ip_or_hostname);
-    let normalized = if let Ok(address) = unbracketed_host.parse::<IpAddr>() {
-        // Canonicalize first: long-form IPv6 loopback parses to `::1`, so the
-        // alias match below covers every equivalent textual representation.
-        address.to_string()
-    } else if host.starts_with('/') {
-        host.to_string()
-    } else {
-        unbracketed_host.to_ascii_lowercase()
-    };
-    match normalized.as_str() {
-        "localhost" | "127.0.0.1" | "::1" => {
-            // Keep one recognizable label for loopback spellings while the raw
-            // host field below remains the authority discriminator. Angle
-            // brackets cannot occur in a URL host, so the sentinel cannot
-            // collide with a real DNS hostname such as `loopback`.
-            "<loopback>".to_string()
-        }
-        _ => normalized,
     }
 }
 
@@ -100,33 +67,17 @@ fn tls_mode(options: &PgConnectOptions) -> TlsMode {
 
 fn fixture_identity(options: &PgConnectOptions) -> FixtureIdentity {
     let raw_host = options.get_host().to_string();
-    let normalized_host = normalized_host(options.get_host());
-    // TCP uses the raw host for both connect and TLS; socket transport uses it
-    // only for TLS routing. Keep the relevant raw value in a distinct field.
-    let (transport, routing_host, tcp_connect_host) = if let Some(socket) = options.get_socket() {
-        (
-            FixtureTransport::Socket(socket.to_string_lossy().into_owned()),
-            raw_host,
-            None,
-        )
+    let transport = if let Some(socket) = options.get_socket() {
+        FixtureTransport::Socket(socket.to_string_lossy().into_owned())
     } else if options.get_host().starts_with('/') {
-        (
-            FixtureTransport::Socket(options.get_host().to_string()),
-            raw_host,
-            None,
-        )
+        FixtureTransport::Socket(options.get_host().to_string())
     } else {
-        (
-            FixtureTransport::Tcp(normalized_host.clone()),
-            normalized_host,
-            Some(raw_host),
-        )
+        FixtureTransport::Tcp
     };
     FixtureIdentity {
         transport,
         port: options.get_port(),
-        routing_host,
-        tcp_connect_host,
+        routing_host: raw_host,
         tls_mode: tls_mode(options),
     }
 }
@@ -206,12 +157,7 @@ pub(super) fn options_match(
 ) -> Result<(), String> {
     let base = fixture_identity(base_options);
     let candidate = fixture_identity(candidate_options);
-    if candidate.transport == base.transport
-        && candidate.port == base.port
-        && candidate.routing_host == base.routing_host
-        && candidate.tcp_connect_host == base.tcp_connect_host
-        && candidate.tls_mode == base.tls_mode
-    {
+    if candidate == base {
         return Ok(());
     }
     Err(format!(
@@ -388,32 +334,10 @@ mod tests {
     }
 
     #[test]
-    fn loopback_aliases_share_a_label_but_raw_host_discriminates() {
-        let expected = normalized_host("localhost");
-        for host in [
-            "localhost",
-            "127.0.0.1",
-            "127.0.0.1.",
-            "::1",
-            "[::1]",
-            "[::1].",
-            "0:0:0:0:0:0:0:1",
-            "LOCALHOST.",
-        ] {
-            assert_eq!(
-                normalized_host(host),
-                expected,
-                "loopback spelling {host:?}"
-            );
-        }
-        assert_ne!(expected, normalized_host("loopback"));
-
+    fn raw_tcp_hosts_discriminate() {
         let ipv4 = parsed("postgresql://user@127.0.0.1:15432/root?sslmode=disable");
         let ipv6 = parsed("postgresql://user@[::1]:15432/db?sslmode=disable");
-        assert!(
-            options_match(&ipv4.options, &ipv6.options).is_err(),
-            "distinct IPv4 and IPv6 listeners must not share target authority"
-        );
+        assert!(options_match(&ipv4.options, &ipv6.options).is_err());
     }
 
     #[test]

--- a/src/db/fixture_target.rs
+++ b/src/db/fixture_target.rs
@@ -177,7 +177,11 @@ pub(super) fn options_match(
 ) -> Result<(), String> {
     let base = fixture_identity(base_options);
     let candidate = fixture_identity(candidate_options);
-    if candidate == base {
+    if candidate.transport == base.transport
+        && candidate.port == base.port
+        && candidate.routing_host == base.routing_host
+        && candidate.tls_mode == base.tls_mode
+    {
         return Ok(());
     }
     Err(format!(
@@ -198,15 +202,11 @@ pub(super) fn config_base_is_representable(parsed_base: &ParsedFixtureUrl) -> Re
 pub(super) fn enforce_configured_target(
     configured_base: Option<&str>,
     candidate_options: &PgConnectOptions,
-) {
-    let result = (|| {
-        let base = configured_base.ok_or_else(|| {
-            "fixture base unconfigured (POSTGRES_TEST_DATABASE_URL_BASE)".to_string()
-        })?;
-        let parsed_base = parse_fixture_url(base, "configured PostgreSQL fixture base")?;
-        options_match(&parsed_base.options, candidate_options)
-    })();
-    result.unwrap_or_else(|error| panic!("unsafe PostgreSQL fixture target: {error}"));
+) -> Result<(), String> {
+    let base = configured_base
+        .ok_or_else(|| "fixture base unconfigured (POSTGRES_TEST_DATABASE_URL_BASE)".to_string())?;
+    let parsed_base = parse_fixture_url(base, "configured PostgreSQL fixture base")?;
+    options_match(&parsed_base.options, candidate_options)
 }
 
 #[cfg(test)]
@@ -384,14 +384,29 @@ mod tests {
     }
 
     #[test]
-    fn mismatch_is_always_a_hard_failure() {
+    fn configured_target_rejects_changed_host() {
         let candidate = parsed("postgresql://user@other.example:15432/db?sslmode=disable");
-        let panic = std::panic::catch_unwind(|| {
-            enforce_configured_target(
-                Some("postgresql://user@db.example:15432/root?sslmode=disable"),
-                &candidate.options,
-            );
-        });
-        assert!(panic.is_err(), "a target mismatch must panic");
+        let result = enforce_configured_target(
+            Some("postgresql://user@db.example:15432/root?sslmode=disable"),
+            &candidate.options,
+        );
+        assert!(result.is_err(), "a changed host must be rejected");
+    }
+
+    #[test]
+    fn configured_target_rejects_changed_port() {
+        let candidate = parsed("postgresql://user@db.example:15433/db?sslmode=disable");
+        let result = enforce_configured_target(
+            Some("postgresql://user@db.example:15432/root?sslmode=disable"),
+            &candidate.options,
+        );
+        assert!(result.is_err(), "a changed port must be rejected");
+    }
+
+    #[test]
+    fn unconfigured_target_is_rejected_without_panicking() {
+        let candidate = parsed("postgresql://user@127.0.0.1:5432/db?sslmode=disable");
+        let result = enforce_configured_target(None, &candidate.options);
+        assert!(result.is_err(), "an ambient target must be rejected");
     }
 }

--- a/src/db/fixture_target.rs
+++ b/src/db/fixture_target.rs
@@ -3,8 +3,9 @@
 //! SQLx 0.8.6 chooses a physical peer from `socket`, `host`, and `port`, then
 //! uses `host` plus `ssl_mode` while negotiating TLS. Fixture authorization
 //! therefore compares both the physical peer and those TLS routing inputs.
-//! URL authority host and port must be explicit so `PGHOST`, `PGPORT`, and
-//! SQLx's filesystem-based default-host probe cannot select the peer.
+//! URL authority host and port must be explicit so `PGHOSTADDR`, `PGHOST`,
+//! `PGPORT`, and SQLx's filesystem-based default-host probe cannot select the
+//! peer.
 
 use std::fmt;
 use std::net::IpAddr;
@@ -41,6 +42,7 @@ struct FixtureIdentity {
     transport: FixtureTransport,
     port: u16,
     routing_host: String,
+    tcp_connect_host: Option<String>,
     tls_mode: TlsMode,
 }
 
@@ -48,20 +50,25 @@ impl fmt::Display for FixtureIdentity {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             formatter,
-            "{:?}:{};route={};tls={:?}",
-            self.transport, self.port, self.routing_host, self.tls_mode
+            "{:?}:{};route={};tcp-host={:?};tls={:?}",
+            self.transport, self.port, self.routing_host, self.tcp_connect_host, self.tls_mode
         )
     }
 }
 
 fn normalized_host(host: &str) -> String {
     let host = host.trim();
+    // Strip a DNS-style trailing dot before removing IPv6 brackets so both
+    // `[::1]` and `[::1].` reach the same canonical parser input. Preserve
+    // Unix-socket paths verbatim below; a path is not a DNS host name.
     let host_for_ip_or_hostname = host.trim_end_matches('.');
     let unbracketed_host = host_for_ip_or_hostname
         .strip_prefix('[')
         .and_then(|value| value.strip_suffix(']'))
         .unwrap_or(host_for_ip_or_hostname);
     let normalized = if let Ok(address) = unbracketed_host.parse::<IpAddr>() {
+        // Canonicalize first: long-form IPv6 loopback parses to `::1`, so the
+        // alias match below covers every equivalent textual representation.
         address.to_string()
     } else if host.starts_with('/') {
         host.to_string()
@@ -69,7 +76,13 @@ fn normalized_host(host: &str) -> String {
         unbracketed_host.to_ascii_lowercase()
     };
     match normalized.as_str() {
-        "localhost" | "127.0.0.1" | "::1" => "<loopback>".to_string(),
+        "localhost" | "127.0.0.1" | "::1" => {
+            // Keep one recognizable label for loopback spellings while the raw
+            // host field below remains the authority discriminator. Angle
+            // brackets cannot occur in a URL host, so the sentinel cannot
+            // collide with a real DNS hostname such as `loopback`.
+            "<loopback>".to_string()
+        }
         _ => normalized,
     }
 }
@@ -86,18 +99,34 @@ fn tls_mode(options: &PgConnectOptions) -> TlsMode {
 }
 
 fn fixture_identity(options: &PgConnectOptions) -> FixtureIdentity {
-    let routing_host = normalized_host(options.get_host());
-    let transport = if let Some(socket) = options.get_socket() {
-        FixtureTransport::Socket(socket.to_string_lossy().into_owned())
+    let raw_host = options.get_host().to_string();
+    let normalized_host = normalized_host(options.get_host());
+    // TCP uses the raw host for both connect and TLS; socket transport uses it
+    // only for TLS routing. Keep the relevant raw value in a distinct field.
+    let (transport, routing_host, tcp_connect_host) = if let Some(socket) = options.get_socket() {
+        (
+            FixtureTransport::Socket(socket.to_string_lossy().into_owned()),
+            raw_host,
+            None,
+        )
     } else if options.get_host().starts_with('/') {
-        FixtureTransport::Socket(options.get_host().to_string())
+        (
+            FixtureTransport::Socket(options.get_host().to_string()),
+            raw_host,
+            None,
+        )
     } else {
-        FixtureTransport::Tcp(routing_host.clone())
+        (
+            FixtureTransport::Tcp(normalized_host.clone()),
+            normalized_host,
+            Some(raw_host),
+        )
     };
     FixtureIdentity {
         transport,
         port: options.get_port(),
         routing_host,
+        tcp_connect_host,
         tls_mode: tls_mode(options),
     }
 }
@@ -180,6 +209,7 @@ pub(super) fn options_match(
     if candidate.transport == base.transport
         && candidate.port == base.port
         && candidate.routing_host == base.routing_host
+        && candidate.tcp_connect_host == base.tcp_connect_host
         && candidate.tls_mode == base.tls_mode
     {
         return Ok(());
@@ -230,7 +260,7 @@ mod tests {
             (
                 "authority-host",
                 "postgresql://user@DB.EXAMPLE:15432/db?sslmode=disable",
-                true,
+                false,
             ),
             (
                 "socket-authority",
@@ -324,7 +354,7 @@ mod tests {
             "postgresql://route.example:secret@db.example:15432/root?sslmode=disable&host=%2Ftmp%2Fsafe",
         );
         let same = parsed(
-            "postgresql://route.example:secret@DB.EXAMPLE:15432/db?sslmode=disable&host=%2Ftmp%2Fsafe",
+            "postgresql://route.example:secret@db.example:15432/db?sslmode=disable&host=%2Ftmp%2Fsafe",
         );
         let other_socket = parsed(
             "postgresql://route.example:secret@db.example:15432/db?sslmode=disable&host=%2Ftmp%2Fother",
@@ -358,16 +388,8 @@ mod tests {
     }
 
     #[test]
-    fn loopback_aliases_normalize_without_collisions() {
-        fn identity(host: &str) -> String {
-            server_identity(
-                &PgConnectOptions::new()
-                    .host(host)
-                    .port(15432)
-                    .ssl_mode(PgSslMode::Disable),
-            )
-        }
-        let expected = identity("localhost");
+    fn loopback_aliases_share_a_label_but_raw_host_discriminates() {
+        let expected = normalized_host("localhost");
         for host in [
             "localhost",
             "127.0.0.1",
@@ -378,9 +400,20 @@ mod tests {
             "0:0:0:0:0:0:0:1",
             "LOCALHOST.",
         ] {
-            assert_eq!(identity(host), expected, "loopback spelling {host:?}");
+            assert_eq!(
+                normalized_host(host),
+                expected,
+                "loopback spelling {host:?}"
+            );
         }
-        assert_ne!(expected, identity("loopback"));
+        assert_ne!(expected, normalized_host("loopback"));
+
+        let ipv4 = parsed("postgresql://user@127.0.0.1:15432/root?sslmode=disable");
+        let ipv6 = parsed("postgresql://user@[::1]:15432/db?sslmode=disable");
+        assert!(
+            options_match(&ipv4.options, &ipv6.options).is_err(),
+            "distinct IPv4 and IPv6 listeners must not share target authority"
+        );
     }
 
     #[test]
@@ -391,6 +424,17 @@ mod tests {
             &candidate.options,
         );
         assert!(result.is_err(), "a changed host must be rejected");
+
+        let socket_candidate =
+            parsed("postgresql://user@other.example:15432/db?sslmode=disable&host=%2Ftmp%2Fsafe");
+        let socket_result = enforce_configured_target(
+            Some("postgresql://user@db.example:15432/root?sslmode=disable&host=%2Ftmp%2Fsafe"),
+            &socket_candidate.options,
+        );
+        assert!(
+            socket_result.is_err(),
+            "a changed TLS routing host over the same socket must be rejected"
+        );
     }
 
     #[test]

--- a/src/db/fixture_target.rs
+++ b/src/db/fixture_target.rs
@@ -1,0 +1,397 @@
+//! Pure PostgreSQL fixture-target parsing and comparison.
+//!
+//! SQLx 0.8.6 chooses a physical peer from `socket`, `host`, and `port`, then
+//! uses `host` plus `ssl_mode` while negotiating TLS. Fixture authorization
+//! therefore compares both the physical peer and those TLS routing inputs.
+//! URL authority host and port must be explicit so `PGHOST`, `PGPORT`, and
+//! SQLx's filesystem-based default-host probe cannot select the peer.
+
+use std::fmt;
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use sqlx::postgres::{PgConnectOptions, PgSslMode};
+use url::Url;
+
+#[derive(Clone, Debug)]
+pub(super) struct ParsedFixtureUrl {
+    pub(super) options: PgConnectOptions,
+    pub(super) password: Option<String>,
+    pub(super) url: Url,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum FixtureTransport {
+    Socket(String),
+    Tcp(String),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TlsMode {
+    Disable,
+    Allow,
+    Prefer,
+    Require,
+    VerifyCa,
+    VerifyFull,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct FixtureIdentity {
+    transport: FixtureTransport,
+    port: u16,
+    routing_host: String,
+    tls_mode: TlsMode,
+}
+
+impl fmt::Display for FixtureIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{:?}:{};route={};tls={:?}",
+            self.transport, self.port, self.routing_host, self.tls_mode
+        )
+    }
+}
+
+fn normalized_host(host: &str) -> String {
+    let host = host.trim();
+    let host_for_ip_or_hostname = host.trim_end_matches('.');
+    let unbracketed_host = host_for_ip_or_hostname
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(host_for_ip_or_hostname);
+    let normalized = if let Ok(address) = unbracketed_host.parse::<IpAddr>() {
+        address.to_string()
+    } else if host.starts_with('/') {
+        host.to_string()
+    } else {
+        unbracketed_host.to_ascii_lowercase()
+    };
+    match normalized.as_str() {
+        "localhost" | "127.0.0.1" | "::1" => "<loopback>".to_string(),
+        _ => normalized,
+    }
+}
+
+fn tls_mode(options: &PgConnectOptions) -> TlsMode {
+    match options.get_ssl_mode() {
+        PgSslMode::Disable => TlsMode::Disable,
+        PgSslMode::Allow => TlsMode::Allow,
+        PgSslMode::Prefer => TlsMode::Prefer,
+        PgSslMode::Require => TlsMode::Require,
+        PgSslMode::VerifyCa => TlsMode::VerifyCa,
+        PgSslMode::VerifyFull => TlsMode::VerifyFull,
+    }
+}
+
+fn fixture_identity(options: &PgConnectOptions) -> FixtureIdentity {
+    let routing_host = normalized_host(options.get_host());
+    let transport = if let Some(socket) = options.get_socket() {
+        FixtureTransport::Socket(socket.to_string_lossy().into_owned())
+    } else if options.get_host().starts_with('/') {
+        FixtureTransport::Socket(options.get_host().to_string())
+    } else {
+        FixtureTransport::Tcp(routing_host.clone())
+    };
+    FixtureIdentity {
+        transport,
+        port: options.get_port(),
+        routing_host,
+        tls_mode: tls_mode(options),
+    }
+}
+
+pub(super) fn server_identity(options: &PgConnectOptions) -> String {
+    fixture_identity(options).to_string()
+}
+
+fn authority_decodes_to_socket(host: &str) -> bool {
+    host.starts_with('/')
+        || host
+            .as_bytes()
+            .get(..3)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"%2f"))
+}
+
+fn decode_percent_encoded(input: &str) -> Result<String, String> {
+    let bytes = input.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            let encoded = bytes
+                .get(index + 1..index + 3)
+                .ok_or_else(|| "truncated percent escape in fixture credential".to_string())?;
+            let encoded = std::str::from_utf8(encoded).map_err(|error| {
+                format!("invalid percent escape in fixture credential: {error}")
+            })?;
+            decoded.push(u8::from_str_radix(encoded, 16).map_err(|error| {
+                format!("invalid percent escape in fixture credential: {error}")
+            })?);
+            index += 3;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+    String::from_utf8(decoded)
+        .map_err(|error| format!("fixture credential is not valid UTF-8: {error}"))
+}
+
+pub(super) fn parse_fixture_url(
+    database_url: &str,
+    label: &str,
+) -> Result<ParsedFixtureUrl, String> {
+    let url = Url::parse(database_url).map_err(|error| format!("{label} parse URL: {error}"))?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| format!("{label} URL authority must explicitly name a host"))?;
+    if url.port().is_none() {
+        return Err(format!("{label} URL authority must explicitly name a port"));
+    }
+    if authority_decodes_to_socket(host) {
+        return Err(format!(
+            "{label} URL must express a Unix socket as ?host=/path over an explicit hostname authority"
+        ));
+    }
+
+    let mut password = url.password().map(decode_percent_encoded).transpose()?;
+    for (key, value) in url.query_pairs() {
+        if key == "password" {
+            password = Some(value.into_owned());
+        }
+    }
+    let options = PgConnectOptions::from_str(database_url)
+        .map_err(|error| format!("{label} parse postgres URL: {error}"))?;
+    Ok(ParsedFixtureUrl {
+        options,
+        password,
+        url,
+    })
+}
+
+pub(super) fn options_match(
+    base_options: &PgConnectOptions,
+    candidate_options: &PgConnectOptions,
+) -> Result<(), String> {
+    let base = fixture_identity(base_options);
+    let candidate = fixture_identity(candidate_options);
+    if candidate == base {
+        return Ok(());
+    }
+    Err(format!(
+        "fixture connection target {candidate} does not match configured fixture base {base}"
+    ))
+}
+
+pub(super) fn config_base_is_representable(parsed_base: &ParsedFixtureUrl) -> Result<(), String> {
+    if parsed_base.options.get_socket().is_some() {
+        return Err("Config fixture base uses a Unix socket".to_string());
+    }
+    let candidate = PgConnectOptions::new()
+        .host(parsed_base.options.get_host())
+        .port(parsed_base.options.get_port());
+    options_match(&parsed_base.options, &candidate)
+}
+
+pub(super) fn enforce_configured_target(
+    configured_base: Option<&str>,
+    candidate_options: &PgConnectOptions,
+) {
+    let result = (|| {
+        let base = configured_base.ok_or_else(|| {
+            "fixture base unconfigured (POSTGRES_TEST_DATABASE_URL_BASE)".to_string()
+        })?;
+        let parsed_base = parse_fixture_url(base, "configured PostgreSQL fixture base")?;
+        options_match(&parsed_base.options, candidate_options)
+    })();
+    result.unwrap_or_else(|error| panic!("unsafe PostgreSQL fixture target: {error}"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parsed(url: &str) -> ParsedFixtureUrl {
+        parse_fixture_url(url, "matrix input").expect("parse explicit matrix URL")
+    }
+
+    fn accepted(base: &str, candidate: &str) -> bool {
+        let base = parse_fixture_url(base, "matrix base");
+        let candidate = parse_fixture_url(candidate, "matrix candidate");
+        matches!((base, candidate), (Ok(base), Ok(candidate)) if options_match(&base.options, &candidate.options).is_ok())
+    }
+
+    #[test]
+    fn endpoint_enumeration_matrix_has_no_ambient_authority() {
+        let base = "postgresql://user@db.example:15432/root?sslmode=disable";
+        let cases = [
+            (
+                "authority-host",
+                "postgresql://user@DB.EXAMPLE:15432/db?sslmode=disable",
+                true,
+            ),
+            (
+                "socket-authority",
+                "postgresql://user@%2Ftmp%2Fsafe:15432/db?sslmode=disable",
+                false,
+            ),
+            (
+                "authority-port",
+                "postgresql://user@db.example:15432/db?sslmode=disable",
+                true,
+            ),
+            (
+                "query-host",
+                "postgresql://user@db.example:15432/db?sslmode=disable&host=other.example",
+                false,
+            ),
+            (
+                "query-socket",
+                "postgresql://user@db.example:15432/db?sslmode=disable&host=%2Ftmp%2Fsafe",
+                false,
+            ),
+            (
+                "query-address",
+                "postgresql://user@db.example:15432/db?sslmode=disable&hostaddr=192.0.2.9",
+                false,
+            ),
+            (
+                "query-port",
+                "postgresql://user@db.example:15432/db?sslmode=disable&port=15433",
+                false,
+            ),
+            ("missing-host", "postgresql:///db?sslmode=disable", false),
+            (
+                "missing-port",
+                "postgresql://user@db.example/db?sslmode=disable",
+                false,
+            ),
+        ];
+        for (name, candidate, expected) in cases {
+            assert_eq!(accepted(base, candidate), expected, "matrix case {name}");
+        }
+
+        let direct = parsed(base).options;
+        let changed_host = PgConnectOptions::new()
+            .host("other.example")
+            .port(15432)
+            .ssl_mode(PgSslMode::Disable);
+        let changed_port = PgConnectOptions::new()
+            .host("db.example")
+            .port(15433)
+            .ssl_mode(PgSslMode::Disable);
+        let changed_socket = PgConnectOptions::new()
+            .host("db.example")
+            .port(15432)
+            .socket("/tmp/safe")
+            .ssl_mode(PgSslMode::Disable);
+        assert!(
+            options_match(&direct, &changed_host).is_err(),
+            "builder host"
+        );
+        assert!(
+            options_match(&direct, &changed_port).is_err(),
+            "builder port"
+        );
+        assert!(
+            options_match(&direct, &changed_socket).is_err(),
+            "builder socket"
+        );
+    }
+
+    #[test]
+    fn explicit_authority_fields_are_required() {
+        let missing_port = parse_fixture_url(
+            "postgresql://user@db.example/db?sslmode=disable",
+            "missing port",
+        )
+        .expect_err("an omitted authority port must not inherit ambient input");
+        assert!(missing_port.contains("explicitly name a port"));
+
+        let socket_authority = parse_fixture_url(
+            "postgresql://user@%2Ftmp%2Fsafe:15432/db?sslmode=disable",
+            "socket authority",
+        )
+        .expect_err("socket authority must not leave an ambient TLS hostname");
+        assert!(socket_authority.contains("express a Unix socket as ?host=/path"));
+    }
+
+    #[test]
+    fn socket_transport_precedes_host_transport() {
+        let base = parsed(
+            "postgresql://route.example:secret@db.example:15432/root?sslmode=disable&host=%2Ftmp%2Fsafe",
+        );
+        let same = parsed(
+            "postgresql://route.example:secret@DB.EXAMPLE:15432/db?sslmode=disable&host=%2Ftmp%2Fsafe",
+        );
+        let other_socket = parsed(
+            "postgresql://route.example:secret@db.example:15432/db?sslmode=disable&host=%2Ftmp%2Fother",
+        );
+        let other_route = parsed(
+            "postgresql://route.example:secret@other.example:15432/db?sslmode=disable&host=%2Ftmp%2Fsafe",
+        );
+        assert!(options_match(&base.options, &same.options).is_ok());
+        assert!(options_match(&base.options, &other_socket.options).is_err());
+        assert!(options_match(&base.options, &other_route.options).is_err());
+    }
+
+    #[test]
+    fn tls_routing_is_part_of_identity() {
+        let base = parsed("postgresql://user@db.example:15432/root?sslmode=disable");
+        for mode in ["allow", "prefer", "require", "verify-ca", "verify-full"] {
+            let candidate = parsed(&format!(
+                "postgresql://user@db.example:15432/db?sslmode={mode}"
+            ));
+            assert!(
+                options_match(&base.options, &candidate.options).is_err(),
+                "TLS mode {mode} must discriminate"
+            );
+        }
+    }
+
+    #[test]
+    fn config_representation_rejects_socket_transport() {
+        let socket = parsed("postgresql://user@db.example:15432/root?host=%2Ftmp%2Fsafe");
+        assert!(config_base_is_representable(&socket).is_err());
+    }
+
+    #[test]
+    fn loopback_aliases_normalize_without_collisions() {
+        fn identity(host: &str) -> String {
+            server_identity(
+                &PgConnectOptions::new()
+                    .host(host)
+                    .port(15432)
+                    .ssl_mode(PgSslMode::Disable),
+            )
+        }
+        let expected = identity("localhost");
+        for host in [
+            "localhost",
+            "127.0.0.1",
+            "127.0.0.1.",
+            "::1",
+            "[::1]",
+            "[::1].",
+            "0:0:0:0:0:0:0:1",
+            "LOCALHOST.",
+        ] {
+            assert_eq!(identity(host), expected, "loopback spelling {host:?}");
+        }
+        assert_ne!(expected, identity("loopback"));
+    }
+
+    #[test]
+    fn mismatch_is_always_a_hard_failure() {
+        let candidate = parsed("postgresql://user@other.example:15432/db?sslmode=disable");
+        let panic = std::panic::catch_unwind(|| {
+            enforce_configured_target(
+                Some("postgresql://user@db.example:15432/root?sslmode=disable"),
+                &candidate.options,
+            );
+        });
+        assert!(panic.is_err(), "a target mismatch must panic");
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -10,6 +10,8 @@ pub(crate) mod dispatched_session_canonical_identity;
 pub(crate) mod dispatched_session_rebind_override;
 pub mod dispatched_sessions;
 pub mod dispatches;
+#[cfg(test)]
+mod fixture_target;
 pub mod idempotency;
 pub mod intake_outbox;
 pub mod kanban;

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -2105,14 +2105,20 @@ mod tests {
     impl TestDatabase {
         async fn create() -> Self {
             let base = super::postgres_test_database_url_base()
-                .expect("POSTGRES_TEST_DATABASE_URL_BASE must name the fixture server");
+                .unwrap_or_else(|| panic!("db::postgres Config fixtures require POSTGRES_TEST_DATABASE_URL_BASE before CREATE"));
             let parsed_base = crate::db::fixture_target::parse_fixture_url(
                 &base,
                 "db::postgres configured fixture base",
             )
-            .expect("parse configured fixture base before CREATE");
-            crate::db::fixture_target::config_base_is_representable(&parsed_base).expect(
-                "db::postgres Config fixtures require a TCP-representable base before CREATE",
+            .unwrap_or_else(|error| {
+                panic!("db::postgres fixture base is invalid before CREATE: {error}")
+            });
+            crate::db::fixture_target::config_base_is_representable(&parsed_base).unwrap_or_else(
+                |error| {
+                    panic!(
+                        "db::postgres Config fixtures cannot represent the configured base before CREATE: {error}"
+                    )
+                },
             );
             let admin_db = std::env::var("POSTGRES_TEST_ADMIN_DB")
                 .ok()
@@ -2289,6 +2295,24 @@ mod tests {
             preferred_intake_node_labels: None,
         }];
         config
+    }
+
+    #[test]
+    fn ownership_registry_key_matches_between_admin_url_and_config_options() {
+        let admin_url = "postgresql://fixture@db.example:15432/postgres";
+        let admin_options = super::parse_test_postgres_options(admin_url, "registry-key admin")
+            .expect("parse registry-key admin URL");
+        let database_name = "agentdesk_pg_key";
+        let mut config = crate::config::Config::default();
+        config.database.host = admin_options.get_host().to_string();
+        config.database.port = admin_options.get_port();
+        config.database.dbname = database_name.to_string();
+        let database_options = super::test_database_config_options(&config);
+
+        assert_eq!(
+            super::test_database_registry_key(&admin_options, database_name),
+            super::test_database_registry_key(&database_options, database_name)
+        );
     }
 
     #[test]

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1359,7 +1359,7 @@ async fn connect_test_pool_with_options(
     super::fixture_target::enforce_configured_target(
         postgres_test_database_url_base().as_deref(),
         &options,
-    );
+    )?;
     let acquire_timeout = std::env::var(TEST_POSTGRES_ACQUIRE_TIMEOUT_ENV)
         .ok()
         .and_then(|value| value.parse::<u64>().ok())

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1,8 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::future::Future;
-#[cfg(test)]
-use std::net::IpAddr;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};
@@ -1158,10 +1156,13 @@ fn database_url_override() -> Option<String> {
 /// PG fixture constructors still read environment variables directly and are
 /// deferred to the S3 follow-up.
 pub(crate) fn postgres_test_database_url_base() -> Option<String> {
-    let base = std::env::var("POSTGRES_TEST_DATABASE_URL_BASE")
-        .ok()
-        .map(|value| value.trim().trim_end_matches('/').to_string())
-        .filter(|value| !value.is_empty());
+    let override_value = FIXTURE_BASE_OVERRIDE.with(|slot| slot.borrow().clone());
+    let base = override_value.unwrap_or_else(|| {
+        std::env::var("POSTGRES_TEST_DATABASE_URL_BASE")
+            .ok()
+            .map(|value| value.trim().trim_end_matches('/').to_string())
+            .filter(|value| !value.is_empty())
+    });
     if base.is_none() && std::env::var(AGENTDESK_REQUIRE_PG_ENV).ok().as_deref() == Some("1") {
         panic!("PG required but POSTGRES_TEST_DATABASE_URL_BASE unset"); // agentdesk-audit: allow-unwrap — AGENTDESK_REQUIRE_PG=1 CI 계약: PG fixture base 누락을 soft-skip green으로 붕괴시키지 않는 의도적 hard-fail (#4979 S2)
     }
@@ -1188,6 +1189,11 @@ static POSTGRES_TEST_LIFECYCLE_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> =
 static POSTGRES_TEST_DATABASE_OWNERS: std::sync::OnceLock<
     std::sync::Mutex<BTreeMap<(String, String), TestDatabaseOwnershipToken>>,
 > = std::sync::OnceLock::new();
+#[cfg(test)]
+thread_local! {
+    static FIXTURE_BASE_OVERRIDE: std::cell::RefCell<Option<Option<String>>> =
+        const { std::cell::RefCell::new(None) };
+}
 
 #[cfg(test)]
 struct TestDatabaseOwnershipToken {
@@ -1204,40 +1210,7 @@ fn test_database_owners()
 
 #[cfg(test)]
 fn test_database_server_identity(options: &PgConnectOptions) -> String {
-    let host = options.get_host().trim();
-    // Strip a DNS-style trailing dot before removing IPv6 brackets so both
-    // `[::1]` and `[::1].` reach the same canonical parser input. Preserve
-    // Unix-socket paths verbatim below; a path is not a DNS host name.
-    let host_for_ip_or_hostname = host.trim_end_matches('.');
-    let unbracketed_host = host_for_ip_or_hostname
-        .strip_prefix('[')
-        .and_then(|value| value.strip_suffix(']'))
-        .unwrap_or(host_for_ip_or_hostname);
-    let normalized_host = if let Ok(address) = unbracketed_host.parse::<IpAddr>() {
-        // Canonicalize first: long-form IPv6 loopback parses to `::1`, so the
-        // alias match below covers every equivalent textual representation.
-        address.to_string()
-    } else if host.starts_with('/') {
-        host.to_string()
-    } else {
-        unbracketed_host.to_ascii_lowercase()
-    };
-    let normalized_host = match normalized_host.as_str() {
-        "localhost" | "127.0.0.1" | "::1" => {
-            // PostgreSQL fixtures may create through the CI base URL and connect
-            // through config.host; treat the three loopback spellings as one
-            // server identity so ownership cleanup cannot split its registry key.
-            // Angle brackets cannot occur in a URL host, keeping this key distinct
-            // from a real DNS hostname such as `loopback`.
-            "<loopback>".to_string()
-        }
-        _ => normalized_host,
-    };
-    if normalized_host.contains(':') {
-        format!("[{normalized_host}]:{}", options.get_port())
-    } else {
-        format!("{normalized_host}:{}", options.get_port())
-    }
+    super::fixture_target::server_identity(options)
 }
 
 #[cfg(test)]
@@ -1374,8 +1347,7 @@ fn parse_test_postgres_options(
     database_url: &str,
     label: &str,
 ) -> Result<PgConnectOptions, String> {
-    PgConnectOptions::from_str(database_url)
-        .map_err(|error| format!("{label} parse postgres url: {error}"))
+    super::fixture_target::parse_fixture_url(database_url, label).map(|parsed| parsed.options)
 }
 
 #[cfg(test)]
@@ -1384,6 +1356,10 @@ async fn connect_test_pool_with_options(
     label: &str,
     max_connections: u32,
 ) -> Result<PgPool, String> {
+    super::fixture_target::enforce_configured_target(
+        postgres_test_database_url_base().as_deref(),
+        &options,
+    );
     let acquire_timeout = std::env::var(TEST_POSTGRES_ACQUIRE_TIMEOUT_ENV)
         .ok()
         .and_then(|value| value.parse::<u64>().ok())
@@ -1723,14 +1699,7 @@ pub(crate) async fn connect_test_pool_with_max_connections_and_migrate(
 }
 
 #[cfg(test)]
-async fn connect_test_pool_and_migrate_config_inner(
-    config: &Config,
-    label: &str,
-) -> Result<Option<PgPool>, String> {
-    if !database_enabled(config) {
-        return Ok(None);
-    }
-
+fn test_database_config_options(config: &Config) -> PgConnectOptions {
     let mut options = PgConnectOptions::new()
         .host(&config.database.host)
         .port(config.database.port)
@@ -1739,6 +1708,19 @@ async fn connect_test_pool_and_migrate_config_inner(
     if let Some(password) = config.database.password.as_deref() {
         options = options.password(password);
     }
+    options
+}
+
+#[cfg(test)]
+async fn connect_test_pool_and_migrate_config_inner(
+    config: &Config,
+    label: &str,
+) -> Result<Option<PgPool>, String> {
+    if !database_enabled(config) {
+        return Ok(None);
+    }
+
+    let options = test_database_config_options(config);
 
     let pool =
         connect_test_pool_with_options(options.clone(), label, config.database.pool_max.max(1))
@@ -1879,7 +1861,7 @@ mod tests {
         connect_test_pool_with_max_connections_and_migrate, create_test_database, database_enabled,
         database_summary, health_check, require_pg_guard, run_test_postgres_sqlx_op_with_timeout,
         runtime_pool_settings, should_yield_for_counters, startup_pool_settings, startup_reseed,
-        sync_agents_from_config_pg, test_database_server_identity, with_startup_advisory_lock,
+        sync_agents_from_config_pg, with_startup_advisory_lock,
     };
     use sqlx::postgres::PgConnectOptions;
     use sqlx::{Executor as _, PgPool, Row};
@@ -1905,15 +1887,18 @@ mod tests {
         _lifecycle: super::PostgresTestLifecycleGuard,
         previous: Option<std::ffi::OsString>,
         previous_acquire_timeout: Option<std::ffi::OsString>,
+        previous_fixture_base_override: Option<Option<String>>,
     }
 
     impl RequirePgEnvGuard {
-        fn set(value: Option<&str>) -> Self {
+        fn set(value: Option<&str>, fixture_base: Option<&str>) -> Self {
             let env_lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
             let lifecycle = super::lock_test_lifecycle();
             let previous = std::env::var_os(AGENTDESK_REQUIRE_PG_ENV);
             let previous_acquire_timeout =
                 std::env::var_os(super::TEST_POSTGRES_ACQUIRE_TIMEOUT_ENV);
+            let previous_fixture_base_override = super::FIXTURE_BASE_OVERRIDE
+                .with(|slot| slot.replace(Some(fixture_base.map(str::to_string))));
             match value {
                 Some(value) => unsafe { std::env::set_var(AGENTDESK_REQUIRE_PG_ENV, value) },
                 None => unsafe { std::env::remove_var(AGENTDESK_REQUIRE_PG_ENV) },
@@ -1926,6 +1911,7 @@ mod tests {
                 _lifecycle: lifecycle,
                 previous,
                 previous_acquire_timeout,
+                previous_fixture_base_override,
             }
         }
     }
@@ -1942,6 +1928,9 @@ mod tests {
                 },
                 None => unsafe { std::env::remove_var(super::TEST_POSTGRES_ACQUIRE_TIMEOUT_ENV) },
             }
+            super::FIXTURE_BASE_OVERRIDE.with(|slot| {
+                slot.replace(self.previous_fixture_base_override.take());
+            });
         }
     }
 
@@ -2025,7 +2014,7 @@ mod tests {
 
     #[test]
     fn require_pg_guard_panics_for_all_entrypoints_on_unreachable_database() {
-        let _env = RequirePgEnvGuard::set(Some("1"));
+        let _env = RequirePgEnvGuard::set(Some("1"), Some(UNREACHABLE_POSTGRES_URL));
         // Environment premise: CI runners and developer machines do not run a
         // PostgreSQL listener on privileged loopback port 1. If that premise
         // is violated, the assertions above must identify it as the cause.
@@ -2059,7 +2048,7 @@ mod tests {
 
     #[test]
     fn require_pg_guard_preserves_errors_when_ci_lane_does_not_require_postgres() {
-        let _env = RequirePgEnvGuard::set(None);
+        let _env = RequirePgEnvGuard::set(None, Some(UNREACHABLE_POSTGRES_URL));
         // Keep the same explicit no-listener premise as the required-lane
         // probe; a live port-1 service would invalidate the timeout contract.
         const UNREACHABLE_POSTGRES_URL: &str = "postgresql://postgres@127.0.0.1:1/postgres";
@@ -2092,7 +2081,7 @@ mod tests {
 
     #[test]
     fn require_pg_guard_leaves_success_untouched_when_ci_lane_requires_postgres() {
-        let _env = RequirePgEnvGuard::set(Some("1"));
+        let _env = RequirePgEnvGuard::set(Some("1"), None);
         assert_eq!(require_pg_guard(Ok::<_, String>(42)), Ok(42));
         let config = crate::config::Config::default();
         assert!(matches!(
@@ -2104,46 +2093,39 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_database_server_identity_normalizes_loopback_aliases_without_collisions() {
-        fn identity(host: &str) -> String {
-            let options = PgConnectOptions::new().host(host).port(5432);
-            test_database_server_identity(&options)
-        }
-
-        let expected = identity("localhost");
-        for host in [
-            "localhost",
-            "127.0.0.1",
-            "127.0.0.1.",
-            "::1",
-            "[::1]",
-            "[::1].",
-            "0:0:0:0:0:0:0:1",
-            "LOCALHOST.",
-        ] {
-            assert_eq!(identity(host), expected, "loopback spelling {host:?}");
-        }
-
-        assert_ne!(
-            expected,
-            identity("loopback"),
-            "the loopback sentinel must not collide with a real DNS hostname"
-        );
-        assert_eq!(identity("DB.Example.COM."), "db.example.com:5432");
-    }
-
     struct TestDatabase {
         admin_url: String,
         database_name: String,
         database_url: String,
+        base_options: PgConnectOptions,
+        base_password: Option<String>,
+        cleanup_armed: bool,
     }
 
     impl TestDatabase {
         async fn create() -> Self {
-            let admin_url = admin_database_url();
+            let base = super::postgres_test_database_url_base()
+                .expect("POSTGRES_TEST_DATABASE_URL_BASE must name the fixture server");
+            let parsed_base = crate::db::fixture_target::parse_fixture_url(
+                &base,
+                "db::postgres configured fixture base",
+            )
+            .expect("parse configured fixture base before CREATE");
+            crate::db::fixture_target::config_base_is_representable(&parsed_base).expect(
+                "db::postgres Config fixtures require a TCP-representable base before CREATE",
+            );
+            let admin_db = std::env::var("POSTGRES_TEST_ADMIN_DB")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| "postgres".to_string());
             let database_name = format!("agentdesk_pg_{}", uuid::Uuid::new_v4().simple());
-            let database_url = format!("{}/{}", base_database_url(), database_name);
+            let database_url_for = |database: &str| {
+                let mut url = parsed_base.url.clone();
+                url.set_path(&format!("/{database}"));
+                url.to_string()
+            };
+            let admin_url = database_url_for(&admin_db);
+            let database_url = database_url_for(&database_name);
             create_test_database(&admin_url, &database_name, "db::postgres tests")
                 .await
                 .expect("create postgres test db");
@@ -2152,57 +2134,72 @@ mod tests {
                 admin_url,
                 database_name,
                 database_url,
+                base_options: parsed_base.options,
+                base_password: parsed_base.password,
+                cleanup_armed: true,
             }
         }
 
-        async fn drop(self) {
-            super::drop_test_database(&self.admin_url, &self.database_name, "db::postgres tests")
-                .await
-                .expect("drop postgres test db");
+        async fn drop(mut self) {
+            let result = super::drop_test_database(
+                &self.admin_url,
+                &self.database_name,
+                "db::postgres tests",
+            )
+            .await;
+            if result.is_ok() {
+                self.cleanup_armed = false;
+            }
+            result.expect("drop postgres test db");
         }
     }
 
-    fn base_database_url() -> String {
-        if let Ok(base) = std::env::var("POSTGRES_TEST_DATABASE_URL_BASE") {
-            let trimmed = base.trim();
-            if !trimmed.is_empty() {
-                return trimmed.trim_end_matches('/').to_string();
+    impl Drop for TestDatabase {
+        fn drop(&mut self) {
+            if !self.cleanup_armed {
+                return;
+            }
+            let result =
+                cleanup_test_database_from_drop(self.admin_url.clone(), self.database_name.clone());
+            if let Err(error) = result {
+                if std::thread::panicking() {
+                    eprintln!("LEAKED-TEST-DATABASE {}: {error}", self.database_name);
+                } else {
+                    panic!(
+                        "postgres test database {} leaked: {error}",
+                        self.database_name
+                    );
+                }
             }
         }
+    }
 
-        let user = std::env::var("PGUSER")
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-            .or_else(|| {
-                std::env::var("USER")
-                    .ok()
-                    .filter(|value| !value.trim().is_empty())
+    fn cleanup_test_database_from_drop(
+        admin_url: String,
+        database_name: String,
+    ) -> Result<(), String> {
+        let worker_name = format!("db fixture cleanup {database_name}");
+        let handle = std::thread::Builder::new()
+            .name(worker_name)
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|error| format!("cleanup runtime build failed: {error}"))?;
+                runtime.block_on(super::drop_test_database(
+                    &admin_url,
+                    &database_name,
+                    "db::postgres tests Drop",
+                ))
             })
-            .unwrap_or_else(|| "postgres".to_string());
-        let password = std::env::var("PGPASSWORD")
-            .ok()
-            .filter(|value| !value.trim().is_empty());
-        let host = std::env::var("PGHOST")
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or_else(|| "localhost".to_string());
-        let port = std::env::var("PGPORT")
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or_else(|| "5432".to_string());
-
-        match password {
-            Some(password) => format!("postgresql://{user}:{password}@{host}:{port}"),
-            None => format!("postgresql://{user}@{host}:{port}"),
+            .map_err(|error| format!("cleanup worker spawn failed: {error}"))?;
+        match handle.join() {
+            Ok(result) => result.map_err(|error| format!("async cleanup failed: {error}")),
+            Err(payload) => Err(format!(
+                "cleanup worker panicked: {}",
+                panic_message(payload)
+            )),
         }
-    }
-
-    fn admin_database_url() -> String {
-        let admin_db = std::env::var("POSTGRES_TEST_ADMIN_DB")
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or_else(|| "postgres".to_string());
-        format!("{}/{}", base_database_url(), admin_db)
     }
 
     async fn migrate_through_version(pool: &PgPool, max_version: i64) -> Result<(), String> {
@@ -2266,24 +2263,11 @@ mod tests {
         let mut config = crate::config::Config::default();
         config.database.enabled = true;
         config.database.pool_max = 4;
-        config.database.host = "localhost".to_string();
-        config.database.port = std::env::var("PGPORT")
-            .ok()
-            .and_then(|raw| raw.parse::<u16>().ok())
-            .unwrap_or(5432);
+        config.database.host = test_db.base_options.get_host().to_string();
+        config.database.port = test_db.base_options.get_port();
         config.database.dbname = test_db.database_name.clone();
-        config.database.user = std::env::var("PGUSER")
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-            .or_else(|| {
-                std::env::var("USER")
-                    .ok()
-                    .filter(|value| !value.trim().is_empty())
-            })
-            .unwrap_or_else(|| "postgres".to_string());
-        config.database.password = std::env::var("PGPASSWORD")
-            .ok()
-            .filter(|value| !value.trim().is_empty());
+        config.database.user = test_db.base_options.get_username().to_string();
+        config.database.password = test_db.base_password.clone();
         config.github.repos = vec!["itismyfield/AgentDesk".to_string()];
         config.agents = vec![crate::config::AgentDef {
             id: "pg-agent".to_string(),

--- a/tests/test_non_pg_test_filter.py
+++ b/tests/test_non_pg_test_filter.py
@@ -26,8 +26,6 @@ EXPECTED_FALSE_POSITIVES = (
     "db::postgres::tests::clamp_foreground_reserve_always_leaves_a_background_slot",
     "db::postgres::tests::runtime_pool_settings_enable_dead_peer_detection",
     "db::postgres::tests::startup_pool_settings_raise_pool_size_and_acquire_timeout",
-    "db::postgres::tests::"
-    "test_database_server_identity_normalizes_loopback_aliases_without_collisions",
     "reconcile::dispatch_delivery_reconcile_tests::"
     "dispatch_delivery_reconcile_classifies_rows_without_postgres",
     "services::discord::turn_bridge::completion_guard::completion_postgres::"


### PR DESCRIPTION
#5229의 첫 슬라이스다. **런타임 접속 대상 권위**만 담는다.

원래 구현은 PR 상한을 넘어 슬라이스 A(접속 대상 권위)와 후속 B(소스 불변식 + DDL 게이트)로 나눴다.

## 무엇을 하는가

테스트 픽스처가 어느 PostgreSQL 인스턴스에 붙는지를 명시적 권위로 강제한다. 암묵적 fallback을 fail-closed로 바꾸고, 최종 접속 옵션 검증을 단일 funnel로 모은다.

- **U1** `parse_test_postgres_options`의 **operational/runtime fixture entrypoint 6곳**에 URL authority host·port 명시성과 socket-authority 금지를 적용한다. test-only 직접 호출 1곳(`ownership_registry_key_matches_between_admin_url_and_config_options`)은 operational count에서 제외하며, `TestDatabase::create()`의 별도 `parse_fixture_url` 경로 1곳을 더하면 source parser 호출식은 **7 + 1 = 8곳**이다.
- **U2** `fetch_socket()`의 우선순위(socket → slash-leading host → TCP)를 미러링한다. TCP/UDS 모두 `PgConnectOptions::get_host()`의 raw 값을 routing identity로 exact 비교한다. TCP에서 이 값은 SQLx가 `connect_tcp`를 호출하는 경계의 host이며, 최종 OS resolver 입력과 항상 바이트 동일하다고 주장하지 않는다.
- **U3** `connect_test_pool_with_options` 단일 funnel에서 최종 options를 검증한다. `auto_queue/test_support.rs` 등 sibling 3모듈의 `localhost:5432` fallback도 이 funnel의 base-unconfigured/identity-mismatch fail-closed 경로로 막히는 positive coverage를 포함한다.
- **U4** `postgres_test_config()`를 parsed base에서 파생하고, `TestDatabase::create()`가 CREATE 전에 Config representability preflight를 수행한다.
- **registry key** 등록용 `admin_options`와 Config 소비용 `database_options`가 동일한 server identity/database key를 만드는 순수 테스트를 둔다.
- **Drop backstop** 전용 OS thread + current-thread runtime cleanup을 유지한다. 정상 실행 중 cleanup 오류는 hard-fail, unwind 중에는 `LEAKED-TEST-DATABASE` 마커를 best-effort로 출력한다.

### 실패 경계와 Config 전제조건

`enforce_configured_target`은 `Result<(), String>`을 반환하고 `connect_test_pool_with_options`가 `?`로 연결 전에 전파한다. base 미설정이나 candidate identity 불일치는 non-PG lane에서 처리 가능한 `Err`이며, `AGENTDESK_REQUIRE_PG=1`의 기존 hard-fail 계약은 유지한다.

이와 별개로 test-only `TestDatabase::create()`의 Config fixture preflight는 의도적 hard-fail이다. `POSTGRES_TEST_DATABASE_URL_BASE`가 없거나 URL이 잘못됐거나 Config로 표현할 수 없으면 CREATE 전에 원인을 포함한 메시지로 panic한다. Config fixture의 base `sslmode`는 Config-derived options와 같아야 하며, `PGSSLMODE`가 없으면 생략하거나 `prefer`를 사용해야 한다. 이 전제조건을 `docs/auto-queue-preflight.md`에 명시했다.

## mutation 결과

모두 소스 복원 전 컴파일을 완료한 뒤 테스트 본문의 자기 assert로 실패했고, 복원 후 fixture 9개와 registry-key 테스트가 통과했다.

| 뮤턴트 | 결과 | 실측 killer 테스트 |
|---|---:|---|
| M1 raw routing-host 비교 제거 | rc=101, 4 failed | `raw_tcp_hosts_discriminate`, `configured_target_rejects_changed_host`, `socket_transport_precedes_host_transport`, `endpoint_enumeration_matrix_has_no_ambient_authority` |
| M6 UDS에 한해 raw TLS routing-host 비교 제거 | rc=101, 2 failed | `configured_target_rejects_changed_host`, `socket_transport_precedes_host_transport` |
| M-new Config options의 host 전달 제거 | rc=101, 1 failed | `ownership_registry_key_matches_between_admin_url_and_config_options` |

r2의 M4가 교체하던 `normalized_host`, `tcp_connect_host`, loopback label 기계는 삭제됐다. 따라서 같은 등가 치환을 적용할 표면 자체가 없으며 M4 등가성은 소멸했다.

## 게이트

| 게이트 | rc | 결과 |
|---|---:|---|
| `cargo fmt --all --check` | 0 | clean |
| `cargo check --lib` | 0 | 기존 warning 239개 |
| `cargo test --lib db::fixture_target` | 0 | 9 passed / 0 failed |
| registry-key exact test | 0 | 1 passed / 0 failed |
| 기존 `database_fixture_invariant_tests` | 0 | 7 passed / 0 failed |
| `bash -n` / `shellcheck` | 0 / 0 | 변경된 shell script 통과 |
| 리포 밖 just guard 사본 | — | UNSET rc=1, SET rc=0, 빈 문자열 rc=1; cargo 본문은 `echo`로 치환 |
| inventory 생성 + maintenance freshness | 0 / 0 | freshness passed, tracked drift 없음 |
| lib test inventory exact 검사 | 0 | manifest=actual 7,673, delta 0 |
| PG lane membership | 0 | 477 tests / 74 files, rule4=0 |

실제 `just test-postgres`와 실제 PostgreSQL 회귀는 실행하지 않았고, `POSTGRES_TEST_DATABASE_URL_BASE` 값은 읽거나 출력·기록하지 않았다.

## 이 PR이 하지 않는 것

- 슬라이스 B의 **repository-wide exact 집합 감사**와 DDL gate는 없다. 기존 `database_fixture_invariant_tests`의 4-fixture 한정 7개 방어는 그대로 유지되고 통과한다.
- 같은 raw host를 전달하는 현재 등록/소비 경로에서는 registry key가 갈라지지 않는다. 반면 raw spelling이 다르면 key도 의도적으로 다르다. DNS 대소문자·trailing dot·IPv6 bracket spelling의 resolver 동치와 예전 `DB.Example.COM.` → `db.example.com` canonical identity는 보장하지 않는다.
- DNS rebinding, UDS symlink retarget, direct SQLx API repository-wide dominance, lexical gate 밖 runtime SQL은 이 슬라이스의 보장이 아니다.
- 실제 PostgreSQL, DNS resolver, UDS listener에는 접속하지 않았다.
- `tests/test_non_pg_test_filter.py`의 CI 배선은 이 PR 범위가 아니며, 현재 `.github/`·`scripts/` 어디에도 참조되지 않고 `ci-script-checks.sh` unittest 목록과 `tests/*.sh` 자동 루프에도 없으므로 #5003 S3에서 다룬다.

## 표면

`git diff --stat origin/main...HEAD` 기준 **10 files, +553 −151**. r3의 +552/−148 대비 K1 fixture assertion과 K3 문서 좌표 정정으로 `+1/−3` 증감했고, r1의 +559보다 insertion 6줄 감소해 PR 상한 안이다.

Closes #5229는 붙이지 않는다. 슬라이스 B 착지 전까지 이슈 범위가 닫히지 않는다.

Refs #5229

## 2026-08-10 landing freshness (rebase-only)

This supersedes the old landing coordinates without changing the reviewed patch.

- reviewed head/base: `d8d2c6f0b6e5918b68c69b6b6210d942c38c3b5b` / `309da6db476258afbc3339d9a0e986b42ddbe5d1`
- landing head/base: `38fd78ded4d686d2c2e06be4f3ea65acf648362d` / `283dad5f43b630fb5d19c14a077f7aceb5e5a743`
- replay: 5/5 commits, no conflicts and no manual resolution
- stable patch IDs: 5/5 identical
- range-diff: 5/5 `=`
- exact added/deleted-line comparison: 0 diff lines
- new-base gates: fmt, `cargo check --lib`, fixture-target 9, registry-key exact 1, fixture invariants 7, inventory 7,687/7,687, PG membership 477 tests / 74 files with rule4=0, docs generation/freshness, and diff check all passed; final worktree clean
- not run: actual PostgreSQL or port 5432, DB creation/drop, full PostgreSQL lane, deploy/restart/runtime/Discord/tmux/marker/mailbox operations