### PR TITLE
feat(e2e): probe durable delivery records post-deploy

### DIFF
--- a/docs/e2e/multi-provider-e2e.md
+++ b/docs/e2e/multi-provider-e2e.md
@@ -126,6 +126,31 @@ health/queue degradation. `E-26` through `E-29` are explicit
 CronCreate live creation, Codex modern-schema production-parser/live stream,
 Codex live tool-command coverage, and `claude-e` tool-use-to-text completeness.
 
+`E-35` preserves the headless `E-1` and adds one normal Discord short-response
+turn. It passes only when the newly observed outbound Discord response ID has
+exactly one authoritative receipt and that receipt has a same-generation
+covering frontier in the local atomic sidecar record. Inbound prompt IDs, old
+frontiers, completed-turn ledgers, leases, and in-memory offsets cannot pass it.
+The post-deploy invocation disables reset/force-cancel, rechecks standby,
+target-idle/queue state, and its cell lease immediately before setup, and makes
+busy or dirty residue `unevaluable` without attempting cleanup. Its single
+900-second wall-clock deadline covers the gate, lease, setup/send/fetch HTTP,
+response wait, record poll, final refetch, idle check, and teardown; expiry is a
+fail-open functional finding after `DEPLOY_OK`.
+
+#5264 is a hard prerequisite only for default `claude-tui` live acceptance.
+`claude-pipe` is allowed as `partial coverage`, but is not S8 TUI-surface
+evidence. The minimum positive claim is: 이 노드의 이번 배포 세대에서 E-35의
+한 short-response normal Discord turn이 confirmed durable record funnel을
+통과해, 그 새 Discord response에 결속된 exact receipt와 covering frontier를
+atomic sidecar record에 남겼다. Here “이번 배포 세대” means the local
+post-`DEPLOY_OK` probe transaction; it does not bind a peer, deployed commit SHA,
+or poll-time-current tmux generation. The proof also does not cover power-loss
+durability, every provider/call site, long/fallback/recovery/headless paths,
+completed-ledger persistence, continuous health, or S8 rollout. It does catch
+the probed `claude-tui` `.generation` absence from #5264 because ledger-only
+state lacks the required receipt/frontier pair.
+
 ## #2943 Scenario Coverage And Gaps
 
 Covered P0/P1 backlog items:

--- a/docs/e2e/multi-provider-e2e.md
+++ b/docs/e2e/multi-provider-e2e.md
@@ -137,12 +137,16 @@ and turn nonce identities; and was current-generation at writer-lock time. On
 this probed short terminal path, reaching the writer follows that turn's
 successful lease commit. E-35 therefore detects both a frontier-only partial
 write and a normal-to-headless `send_prompt` regression that omits the receipt.
-The post-deploy invocation disables reset/force-cancel, rechecks standby,
-target-idle/queue state, and its cell lease immediately before setup, and makes
-busy or dirty residue `unevaluable` without attempting cleanup. Its single
-900-second wall-clock deadline covers the gate, lease, setup/send/fetch HTTP,
-response wait, record poll, final refetch, idle check, and teardown; expiry is a
-fail-open functional finding after `DEPLOY_OK`.
+The post-deploy invocation disables reset/force-cancel and rechecks standby,
+target-idle/queue state, and its cell lease before setup and immediately before
+the normal prompt. Busy or dirty residue becomes `unevaluable` without cleanup.
+With the default HTTP timeouts, the prompt-time recheck narrows the nominal
+gate-return-to-prompt window from 368 seconds to 0 seconds, and the
+last-mailbox-snapshot-to-prompt window from 373 seconds to 5 seconds. It does not close the
+TOCTOU: local filesystem/scheduling has no hard bound, and a turn can start after
+the recheck and before send. Its single 900-second wall-clock deadline covers the
+gate, lease, setup/send/fetch HTTP, response wait, record poll, final refetch,
+idle check, and teardown; expiry is a fail-open finding after `DEPLOY_OK`.
 
 #5264 is a hard prerequisite only for default `claude-tui` live acceptance.
 `claude-pipe` is allowed as `partial coverage`, but is not S8 TUI-surface
@@ -157,8 +161,15 @@ completed-ledger persistence, lease acquisition/clear/restart reconciliation,
 continuous health, or S8 rollout. E-35 PASS does not distinguish the spawn writer
 from the `restore.rs` old-generation adoption writer. When `.generation` remains
 absent, ledger-only state cannot satisfy the receipt/frontier conjunct; however,
-adoption can create the marker first, so without #5264 default `claude-tui`
-acceptance can pass nondeterministically (a flaky green). The safety gate also
+adoption can create the marker first and let the redundant positive/current-
+generation defenses be satisfied together, so without #5264 default `claude-tui`
+acceptance can pass nondeterministically (a flaky green). Those Rust defenses are
+repeated across `exact_receipt_from_inflight`,
+`ExactJsonlSourceIdentity::is_authoritative`, `shadow_mirror_delivered_frontier_inner`,
+and `write_confirmed_frontier_guarded_at_with_lock_authority`: construction and
+identity checks reject zero/incomplete authority, the mirror rejects a zero
+generation or range, and the lock-held writer rereads the current generation. An
+E-35 PASS also includes post-scenario mailbox/queue idle evidence. The safety gate
 depends directly on private `lease._read_lease` because no public read API exists;
 an underscore-function refactor can silently leave E-35 fail-closed and
 `unevaluable` until the coupling is updated.

--- a/docs/e2e/multi-provider-e2e.md
+++ b/docs/e2e/multi-provider-e2e.md
@@ -131,6 +131,12 @@ turn. It passes only when the newly observed outbound Discord response ID has
 exactly one authoritative receipt and that receipt has a same-generation
 covering frontier in the local atomic sidecar record. Inbound prompt IDs, old
 frontiers, completed-turn ledgers, leases, and in-memory offsets cannot pass it.
+For production-written records, that receipt also binds the provider, owner
+filename, source and delivery channels, and range; requires nonempty tmux session
+and turn nonce identities; and was current-generation at writer-lock time. On
+this probed short terminal path, reaching the writer follows that turn's
+successful lease commit. E-35 therefore detects both a frontier-only partial
+write and a normal-to-headless `send_prompt` regression that omits the receipt.
 The post-deploy invocation disables reset/force-cancel, rechecks standby,
 target-idle/queue state, and its cell lease immediately before setup, and makes
 busy or dirty residue `unevaluable` without attempting cleanup. Its single
@@ -147,9 +153,20 @@ atomic sidecar record에 남겼다. Here “이번 배포 세대” means the lo
 post-`DEPLOY_OK` probe transaction; it does not bind a peer, deployed commit SHA,
 or poll-time-current tmux generation. The proof also does not cover power-loss
 durability, every provider/call site, long/fallback/recovery/headless paths,
-completed-ledger persistence, continuous health, or S8 rollout. It does catch
-the probed `claude-tui` `.generation` absence from #5264 because ledger-only
-state lacks the required receipt/frontier pair.
+completed-ledger persistence, lease acquisition/clear/restart reconciliation,
+continuous health, or S8 rollout. E-35 PASS does not distinguish the spawn writer
+from the `restore.rs` old-generation adoption writer. When `.generation` remains
+absent, ledger-only state cannot satisfy the receipt/frontier conjunct; however,
+adoption can create the marker first, so without #5264 default `claude-tui`
+acceptance can pass nondeterministically (a flaky green). The safety gate also
+depends directly on private `lease._read_lease` because no public read API exists;
+an underscore-function refactor can silently leave E-35 fail-closed and
+`unevaluable` until the coupling is updated.
+
+E-35 alone supplies the durable-record provenance above. The full post-deploy
+E-1 + E-35 sequence additionally checks that the existing headless relay
+round-trip still works; it does not turn the headless E-1 response into S8 TUI
+durability evidence or broaden E-35 to the excluded paths.
 
 ## #2943 Scenario Coverage And Gaps
 

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -3213,7 +3213,7 @@ _report_post_deploy_smoke_failure() {
         printf -- '- Port: `%s`\n' "$REL_PORT"
         printf -- '- Evidence: `%s`\n\n' "$POST_DEPLOY_SMOKE_EVIDENCE"
         printf -- '- Relay wedge coverage: `%s`\n\n' "${POST_DEPLOY_SMOKE_WEDGE_COVERAGE:-not run: wedge check did not execute}"
-        printf -- '- Durable record coverage: `%s`\n\n' "$POST_DEPLOY_SMOKE_DURABLE_COVERAGE"
+        printf -- '- Durable record coverage: `%s`\n\n' "${POST_DEPLOY_SMOKE_DURABLE_COVERAGE:-unevaluable: E-35 did not run}"
         printf '## Findings\n\n'
         for finding in "${POST_DEPLOY_SMOKE_FAILURES[@]}"; do
             printf -- '- %s\n' "$finding"
@@ -3233,7 +3233,7 @@ evidence: ${POST_DEPLOY_SMOKE_EVIDENCE}"
     alert_text="${alert_text}
 relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE:-not run: wedge check did not execute}"
     alert_text="${alert_text}
-durable record coverage: ${POST_DEPLOY_SMOKE_DURABLE_COVERAGE}"
+durable record coverage: ${POST_DEPLOY_SMOKE_DURABLE_COVERAGE:-unevaluable: E-35 did not run}"
     for finding in "${POST_DEPLOY_SMOKE_FAILURES[@]}"; do
         alert_text="${alert_text}
 - ${finding}"

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -2656,6 +2656,7 @@ POST_DEPLOY_SMOKE_SESSIONS_BODY=""
 POST_DEPLOY_SMOKE_FAILURES=()
 POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID=""
 POST_DEPLOY_SMOKE_DURABLE_COVERAGE="unevaluable: E-35 did not run"
+POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE="evaluated"
 
 # >>> BEGIN wedge-check region (#5244) — coverage is report-only and point-in-time
 POST_DEPLOY_SMOKE_WEDGE_MARKER_COVERAGE='evaluated: %s stall-state marker(s) observed (point-in-time)'; POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE="${POST_DEPLOY_SMOKE_WEDGE_MARKER_COVERAGE/\%s/0}"
@@ -3297,6 +3298,11 @@ echo "▸ Running post-deploy functional smoke (#4262)..."
 # The smoke function runs from an `if` guard, suspending `set -e` within it;
 # each fallible step is nevertheless explicitly guarded or carries `|| return`.
 if _run_post_deploy_functional_smoke; then
+    if case "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE:$POST_DEPLOY_SMOKE_DURABLE_COVERAGE" in
+        "$POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE:$POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE") true ;;
+        *) false ;;
+    esac
+    then
     case "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE" in
         "$POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE")
             echo "✓ Post-deploy functional smoke passed (relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}; evidence: $POST_DEPLOY_SMOKE_EVIDENCE)"
@@ -3305,6 +3311,10 @@ if _run_post_deploy_functional_smoke; then
             echo "△ Post-deploy functional smoke completed with coverage gap (relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}; evidence: $POST_DEPLOY_SMOKE_EVIDENCE)"
             ;;
     esac
+            echo "  durable record coverage: ${POST_DEPLOY_SMOKE_DURABLE_COVERAGE}"
+    else
+            echo "△ Post-deploy functional smoke completed with coverage gap (relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}; durable record coverage: ${POST_DEPLOY_SMOKE_DURABLE_COVERAGE}; evidence: $POST_DEPLOY_SMOKE_EVIDENCE)"
+    fi
 else
     echo "⚠ POST-DEPLOY FUNCTIONAL SMOKE FAILED — deploy remains healthy (fail-open)"
     echo "  relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}"

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -2640,10 +2640,11 @@ POST_DEPLOY_SMOKE_CORE_API_ENDPOINTS=(
 POST_DEPLOY_SMOKE_LOG_LINES="${AGENTDESK_POST_DEPLOY_SMOKE_LOG_LINES:-500}"
 POST_DEPLOY_SMOKE_WARN_LIMIT="${AGENTDESK_POST_DEPLOY_SMOKE_WARN_LIMIT:-5}"
 POST_DEPLOY_SMOKE_RELAY_CELL="${AGENTDESK_POST_DEPLOY_SMOKE_RELAY_CELL:-claude-tui}"
-# The whole E-35 invocation is capped, including its live safety gate, lease,
-# setup/send/fetch HTTP, response wait, record poll, refetch, idle check, and
-# teardown. Reset costs zero because E-35 forbids reset/force-cancel. The
-# 900-second operational cap turns longer sequential stalls into unevaluable.
+# The E-35 phase from lease acquisition through scenario execution is capped,
+# including its live safety gate, setup/send/fetch HTTP, response wait, record
+# poll, refetch, idle check, and teardown. Reset costs zero because E-35 forbids
+# reset/force-cancel. The 900-second operational cap deliberately cuts off
+# longer combinations of those component timeouts as unevaluable.
 POST_DEPLOY_SMOKE_E35_DEADLINE_S="${AGENTDESK_POST_DEPLOY_SMOKE_E35_DEADLINE_S:-900}"
 POST_DEPLOY_SMOKE_CREATE_ISSUE="${AGENTDESK_POST_DEPLOY_SMOKE_CREATE_ISSUE:-off}"
 POST_DEPLOY_SMOKE_STAMP="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || printf 'unknown')-$$"
@@ -3132,8 +3133,8 @@ _post_deploy_smoke_check_durable_record() {
     # #5264 is a hard prerequisite only for default claude-tui live acceptance.
     # claude-pipe is partial coverage and is not S8 TUI-surface evidence.
     if [ -z "$POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID" ]; then
-        _post_deploy_smoke_fail "durable_record_probe=unevaluable: E-35 channel unavailable; probe did not run" || true
-        return 1
+        _post_deploy_smoke_note "durable_record_probe=unevaluable: E-35 channel unavailable; probe did not run" || return 1
+        return 0
     fi
     output="$ADK_REL/logs/post-deploy-smoke-durable-${POST_DEPLOY_SMOKE_STAMP}"
     log="$POST_DEPLOY_SMOKE_TMP_DIR/relay-e35.log"

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -2640,6 +2640,11 @@ POST_DEPLOY_SMOKE_CORE_API_ENDPOINTS=(
 POST_DEPLOY_SMOKE_LOG_LINES="${AGENTDESK_POST_DEPLOY_SMOKE_LOG_LINES:-500}"
 POST_DEPLOY_SMOKE_WARN_LIMIT="${AGENTDESK_POST_DEPLOY_SMOKE_WARN_LIMIT:-5}"
 POST_DEPLOY_SMOKE_RELAY_CELL="${AGENTDESK_POST_DEPLOY_SMOKE_RELAY_CELL:-claude-tui}"
+# The whole E-35 invocation is capped, including its live safety gate, lease,
+# setup/send/fetch HTTP, response wait, record poll, refetch, idle check, and
+# teardown. Reset costs zero because E-35 forbids reset/force-cancel. The
+# 900-second operational cap turns longer sequential stalls into unevaluable.
+POST_DEPLOY_SMOKE_E35_DEADLINE_S="${AGENTDESK_POST_DEPLOY_SMOKE_E35_DEADLINE_S:-900}"
 POST_DEPLOY_SMOKE_CREATE_ISSUE="${AGENTDESK_POST_DEPLOY_SMOKE_CREATE_ISSUE:-off}"
 POST_DEPLOY_SMOKE_STAMP="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || printf 'unknown')-$$"
 POST_DEPLOY_SMOKE_EVIDENCE="$ADK_REL/logs/post-deploy-smoke-${POST_DEPLOY_SMOKE_STAMP}.log"
@@ -2648,6 +2653,8 @@ POST_DEPLOY_SMOKE_HEALTH_BODY=""
 POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY=""
 POST_DEPLOY_SMOKE_SESSIONS_BODY=""
 POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID=""
+POST_DEPLOY_SMOKE_DURABLE_COVERAGE="unevaluable: E-35 did not run"
 
 # >>> BEGIN wedge-check region (#5244) — coverage is report-only and point-in-time
 POST_DEPLOY_SMOKE_WEDGE_MARKER_COVERAGE='evaluated: %s stall-state marker(s) observed (point-in-time)'; POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE="${POST_DEPLOY_SMOKE_WEDGE_MARKER_COVERAGE/\%s/0}"
@@ -3009,6 +3016,8 @@ PY
         return 1
     fi
 
+    POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID="$channel_id"
+
     # E-1 is a real live turn, so reuse the E2E driver's mailbox/session busy
     # predicates against the authenticated core-probe snapshots before sending.
     # An unreadable snapshot skips the injection fail-open: safety requires
@@ -3118,6 +3127,49 @@ PY
     _post_deploy_smoke_note "relay E-1 round-trip=pass" || return 1
 }
 
+_post_deploy_smoke_check_durable_record() {
+    local output log report status rc=0
+    # #5264 is a hard prerequisite only for default claude-tui live acceptance.
+    # claude-pipe is partial coverage and is not S8 TUI-surface evidence.
+    if [ -z "$POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID" ]; then
+        _post_deploy_smoke_fail "durable_record_probe=unevaluable: E-35 channel unavailable; probe did not run" || true
+        return 1
+    fi
+    output="$ADK_REL/logs/post-deploy-smoke-durable-${POST_DEPLOY_SMOKE_STAMP}"
+    log="$POST_DEPLOY_SMOKE_TMP_DIR/relay-e35.log"
+    (
+        cd "$REPO" || exit 1
+        python3 scripts/e2e/run_tui_relay.py \
+            --base-url "http://${ADK_DEFAULT_LOOPBACK}:${REL_PORT}" \
+            --cell "$POST_DEPLOY_SMOKE_RELAY_CELL" \
+            --channel-id "$POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID" \
+            --scenarios "$REPO/tests/e2e/tui_relay/scenarios" \
+            --filter E-35 --no-reset-before-each \
+            --phase-deadline-s "$POST_DEPLOY_SMOKE_E35_DEADLINE_S" \
+            --output "$output" --queue-runtime-root "$ADK_REL/runtime" \
+            --required-agent-mode real_live --required-coverage-class live
+    ) > "$log" 2>&1 || rc=$?
+    tail -n 40 "$log" >> "$POST_DEPLOY_SMOKE_EVIDENCE" 2>/dev/null || true
+    report="$output/report.${POST_DEPLOY_SMOKE_RELAY_CELL}.json"
+    status=$(python3 - "$report" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE" <<'PY' || printf 'unevaluable'
+import json, sys
+try:
+    report = json.load(open(sys.argv[1], encoding="utf-8"))
+    probes = [s.get("durable_record_probe", {}) for s in report.get("scenarios", []) if s.get("id") == "E-35"]
+    print(probes[-1].get("status", "unevaluable") if probes else "unevaluable")
+except Exception:
+    print("unevaluable")
+PY
+    )
+    POST_DEPLOY_SMOKE_DURABLE_COVERAGE="$status"
+    if [ "$rc" -eq 0 ] && [ "$status" = "evaluated" ]; then
+        _post_deploy_smoke_note "durable_record_probe=evaluated: exact durable receipt and covering frontier observed" || return 1
+        return 0
+    fi
+    _post_deploy_smoke_fail "durable_record_probe=${status}: E-35 rc=${rc}; no cleanup attempted; dirty/active residue may remain (evidence: ${output})" || true
+    return 1
+}
+
 _run_post_deploy_functional_smoke() {
     local failed=0
     mkdir -p "$ADK_REL/logs" || return 1
@@ -3135,6 +3187,9 @@ _run_post_deploy_functional_smoke() {
         failed=1
     fi
     if ! _post_deploy_smoke_check_relay_round_trip; then
+        failed=1
+    fi
+    if ! _post_deploy_smoke_check_durable_record; then
         failed=1
     fi
     rm -rf "$POST_DEPLOY_SMOKE_TMP_DIR" 2>/dev/null || true
@@ -3157,6 +3212,7 @@ _report_post_deploy_smoke_failure() {
         printf -- '- Port: `%s`\n' "$REL_PORT"
         printf -- '- Evidence: `%s`\n\n' "$POST_DEPLOY_SMOKE_EVIDENCE"
         printf -- '- Relay wedge coverage: `%s`\n\n' "${POST_DEPLOY_SMOKE_WEDGE_COVERAGE:-not run: wedge check did not execute}"
+        printf -- '- Durable record coverage: `%s`\n\n' "$POST_DEPLOY_SMOKE_DURABLE_COVERAGE"
         printf '## Findings\n\n'
         for finding in "${POST_DEPLOY_SMOKE_FAILURES[@]}"; do
             printf -- '- %s\n' "$finding"
@@ -3175,6 +3231,8 @@ draft: ${draft_path}
 evidence: ${POST_DEPLOY_SMOKE_EVIDENCE}"
     alert_text="${alert_text}
 relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE:-not run: wedge check did not execute}"
+    alert_text="${alert_text}
+durable record coverage: ${POST_DEPLOY_SMOKE_DURABLE_COVERAGE}"
     for finding in "${POST_DEPLOY_SMOKE_FAILURES[@]}"; do
         alert_text="${alert_text}
 - ${finding}"

--- a/scripts/e2e/run_tui_relay.py
+++ b/scripts/e2e/run_tui_relay.py
@@ -32,6 +32,7 @@ import datetime as dt
 import json
 import math
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -44,7 +45,7 @@ import yaml  # type: ignore[import-untyped]
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from tui_relay import assertions, discord, fixtures, lease, tmux  # noqa: E402
+from tui_relay import assertions, discord, durable_delivery, fixtures, lease, tmux  # noqa: E402
 
 
 SUPPORTED_CELLS: tuple[str, ...] = (
@@ -64,6 +65,7 @@ COVERAGE_CLASS_RANK = {
 }
 REAL_PROVIDER_STEP_KEYS: tuple[str, ...] = (
     "send_prompt",
+    "send_discord_prompt",
     "send_provider_hold_prompt",
     "send_timed_response_prompt",
     "send_prompts_concurrent",
@@ -150,7 +152,29 @@ REPORT_RECORD_KEYS: tuple[str, ...] = (
     "real_provider_contacted",
     "controlled_harness_evidence",
     "failure_attribution",
+    "durable_record_probe",
+    "dirty_active_residue",
 )
+
+
+class PhaseDeadlineExpired(BaseException):
+    """Hard wall-clock deadline; bypass scenario cleanup and preserve residue."""
+
+
+def _arm_phase_deadline(seconds: float):
+    previous = signal.getsignal(signal.SIGALRM)
+
+    def expire(_signum, _frame):
+        raise PhaseDeadlineExpired(f"E-35 phase exceeded {seconds:g}s")
+
+    signal.signal(signal.SIGALRM, expire)
+    signal.setitimer(signal.ITIMER_REAL, max(seconds, 0.001))
+    return previous
+
+
+def _disarm_phase_deadline(previous) -> None:
+    signal.setitimer(signal.ITIMER_REAL, 0)
+    signal.signal(signal.SIGALRM, previous)
 
 
 class ScenarioStepAssertionError(assertions.AssertionError):
@@ -265,6 +289,12 @@ def parse_args() -> argparse.Namespace:
         "--turn-start-timeout-s",
         default=turn_start_timeout_default,
         help="How long send_prompt retries transient mailbox-busy turn/start responses.",
+    )
+    parser.add_argument(
+        "--phase-deadline-s",
+        type=float,
+        default=None,
+        help="Hard wall-clock limit for the whole invocation (E-35 post-deploy use).",
     )
     parser.add_argument(
         "--required-agent-mode",
@@ -2083,6 +2113,67 @@ def _mailbox_busy_reasons(mailbox: dict[str, Any]) -> list[str]:
     return reasons
 
 
+def durable_probe_safety_gate(
+    *, base_url: str, cell: str, channel_id: str, runtime_root: Path, lease_run_id: str
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    try:
+        status, health = _read_api_json(base_url, "/api/health", timeout=5)
+        detail = _read_health_detail(base_url, timeout=5)
+        sessions_status, sessions_payload = _read_api_json(
+            base_url, "/api/sessions", timeout=5
+        )
+    except Exception as error:  # noqa: BLE001 - unreadable safety state forbids injection
+        return {
+            "status": "unevaluable",
+            "dirty_active_residue": True,
+            "reasons": [f"safety state unreadable: {type(error).__name__}: {error}"],
+        }
+    if status >= 400 or not isinstance(health, dict) or health.get("cluster_standby") is not False:
+        reasons.append("cluster_standby is true or unreadable")
+    mailboxes = detail.get("mailboxes")
+    provider = cell_provider(cell)
+    targets = [
+        box for box in mailboxes if isinstance(box, dict)
+        and _mailbox_channel_id(box) == str(channel_id)
+        and _mailbox_provider(box) == provider
+    ] if isinstance(mailboxes, list) else []
+    if not targets:
+        reasons.append("target mailbox unavailable")
+    for mailbox in targets:
+        reasons.extend(_mailbox_busy_reasons(mailbox))
+    sessions = (
+        sessions_payload.get("sessions")
+        if isinstance(sessions_payload, dict)
+        else sessions_payload
+    )
+    if sessions_status >= 400 or not isinstance(sessions, list):
+        reasons.append("target sessions unavailable")
+    else:
+        workspace = cell_workspace_substring(cell)
+        for session in sessions:
+            if not isinstance(session, dict):
+                continue
+            state = str(session.get("status") or "").lower()
+            session_channel = str(
+                session.get("channel_id") or session.get("channelId") or ""
+            )
+            session_key = str(session.get("session_key") or "")
+            if state in {"turn_active", "turn_busy", "active"} and (
+                session_channel == str(channel_id) or workspace in session_key
+            ):
+                reasons.append(f"active target session={session_key or session_channel}")
+    reasons.extend(_runtime_queue_violations(
+        runtime_root=runtime_root, provider=provider, channel_id=str(channel_id)
+    ))
+    held = lease._read_lease(lease.lease_path_for(cell))  # noqa: SLF001
+    if not held or held.get("run_id") != lease_run_id:
+        reasons.append("E2E cell lease is not held by this probe")
+    if reasons:
+        return {"status": "unevaluable", "dirty_active_residue": True, "reasons": reasons}
+    return {"status": "idle", "dirty_active_residue": False}
+
+
 def _mailbox_idle_evidence(mailbox: dict[str, Any]) -> dict[str, Any]:
     """Capture the /api/health/detail idle fields a regression like #2935 watches.
 
@@ -2768,7 +2859,22 @@ def run_scenario(
             )
         return result
 
-    if args.reset_before_each and not args.dry_run and not is_local_fixture_scenario(scenario):
+    durable_probe = bool(scenario.get("durable_delivery_probe"))
+    if durable_probe and not args.dry_run:
+        safety = durable_probe_safety_gate(
+            base_url=args.base_url,
+            cell=cell,
+            channel_id=target_channel_id,
+            runtime_root=Path(args.queue_runtime_root),
+            lease_run_id=f"{cell}-{run_id}",
+        )
+        if safety["status"] != "idle":
+            result["status"] = "fail"
+            result["reason"] = "E-35 safety gate refused injection"
+            result["durable_record_probe"] = {"status": "unevaluable", "reason": result["reason"]}
+            result["dirty_active_residue"] = safety
+            return result
+    if args.reset_before_each and not durable_probe and not args.dry_run and not is_local_fixture_scenario(scenario):
         runtime_root = Path(args.queue_runtime_root)
         result["resets"] = [
             reset_channel_state(
@@ -2999,6 +3105,12 @@ def run_one_cell(
         "provider_identity": provider_identity(cell, channel_id),
         "real_provider_contacted": False,
     }
+    if scenario.get("durable_delivery_probe"):
+        record["durable_record_probe"] = {
+            "status": "unevaluable",
+            "reason": "response not observed",
+        }
+        record["dirty_active_residue"] = {"possible": True, "cleanup_attempted": False}
     if partial_record_sink is not None:
         partial_record_sink["record"] = record
 
@@ -3048,7 +3160,17 @@ def run_one_cell(
             record.setdefault("controlled_harness_evidence", []).append(
                 controlled_evidence
             )
-        if "send_prompt" in step:
+        if "send_discord_prompt" in step:
+            _prepare_first_prompt_window()
+            window.mark_prompt_sent()
+            last_sent_prompt = str(step["send_discord_prompt"]).replace("{run_id}", run_id)
+            response = client.send(channel_id, last_sent_prompt)
+            record["durable_record_probe"]["inbound_prompt_id"] = str(
+                response.get("message_id") or response.get("id") or ""
+            )
+            _mark_real_provider_contacted(record, declared_agent_mode=declared_agent_mode, dry_run=dry_run)
+            time.sleep(3)
+        elif "send_prompt" in step:
             _prepare_first_prompt_window()
             window.mark_prompt_sent()
             last_sent_prompt = str(step["send_prompt"])
@@ -3142,7 +3264,7 @@ def run_one_cell(
         elif "wait_idle_s" in step:
             time.sleep(float(step["wait_idle_s"]))
         elif "wait_for_discord_text" in step:
-            needle = step["wait_for_discord_text"]
+            needle = str(step["wait_for_discord_text"]).replace("{run_id}", run_id)
             found, observed = wait_for_discord_text_with_tui_idle_draft_guard(
                 client=client,
                 channel_id=channel_id,
@@ -3179,6 +3301,26 @@ def run_one_cell(
                     f"diagnostic={_payload_summary(diagnostic, max_chars=1400)}",
                     record=record,
                 )
+            if scenario.get("durable_delivery_probe"):
+                response_id = str(found.get("id") or "")
+                record["durable_record_probe"] = durable_delivery.poll_records(
+                    Path(args.queue_runtime_root),
+                    provider=cell_provider(cell),
+                    channel_id=channel_id,
+                    message_id=response_id,
+                )
+                record["durable_record_probe"]["coverage_scope"] = (
+                    "partial coverage; not S8 TUI-surface evidence"
+                    if cell == "claude-pipe"
+                    else "default claude-tui live acceptance"
+                )
+                if record["durable_record_probe"]["status"] != "evaluated":
+                    _update_record_window_snapshot(record, window)
+                    raise ScenarioStepAssertionError(
+                        f"durable record probe {record['durable_record_probe']['status']}: "
+                        f"{record['durable_record_probe']['reason']}",
+                        record=record,
+                    )
         elif "wait_for_raw_discord_text" in step:
             needle = step["wait_for_raw_discord_text"]
             predicate = lambda message: (  # noqa: E731
@@ -3510,6 +3652,11 @@ def run_one_cell(
             runtime_root=Path(args.queue_runtime_root),
         )
         record["post_scenario_idle"] = idle_check
+        if scenario.get("durable_delivery_probe"):
+            record["dirty_active_residue"] = {
+                "possible": False,
+                "cleanup_attempted": False,
+            }
         record["assertions"].append(
             {
                 "spec": {"post_scenario_cell_idle": True},
@@ -4101,13 +4248,35 @@ def main() -> int:
     )
 
     lease_token = f"{cell}-{run_id}"
-    with lease.acquire(lease_token, cell=cell) if not args.dry_run else _null_lease(run_id):
-        results: list[dict[str, Any]] = []
-        for scenario in scenarios:
-            print(f"[e2e] running {scenario.get('id')} cell={cell}")
-            result = run_scenario(scenario, args=args, run_id=run_id, client=client)
-            print(f"[e2e]   → {result['status']} {result.get('reason') or ''}")
-            results.append(result)
+    results: list[dict[str, Any]] = []
+    previous_alarm = _arm_phase_deadline(args.phase_deadline_s) if args.phase_deadline_s else None
+    try:
+        with lease.acquire(lease_token, cell=cell) if not args.dry_run else _null_lease(run_id):
+            for scenario in scenarios:
+                print(f"[e2e] running {scenario.get('id')} cell={cell}")
+                result = run_scenario(scenario, args=args, run_id=run_id, client=client)
+                print(f"[e2e]   → {result['status']} {result.get('reason') or ''}")
+                results.append(result)
+    except PhaseDeadlineExpired as error:
+        results.append({
+            "id": "E-35", "cell": cell, "provider": cell_provider(cell),
+            "runtime": cell_runtime(cell), "status": "fail", "reason": str(error),
+            "durable_record_probe": {"status": "unevaluable", "reason": str(error)},
+            "dirty_active_residue": {"possible": True, "cleanup_attempted": False},
+        })
+    except Exception as error:  # lease/safety setup failed before a scenario artifact existed
+        if not args.phase_deadline_s:
+            raise
+        reason = f"E-35 phase unevaluable: {type(error).__name__}: {error}"
+        results.append({
+            "id": "E-35", "cell": cell, "provider": cell_provider(cell),
+            "runtime": cell_runtime(cell), "status": "fail", "reason": reason,
+            "durable_record_probe": {"status": "unevaluable", "reason": reason},
+            "dirty_active_residue": {"possible": True, "cleanup_attempted": False},
+        })
+    finally:
+        if previous_alarm is not None:
+            _disarm_phase_deadline(previous_alarm)
 
     # Always cell-tag the report filename so an orchestrator that passes a
     # shared --output dir for all 5 cells never overwrites a sibling report.

--- a/scripts/e2e/run_tui_relay.py
+++ b/scripts/e2e/run_tui_relay.py
@@ -3162,6 +3162,14 @@ def run_one_cell(
             )
         if "send_discord_prompt" in step:
             _prepare_first_prompt_window()
+            if scenario.get("durable_delivery_probe"):
+                safety = durable_probe_safety_gate(
+                    base_url=args.base_url, cell=cell, channel_id=channel_id,
+                    runtime_root=Path(args.queue_runtime_root), lease_run_id=f"{cell}-{run_id}",
+                )
+                if safety["status"] != "idle":
+                    record["dirty_active_residue"] = safety
+                    return record
             window.mark_prompt_sent()
             last_sent_prompt = str(step["send_discord_prompt"]).replace("{run_id}", run_id)
             response = client.send(channel_id, last_sent_prompt)

--- a/scripts/e2e/run_tui_relay.py
+++ b/scripts/e2e/run_tui_relay.py
@@ -294,7 +294,7 @@ def parse_args() -> argparse.Namespace:
         "--phase-deadline-s",
         type=float,
         default=None,
-        help="Hard wall-clock limit for the whole invocation (E-35 post-deploy use).",
+        help="Hard wall-clock limit from lease acquisition through selected scenario execution.",
     )
     parser.add_argument(
         "--required-agent-mode",

--- a/scripts/e2e/tui_relay/durable_delivery.py
+++ b/scripts/e2e/tui_relay/durable_delivery.py
@@ -1,0 +1,120 @@
+"""Read-after-write validator for the E-35 durable delivery record probe."""
+import json
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+
+def _int(value: Any, minimum: int = 1) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= minimum else None
+
+
+def _range(value: Any) -> tuple[int, int] | None:
+    if not isinstance(value, list) or len(value) != 2:
+        return None
+    start, end = (_int(value[0], 0), _int(value[1]))
+    if start is None or end is None or end <= start:
+        return None
+    return start, end
+
+
+def _matching_receipt(receipt: Any, *, provider: str, channel_id: int,
+                      message_id: int, owner_id: int) -> dict[str, Any] | None:
+    if not isinstance(receipt, dict) or not isinstance(receipt.get("source"), dict):
+        return None
+    source = receipt["source"]
+    source_range = _range(source.get("range"))
+    generation = _int(source.get("generation_mtime_ns"))
+    authoritative = (
+        source.get("provider") == provider
+        and bool(source.get("tmux_session_name"))
+        and bool(source.get("turn_nonce"))
+        and _int(source.get("offset_authority_channel_id")) == owner_id
+        and _int(source.get("delivery_channel_id")) == channel_id
+        and _int(receipt.get("delivery_channel_id")) == channel_id
+        and _int(receipt.get("message_id")) == message_id
+    )
+    if not authoritative or source_range is None or generation is None:
+        return None
+    return {"range": source_range, "generation_mtime_ns": generation}
+
+
+def scan_records(runtime_root: Path, *, provider: str, channel_id: str,
+                 message_id: str) -> dict[str, Any]:
+    provider_dir = runtime_root / "discord_delivery_records" / provider
+    try:
+        paths = sorted(provider_dir.glob("*.json"))
+    except OSError as error:
+        return {"status": "unevaluable", "reason": f"record scan unavailable: {error}"}
+    if not provider_dir.is_dir():
+        return {"status": "unevaluable", "reason": f"record directory unavailable: {provider_dir}"}
+    channel, message = _int(channel_id), _int(message_id)
+    if channel is None or message is None:
+        return {"status": "unevaluable", "reason": "invalid response identity"}
+    matches: list[tuple[Path, dict[str, Any], dict[str, Any]]] = []
+    malformed: list[str] = []
+    for path in paths:
+        try:
+            owner = _int(path.stem)
+            record = json.loads(path.read_text(encoding="utf-8"))
+            if owner is None or not isinstance(record, dict):
+                raise ValueError("invalid owner filename or record object")
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            malformed.append(f"{path.name}: {type(error).__name__}")
+            continue
+        receipts = record.get("confirmed_deliveries") or []
+        if not isinstance(receipts, list):
+            malformed.append(f"{path.name}: confirmed_deliveries is not a list")
+            continue
+        for receipt in receipts:
+            exact = _matching_receipt(receipt, provider=provider, channel_id=channel,
+                                      message_id=message, owner_id=owner)
+            if exact is not None:
+                matches.append((path, exact, record))
+
+    if len(matches) != 1:
+        reason = f"expected one exact receipt, found {len(matches)}"
+        if malformed:
+            reason += f"; malformed={malformed[:4]}"
+        return {"status": "failed", "reason": reason, "exact_receipts": len(matches)}
+    path, receipt, record = matches[0]
+    frontier = record.get("delivered_frontier")
+    frontier_range = _range(frontier.get("range")) if isinstance(frontier, dict) else None
+    covered = (
+        frontier_range is not None
+        and _int(frontier.get("generation_mtime_ns")) == receipt["generation_mtime_ns"]
+        and frontier_range[1] >= receipt["range"][1]
+        and _int(frontier.get("panel_channel_id")) == channel
+    )
+    if not covered:
+        return {"status": "failed", "reason": "exact receipt lacks covering frontier"}
+    return {
+        "status": "evaluated",
+        "reason": "exact durable receipt and covering frontier observed",
+        "record": str(path),
+        "response_message_id": str(message),
+    }
+
+
+def poll_records(
+    runtime_root: Path, *, provider: str, channel_id: str, message_id: str,
+    timeout_s: float = 15.0, interval_s: float = 0.25,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    started = monotonic()
+    deadline = started + max(timeout_s, 0.0)
+    result = scan_records(runtime_root, provider=provider, channel_id=channel_id,
+                          message_id=message_id)
+    while result["status"] != "evaluated" and monotonic() < deadline:
+        sleep(min(interval_s, max(0.0, deadline - monotonic())))
+        result = scan_records(runtime_root, provider=provider, channel_id=channel_id,
+                              message_id=message_id)
+    result["elapsed_s"] = round(monotonic() - started, 3)
+    return result

--- a/scripts/e2e/tui_relay/test_durable_delivery.py
+++ b/scripts/e2e/tui_relay/test_durable_delivery.py
@@ -82,14 +82,20 @@ class RecordFixtures(unittest.TestCase):
         self.assertEqual(result["status"], "failed", result)
         self.assertEqual(result["exact_receipts"], 2)
 
-    def test_generation_rotation_before_write_has_no_acceptable_commit(self):
+    def test_receipt_frontier_generation_mismatch_is_failed(self):
         self.write(_record(_receipt(222, generation=77), generation=88))
         self.assertEqual(self.scan()["status"], "failed")
 
-    def test_generation_rotation_after_atomic_write_preserves_historical_proof(self):
+    def test_unrelated_generation_marker_does_not_override_committed_record_proof(self):
         self.write(_record(_receipt(222)))
         (self.root / "AgentDesk-claude-e2e.generation").write_text("88")
         self.assertEqual(self.scan()["status"], "evaluated")
+
+    def test_zero_generation_cannot_supply_durable_commit_proof(self):
+        self.write(_record(_receipt(222, generation=0), generation=0))
+        result = self.scan()
+        self.assertEqual(result["status"], "failed", result)
+        self.assertEqual(result["exact_receipts"], 0)
 
     def test_delayed_write_is_observed_by_bounded_poll(self):
         calls = 0
@@ -140,8 +146,8 @@ class SafetyAndDeadlineFixtures(unittest.TestCase):
             required_coverage_class=None,
         )
 
-    def test_active_mailbox_residue_counts_as_unevaluable_without_reset(self):
-        scenario = {
+    def _scenario(self) -> dict:
+        return {
             "id": "E-35",
             "agent_mode": "none",
             "coverage_class": "live",
@@ -150,16 +156,34 @@ class SafetyAndDeadlineFixtures(unittest.TestCase):
             "steps": [{"send_discord_prompt": "marker"}],
             "assertions": [],
         }
-        residue = {
-            "status": "unevaluable",
-            "dirty_active_residue": True,
-            "reasons": ["agent_turn_status=active"],
+
+    def test_preexisting_active_mailbox_is_unevaluable_without_reset(self):
+        scenario = {
+            **self._scenario(),
+        }
+        busy_mailbox = {
+            "provider": "claude",
+            "channel_id": "99",
+            "agent_turn_status": "active",
+            "relay_stall_state": "healthy",
+            "relay_health": {"active_turn": "none"},
         }
         with tempfile.TemporaryDirectory() as root, patch.object(
-            driver, "durable_probe_safety_gate", return_value=residue
+            driver,
+            "_read_api_json",
+            side_effect=[
+                (200, {"cluster_standby": False}),
+                (200, {"sessions": []}),
+            ],
+        ) as read_api, patch.object(
+            driver, "_read_health_detail", return_value={"mailboxes": [busy_mailbox]}
+        ) as read_detail, patch.object(
+            driver.lease,
+            "_read_lease",
+            return_value={"run_id": "claude-tui-fixture", "acquired_at": 1.0},
         ), patch.object(driver, "reset_channel_state") as reset, patch.object(
             driver, "run_one_cell", return_value={}
-        ):
+        ) as run_one:
             result = driver.run_scenario(
                 scenario,
                 args=self._args(root),
@@ -173,6 +197,29 @@ class SafetyAndDeadlineFixtures(unittest.TestCase):
             result,
         )
         self.assertTrue(result["dirty_active_residue"]["dirty_active_residue"])
+        self.assertIn("agent_turn_status=active", result["dirty_active_residue"]["reasons"])
+        self.assertEqual(read_api.call_count, 2)
+        read_detail.assert_called_once()
+        run_one.assert_not_called()
+        reset.assert_not_called()
+
+    def test_idle_gate_pass_never_enters_reset_for_durable_probe(self):
+        with tempfile.TemporaryDirectory() as root, patch.object(
+            driver,
+            "durable_probe_safety_gate",
+            return_value={"status": "idle", "dirty_active_residue": False},
+        ) as gate, patch.object(driver, "reset_channel_state") as reset, patch.object(
+            driver, "run_one_cell", return_value={}
+        ) as run_one, patch.object(driver.time, "sleep"):
+            result = driver.run_scenario(
+                self._scenario(),
+                args=self._args(root),
+                run_id="fixture",
+                client=object(),
+            )
+        self.assertNotEqual(result.get("reason"), "E-35 safety gate refused injection")
+        gate.assert_called_once()
+        run_one.assert_called_once()
         reset.assert_not_called()
 
     @unittest.skipUnless(hasattr(signal, "setitimer"), "POSIX wall-clock timer required")

--- a/scripts/e2e/tui_relay/test_durable_delivery.py
+++ b/scripts/e2e/tui_relay/test_durable_delivery.py
@@ -86,6 +86,29 @@ class RecordFixtures(unittest.TestCase):
         self.write(_record(_receipt(222, generation=77), generation=88))
         self.assertEqual(self.scan()["status"], "failed")
 
+    def test_receipt_range_requires_covering_frontier(self):
+        self.write(_record(_receipt(222), end=15))
+        self.assertEqual(self.scan()["status"], "failed")
+
+    def test_frontier_panel_channel_must_match_delivery_channel(self):
+        self.write(_record(_receipt(222)))
+        record_path = self.records / "42.json"
+        record = json.loads(record_path.read_text())
+        record["delivered_frontier"]["panel_channel_id"] = 100
+        record_path.write_text(json.dumps(record))
+        self.assertEqual(self.scan()["status"], "failed")
+
+    def test_receipt_requires_nonempty_tmux_session_and_turn_nonce(self):
+        receipt = _receipt(222)
+        receipt["source"]["tmux_session_name"] = ""
+        receipt["source"]["turn_nonce"] = ""
+        self.write(_record(receipt))
+        self.assertEqual(self.scan()["status"], "failed")
+
+    def test_receipt_owner_must_match_record_filename(self):
+        self.write(_record(_receipt(222)), owner="7")
+        self.assertEqual(self.scan()["status"], "failed")
+
     def test_unrelated_generation_marker_does_not_override_committed_record_proof(self):
         self.write(_record(_receipt(222)))
         (self.root / "AgentDesk-claude-e2e.generation").write_text("88")
@@ -203,6 +226,34 @@ class SafetyAndDeadlineFixtures(unittest.TestCase):
         run_one.assert_not_called()
         reset.assert_not_called()
 
+    def test_safety_gate_requires_current_probe_lease_ownership(self):
+        idle_mailbox = {
+            "provider": "claude",
+            "channel_id": "99",
+            "agent_turn_status": "idle",
+            "relay_stall_state": "healthy",
+            "relay_health": {"active_turn": "none"},
+        }
+        with tempfile.TemporaryDirectory() as root, patch.object(
+            driver,
+            "_read_api_json",
+            side_effect=[
+                (200, {"cluster_standby": False}),
+                (200, {"sessions": []}),
+            ],
+        ), patch.object(
+            driver, "_read_health_detail", return_value={"mailboxes": [idle_mailbox]}
+        ), patch.object(driver.lease, "_read_lease", return_value=None):
+            result = driver.durable_probe_safety_gate(
+                base_url="http://agentdesk.test",
+                cell="claude-tui",
+                channel_id="99",
+                runtime_root=Path(root),
+                lease_run_id="claude-tui-fixture",
+            )
+        self.assertEqual(result["status"], "unevaluable", result)
+        self.assertIn("E2E cell lease is not held by this probe", result["reasons"])
+
     def test_idle_gate_pass_never_enters_reset_for_durable_probe(self):
         with tempfile.TemporaryDirectory() as root, patch.object(
             driver,
@@ -221,6 +272,83 @@ class SafetyAndDeadlineFixtures(unittest.TestCase):
         gate.assert_called_once()
         run_one.assert_called_once()
         reset.assert_not_called()
+
+    def test_prompt_recheck_refuses_new_busy_state_without_cleanup(self):
+        class Client:
+            def send_control(self, _channel, _content): return {"message_id": "100"}
+            def fetch_messages(self, _channel, **_kwargs): return []
+            def send(self, _channel, _content): raise AssertionError("prompt sent")
+
+        idle = {"status": "idle", "dirty_active_residue": False}
+        busy = {
+            "status": "unevaluable",
+            "dirty_active_residue": True,
+            "reasons": ["agent_turn_status=active"],
+        }
+        with tempfile.TemporaryDirectory() as root, patch.object(
+            driver, "durable_probe_safety_gate", side_effect=[idle, busy]
+        ) as gate, patch.object(driver, "reset_channel_state") as reset, patch.object(
+            driver.time, "sleep"
+        ):
+            result = driver.run_scenario(
+                {**self._scenario(), "agent_mode": "real_live"},
+                args=self._args(root),
+                run_id="fixture",
+                client=Client(),
+            )
+        self.assertEqual(gate.call_count, 2)
+        self.assertEqual(result["status"], "fail", result)
+        self.assertEqual(result["durable_record_probe"]["status"], "unevaluable")
+        self.assertEqual(result["dirty_active_residue"], busy)
+        reset.assert_not_called()
+
+    def test_recheck_to_send_residual_window_and_honesty_claim_are_pinned(self):
+        state = {"prompt_sent_after_recheck_race": False}
+        class Client:
+            base_url = "http://agentdesk.test"
+            def send_control(self, _channel, _content): return {"message_id": "100"}
+            def fetch_messages(self, _channel, **_kwargs): return []
+
+            def send(self, _channel, _content):
+                state["prompt_sent_after_recheck_race"] = True
+                return {"message_id": "111"}
+
+        scenario = {
+            **self._scenario(),
+            "agent_mode": "real_live",
+            "steps": [
+                {"send_discord_prompt": "marker"},
+                {"wait_for_discord_text": "marker", "timeout_s": 1},
+            ],
+        }
+        idle = {"status": "idle", "dirty_active_residue": False}
+        with tempfile.TemporaryDirectory() as root, patch.object(
+            driver, "durable_probe_safety_gate", return_value=idle
+        ) as gate, patch.object(driver.time, "sleep"), patch.object(
+            driver,
+            "wait_for_discord_text_with_tui_idle_draft_guard",
+            return_value=({"id": "222"}, []),
+        ), patch.object(
+            driver.durable_delivery,
+            "poll_records",
+            return_value={"status": "evaluated", "reason": "fixture"},
+        ), patch.object(driver, "assert_cell_idle", return_value={"status": "idle"}):
+            result = driver.run_scenario(
+                scenario,
+                args=self._args(root),
+                run_id="fixture",
+                client=Client(),
+            )
+        claim = " ".join((ROOT / "docs/e2e/multi-provider-e2e.md").read_text().split())
+        self.assertIn(
+            "the prompt-time recheck narrows the nominal gate-return-to-prompt window "
+            "from 368 seconds to 0 seconds, and the last-mailbox-snapshot-to-prompt "
+            "window from 373 seconds to 5 seconds. it does not close the toctou",
+            claim.lower(),
+        )
+        self.assertEqual(gate.call_count, 2)
+        self.assertTrue(state["prompt_sent_after_recheck_race"])
+        self.assertEqual(result["status"], "pass", result)
 
     @unittest.skipUnless(hasattr(signal, "setitimer"), "POSIX wall-clock timer required")
     def test_phase_deadline_interrupts_blocking_work(self):

--- a/scripts/e2e/tui_relay/test_durable_delivery.py
+++ b/scripts/e2e/tui_relay/test_durable_delivery.py
@@ -1,0 +1,189 @@
+"""Fixtures for the E-35 exact durable record and live-safety contracts."""
+
+from __future__ import annotations
+
+import json
+import signal
+import sys
+import tempfile
+import time
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "scripts" / "e2e"))
+
+import run_tui_relay as driver  # noqa: E402
+from tui_relay import durable_delivery  # noqa: E402
+
+
+def _receipt(message_id: int, *, generation: int = 77, nonce: str = "turn-1") -> dict:
+    return {
+        "source": {
+            "provider": "claude",
+            "tmux_session_name": "AgentDesk-claude-e2e",
+            "turn_nonce": nonce,
+            "range": [10, 20],
+            "generation_mtime_ns": generation,
+            "offset_authority_channel_id": 42,
+            "delivery_channel_id": 99,
+        },
+        "delivery_channel_id": 99,
+        "message_id": message_id,
+    }
+
+
+def _record(*receipts: dict, generation: int = 77, end: int = 20) -> dict:
+    return {
+        "delivered_frontier": {
+            "range": [10, end],
+            "generation_mtime_ns": generation,
+            "attempts": 1,
+            "panel_msg_id": 222,
+            "panel_channel_id": 99,
+        },
+        "confirmed_deliveries": list(receipts),
+    }
+
+
+class RecordFixtures(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.records = self.root / "discord_delivery_records" / "claude"
+        self.records.mkdir(parents=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write(self, record: dict, owner: str = "42") -> None:
+        (self.records / f"{owner}.json").write_text(json.dumps(record), encoding="utf-8")
+
+    def scan(self, message_id: str = "222") -> dict:
+        return durable_delivery.scan_records(
+            self.root, provider="claude", channel_id="99", message_id=message_id
+        )
+
+    def test_exact_response_receipt_and_covering_frontier_are_evaluated(self):
+        self.write(_record(_receipt(222), end=30))
+        self.assertEqual(self.scan()["status"], "evaluated")
+
+    def test_inbound_prompt_id_cannot_substitute_for_outbound_response_id(self):
+        self.write(_record(_receipt(111)))
+        result = self.scan("222")
+        self.assertEqual(result["status"], "failed", result)
+        self.assertEqual(result["exact_receipts"], 0)
+
+    def test_same_message_multiple_receipts_is_deterministic_failure(self):
+        self.write(_record(_receipt(222), _receipt(222, nonce="turn-2")))
+        result = self.scan()
+        self.assertEqual(result["status"], "failed", result)
+        self.assertEqual(result["exact_receipts"], 2)
+
+    def test_generation_rotation_before_write_has_no_acceptable_commit(self):
+        self.write(_record(_receipt(222, generation=77), generation=88))
+        self.assertEqual(self.scan()["status"], "failed")
+
+    def test_generation_rotation_after_atomic_write_preserves_historical_proof(self):
+        self.write(_record(_receipt(222)))
+        (self.root / "AgentDesk-claude-e2e.generation").write_text("88")
+        self.assertEqual(self.scan()["status"], "evaluated")
+
+    def test_delayed_write_is_observed_by_bounded_poll(self):
+        calls = 0
+
+        def sleep(_seconds: float) -> None:
+            nonlocal calls
+            calls += 1
+            self.write(_record(_receipt(222)))
+
+        ticks = iter((0.0, 0.0, 0.1, 0.1, 0.2))
+        result = durable_delivery.poll_records(
+            self.root,
+            provider="claude",
+            channel_id="99",
+            message_id="222",
+            timeout_s=1,
+            monotonic=lambda: next(ticks),
+            sleep=sleep,
+        )
+        self.assertEqual(result["status"], "evaluated", result)
+        self.assertEqual(calls, 1)
+
+    def test_poll_timeout_never_promotes_old_frontier(self):
+        self.write(_record(_receipt(111)))
+        result = durable_delivery.poll_records(
+            self.root,
+            provider="claude",
+            channel_id="99",
+            message_id="222",
+            timeout_s=0,
+        )
+        self.assertEqual(result["status"], "failed", result)
+
+
+class SafetyAndDeadlineFixtures(unittest.TestCase):
+    def _args(self, root: str) -> Namespace:
+        return Namespace(
+            base_url="http://agentdesk.test",
+            cell="claude-tui",
+            channel_id="99",
+            thread_channel_id=None,
+            reset_before_each=True,
+            dry_run=False,
+            queue_runtime_root=root,
+            hard_reset_session_each=False,
+            allow_destructive=False,
+            required_agent_mode=None,
+            required_coverage_class=None,
+        )
+
+    def test_active_mailbox_residue_counts_as_unevaluable_without_reset(self):
+        scenario = {
+            "id": "E-35",
+            "agent_mode": "none",
+            "coverage_class": "live",
+            "cells": ["claude-tui"],
+            "durable_delivery_probe": True,
+            "steps": [{"send_discord_prompt": "marker"}],
+            "assertions": [],
+        }
+        residue = {
+            "status": "unevaluable",
+            "dirty_active_residue": True,
+            "reasons": ["agent_turn_status=active"],
+        }
+        with tempfile.TemporaryDirectory() as root, patch.object(
+            driver, "durable_probe_safety_gate", return_value=residue
+        ), patch.object(driver, "reset_channel_state") as reset, patch.object(
+            driver, "run_one_cell", return_value={}
+        ):
+            result = driver.run_scenario(
+                scenario,
+                args=self._args(root),
+                run_id="fixture",
+                client=object(),
+            )
+        self.assertEqual(result["status"], "fail", result)
+        self.assertEqual(
+            (result.get("durable_record_probe") or {}).get("status"),
+            "unevaluable",
+            result,
+        )
+        self.assertTrue(result["dirty_active_residue"]["dirty_active_residue"])
+        reset.assert_not_called()
+
+    @unittest.skipUnless(hasattr(signal, "setitimer"), "POSIX wall-clock timer required")
+    def test_phase_deadline_interrupts_blocking_work(self):
+        previous = driver._arm_phase_deadline(0.02)  # noqa: SLF001
+        try:
+            with self.assertRaises(driver.PhaseDeadlineExpired):
+                time.sleep(1)
+        finally:
+            driver._disarm_phase_deadline(previous)  # noqa: SLF001
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/tui_relay/scenarios/E-35-durable-delivery-record.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-35-durable-delivery-record.yaml
@@ -1,0 +1,15 @@
+id: E-35
+title: 새 normal Discord response의 exact durable receipt + covering frontier
+agent_mode: real_live
+coverage_class: live
+cells: [claude-pipe, claude-tui]
+isolation: required
+durable_delivery_probe: true
+# #5264 is a hard prerequisite only for default claude-tui live acceptance.
+# claude-pipe is partial coverage and is not S8 TUI-surface evidence.
+steps:
+  - send_discord_prompt: "응답에 정확히 한 줄로 [E2E:E35:{run_id}:OK] 만 출력해줘."
+  - wait_for_discord_text: "[E2E:E35:{run_id}:OK]"
+    timeout_s: 240
+assertions:
+  - text_present: "[E2E:E35:"

--- a/tests/test_deploy_smoke_wedge_coverage_5244.sh
+++ b/tests/test_deploy_smoke_wedge_coverage_5244.sh
@@ -36,16 +36,31 @@ fi
 runner_source="$TMP_ROOT/runner.sh"
 sed -n '/^_run_post_deploy_functional_smoke()/,/^_report_post_deploy_smoke_failure()/p' "$DEPLOY_SH" \
     | sed '$d' > "$runner_source"
-runner_output=$(bash -s -- "$runner_source" "$TMP_ROOT" <<'CHILD'
+DISPOSITION="$TMP_ROOT/disposition.sh"
+disposition_begin=$(grep -nF '# >>> BEGIN smoke-disposition region (#5244)' "$DEPLOY_SH" | cut -d: -f1 || true)
+disposition_end=$(grep -nF '# <<< END smoke-disposition region (#5244)' "$DEPLOY_SH" | cut -d: -f1 || true)
+sed -n "$((disposition_begin + 1)),$((disposition_end - 1))p" "$DEPLOY_SH" > "$DISPOSITION"
+durable_clean_coverage=$(sed -n 's/^POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE="\([^"]*\)"$/\1/p' "$DEPLOY_SH" | head -1 || true)
+[ -n "$durable_clean_coverage" ] || fail 'durable clean coverage declaration is missing'
+
+runner_output=$(DURABLE_CLEAN_COVERAGE="$durable_clean_coverage" bash -s -- "$runner_source" "$TMP_ROOT" "$DISPOSITION" <<'CHILD'
 set -euo pipefail
-runner_source="$1"; root="$2"; eval "$(<"$runner_source")"
+runner_source="$1"; root="$2"; disposition_source="$3"; eval "$(<"$runner_source")"
 ADK_REL="$root"; POST_DEPLOY_SMOKE_EVIDENCE="$root/runner.evidence"; POST_DEPLOY_SMOKE_TMP_DIR=""; POST_DEPLOY_SMOKE_FAILURES=(); POST_DEPLOY_SMOKE_STAMP=runner; REL_PORT=0; runner_wedge_called=0
-_post_deploy_smoke_note() { :; }; _post_deploy_smoke_probe_apis() { return 0; }; _post_deploy_smoke_check_wedges() { runner_wedge_called=1; return 0; }; _post_deploy_smoke_check_fail_closed_warn_rate() { return 0; }; _post_deploy_smoke_check_relay_round_trip() { return 0; }; _post_deploy_smoke_check_durable_record() { return 0; }
+POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID=""; POST_DEPLOY_SMOKE_WEDGE_COVERAGE="clean-sentinel"; POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE="clean-sentinel"; POST_DEPLOY_SMOKE_DURABLE_COVERAGE="unevaluable: E-35 did not run"; POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE="$DURABLE_CLEAN_COVERAGE"
+_post_deploy_smoke_note() { :; }; _post_deploy_smoke_probe_apis() { return 0; }; _post_deploy_smoke_check_wedges() { runner_wedge_called=1; return 0; }; _post_deploy_smoke_check_fail_closed_warn_rate() { return 0; }
+# E-1 rc-0 skip fixture: leave the channel unset, so the durable probe notes and returns 0.
+_post_deploy_smoke_check_relay_round_trip() { POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID=""; return 0; }
+_post_deploy_smoke_check_durable_record() { [ -z "$POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID" ] || return 1; return 0; }
 if _run_post_deploy_functional_smoke; then rc=0; else rc=$?; fi
+eval "$(<"$disposition_source")"
 printf 'CASE_DONE runner rc=%s wedge_called=%s\n' "$rc" "$runner_wedge_called"
 CHILD
 )
 grep -q 'CASE_DONE runner rc=0 wedge_called=1' <<< "$runner_output" || fail 'smoke runner did not execute check_wedges in its parent shell'
+grep -q '△ Post-deploy functional smoke completed with coverage gap' <<< "$runner_output" || fail 'E-1 skip did not produce a coverage gap'
+grep -q 'durable record coverage: unevaluable: E-35 did not run' <<< "$runner_output" || fail 'E-1 skip omitted durable coverage'
+! grep -q '✓ Post-deploy functional smoke passed' <<< "$runner_output" || fail 'E-1 skip produced a false pass'
 
 cleanup_to_signal=$(sed -n '/^_cleanup_on_exit()/,/^_handle_cleanup_signal()/p' "$DEPLOY_SH")
 grep -q '_finalize_detached_helper' <<< "$cleanup_to_signal" || fail 'cleanup text does not contain finalizer'
@@ -272,17 +287,15 @@ CHILD
 )
 grep -q 'CASE_DONE rc=1 coverage=not evaluated: startup recovery in progress' <<< "$observation_race_output" || fail 'observation evidence failure reverted to not-run coverage'
 
-DISPOSITION="$TMP_ROOT/disposition.sh"
-disposition_begin=$(grep -nF '# >>> BEGIN smoke-disposition region (#5244)' "$DEPLOY_SH" | cut -d: -f1 || true)
-disposition_end=$(grep -nF '# <<< END smoke-disposition region (#5244)' "$DEPLOY_SH" | cut -d: -f1 || true)
-sed -n "$((disposition_begin + 1)),$((disposition_end - 1))p" "$DEPLOY_SH" > "$DISPOSITION"
 disposition_case() {
-    local label="$1" smoke_rc="$2" coverage="$3" clean_coverage="$4" expected="$5"
+    local label="$1" smoke_rc="$2" coverage="$3" durable_coverage="$4" expected="$5"
     local output
-    output=$(SMOKE_RC="$smoke_rc" COVERAGE="$coverage" CLEAN_COVERAGE="$clean_coverage" bash -s -- "$DISPOSITION" <<'CHILD'
+    output=$(SMOKE_RC="$smoke_rc" COVERAGE="$coverage" DURABLE_COVERAGE="$durable_coverage" CLEAN_COVERAGE=clean-sentinel DURABLE_CLEAN_COVERAGE="$durable_clean_coverage" bash -s -- "$DISPOSITION" <<'CHILD'
 set -euo pipefail
 POST_DEPLOY_SMOKE_WEDGE_COVERAGE="$COVERAGE"
 POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE="$CLEAN_COVERAGE"
+POST_DEPLOY_SMOKE_DURABLE_COVERAGE="$DURABLE_COVERAGE"
+POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE="$DURABLE_CLEAN_COVERAGE"
 POST_DEPLOY_SMOKE_EVIDENCE=/tmp/5244-disposition.evidence
 POST_DEPLOY_SMOKE_TMP_DIR=""
 POST_DEPLOY_SMOKE_FAILURES=()
@@ -294,10 +307,40 @@ CHILD
     )
     grep -q 'CASE_DONE disposition' <<< "$output" || fail "$label: disposition completion token missing"
     grep -q "$expected" <<< "$output" || fail "$label: expected [$expected]"
+    if [ "$label" = evaluated_clean ]; then
+        grep -q 'durable record coverage: evaluated' <<< "$output" || fail "$label: durable summary missing"
+    fi
 }
-disposition_case evaluated_clean 0 clean-sentinel clean-sentinel 'passed (relay wedge coverage: clean-sentinel'
-disposition_case coverage_gap 0 'not evaluated: startup recovery in progress' clean-sentinel 'completed with coverage gap'
-disposition_case failed 1 'unevaluable: health/detail scan failed' clean-sentinel 'REPORT_CALLED'
+disposition_case evaluated_clean 0 clean-sentinel evaluated 'passed (relay wedge coverage: clean-sentinel; evidence:'
+disposition_case skip_unevaluable 0 clean-sentinel 'unevaluable: E-35 did not run' 'completed with coverage gap (relay wedge coverage: clean-sentinel; durable record coverage: unevaluable: E-35 did not run'
+disposition_case coverage_gap 0 'not evaluated: startup recovery in progress' evaluated 'completed with coverage gap'
+disposition_case failed 1 'unevaluable: health/detail scan failed' failed 'REPORT_CALLED'
+
+if [ -z "${MUTATION_CHILD:-}" ]; then
+    for mutation in logical_and_removed unevaluable_as_clean; do
+        mut="$TMP_ROOT/mut-$mutation.sh"
+        if [ "$mutation" = logical_and_removed ]; then
+            sed \
+                -e 's/\$POST_DEPLOY_SMOKE_WEDGE_COVERAGE:\$POST_DEPLOY_SMOKE_DURABLE_COVERAGE/\$POST_DEPLOY_SMOKE_WEDGE_COVERAGE/g' \
+                -e 's/\$POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE:\$POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE/\$POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE/g' \
+                "$DEPLOY_SH" > "$mut"
+            expected='E-1 skip produced a false pass'
+        else
+            sed 's/^POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE="evaluated"$/POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE="unevaluable: E-35 did not run"/' \
+                "$DEPLOY_SH" > "$mut"
+            expected='skip_unevaluable: expected'
+        fi
+        if ! bash -n "$mut" > "$mut.bash-n" 2>&1; then
+            fail "$mutation was not syntactically valid"
+        elif MUTATION_CHILD=1 DEPLOY_SH_OVERRIDE="$mut" bash "$0" > "$mut.out" 2>&1; then
+            fail "$mutation survived the skip fixture"
+        elif grep -q "$expected" "$mut.out"; then
+            printf 'MUTATION_CASE %s bash_n=0 fixture_rc=1\n' "$mutation"
+        else
+            fail "$mutation died without its target fixture self-assertion"
+        fi
+    done
+fi
 
 if [ "$failures" -ne 0 ]; then
     printf 'test_deploy_smoke_wedge_coverage_5244: %s assertion(s) failed\n' "$failures" >&2

--- a/tests/test_deploy_smoke_wedge_coverage_5244.sh
+++ b/tests/test_deploy_smoke_wedge_coverage_5244.sh
@@ -40,7 +40,7 @@ runner_output=$(bash -s -- "$runner_source" "$TMP_ROOT" <<'CHILD'
 set -euo pipefail
 runner_source="$1"; root="$2"; eval "$(<"$runner_source")"
 ADK_REL="$root"; POST_DEPLOY_SMOKE_EVIDENCE="$root/runner.evidence"; POST_DEPLOY_SMOKE_TMP_DIR=""; POST_DEPLOY_SMOKE_FAILURES=(); POST_DEPLOY_SMOKE_STAMP=runner; REL_PORT=0; runner_wedge_called=0
-_post_deploy_smoke_note() { :; }; _post_deploy_smoke_probe_apis() { return 0; }; _post_deploy_smoke_check_wedges() { runner_wedge_called=1; return 0; }; _post_deploy_smoke_check_fail_closed_warn_rate() { return 0; }; _post_deploy_smoke_check_relay_round_trip() { return 0; }
+_post_deploy_smoke_note() { :; }; _post_deploy_smoke_probe_apis() { return 0; }; _post_deploy_smoke_check_wedges() { runner_wedge_called=1; return 0; }; _post_deploy_smoke_check_fail_closed_warn_rate() { return 0; }; _post_deploy_smoke_check_relay_round_trip() { return 0; }; _post_deploy_smoke_check_durable_record() { return 0; }
 if _run_post_deploy_functional_smoke; then rc=0; else rc=$?; fi
 printf 'CASE_DONE runner rc=%s wedge_called=%s\n' "$rc" "$runner_wedge_called"
 CHILD


### PR DESCRIPTION
## Summary

- Preserve the existing headless E-1 and add E-35 as a separate normal Discord turn.
- Bind PASS to the newly observed outbound Discord response ID, exactly one authoritative confirmed-delivery receipt, and a same-generation covering frontier from the local atomic sidecar record.
- Wire E-35 into the post-`DEPLOY_OK` functional smoke as a fail-open finding using `evaluated`, `failed`, and `unevaluable` probe status.
- Make the terminal smoke disposition a two-axis conjunction: `✓ passed` requires clean relay-wedge coverage **and** exact durable coverage `evaluated`; any other pair is `△ coverage gap` and prints both coverage values.

Closes #5263.

## GO conditions

1. E-35 cannot enter `reset_channel_state`: scenario metadata suppresses reset even when the driver default is enabled, and post-deploy also passes `--no-reset-before-each`. It re-reads standby, target mailbox, target sessions, queue residue, and the cell lease before setup and again immediately before the normal prompt. Busy/unreadable/residue state returns `unevaluable`; no cancel, turn cleanup, or mailbox release is attempted. The artifact retains `dirty_active_residue`. The gate-pass, real-gate busy, lease-owner, and prompt-time recheck fixtures pin these paths.
2. `--phase-deadline-s 900` arms one real-time `SIGALRM` immediately before lease acquisition and covers selected scenario execution. It does not cover earlier argument/scenario loading and output resolution or later report writing. The default component maxima independently sum to about **1,422 seconds**: two safety gates × (health/detail/sessions 5+5+5 = 15s) + setup control POST 180s + setup sleep 8s + pre-send fetch 180s + prompt send 180s + prompt sleep 3s + response wait 240s + durable poll 15s + final refetches (2 × 180s plus 1s settle) + post-scenario idle 45s + teardown marker 180s. The 900-second value is an operational cap that deliberately cuts off longer combinations as `unevaluable`, not their sum.
3. #5264 is a hard prerequisite only for default `claude-tui` live acceptance. `claude-pipe` is allowed as `partial coverage`, but its artifact says it is not S8 TUI-surface evidence. Restart adoption can create a missing marker, so E-35 may evaluate without distinguishing that adoption writer from the missing spawn writer.
4. Fixtures pin the validator's actual scope: inbound-vs-outbound ID confusion, duplicate receipts, receipt/frontier generation mismatch, generation-zero rejection, delayed read-after-write visibility, frontier range coverage, frontier panel channel, nonempty tmux/nonce identity, record-owner binding, lease ownership, prompt-time isolation recheck, and wall-clock timeout. They do not claim to execute a poll-time marker rotation or prompt-failure-to-next-run residue lifecycle.
5. The durable coverage assignment has three report statuses: `evaluated`, `failed`, and `unevaluable` (the report parser also falls back to `unevaluable`). The shell coverage starts as the prefixed `unevaluable: E-35 did not run` when E-35 has not run. Only the exact clean value `evaluated` is accepted; there is no prefix match, so prefixed `unevaluable: ...`, plain `unevaluable`, `failed`, and decorated/unknown values cannot become clean. A `failed` status already makes `_post_deploy_smoke_check_durable_record` and then `_run_post_deploy_functional_smoke` nonzero, so it cannot reach the success disposition; it remains explicitly non-clean as well. The disposition reuses the existing `case "$a:$b"` idiom.

K2 selected option (a): all five provenance guards are sealed because lease ownership and range/channel/tmux/nonce/owner binding are what make an `idle`/`evaluated` promotion meaningful. Shrinking H5 would understate defenses that the production path actually enforces; no validator mechanism was added.

If E-1 skips because the node is standby or the E2E cell is not configured, E-35 emits a note, leaves the prefixed `unevaluable: E-35 did not run` coverage, and returns 0 fail-open. With a clean wedge, the final disposition is nevertheless `△ coverage gap`, never `✓ passed`, and prints both wedge and durable coverage. An attempted-but-unevaluable E-35 remains a functional-smoke finding. The entire smoke block remains fail-open: `△` does not change exit status, rollback, restart, watchdog installation, source-manifest writing, or peer deployment.

## Verification

- Rebased onto `309da6db476258afbc3339d9a0e986b42ddbe5d1`; merge-base equals that exact `origin/main` SHA.
- `python3 -m unittest discover -s scripts/e2e/tui_relay -p 'test_*.py'` — not run as a final gate in this restricted environment; the changed durable module ran separately as 18 tests, rc 0.
- `python3 -m pytest scripts/e2e/tui_relay/test_durable_delivery.py -q` — rc 1 because this environment has no `pytest` module; equivalent `python3 -m unittest scripts.e2e.tui_relay.test_durable_delivery` ran 18 tests, rc 0.
- `bash -n scripts/deploy-release.sh` — rc 0; the deploy script was not executed.
- `shellcheck scripts/deploy-release.sh` — rc 1 on pre-existing SC1091/SC2016 informational findings; no new warning was introduced by K1.
- `bash tests/test_deploy_smoke_wedge_coverage_5244.sh` — rc 0; includes the E-1 rc-0 skip fixture and two self-asserting mutations.
- `bash tests/test_deploy_bounded_calls_5274.sh` — restricted sandbox rc 2 with `skipped=4`; OS-assigned loopback port rc 0 with `skipped=0`.
- `bash scripts/ci-script-checks.sh` — rc 1 at the existing `TEST_LANE_BASELINE_REF` requirement; it did not reach later shell-suite execution in this invocation.
- `git diff --check` — rc 0.

The K1 fixture's mutation results are source-valid (`bash -n rc=0`) and die by the target fixture's own assertion, not syntax/import failure:

| mutation | removal result | restored result |
|---|---|---|
| remove durable conjunct so wedge alone chooses `✓` | `FAILED` (skip fixture sees false pass) | `ok` |
| classify prefixed `unevaluable` as clean | `FAILED` (skip fixture expected `△`) | `ok` |

No deploy script, live E-35/E2E scenario, Discord delivery, launchctl action, runtime restart, process kill, tmux session, mailbox cancel/release, generation marker mutation, or production database access was performed.

## Size

- Final PR surface: 7 files, **+864/-23 = 887 changed lines**, which is **87 lines over** the 20-file / ±800-line budget.
- r3 was +800/-12 = 812 changed lines (12 over); r4 adds 64 lines and 11 deletions for the K1 disposition and its skip/mutation seal, producing the final 87-line excess.
- The r3 overage was indivisible: the +364-line `test_durable_delivery.py` fixture is required to keep the r2 provenance P1 from returning. The new 5244 rows are likewise indivisible for this round because removing them lets the exact K1 false-green or either mutation survive.
- Executable production surface is now 3 files, +377/-11 (r3 +367/-11); the only production change is the K1 disposition/clean constant. Rust remains 0 files / 0 lines.
- `deploy-release.sh` is **+69/-0 versus `origin/main`**: the #5274 lines were not deleted or reverted.

The record parser remains isolated in the 120-line single authority; no parser logic was added to the driver or shell.

## Honesty boundary

Minimum positive claim: 이 노드의 이번 배포 세대에서 E-35의 한 short-response normal Discord turn이 confirmed durable record funnel을 통과해, 그 새 Discord response에 결속된 exact receipt와 covering frontier를 atomic sidecar record에 남겼다.

For production-written records, an E-35 PASS additionally binds provider, owner filename, source/delivery channel, and range; requires nonempty tmux-session and turn-nonce identities; was current-generation at writer-lock time; follows the probed short turn's successful lease commit; and includes post-scenario mailbox/queue idle evidence. It catches a frontier-only partial write and a normal-to-headless `send_prompt` regression because either shape lacks the required exact receipt.

E-35의 `.generation` 의존은 **5개 심볼 · 4개 독립 집행 단계**다. `shadow_mirror_delivered_frontier_inner`, `exact_receipt_from_inflight`, `write_confirmed_delivery_at_with_lock_authority`, `write_confirmed_frontier_guarded_at_with_lock_authority`가 네 단계이며, `ExactJsonlSourceIdentity::is_authoritative`는 `write_confirmed_delivery_at_with_lock_authority`가 호출하는 하위 predicate다. 따라서 “구조적으로 못 쓴다”가 아니라 **E-35 시점에 그 세션이 부팅 후 adopt됐는지에 따라 비결정적으로 갈린다**가 정확하다. 이는 #5264의 선행성을 강화한다. E-35 PASS만으로는 spawn writer와 adoption writer를 구분할 수 없다.

The prompt-time gate recheck narrows the default HTTP-timeout-accounted gate-return-to-prompt window from 368 seconds to 0 seconds and the last-mailbox-snapshot-to-prompt window from 373 seconds to 5 seconds. It does not close the TOCTOU. Local filesystem/scheduling has no hard bound, and another turn can start after the recheck and before `client.send`; if the later receipt and idle evidence also become valid, the current behavior can still PASS. A fixture deliberately preserves this residual window and pins this declaration.

Here “이번 배포 세대” means the local post-`DEPLOY_OK` probe transaction. The probe does not bind a peer or commit SHA, prove poll-time-current tmux generation or power-loss durability, audit historical records, continuously monitor later turns, validate every provider/call site, cover long/fallback/recovery/headless paths, prove completed-ledger persistence, prove lease acquisition/clear/restart reconciliation generally, synchronize rollout authority, or promote S8. It also does not fixture the full poll-time canonical-marker rotation or prompt-failure-to-next-run residue lifecycle.

The sealed `test_durable_delivery.py` module is not currently executed by CI; among the `scripts/e2e/tui_relay` modules only `test_assertions` is wired. The #5003 S3 registration gate owns that follow-up, and this round intentionally does not change CI wiring.

The gate currently depends on private `lease._read_lease` because there is no public replacement. A refactor of that underscore API can silently leave E-35 fail-closed/`unevaluable`; adding a public lease-read contract is follow-up work, not part of this round.