### PR TITLE
fix(deploy): report post-deploy wedge coverage honestly (#5244, 재구성 v2)

### DIFF
--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -311,6 +311,10 @@ echo "=== Shell test suites (tests/*.sh) ==="
 # while every required check stayed green. Run them here, in the job that already
 # owns script-level gates.
 SHELL_TESTS_FAILED=0
+required_shell_suites=(tests/test_deploy_smoke_wedge_coverage_5244.sh)
+for required_suite in "${required_shell_suites[@]}"; do
+  [ -f "$required_suite" ] || { echo "✗ required shell suite missing: $required_suite" >&2; SHELL_TESTS_FAILED=1; }
+done
 for shell_test in tests/*.sh; do
   [ -f "$shell_test" ] || continue
   echo "--- $shell_test"

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -103,6 +103,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/_defaults.sh"
 
 ADK_REL="${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}"
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
 # The Rust dcserver reads AGENTDESK_DCSERVER_LABEL for the plist Label; honor it first
 # so launchd Label and plist filename never diverge when the operator overrides one side.
 PLIST_REL="${AGENTDESK_DCSERVER_LABEL:-${AGENTDESK_PLIST_REL:-com.agentdesk.release}}"
@@ -764,7 +765,8 @@ _finalize_detached_helper() {
 
     local content
     if [ "$status" -eq 0 ]; then
-        content="✅ release deploy complete"
+        content="✅ release deploy complete
+relay wedge: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE:-not run: wedge check did not execute}"
     else
         content="❌ release deploy failed (exit ${status})
 log: ${DEPLOY_LOG_PATH:-n/a}"
@@ -2637,10 +2639,9 @@ POST_DEPLOY_SMOKE_CORE_API_ENDPOINTS=(
 )
 POST_DEPLOY_SMOKE_LOG_LINES="${AGENTDESK_POST_DEPLOY_SMOKE_LOG_LINES:-500}"
 POST_DEPLOY_SMOKE_WARN_LIMIT="${AGENTDESK_POST_DEPLOY_SMOKE_WARN_LIMIT:-5}"
-POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS=4
 POST_DEPLOY_SMOKE_RELAY_CELL="${AGENTDESK_POST_DEPLOY_SMOKE_RELAY_CELL:-claude-tui}"
 POST_DEPLOY_SMOKE_CREATE_ISSUE="${AGENTDESK_POST_DEPLOY_SMOKE_CREATE_ISSUE:-off}"
-POST_DEPLOY_SMOKE_STAMP="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || printf 'unknown-%s' "$$")"
+POST_DEPLOY_SMOKE_STAMP="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || printf 'unknown')-$$"
 POST_DEPLOY_SMOKE_EVIDENCE="$ADK_REL/logs/post-deploy-smoke-${POST_DEPLOY_SMOKE_STAMP}.log"
 POST_DEPLOY_SMOKE_TMP_DIR=""
 POST_DEPLOY_SMOKE_HEALTH_BODY=""
@@ -2648,6 +2649,8 @@ POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY=""
 POST_DEPLOY_SMOKE_SESSIONS_BODY=""
 POST_DEPLOY_SMOKE_FAILURES=()
 
+# >>> BEGIN wedge-check region (#5244) — coverage is report-only and point-in-time
+POST_DEPLOY_SMOKE_WEDGE_MARKER_COVERAGE='evaluated: %s stall-state marker(s) observed (point-in-time)'; POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE="${POST_DEPLOY_SMOKE_WEDGE_MARKER_COVERAGE/\%s/0}"
 _post_deploy_smoke_note() {
     local message="$1"
     printf '%s\n' "$message"
@@ -2696,141 +2699,123 @@ _post_deploy_smoke_probe_apis() {
     [ "$failed" -eq 0 ]
 }
 
-_post_deploy_smoke_wedge_markers_from_file() {
+_post_deploy_smoke_wedge_scan_from_file() {
     local health_detail_path="$1"
-    # Reuse the health/detail markers consumed by the relay E2E validator:
-    # explicit non-healthy relay_stall_state, ownerless/detached inflight,
-    # desync, stale thread proof, or stale watcher attachment. Ordinary active
-    # turns and queues are deliberately not classified as wedges.
+    # Sole wedge-coverage parser; E-1 parses independently. Scan failures are broad; jq absence is separate.
     jq -r '
-        [
-          .degraded_reasons[]?
-          | strings
-          | select(test("relay.*(wedge|dead|stall|stuck)|(?:wedge|dead|stall|stuck).*relay"; "i"))
-          | "degraded_reason=" + .
-        ] + [
-          .mailboxes[]?
-          | . as $mailbox
-          | (($mailbox.relay_stall_state // "healthy") | ascii_downcase) as $stall
-          | select(
-              ($stall != "" and $stall != "healthy")
-              or ($mailbox.relay_health.desynced == true)
-              or ($mailbox.relay_health.stale_thread_proof == true)
-              or ($mailbox.relay_health.watcher_attached_stale == true)
-              or (
-                $mailbox.inflight_state_present == true
-                and (($mailbox.relay_owner_kind // "none") | ascii_downcase) as $owner
-                | ($owner == "" or $owner == "none" or $owner == "unknown")
-              )
-              or (
-                $mailbox.inflight_state_present == true
-                and $mailbox.watcher_attached == false
-              )
-            )
-          | "mailbox provider=\($mailbox.provider // "unknown") channel=\($mailbox.channel_id // "unknown") stall=\($stall)"
-        ]
-        | .[]
+        def die($message): error("wedge-schema: " + $message);
+        if (type != "object") then die("root is not an object")
+        elif ((.fully_recovered | type) != "boolean") then die("fully_recovered is not boolean")
+        elif ((.mailboxes | type) != "array") then die(".mailboxes is not an array")
+        else
+          ([ .mailboxes[]
+             | if (type != "object") then die("mailbox entry is not an object")
+               elif ((.relay_stall_state | type) != "string") then die("mailbox relay_stall_state is not a string")
+               else { ch: ((.channel_id // "?") | tostring),
+                      pv: ((.provider // "?") | tostring),
+                      s: (.relay_stall_state | ascii_downcase) }
+               end ]) as $mailboxes
+          | ([ $mailboxes[]
+               | select(.s == "tmux_alive_relay_dead"
+                       or .s == "stale_thread_proof"
+                       or .s == "orphan_pending_token")
+               | "marker=stall-state provider=\(.pv) channel=\(.ch) state=\(.s)" ]) as $markers
+          | ([ $mailboxes[] | select(.s == "queue_blocked")
+               | "obs=queue_blocked provider=\(.pv) channel=\(.ch)" ]) as $queue_observations
+          | ([ $mailboxes[]
+               | select(.s | IN("healthy", "active_foreground_stream", "explicit_background_work",
+                               "queue_blocked", "tmux_alive_relay_dead", "stale_thread_proof",
+                               "orphan_pending_token") | not)
+               | "obs=unknown_stall_state provider=\(.pv) channel=\(.ch) stall=\(.s)" ]) as $unknown_observations
+          | ([ "recovered=\(.fully_recovered)",
+               "count=\($markers | length)" ] + $markers
+             + $queue_observations + $unknown_observations)
+          | .[]
+        end
     ' "$health_detail_path" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
 }
 
-_post_deploy_smoke_fully_recovered_from_file() {
-    local health_path="$1"
-    jq -r '
-        if (.fully_recovered | type) == "boolean" then
-            .fully_recovered
-        else
-            error("fully_recovered is not boolean")
-        end
-    ' "$health_path" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE"
+_post_deploy_smoke_wedge_unevaluable() {
+    POST_DEPLOY_SMOKE_WEDGE_COVERAGE="unevaluable: $1"
+    _post_deploy_smoke_fail "relay wedge check ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}" || true
+    return 1
 }
 
 _post_deploy_smoke_check_wedges() {
-    local fully_recovered wedge_markers wedge_markers_resampled persistent_markers wedge_summary
-    local resample_path="$POST_DEPLOY_SMOKE_TMP_DIR/api_health_detail_resample.json"
+    local scan_out recovered marker_count markers line
     if [ -z "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY" ] \
       || [ ! -s "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY" ]; then
-        _post_deploy_smoke_fail "relay wedge check: /api/health/detail body unavailable" || true
+        _post_deploy_smoke_wedge_unevaluable "/api/health/detail body unavailable"
         return 1
     fi
-
-    if ! fully_recovered=$(
-        _post_deploy_smoke_fully_recovered_from_file "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
-    ); then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: startup recovery state unavailable" || return 1
-        return 0
-    fi
-    if [ "$fully_recovered" = "false" ]; then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: startup recovery in progress" || return 1
-        return 0
-    fi
-
-    if ! wedge_markers=$(
-        _post_deploy_smoke_wedge_markers_from_file "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"
-    ); then
-        _post_deploy_smoke_fail "relay wedge check: health/detail JSON could not be parsed" || true
+    if ! command -v jq >/dev/null 2>&1; then
+        _post_deploy_smoke_wedge_unevaluable "jq unavailable"
         return 1
     fi
-    if [ -z "$wedge_markers" ]; then
-        _post_deploy_smoke_note "relay wedge markers=absent" || return 1
+    if ! scan_out=$(_post_deploy_smoke_wedge_scan_from_file \
+        "$POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY"); then
+        _post_deploy_smoke_wedge_unevaluable "health/detail scan failed"
+        return 1
+    fi
+    while IFS= read -r line; do
+        case "$line" in
+            recovered=*|count=*|marker=*|obs=*) : ;;
+            '') : ;;
+            *)
+                _post_deploy_smoke_wedge_unevaluable "wedge scan output contract violated"
+                return 1
+                ;;
+        esac
+    done <<< "$scan_out"
+    recovered=$(printf '%s\n' "$scan_out" | sed -n 's/^recovered=//p')
+    marker_count=$(printf '%s\n' "$scan_out" | sed -n 's/^count=//p')
+    markers=$(printf '%s\n' "$scan_out" | grep '^marker=' || true)
+    case "$recovered" in
+        true|false) : ;;
+        *)
+            _post_deploy_smoke_wedge_unevaluable "wedge scan output contract violated"
+            return 1
+            ;;
+    esac
+    case "$marker_count" in
+        0) : ;;
+        ''|*[!0-9]*|0*)
+            _post_deploy_smoke_wedge_unevaluable "wedge scan output contract violated"
+            return 1
+            ;;
+        *) : ;;
+    esac
+    if { [ "$marker_count" = "0" ] && [ -n "$markers" ]; } \
+      || { [ "$marker_count" != "0" ] && [ -z "$markers" ]; }; then
+        _post_deploy_smoke_wedge_unevaluable "wedge scan output contract violated"
+        return 1
+    fi
+    case "$recovered:$marker_count" in
+        false:*) POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not evaluated: startup recovery in progress" ;;
+        true:0) POST_DEPLOY_SMOKE_WEDGE_COVERAGE="$POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE" ;;
+        *) POST_DEPLOY_SMOKE_WEDGE_COVERAGE="${POST_DEPLOY_SMOKE_WEDGE_MARKER_COVERAGE/\%s/$marker_count}" ;;
+    esac
+    while IFS= read -r line; do
+        case "$line" in
+            obs=*) _post_deploy_smoke_note "relay wedge observation: ${line#obs=}" || return 1 ;;
+            marker=*) [ "$recovered" = "false" ] && { _post_deploy_smoke_note "relay wedge observation: ${line#marker=}" || return 1; } ;;
+        esac
+    done <<< "$scan_out"
+    if [ "$recovered" = "false" ]; then
+        _post_deploy_smoke_note "relay wedge=${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}" || return 1
         return 0
     fi
-
-    _post_deploy_smoke_note \
-        "relay wedge marker observed; settling ${POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS}s before resample" \
-        || return 1
-    sleep "$POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS"
-    if ! curl -fsS --connect-timeout 2 --max-time 15 \
-        -H "Origin: http://${ADK_DEFAULT_LOOPBACK}:${REL_PORT}" \
-        -o "$resample_path" \
-        "http://${ADK_DEFAULT_LOOPBACK}:${REL_PORT}/api/health/detail"; then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle resample unavailable" || return 1
+    if [ "$marker_count" = "0" ]; then
+        _post_deploy_smoke_note "relay wedge=${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}" || return 1
         return 0
     fi
-    if [ ! -s "$resample_path" ]; then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle resample body empty" || return 1
-        return 0
-    fi
-    if ! fully_recovered=$(_post_deploy_smoke_fully_recovered_from_file "$resample_path"); then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle recovery state unavailable" || return 1
-        return 0
-    fi
-    if [ "$fully_recovered" = "false" ]; then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: startup recovery in progress" || return 1
-        return 0
-    fi
-    if ! wedge_markers_resampled=$(
-        _post_deploy_smoke_wedge_markers_from_file "$resample_path"
-    ); then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle resample JSON could not be parsed" || return 1
-        return 0
-    fi
-    if ! persistent_markers=$(comm -12 \
-        <(printf '%s\n' "$wedge_markers" | LC_ALL=C sort -u) \
-        <(printf '%s\n' "$wedge_markers_resampled" | LC_ALL=C sort -u)); then
-        _post_deploy_smoke_note \
-            "relay wedge=skipped: settle resample comparison failed" || return 1
-        return 0
-    fi
-    if [ -z "$persistent_markers" ]; then
-        _post_deploy_smoke_note \
-            "relay wedge markers=cleared after ${POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS}s settle" \
-            || return 1
-        return 0
-    fi
-
-    wedge_summary="${persistent_markers//$'\n'/; }"
     _post_deploy_smoke_fail \
-        "relay wedge marker persisted after ${POST_DEPLOY_SMOKE_WEDGE_SETTLE_SECS}s settle: ${wedge_summary}" \
+        "relay stall-state marker(s) observed (point-in-time): ${markers//$'\n'/; }" \
         || true
     return 1
 }
+
+# <<< END wedge-check region (#5244)
 
 _post_deploy_smoke_check_fail_closed_warn_rate() {
     local log_path="$POST_DEPLOY_SMOKE_LOG_PATH"
@@ -3170,6 +3155,7 @@ _report_post_deploy_smoke_failure() {
         printf -- '- Commit: `%s`\n' "$commit_sha"
         printf -- '- Port: `%s`\n' "$REL_PORT"
         printf -- '- Evidence: `%s`\n\n' "$POST_DEPLOY_SMOKE_EVIDENCE"
+        printf -- '- Relay wedge coverage: `%s`\n\n' "${POST_DEPLOY_SMOKE_WEDGE_COVERAGE:-not run: wedge check did not execute}"
         printf '## Findings\n\n'
         for finding in "${POST_DEPLOY_SMOKE_FAILURES[@]}"; do
             printf -- '- %s\n' "$finding"
@@ -3186,6 +3172,8 @@ node: ${node_name}
 commit: ${commit_sha}
 draft: ${draft_path}
 evidence: ${POST_DEPLOY_SMOKE_EVIDENCE}"
+    alert_text="${alert_text}
+relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE:-not run: wedge check did not execute}"
     for finding in "${POST_DEPLOY_SMOKE_FAILURES[@]}"; do
         alert_text="${alert_text}
 - ${finding}"
@@ -3213,6 +3201,7 @@ evidence: ${POST_DEPLOY_SMOKE_EVIDENCE}"
     return 0
 }
 
+# >>> BEGIN smoke-disposition region (#5244)
 echo "▸ Running post-deploy functional smoke (#4262)..."
 # INVARIANT: the ENTIRE smoke block is fail-open. We are past DEPLOY_OK, so a
 # functional failure must degrade to a loud warning + channel alert + local
@@ -3223,9 +3212,17 @@ echo "▸ Running post-deploy functional smoke (#4262)..."
 # The smoke function runs from an `if` guard, suspending `set -e` within it;
 # each fallible step is nevertheless explicitly guarded or carries `|| return`.
 if _run_post_deploy_functional_smoke; then
-    echo "✓ Post-deploy functional smoke passed (evidence: $POST_DEPLOY_SMOKE_EVIDENCE)"
+    case "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE" in
+        "$POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE")
+            echo "✓ Post-deploy functional smoke passed (relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}; evidence: $POST_DEPLOY_SMOKE_EVIDENCE)"
+            ;;
+        *)
+            echo "△ Post-deploy functional smoke completed with coverage gap (relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}; evidence: $POST_DEPLOY_SMOKE_EVIDENCE)"
+            ;;
+    esac
 else
     echo "⚠ POST-DEPLOY FUNCTIONAL SMOKE FAILED — deploy remains healthy (fail-open)"
+    echo "  relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}"
     echo "  evidence: $POST_DEPLOY_SMOKE_EVIDENCE"
     if [ -n "$POST_DEPLOY_SMOKE_TMP_DIR" ]; then
         rm -rf "$POST_DEPLOY_SMOKE_TMP_DIR" 2>/dev/null || true
@@ -3236,6 +3233,7 @@ else
     fi
     _report_post_deploy_smoke_failure || true
 fi
+# <<< END smoke-disposition region (#5244)
 
 # ── Out-of-band relay watchdog (#4381) ────────────────────────────────────────
 # Deliberately OUTSIDE dcserver's launchd job: the watchdog must survive exactly

--- a/tests/test_deploy_smoke_wedge_coverage_5244.sh
+++ b/tests/test_deploy_smoke_wedge_coverage_5244.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# #5244 is a report-coverage test. It extracts only the sentinel region and
+# never sources deploy-release.sh (which would execute a real deployment).
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEPLOY_SH="${DEPLOY_SH_OVERRIDE:-$ROOT_DIR/scripts/deploy-release.sh}"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agentdesk-wedge-coverage-5244.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+failures=0
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+begin_line=$(grep -nF '# >>> BEGIN wedge-check region (#5244)' "$DEPLOY_SH" | cut -d: -f1 || true)
+end_line=$(grep -nF '# <<< END wedge-check region (#5244)' "$DEPLOY_SH" | cut -d: -f1 || true)
+[ -n "$begin_line" ] || fail 'wedge-check BEGIN sentinel missing'
+[ -n "$end_line" ] || fail 'wedge-check END sentinel missing'
+if [ -n "$begin_line" ] && [ -n "$end_line" ]; then
+    [ "$begin_line" -lt "$end_line" ] || fail 'wedge-check sentinels are reversed'
+fi
+
+REGION="$TMP_ROOT/wedge-region.sh"
+if [ -n "$begin_line" ] && [ -n "$end_line" ]; then
+    sed -n "$((begin_line + 1)),$((end_line - 1))p" "$DEPLOY_SH" > "$REGION"
+fi
+
+# Boundary declaration: this suite fixes behavior but cannot protect itself
+# from harness bypass; seven measured forms include multiline/eval functions,
+# trap handler/signal variants, and eval/compound source hooks. CASE_DONE is
+# not an authenticated return witness (a forged token plus exit 0 passes).
+# Code review and CI's required-suite existence check own harness integrity.
+
+runner_source="$TMP_ROOT/runner.sh"
+sed -n '/^_run_post_deploy_functional_smoke()/,/^_report_post_deploy_smoke_failure()/p' "$DEPLOY_SH" \
+    | sed '$d' > "$runner_source"
+runner_output=$(bash -s -- "$runner_source" "$TMP_ROOT" <<'CHILD'
+set -euo pipefail
+runner_source="$1"; root="$2"; eval "$(<"$runner_source")"
+ADK_REL="$root"; POST_DEPLOY_SMOKE_EVIDENCE="$root/runner.evidence"; POST_DEPLOY_SMOKE_TMP_DIR=""; POST_DEPLOY_SMOKE_FAILURES=(); POST_DEPLOY_SMOKE_STAMP=runner; REL_PORT=0; runner_wedge_called=0
+_post_deploy_smoke_note() { :; }; _post_deploy_smoke_probe_apis() { return 0; }; _post_deploy_smoke_check_wedges() { runner_wedge_called=1; return 0; }; _post_deploy_smoke_check_fail_closed_warn_rate() { return 0; }; _post_deploy_smoke_check_relay_round_trip() { return 0; }
+if _run_post_deploy_functional_smoke; then rc=0; else rc=$?; fi
+printf 'CASE_DONE runner rc=%s wedge_called=%s\n' "$rc" "$runner_wedge_called"
+CHILD
+)
+grep -q 'CASE_DONE runner rc=0 wedge_called=1' <<< "$runner_output" || fail 'smoke runner did not execute check_wedges in its parent shell'
+
+cleanup_to_signal=$(sed -n '/^_cleanup_on_exit()/,/^_handle_cleanup_signal()/p' "$DEPLOY_SH")
+grep -q '_finalize_detached_helper' <<< "$cleanup_to_signal" || fail 'cleanup text does not contain finalizer'
+coverage_decl_line=$(grep -nE '^POST_DEPLOY_SMOKE_WEDGE_COVERAGE=' "$DEPLOY_SH" | head -1 | cut -d: -f1 || true)
+trap_line=$(grep -nF 'trap _cleanup_on_exit EXIT' "$DEPLOY_SH" | head -1 | cut -d: -f1 || true)
+[ -n "$coverage_decl_line" ] && [ -n "$trap_line" ] && [ "$coverage_decl_line" -lt "$trap_line" ] || fail 'coverage declaration is not before EXIT trap'
+while IFS=: read -r assignment_line _; do
+    [ -n "$assignment_line" ] || continue
+    if [ "$assignment_line" != "$coverage_decl_line" ]; then
+        [ "$assignment_line" -ge "$begin_line" ] && [ "$assignment_line" -le "$end_line" ] || fail "coverage assignment escaped region at line $assignment_line"
+    fi
+done < <(grep -nE '^[[:space:]]*POST_DEPLOY_SMOKE_WEDGE_COVERAGE=' "$DEPLOY_SH" || true)
+
+scanner_text=$(sed -n '/^_post_deploy_smoke_wedge_scan_from_file()/,/^_post_deploy_smoke_wedge_unevaluable()/p' "$DEPLOY_SH")
+check_text=$(sed -n '/^_post_deploy_smoke_check_wedges()/,/^# <<< END wedge-check region/p' "$DEPLOY_SH")
+grep -qF 'count=\($markers | length)' <<< "$scanner_text" || fail 'count is not produced by jq array length'
+grep -q 'queue_blocked' <<< "$scanner_text" || fail 'queue_blocked observation was removed'
+grep -q 'unknown_stall_state' <<< "$scanner_text" || fail 'unknown stall observation was removed'
+for state in tmux_alive_relay_dead stale_thread_proof orphan_pending_token; do
+    grep -q "$state" <<< "$scanner_text" || fail "marker state $state is not in the classifier filter"
+done
+grep -q 'relay_stall_state.*type' <<< "$scanner_text" || fail 'relay_stall_state type guard is missing'
+! grep -q 'degraded_reasons' <<< "$scanner_text" || fail 'degraded_reasons became a second authority'
+! grep -qE 'desynced|watcher_attached_stale|relay_owner_kind' <<< "$scanner_text" || fail 'input booleans were re-promoted'
+! grep -qE '\b(sleep|curl|comm|sort)\b' <<< "$check_text" || fail 'deleted transient machinery remains in check_wedges'
+! grep -qE 'marker_count.*(\$\(\(|-gt|-ge|-lt|-le)' <<< "$check_text" || fail 'marker count uses shell arithmetic'
+grep -qF 'POST_DEPLOY_SMOKE_STAMP="$(date' "$DEPLOY_SH" || fail 'stamp assignment disappeared'
+grep -qF ')-$$"' "$DEPLOY_SH" || fail 'stamp has no PID suffix'
+for old_name in consecutive_skips WEDGE_SETTLE RECOVERY_WAIT; do
+    ! grep -q "$old_name" "$DEPLOY_SH" || fail "deleted persistent/wait mechanism remains: $old_name"
+done
+
+fixture() {
+    local name="$1" body="$2"
+    printf '%s\n' "$body" > "$TMP_ROOT/$name.json"
+}
+fixture clean '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"healthy"}]}'
+fixture active_stream '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"active_foreground_stream","relay_health":{"desynced":true,"stale_thread_proof":true,"watcher_attached_stale":true}}]}'
+fixture recovering '{"fully_recovered":false,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"healthy"}]}'
+fixture tmux_dead '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"tmux_alive_relay_dead"}]}'
+fixture stale_thread '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"stale_thread_proof"}]}'
+fixture orphan_token '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"orphan_pending_token"}]}'
+fixture observations '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"queue_blocked"},{"provider":"claude","channel_id":2,"relay_stall_state":"future_state"}]}'
+fixture recovering_observations '{"fully_recovered":false,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":"tmux_alive_relay_dead"},{"provider":"claude","channel_id":2,"relay_stall_state":"queue_blocked"},{"provider":"claude","channel_id":3,"relay_stall_state":"future_state"}]}'
+fixture malformed '{"fully_recovered":true,"mailboxes":[{"provider":"claude","channel_id":1,"relay_stall_state":42}]}'
+fixture malformed_json '{broken'
+fixture empty_mailboxes '{"fully_recovered":true,"mailboxes":null}'
+fixture empty_mailboxes_valid '{"fully_recovered":true,"mailboxes":[]}'
+fixture root_scalar '[]'
+fixture recovery_missing '{"mailboxes":[]}'
+fixture mailbox_scalar '{"fully_recovered":true,"mailboxes":["mailbox"]}'
+fixture mailbox_missing_state '{"fully_recovered":true,"mailboxes":[{"provider":"claude"}]}'
+fixture recovery_string '{"fully_recovered":"yes","mailboxes":[]}'
+
+WEDGE_MARKER_COVERAGE='evaluated: %s stall-state marker(s) observed (point-in-time)'
+WEDGE_CLEAN_COVERAGE="${WEDGE_MARKER_COVERAGE/\%s/0}"
+
+run_case() {
+    local name="$1" expected_rc="$2" fixture_path="$3" expected_coverage="$4"
+    local output rc case_line coverage_line
+    output=$(bash -s -- "$REGION" "$fixture_path" <<'CHILD'
+set -euo pipefail
+region_path="$1"
+body_path="$2"
+eval "$(<"$region_path")"
+POST_DEPLOY_SMOKE_EVIDENCE="${body_path}.evidence"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$body_path"
+POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+if _post_deploy_smoke_check_wedges; then
+    rc=0
+else
+    rc=$?
+fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+    )
+    case_line=$(grep '^CASE_DONE ' <<< "$output" || true)
+    [ -n "$case_line" ] || { fail "$name: completion token missing"; return; }
+    rc=${case_line#*rc=}
+    rc=${rc%% *}
+    coverage_line=${case_line#*coverage=}
+    [ "$rc" -eq "$expected_rc" ] || fail "$name: expected rc $expected_rc, got $rc"
+    [ "$coverage_line" = "$expected_coverage" ] || fail "$name: expected coverage [$expected_coverage], got [$coverage_line]"
+}
+
+run_case clean 0 "$TMP_ROOT/clean.json" "$WEDGE_CLEAN_COVERAGE"
+run_case active_stream 0 "$TMP_ROOT/active_stream.json" "$WEDGE_CLEAN_COVERAGE"
+run_case recovering 0 "$TMP_ROOT/recovering.json" 'not evaluated: startup recovery in progress'
+run_case tmux_alive_relay_dead 1 "$TMP_ROOT/tmux_dead.json" "${WEDGE_MARKER_COVERAGE/\%s/1}"
+run_case stale_thread_proof 1 "$TMP_ROOT/stale_thread.json" "${WEDGE_MARKER_COVERAGE/\%s/1}"
+run_case orphan_pending_token 1 "$TMP_ROOT/orphan_token.json" "${WEDGE_MARKER_COVERAGE/\%s/1}"
+run_case observations 0 "$TMP_ROOT/observations.json" "$WEDGE_CLEAN_COVERAGE"
+run_case recovering_observations 0 "$TMP_ROOT/recovering_observations.json" 'not evaluated: startup recovery in progress'
+run_case malformed 1 "$TMP_ROOT/malformed.json" 'unevaluable: health/detail scan failed'
+run_case malformed_json 1 "$TMP_ROOT/malformed_json.json" 'unevaluable: health/detail scan failed'
+run_case empty_mailboxes 1 "$TMP_ROOT/empty_mailboxes.json" 'unevaluable: health/detail scan failed'
+run_case empty_mailboxes_valid 0 "$TMP_ROOT/empty_mailboxes_valid.json" "$WEDGE_CLEAN_COVERAGE"
+run_case root_scalar 1 "$TMP_ROOT/root_scalar.json" 'unevaluable: health/detail scan failed'
+run_case recovery_missing 1 "$TMP_ROOT/recovery_missing.json" 'unevaluable: health/detail scan failed'
+run_case mailbox_scalar 1 "$TMP_ROOT/mailbox_scalar.json" 'unevaluable: health/detail scan failed'
+run_case mailbox_missing_state 1 "$TMP_ROOT/mailbox_missing_state.json" 'unevaluable: health/detail scan failed'
+run_case recovery_string 1 "$TMP_ROOT/recovery_string.json" 'unevaluable: health/detail scan failed'
+
+marker_template_output=$(MARKER_COVERAGE='marker-sentinel-%s' bash -s -- "$REGION" "$TMP_ROOT/tmux_dead.json" <<'CHILD'
+set -euo pipefail
+eval "$(<"$1")"; POST_DEPLOY_SMOKE_WEDGE_MARKER_COVERAGE="$MARKER_COVERAGE"; POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE="${POST_DEPLOY_SMOKE_WEDGE_MARKER_COVERAGE/\%s/0}"
+POST_DEPLOY_SMOKE_EVIDENCE="${TMPDIR:-/tmp}/5244-marker-template.evidence"; POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$2"; POST_DEPLOY_SMOKE_FAILURES=(); POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"; : > "$POST_DEPLOY_SMOKE_EVIDENCE"
+if _post_deploy_smoke_check_wedges; then rc=0; else rc=$?; fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+)
+grep -q 'CASE_DONE rc=1 coverage=marker-sentinel-1' <<< "$marker_template_output" || fail 'marker coverage drifted from the shared template'
+
+missing_body_output=$(bash -s -- "$REGION" <<'CHILD'
+set -euo pipefail
+eval "$(<"$1")"
+POST_DEPLOY_SMOKE_EVIDENCE="${TMPDIR:-/tmp}/5244-missing.evidence"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY=""
+POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+if _post_deploy_smoke_check_wedges; then rc=0; else rc=$?; fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+)
+grep -q 'CASE_DONE rc=1 coverage=unevaluable: /api/health/detail body unavailable' <<< "$missing_body_output" || fail 'body-unavailable case did not fail with unevaluable coverage'
+
+jq_missing_output=$(bash -s -- "$REGION" "$TMP_ROOT/clean.json" <<'CHILD'
+set -euo pipefail
+eval "$(<"$1")"
+POST_DEPLOY_SMOKE_EVIDENCE="${TMPDIR:-/tmp}/5244-jq-missing.evidence"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$2"
+POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+PATH="${TMPDIR:-/tmp}/does-not-contain-jq"
+if _post_deploy_smoke_check_wedges; then rc=0; else rc=$?; fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+)
+grep -q 'CASE_DONE rc=1 coverage=unevaluable: jq unavailable' <<< "$jq_missing_output" || fail 'jq-unavailable case did not use separate vocabulary'
+
+run_contract_case() {
+    local label="$1" encoded_count="$2"
+    local output
+    output=$(COUNT_VALUE="$encoded_count" bash -s -- "$REGION" "$TMP_ROOT/clean.json" <<'CHILD'
+set -euo pipefail
+eval "$(<"$1")"
+POST_DEPLOY_SMOKE_EVIDENCE="${TMPDIR:-/tmp}/5244-contract.evidence"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$2"
+POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
+_post_deploy_smoke_wedge_scan_from_file() {
+    printf 'recovered=true\ncount=%s\nmarker=fake\n' "$COUNT_VALUE"
+}
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+if _post_deploy_smoke_check_wedges; then rc=0; else rc=$?; fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+    )
+    grep -q 'CASE_DONE rc=1 coverage=unevaluable: wedge scan output contract violated' <<< "$output" || fail "$label: malformed count was accepted"
+}
+run_contract_case count_10x '10x'
+run_contract_case count_space '10 2'
+run_contract_case count_newline $'10\n2'
+run_contract_case count_08 '08'
+run_contract_case count_negative '-1'
+run_contract_case count_empty ''
+
+observation_output=$(bash -s -- "$REGION" "$TMP_ROOT/observations.json" <<'CHILD'
+set -euo pipefail
+eval "$(<"$1")"
+POST_DEPLOY_SMOKE_EVIDENCE="${TMPDIR:-/tmp}/5244-observation.evidence"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$2"
+POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+if _post_deploy_smoke_check_wedges; then rc=0; else rc=$?; fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+)
+grep -q 'relay wedge observation: queue_blocked' <<< "$observation_output" || fail 'queue_blocked was not reported as an observation'
+grep -q 'relay wedge observation: unknown_stall_state' <<< "$observation_output" || fail 'unknown stall was not reported as an observation'
+
+recovery_observation_output=$(RECOVERY_EVIDENCE="$TMP_ROOT/recovery-observation.evidence" bash -s -- "$REGION" "$TMP_ROOT/recovering_observations.json" <<'CHILD'
+set -euo pipefail
+eval "$(<"$1")"
+POST_DEPLOY_SMOKE_EVIDENCE="$RECOVERY_EVIDENCE"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$2"
+POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+if _post_deploy_smoke_check_wedges; then rc=0; else rc=$?; fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+)
+grep -q 'relay wedge observation: stall-state provider=claude channel=1 state=tmux_alive_relay_dead' <<< "$recovery_observation_output" || fail 'recovery marker observation was discarded from stdout'
+grep -q 'relay wedge observation: queue_blocked' <<< "$recovery_observation_output" || fail 'recovery queue observation was discarded'
+grep -q 'relay wedge observation: unknown_stall_state' <<< "$recovery_observation_output" || fail 'recovery unknown observation was discarded'
+grep -q 'relay wedge observation: stall-state provider=claude channel=1 state=tmux_alive_relay_dead' "$TMP_ROOT/recovery-observation.evidence" || fail 'recovery marker observation was discarded from evidence'
+
+observation_race_output=$(bash -s -- "$REGION" "$TMP_ROOT/recovering_observations.json" "$TMP_ROOT/race.evidence" 2>&1 <<'CHILD'
+set -euo pipefail
+eval "$(<"$1")"
+POST_DEPLOY_SMOKE_EVIDENCE="$3"
+POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY="$2"
+POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="not run: wedge check did not execute"
+eval "$(declare -f _post_deploy_smoke_note | sed 's/_post_deploy_smoke_note/_post_deploy_smoke_note_real/')"
+_post_deploy_smoke_note() {
+    local message="$1"
+    if [[ "$message" == relay\ wedge\ observation:* ]]; then
+        rm -f "$POST_DEPLOY_SMOKE_EVIDENCE"
+        mkdir "$POST_DEPLOY_SMOKE_EVIDENCE"
+    fi
+    _post_deploy_smoke_note_real "$message"
+}
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+if _post_deploy_smoke_check_wedges; then rc=0; else rc=$?; fi
+printf 'CASE_DONE rc=%s coverage=%s\n' "$rc" "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE"
+CHILD
+)
+grep -q 'CASE_DONE rc=1 coverage=not evaluated: startup recovery in progress' <<< "$observation_race_output" || fail 'observation evidence failure reverted to not-run coverage'
+
+DISPOSITION="$TMP_ROOT/disposition.sh"
+disposition_begin=$(grep -nF '# >>> BEGIN smoke-disposition region (#5244)' "$DEPLOY_SH" | cut -d: -f1 || true)
+disposition_end=$(grep -nF '# <<< END smoke-disposition region (#5244)' "$DEPLOY_SH" | cut -d: -f1 || true)
+sed -n "$((disposition_begin + 1)),$((disposition_end - 1))p" "$DEPLOY_SH" > "$DISPOSITION"
+disposition_case() {
+    local label="$1" smoke_rc="$2" coverage="$3" clean_coverage="$4" expected="$5"
+    local output
+    output=$(SMOKE_RC="$smoke_rc" COVERAGE="$coverage" CLEAN_COVERAGE="$clean_coverage" bash -s -- "$DISPOSITION" <<'CHILD'
+set -euo pipefail
+POST_DEPLOY_SMOKE_WEDGE_COVERAGE="$COVERAGE"
+POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE="$CLEAN_COVERAGE"
+POST_DEPLOY_SMOKE_EVIDENCE=/tmp/5244-disposition.evidence
+POST_DEPLOY_SMOKE_TMP_DIR=""
+POST_DEPLOY_SMOKE_FAILURES=()
+_run_post_deploy_functional_smoke() { return "$SMOKE_RC"; }
+_report_post_deploy_smoke_failure() { printf 'REPORT_CALLED\n'; }
+eval "$(<"$1")"
+printf 'CASE_DONE disposition\n'
+CHILD
+    )
+    grep -q 'CASE_DONE disposition' <<< "$output" || fail "$label: disposition completion token missing"
+    grep -q "$expected" <<< "$output" || fail "$label: expected [$expected]"
+}
+disposition_case evaluated_clean 0 clean-sentinel clean-sentinel 'passed (relay wedge coverage: clean-sentinel'
+disposition_case coverage_gap 0 'not evaluated: startup recovery in progress' clean-sentinel 'completed with coverage gap'
+disposition_case failed 1 'unevaluable: health/detail scan failed' clean-sentinel 'REPORT_CALLED'
+
+if [ "$failures" -ne 0 ]; then
+    printf 'test_deploy_smoke_wedge_coverage_5244: %s assertion(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'test_deploy_smoke_wedge_coverage_5244: all assertions passed\n'


### PR DESCRIPTION
post-deploy 스모크의 relay wedge 체크가 **평가하지 못한 것을 평가한 것처럼** 보고하던 문제를 닫는다.
이 PR 의 유일한 산출물은 **보고**다 — 배포 판정은 fail-open 그대로다.

`#5244` 는 이전에 브랜치 3개(`wt/5244-durable-axis-wedge` 3라운드, `wt/5244-skip-accounting`,
`wt/5244-wedge-report` 2라운드)가 전부 발산해 한 줄도 착지하지 못했다. 이 브랜치는 `origin/main`
(`8fba7271a`) 위 **두 번째 최소집합 재구성**이고, 앞 브랜치들에서 **cherry-pick 하지 않았다.**

## 재구성한 이유 — 결함의 크기가 아니라 형태

`wt/5244-wedge-report` r2 는 하네스 우회 4형태를 *r1 이 시도한 철자 그대로는* 전부 막았다.
그런데 같은 라운드에서 리뷰 두 leg 이 **새 철자 7가지**를 찾았다 —
`{` 개행 정의 · `eval` 정의 · `trap 'exit 0' EXIT` · `trap 'true' EXIT INT` · `trap -- 'true' EXIT` ·
signal `0` · region 내 `eval "$(cat …)"` · 행두 아닌 `. …`.

정규식으로 셸의 구조적 불변식을 집행하려는 **군비경쟁**이고 셸 문법상 철자는 무한하다.
그래서 이 브랜치는 **정규식 검사 4종(함수 정의 exact-one · EXIT trap 개수 · region 내 source 훅 ·
러너 호출 서브셸 금지)을 삭제**하고, 그 자리에 **정직한 한계 선언**을 넣었다.

## 무엇이 바뀌었나

- **커버리지가 항상 확정된다.** `_post_deploy_smoke_check_wedges` 가 **실행된 뒤 반환하는 모든 경로**
  (body 부재 / jq 부재 / scan 실패 / 계약 위반 3지점 / `recovered:marker_count` 3분기)에서
  coverage 를 먼저 쓴다. **coverage 를 쓰지 않고 반환하는 경로는 0개다.**
  초기값 `not run: wedge check did not execute` 는 함수가 **아예 호출되지 않은 경우**에만 남고,
  그때는 참인 진술이다.
- **어휘를 분리한다.** jq 부재(`unevaluable: jq unavailable`) · body 부재
  (`unevaluable: /api/health/detail body unavailable`) · 스캔 실패(`unevaluable: health/detail scan failed`)
  가 각각 다른 문장을 쓴다. 셸 경계에서 구분할 수 없는 것은 **broad scan failure** 로 정직하게 보고한다.
- **복구 중에도 관측을 버리지 않는다.** `fully_recovered=false` 경로에서 `marker=` 3종과 `obs=` 가
  stdout·evidence 양쪽에 남는다. 커버리지 판정만 `not evaluated: startup recovery in progress` 다.
- **대기·재샘플링 기계를 제거했다.** settle 대기 · 재샘플링 curl · `comm` 교집합 · 이중 파서가 전부 빠졌다.
  마커는 **point-in-time 관측**이며 지속 wedge 증명이 아니다.

## 이 게이트가 보장하지 않는 것 (정직성 선언)

- 이 스위트는 **행동을 고정하지만 자기 자신을 우회로부터 보호하지 못한다.** 우회 철자는 열거 불가다.
- `CASE_DONE` 은 **인증된 return witness 가 아니다** — 해당 케이스의 토큰 검사는 위조 토큰 + `exit 0` 으로 통과한다.
- 하네스 무결성은 **코드 리뷰와 CI 의 required-suite 존재 검사**가 소유한다(`ci-script-checks.sh`,
  스위트 파일을 지우면 rc=1).
- **durable 축(`delivered_frontier` / `discord_delivery_records` / `watcher_owner_channel_id`)은
  이 PR 에 한 줄도 없다.** #5244 의 "durable 축 신호 부재"는 **읽기·검출기 쪽 주장**이며 별도 PR 로 분리했다.
  따라서 이 PR 만으로 `#5071` T1 S8 의 선행 조건이 충족되지 않는다.

## 표면 — 이슈 전체에서 처음으로 감소

`git diff --numstat origin/main...HEAD`:
```
4       0       scripts/ci-script-checks.sh
113     115     scripts/deploy-release.sh
306     0       tests/test_deploy_smoke_wedge_coverage_5244.sh
```
`deploy-release.sh` 프로덕션 삽입 **r1 +120 → r2 +126 → v2 +113**, 순증 **−2**.
감축분의 출처는 전부 **기계 제거**이고 방어 제거가 아니다 — 스키마 하드 가드(`die`) · 출력 계약 검증 ·
관측 3종은 **신규 추가**됐다.

## 검증 (dual 적대 리뷰, 양쪽 `VERDICT: CLEAN`)

- **뮤턴트 24종 전건 사망**, `bash -n` rc=0 **24/24** — **문법 사망 0건**, 전부 스위트 자신의 `FAIL:` 로 사망
- 형제 스위트 5종 + 정적 게이트(`bash -n` 3종, `shellcheck -S warning` 2종) **전건 rc=0**
- **fail-open 유지** — 스모크 실패(rc=1)에도 disposition 블록 rc=0
- `_notify_channel` 본체 **바이트 동일**(635 B, md5 `7cfdf6e2ade2fa4259f1d6af3c378508`) — PR #5277 표면 무접촉
- `_run_post_deploy_functional_smoke` 에 **부모 deadline 미생성**
- jq 의 `IN(...)` 7개 값이 `src/services/discord/relay_health.rs` 의 `RelayStallState` 열거형과 **정확히 일치**
- 이 브랜치가 추가한 주석에 **절대 행번호 0건** — 이전 브랜치가 쓴 `:3024` 는 그 커밋 자신이 +6줄을 밀어
  빈 줄이 됐었다. 대체 주석은 심볼(`E-1`)로 지목한다.

## 알려진 후속 (P2, 이 PR 을 막지 않음)

- disposition 리전 추출(스위트)이 웨지 리전과 달리 `|| true` 가드가 없다 — END 센티널 개명 시
  `sed` 가 죽어 해당 케이스가 실행되지 않는다. **suite rc 는 1 이라 거짓 그린은 없다.** 3줄 수정.
- 한계 선언의 "seven measured forms" 는 **삭제된 정규식 기준의 역사적 계수**라 v2 에서 재현 불가 —
  수를 빼고 범주만 남기는 편이 낫다.
- `/api/health/detail` 의 standalone 분기(`health_registry == None`)는 `mailboxes` 키가 없어
  `unevaluable` + FAIL 이 된다. 배포 스모크 대상은 `Some(registry)` 로 뜨는 로컬 릴리스 dcserver 이므로
  **이 경로에서는 도달하지 않는다.**
- jq `IN/1` 은 이 리포 셸 스크립트 통틀어 첫 사용이며 jq 하한이 선언돼 있지 않다.

Closes #5244
