### PR TITLE
fix(discord): pin generation marker writes to a single inode (#5264)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -307,6 +307,24 @@ time for diagnostics; neither is a stored approval value.
   logging), `src/services/discord/inflight/clear_store/mod.rs` and
   `src/services/discord/inflight/clear_store/abandon.rs` (clear/abandon
   store-side CAS paths).
+- `.generation` writer contract (#5264):
+
+  | Writer family | Spawn/adoption sites | Contract |
+  |---|---|---|
+  | Claude spawn | legacy wrapper + direct TUI | `stamp_spawn_markers` installs generation before nonce |
+  | Codex spawn | legacy wrapper + direct TUI | same combined helper |
+  | Qwen spawn | legacy wrapper | same combined helper |
+  | restart adoption | `watchers::lifecycle::restore_tmux_watchers` | `preserve_mtime_after_write` pins metadata, content replacement, and `set_times` to one fd |
+
+  A successful spawn stamp writes a `create_new` sibling and atomically renames
+  that new inode over `.generation`; adoption therefore cannot project an old
+  inode's mtime onto the successful spawn marker. Stamp failure leaves the
+  destination untouched, logs one warning, and does not fail the spawn, so
+  marker presence is not guaranteed on an I/O failure. Adoption retains the
+  missing-marker restart-healing path with `create_new`; `AlreadyExists` retries
+  the existing-fd path, and already-current content is not rewritten. The
+  source-level test covers the five sites in the three provider files but does
+  not automatically discover a future provider file.
 - legacy_modules: none — relay routes are being consolidated, not replaced.
 - do_not_edit_without_migration_plan (giant-file):
   - `src/services/discord/watchers/lifecycle.rs` retired as a frozen giant in
@@ -314,7 +332,7 @@ time for diagnostics; neither is a stored approval value.
     output policy, recovery marker, and test clusters moved verbatim into
     sub-1000-LoC `watchers/lifecycle/*.rs` modules. The root remains the
     canonical facade and preserves all prior call paths through re-exports.
-  - `src/services/discord/tmux.rs` (frozen giant surface; current generated inventory: 1677 production LoC; #4895 removes untyped auth/overload terminal variants and authority-bearing outcome fields; parser diagnostics now use a fixed redacted category while generic error results remain `HardResult`; test-only #4277 re-exports
+  - `src/services/discord/tmux.rs` (frozen giant surface; current generated inventory: 1690 production LoC; #4895 removes untyped auth/overload terminal variants and authority-bearing outcome fields; parser diagnostics now use a fixed redacted category while generic error results remain `HardResult`; test-only #4277 re-exports
     the watcher delivery-lease key helper so session-sink production-entry tests
     prove bidirectional contention on the same idle JSONL range; -9 from the #4804
     Windows-compile hotfix moving `footer_background_marker_session_key` into

--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -4658,7 +4658,16 @@ services::discord::tmux::tmux_output_stream::tests::string_api_error_envelope_ha
 services::discord::tmux::tmux_output_stream::tests::unique_provider_prose_flood_uses_fixed_category_slots
 services::discord::tmux::tmux_output_stream::tests::watcher_status_panel_bound_placeholder_keeps_events_on_status_panel
 services::discord::tmux::tmux_output_stream::tests::watcher_status_panel_fallback_inlines_events_without_status_message
+services::discord::tmux::tmux_session_files::tests::adoption_current_generation_marker_is_a_noop
+services::discord::tmux::tmux_session_files::tests::adoption_never_stamps_a_fresh_incarnation_with_an_old_mtime
+services::discord::tmux::tmux_session_files::tests::adoption_recovers_an_absent_marker_with_nonzero_identity
 services::discord::tmux::tmux_session_files::tests::committed_frontier_gated_on_same_generation
+services::discord::tmux::tmux_session_files::tests::every_spawn_site_uses_the_combined_marker_gate
+services::discord::tmux::tmux_session_files::tests::generation_write_failure_emits_exactly_one_warn_and_still_writes_nonce
+services::discord::tmux::tmux_session_files::tests::spawn_markers_log_fixture_legacy_paths_unchanged
+services::discord::tmux::tmux_session_files::tests::spawn_markers_stamp_generation_before_nonce
+services::discord::tmux::tmux_session_files::tests::spawn_stamp_replaces_the_inode
+services::discord::tmux::tmux_session_files::tests::stamp_spawn_markers_returns_nonce_result_verbatim
 services::discord::tmux::tmux_watcher::commit_decisions::runtime_binding_offset_tests::acknowledged_session_bound_delivery_is_not_missing_inflight_fallback
 services::discord::tmux::tmux_watcher::commit_decisions::runtime_binding_offset_tests::busy_observation_without_delivery_still_advances_runtime_binding
 services::discord::tmux::tmux_watcher::commit_decisions::runtime_binding_offset_tests::busy_observation_without_terminal_delivery_allows_cleanup

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -1847,7 +1847,7 @@ fn execute_streaming_local_tui_tmux(
     // #3087: stamp a per-spawn nonce on the Claude-TUI DIRECT spawn path too.
     // Without it this path produces no `.spawn_nonce`, so the status-panel
     // instance key is `None` and the new-session boundary cannot be detected.
-    if let Err(e) = crate::services::discord::write_spawn_nonce(tmux_session_name) {
+    if let Err(e) = crate::services::discord::stamp_spawn_markers(tmux_session_name) {
         debug_log(&format!(
             "failed to write spawn nonce for {tmux_session_name} (claude-tui): {e}"
         ));
@@ -2886,19 +2886,13 @@ fn execute_streaming_local_tmux(
     // Keep tmux session alive after process exits for post-mortem analysis
     crate::services::platform::tmux::set_option(tmux_session_name, "remain-on-exit", "on");
 
-    // Stamp generation marker so post-restart watcher restore can detect old sessions
-    let gen_marker_path =
-        crate::services::tmux_common::session_temp_path(tmux_session_name, "generation");
-    let current_gen = crate::services::discord::runtime_store::process_generation();
-    let _ = std::fs::write(&gen_marker_path, current_gen.to_string());
-
     // #3087: stamp a per-spawn nonce in a SEPARATE marker. The status-panel
     // session-instance key reads this nonce (unique per spawn) instead of the
     // `.generation` mtime, so a missing/duplicate mtime can never collapse two
     // distinct spawns into one instance key. Write errors are logged (not
     // silently swallowed) since a missing nonce degrades the panel-reset
     // boundary to best-effort.
-    if let Err(e) = crate::services::discord::write_spawn_nonce(tmux_session_name) {
+    if let Err(e) = crate::services::discord::stamp_spawn_markers(tmux_session_name) {
         debug_log(&format!(
             "failed to write spawn nonce for {tmux_session_name}: {e}"
         ));

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -1906,7 +1906,7 @@ fn execute_streaming_local_tui_tmux(
     // #3087: stamp a per-spawn nonce on the Codex-TUI DIRECT spawn path too.
     // Without it this path produces no `.spawn_nonce`, so the status-panel
     // instance key is `None` and the new-session boundary cannot be detected.
-    if let Err(e) = crate::services::discord::write_spawn_nonce(tmux_session_name) {
+    if let Err(e) = crate::services::discord::stamp_spawn_markers(tmux_session_name) {
         tracing::warn!("failed to write spawn nonce for {tmux_session_name} (codex-tui): {e}");
     }
 
@@ -2418,16 +2418,10 @@ fn execute_streaming_local_tmux(
     // Keep tmux session alive after process exits for post-mortem analysis
     crate::services::platform::tmux::set_option(tmux_session_name, "remain-on-exit", "on");
 
-    // Stamp generation marker so post-restart watcher restore can detect old sessions
-    let gen_marker_path =
-        crate::services::tmux_common::session_temp_path(tmux_session_name, "generation");
-    let current_gen = crate::services::discord::runtime_store::process_generation();
-    let _ = std::fs::write(&gen_marker_path, current_gen.to_string());
-
     // #3087: stamp a per-spawn nonce in a SEPARATE marker (see claude.rs). The
     // status-panel session-instance key reads this unique nonce instead of the
     // `.generation` mtime, eliminating mtime missing/duplicate collisions.
-    if let Err(e) = crate::services::discord::write_spawn_nonce(tmux_session_name) {
+    if let Err(e) = crate::services::discord::stamp_spawn_markers(tmux_session_name) {
         tracing::warn!("failed to write spawn nonce for {tmux_session_name}: {e}");
     }
 

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -130,7 +130,7 @@ pub(crate) fn claim_cross_channel_tmux_watcher_for_high_risk_test(
 mod turn_completion_events;
 pub(in crate::services::discord) mod turn_end_wip_warning;
 #[cfg(unix)]
-pub(crate) use tmux::write_spawn_nonce;
+pub(crate) use tmux::{stamp_spawn_markers, write_spawn_nonce};
 #[cfg(unix)]
 mod tmux_error_detect;
 #[cfg(unix)]

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -61,11 +61,11 @@ pub(super) use self::tmux_session_files::read_generation_file_mtime_ns;
 pub(in crate::services::discord) use self::tmux_session_files::reset_relay_watermark_on_generation_change;
 pub(in crate::services::discord) use self::tmux_session_files::reset_stale_relay_watermark_if_output_regressed;
 pub(super) use self::tmux_session_files::session_panel_instance_key;
-pub(crate) use self::tmux_session_files::write_spawn_nonce;
 use self::tmux_session_files::{
     preserve_mtime_after_write, reset_stale_local_relay_offset_if_output_regressed,
     sweep_orphan_session_files,
 };
+pub(crate) use self::tmux_session_files::{stamp_spawn_markers, write_spawn_nonce};
 #[cfg(test)]
 pub(in crate::services::discord) use self::watcher_lifecycle::claim_cross_channel_tmux_watcher_for_test;
 use self::watcher_lifecycle::*;

--- a/src/services/discord/tmux_session_files.rs
+++ b/src/services/discord/tmux_session_files.rs
@@ -1,5 +1,7 @@
 use poise::serenity_prelude::ChannelId;
 
+use std::io::{Read, Seek, Write};
+
 use super::SharedData;
 
 /// Read the `.generation` marker file mtime in nanoseconds since the unix
@@ -9,13 +11,12 @@ use super::SharedData;
 /// migration window). All of those conditions are treated by callers as
 /// "fresh wrapper".
 ///
-/// `.generation` is written exactly once per spawn by `claude.rs` after
-/// `tmux::create_session` and never touched by the live wrapper, so its
-/// mtime uniquely identifies the wrapper instance even when jsonl
-/// rotation changes the jsonl inode (#1270). NOTE: this mtime signal is the
-/// #1270 wrapper-identity consumer ONLY. The status-panel session-instance
-/// key (#3087) no longer reads this mtime — it reads the dedicated
-/// `.spawn_nonce` marker content instead (see `session_panel_instance_key`).
+/// `.generation` is atomically replaced once per successful provider spawn and
+/// rewritten through a pinned fd when a surviving wrapper is adopted after a
+/// dcserver restart. Spawn replacement changes the wrapper identity mtime;
+/// adoption preserves it. NOTE: this mtime signal is the #1270 wrapper-identity
+/// consumer ONLY. The status-panel session-instance key (#3087) reads the
+/// dedicated `.spawn_nonce` marker content instead.
 pub(in crate::services::discord) fn read_generation_file_mtime_ns(tmux_session_name: &str) -> i64 {
     let Some(path) =
         crate::services::tmux_common::resolve_session_temp_path(tmux_session_name, "generation")
@@ -41,6 +42,102 @@ pub(in crate::services::discord) fn read_generation_file_mtime_ns(tmux_session_n
 /// parsed by the adoption path (`watchers::lifecycle`). The nonce lives in its
 /// own file so neither of those `.generation` consumers is perturbed.
 const SPAWN_NONCE_SUFFIX: &str = "spawn_nonce";
+
+#[cfg(test)]
+type GenerationStampBeforeCreateHook = std::sync::Arc<dyn Fn() + Send + Sync + 'static>;
+#[cfg(test)]
+static GENERATION_STAMP_BEFORE_CREATE_HOOK: std::sync::LazyLock<
+    std::sync::Mutex<Option<GenerationStampBeforeCreateHook>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+#[cfg(test)]
+fn run_generation_stamp_before_create_hook_for_tests() {
+    let hook = GENERATION_STAMP_BEFORE_CREATE_HOOK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .clone();
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
+/// Stamp the `.generation` marker for one successful provider spawn.
+///
+/// A successful call creates a new sibling inode with `create_new` and atomically
+/// renames that inode over the marker path. Adoption can therefore keep writing
+/// an fd for the prior inode without changing the marker visible at this path.
+/// Failures leave the destination untouched, emit one warning, and do not fail
+/// the provider spawn. The write is not fsynced.
+pub(in crate::services::discord) fn stamp_session_generation_marker(
+    tmux_session_name: &str,
+) -> Option<i64> {
+    let generation = crate::services::discord::runtime_store::process_generation();
+    let path = crate::services::tmux_common::session_temp_path(tmux_session_name, "generation");
+    let tmp_path = format!(
+        "{path}.tmp.{}.{}",
+        std::process::id(),
+        uuid::Uuid::new_v4().simple()
+    );
+
+    #[cfg(test)]
+    run_generation_stamp_before_create_hook_for_tests();
+
+    let stamp = || -> std::io::Result<i64> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)?;
+        file.write_all(generation.to_string().as_bytes())?;
+        let modified = file.metadata()?.modified()?;
+        let modified_ns = modified
+            .duration_since(std::time::UNIX_EPOCH)
+            .ok()
+            .and_then(|duration| i64::try_from(duration.as_nanos()).ok())
+            .ok_or_else(|| std::io::Error::other("generation marker mtime is out of range"))?;
+        drop(file);
+        std::fs::rename(&tmp_path, &path)?;
+        Ok(modified_ns)
+    };
+
+    match stamp() {
+        Ok(modified_ns) => Some(modified_ns),
+        Err(error) => {
+            let _ = std::fs::remove_file(&tmp_path);
+            tracing::warn!("failed to stamp generation marker for {tmux_session_name}: {error}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+type SpawnMarkersAfterGenerationHook = std::sync::Arc<dyn Fn() + Send + Sync + 'static>;
+#[cfg(test)]
+static SPAWN_MARKERS_AFTER_GENERATION_HOOK: std::sync::LazyLock<
+    std::sync::Mutex<Option<SpawnMarkersAfterGenerationHook>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+#[cfg(test)]
+fn run_spawn_markers_after_generation_hook_for_tests() {
+    let hook = SPAWN_MARKERS_AFTER_GENERATION_HOOK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .clone();
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
+/// Stamp the generation identity before the per-spawn nonce.
+///
+/// Generation failures remain best-effort and do not suppress nonce creation.
+/// The returned result is exactly `write_spawn_nonce`'s result, including its
+/// successful nonce value and its `std::io::Error`.
+pub(crate) fn stamp_spawn_markers(tmux_session_name: &str) -> std::io::Result<String> {
+    let _ = stamp_session_generation_marker(tmux_session_name);
+    #[cfg(test)]
+    run_spawn_markers_after_generation_hook_for_tests();
+    write_spawn_nonce(tmux_session_name)
+}
 
 /// Write a fresh, globally-unique per-spawn nonce to the `.spawn_nonce` marker.
 ///
@@ -138,61 +235,129 @@ pub(in crate::services::discord) fn session_panel_instance_key(
     Some(format!("{name}#{nonce}"))
 }
 
-/// Rewrite a file's contents while preserving its prior modified time. Used
-/// by the adoption path to refresh the `.generation` marker payload (so the
-/// generation number on disk matches the current dcserver runtime) without
-/// changing the file's mtime — the mtime is the wrapper-identity signal that
-/// the regression resolver uses to distinguish "same wrapper, mid-flight
-/// rotation" from "fresh wrapper after cancel→respawn" (see
-/// `watermark_after_output_regression`). Adoption changes the runtime that
-/// owns the wrapper, but it does NOT respawn the wrapper itself, so the
-/// identity signal must stay pinned.
-///
-/// Failures are logged and swallowed: the worst case is a redundant fresh-
-/// wrapper reset on a restored offset, which is the same behaviour the
-/// codebase had before #1271. Returning an error would not unblock the
-/// adoption.
-pub(super) fn preserve_mtime_after_write(path: &str, content: &[u8], context: &str) {
-    let prior_mtime = std::fs::metadata(path).ok().and_then(|m| m.modified().ok());
-    if let Err(e) = std::fs::write(path, content) {
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::warn!(
-            "  [{ts}] ⚠ preserve_mtime_after_write: failed to write {} (context={}, error={})",
-            path,
-            context,
-            e
-        );
-        return;
+#[cfg(test)]
+type PreserveMtimeAfterMetadataHook = std::sync::Arc<dyn Fn() + Send + Sync + 'static>;
+#[cfg(test)]
+static PRESERVE_MTIME_AFTER_METADATA_HOOK: std::sync::LazyLock<
+    std::sync::Mutex<Option<PreserveMtimeAfterMetadataHook>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+#[cfg(test)]
+static PRESERVE_MTIME_BEFORE_REWRITE_HOOK: std::sync::LazyLock<
+    std::sync::Mutex<Option<PreserveMtimeAfterMetadataHook>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+#[cfg(test)]
+fn run_preserve_mtime_after_metadata_hook_for_tests() {
+    let hook = PRESERVE_MTIME_AFTER_METADATA_HOOK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .clone();
+    if let Some(hook) = hook {
+        hook();
     }
-    let Some(prior) = prior_mtime else {
-        // No prior mtime to preserve (file did not exist or metadata unavailable).
-        // The post-write mtime is the only baseline we have, which is the same
-        // outcome as before this helper existed.
-        return;
+}
+
+#[cfg(test)]
+fn run_preserve_mtime_before_rewrite_hook_for_tests() {
+    let hook = PRESERVE_MTIME_BEFORE_REWRITE_HOOK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .clone();
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
+/// Rewrite an adopted `.generation` marker through one pinned file descriptor.
+///
+/// For an existing marker, metadata, content replacement, and mtime restoration
+/// all target the inode opened at entry. If a concurrent spawn atomically
+/// replaces the path, adoption can only modify the unlinked prior inode. If the
+/// marker is absent, `create_new` retains restart healing; `AlreadyExists`
+/// retries the existing-fd path so adoption never joins a concurrent writer by
+/// using `create(true)`. Existing current-generation content is a no-op.
+/// Failures are logged and swallowed because adoption itself can still proceed.
+pub(super) fn preserve_mtime_after_write(path: &str, content: &[u8], context: &str) {
+    let mut file = loop {
+        match std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+        {
+            Ok(file) => break file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                match std::fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create_new(true)
+                    .open(path)
+                {
+                    Ok(mut file) => {
+                        if let Err(error) = file.write_all(content) {
+                            warn_preserve_mtime_failure(path, context, "create/write", &error);
+                        }
+                        return;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(error) => {
+                        warn_preserve_mtime_failure(path, context, "create", &error);
+                        return;
+                    }
+                }
+            }
+            Err(error) => {
+                warn_preserve_mtime_failure(path, context, "open", &error);
+                return;
+            }
+        }
     };
-    let times = std::fs::FileTimes::new().set_modified(prior);
-    let file = match std::fs::OpenOptions::new().write(true).open(path) {
-        Ok(f) => f,
-        Err(e) => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::warn!(
-                "  [{ts}] ⚠ preserve_mtime_after_write: failed to reopen {} for set_times (context={}, error={})",
-                path,
-                context,
-                e
-            );
+
+    let prior_mtime = match file.metadata().and_then(|metadata| metadata.modified()) {
+        Ok(modified) => modified,
+        Err(error) => {
+            warn_preserve_mtime_failure(path, context, "metadata", &error);
             return;
         }
     };
-    if let Err(e) = file.set_times(times) {
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::warn!(
-            "  [{ts}] ⚠ preserve_mtime_after_write: set_times failed for {} (context={}, error={})",
-            path,
-            context,
-            e
-        );
+
+    #[cfg(test)]
+    run_preserve_mtime_after_metadata_hook_for_tests();
+
+    let mut existing = Vec::new();
+    if let Err(error) = file.read_to_end(&mut existing) {
+        warn_preserve_mtime_failure(path, context, "read", &error);
+        return;
     }
+    if existing == content {
+        return;
+    }
+
+    #[cfg(test)]
+    run_preserve_mtime_before_rewrite_hook_for_tests();
+
+    if let Err(error) = file.set_len(0) {
+        warn_preserve_mtime_failure(path, context, "truncate", &error);
+        return;
+    }
+    if let Err(error) = file.rewind().and_then(|()| file.write_all(content)) {
+        warn_preserve_mtime_failure(path, context, "write", &error);
+        return;
+    }
+    let times = std::fs::FileTimes::new().set_modified(prior_mtime);
+    if let Err(error) = file.set_times(times) {
+        warn_preserve_mtime_failure(path, context, "set_times", &error);
+    }
+}
+
+fn warn_preserve_mtime_failure(path: &str, context: &str, operation: &str, error: &std::io::Error) {
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    tracing::warn!(
+        "  [{ts}] ⚠ preserve_mtime_after_write: {} failed for {} (context={}, error={})",
+        operation,
+        path,
+        context,
+        error
+    );
 }
 
 /// Decide what watermark a stale-output regression (current EOF lower than
@@ -548,6 +713,124 @@ pub(super) async fn sweep_orphan_session_files() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::writer::MakeWriter;
+
+    struct TestHookGuard;
+
+    impl Drop for TestHookGuard {
+        fn drop(&mut self) {
+            *PRESERVE_MTIME_AFTER_METADATA_HOOK
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner()) = None;
+            *PRESERVE_MTIME_BEFORE_REWRITE_HOOK
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner()) = None;
+            *SPAWN_MARKERS_AFTER_GENERATION_HOOK
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner()) = None;
+            *GENERATION_STAMP_BEFORE_CREATE_HOOK
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner()) = None;
+        }
+    }
+
+    fn set_preserve_after_metadata_hook(hook: PreserveMtimeAfterMetadataHook) -> TestHookGuard {
+        *PRESERVE_MTIME_AFTER_METADATA_HOOK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = Some(hook);
+        TestHookGuard
+    }
+
+    fn set_preserve_before_rewrite_hook(hook: PreserveMtimeAfterMetadataHook) -> TestHookGuard {
+        *PRESERVE_MTIME_BEFORE_REWRITE_HOOK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = Some(hook);
+        TestHookGuard
+    }
+
+    fn set_spawn_after_generation_hook(hook: SpawnMarkersAfterGenerationHook) -> TestHookGuard {
+        *SPAWN_MARKERS_AFTER_GENERATION_HOOK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = Some(hook);
+        TestHookGuard
+    }
+
+    fn set_generation_before_create_hook(hook: GenerationStampBeforeCreateHook) -> TestHookGuard {
+        *GENERATION_STAMP_BEFORE_CREATE_HOOK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = Some(hook);
+        TestHookGuard
+    }
+
+    fn isolated_runtime_root() -> (tempfile::TempDir, crate::config::TestEnvVarGuard) {
+        let root = tempfile::tempdir().expect("isolated runtime root");
+        let env = crate::config::TestEnvVarGuard::set_path("AGENTDESK_ROOT_DIR", root.path());
+        (root, env)
+    }
+
+    fn unique_session(label: &str) -> String {
+        format!("AgentDesk-5264-{label}-{}", uuid::Uuid::new_v4().simple())
+    }
+
+    fn generation_path(session: &str) -> String {
+        crate::services::tmux_common::session_temp_path(session, "generation")
+    }
+
+    fn nonce_path(session: &str) -> String {
+        crate::services::tmux_common::session_temp_path(session, SPAWN_NONCE_SUFFIX)
+    }
+
+    #[derive(Clone)]
+    struct CapturingWriter {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl io::Write for CapturingWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.buffer
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CapturingWriter {
+        type Writer = CapturingWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn capture_warns<F>(emit: F) -> String
+    where
+        F: FnOnce(),
+    {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .without_time()
+            .with_writer(CapturingWriter {
+                buffer: buffer.clone(),
+            })
+            .finish();
+        tracing::subscriber::with_default(subscriber, emit);
+        String::from_utf8(
+            buffer
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .clone(),
+        )
+        .expect("captured warnings are utf-8")
+    }
 
     // #3358 round 2 — Finding 1 guard at the pure-decision level.
     #[test]
@@ -575,5 +858,255 @@ mod tests {
         );
         // No committed delivery yet (offset 0) → None even if generations match.
         assert_eq!(committed_frontier_for_same_generation(0, 42, 42), None);
+    }
+
+    #[test]
+    fn spawn_markers_stamp_generation_before_nonce() {
+        let (_root, _env) = isolated_runtime_root();
+        let session = unique_session("stamp-order");
+
+        stamp_spawn_markers(&session).expect("stamp both spawn markers");
+
+        assert_ne!(
+            read_generation_file_mtime_ns(&session),
+            0,
+            "combined marker gate must create generation identity"
+        );
+        let generation =
+            std::fs::read_to_string(generation_path(&session)).expect("generation marker content");
+        assert_eq!(
+            generation,
+            crate::services::discord::runtime_store::process_generation().to_string()
+        );
+        let generation_mtime = std::fs::metadata(generation_path(&session))
+            .and_then(|metadata| metadata.modified())
+            .expect("generation marker mtime");
+        let nonce_mtime = std::fs::metadata(nonce_path(&session))
+            .and_then(|metadata| metadata.modified())
+            .expect("nonce marker mtime");
+        assert!(
+            generation_mtime <= nonce_mtime,
+            "generation must be written before the nonce"
+        );
+    }
+
+    #[test]
+    fn every_spawn_site_uses_the_combined_marker_gate() {
+        let claude = include_str!("../claude.rs");
+        let codex = include_str!("../codex.rs");
+        let qwen = include_str!("../qwen.rs");
+        let combined = "crate::services::discord::stamp_spawn_markers(tmux_session_name)";
+        let nonce_only = "crate::services::discord::write_spawn_nonce(tmux_session_name)";
+        let inline_generation = "session_temp_path(tmux_session_name, \"generation\")";
+
+        assert_eq!(claude.matches(combined).count(), 2);
+        assert_eq!(codex.matches(combined).count(), 2);
+        assert_eq!(qwen.matches(combined).count(), 1);
+        for source in [claude, codex, qwen] {
+            assert!(!source.contains(nonce_only));
+            assert!(!source.contains(inline_generation));
+        }
+    }
+
+    #[test]
+    fn adoption_never_stamps_a_fresh_incarnation_with_an_old_mtime() {
+        let (_root, _env) = isolated_runtime_root();
+        let session = unique_session("adoption-race");
+        let path = generation_path(&session);
+        std::fs::write(&path, b"old").expect("old marker");
+        let old_time = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000);
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("open old marker")
+            .set_times(std::fs::FileTimes::new().set_modified(old_time))
+            .expect("set old marker time");
+
+        let fresh_mtime = Arc::new(Mutex::new(None));
+        let fresh_mtime_from_hook = fresh_mtime.clone();
+        let session_from_hook = session.clone();
+        let path_from_hook = path.clone();
+        let _hook = set_preserve_after_metadata_hook(Arc::new(move || {
+            stamp_session_generation_marker(&session_from_hook).expect("fresh spawn stamp");
+            *fresh_mtime_from_hook
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner()) = Some(
+                std::fs::metadata(&path_from_hook)
+                    .and_then(|metadata| metadata.modified())
+                    .expect("fresh marker mtime"),
+            );
+        }));
+        let current = crate::services::discord::runtime_store::process_generation().to_string();
+
+        preserve_mtime_after_write(&path, current.as_bytes(), "adoption-race-test");
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), current);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().modified().unwrap(),
+            fresh_mtime
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .expect("hook captured fresh mtime"),
+            "adoption must not copy the old inode mtime onto the fresh marker"
+        );
+    }
+
+    #[test]
+    fn adoption_recovers_an_absent_marker_with_nonzero_identity() {
+        let (_root, _env) = isolated_runtime_root();
+        let session = unique_session("adoption-absent");
+        let path = generation_path(&session);
+        let current = crate::services::discord::runtime_store::process_generation().to_string();
+        assert!(!std::path::Path::new(&path).exists());
+
+        preserve_mtime_after_write(&path, current.as_bytes(), "adoption-absent-test");
+
+        assert!(
+            std::path::Path::new(&path).exists(),
+            "restart adoption must recreate an absent marker"
+        );
+        assert_ne!(
+            read_generation_file_mtime_ns(&session),
+            0,
+            "restart adoption must recover a usable generation identity"
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), current);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn spawn_stamp_replaces_the_inode() {
+        use std::os::unix::fs::MetadataExt;
+
+        let (_root, _env) = isolated_runtime_root();
+        let session = unique_session("inode-replace");
+        let path = generation_path(&session);
+        std::fs::write(&path, b"old").expect("old marker");
+        let old_inode = std::fs::metadata(&path).unwrap().ino();
+
+        stamp_session_generation_marker(&session).expect("spawn generation stamp");
+
+        let new_inode = std::fs::metadata(&path).unwrap().ino();
+        assert_ne!(
+            new_inode, old_inode,
+            "successful stamp must install a new inode"
+        );
+    }
+
+    #[test]
+    fn adoption_current_generation_marker_is_a_noop() {
+        let (_root, _env) = isolated_runtime_root();
+        let session = unique_session("adoption-current-noop");
+        let path = generation_path(&session);
+        let current = crate::services::discord::runtime_store::process_generation().to_string();
+        std::fs::write(&path, current.as_bytes()).expect("current marker");
+        let rewrite_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let rewrite_count_from_hook = rewrite_count.clone();
+        let _hook = set_preserve_before_rewrite_hook(Arc::new(move || {
+            rewrite_count_from_hook.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }));
+
+        preserve_mtime_after_write(&path, current.as_bytes(), "adoption-current-test");
+
+        assert_eq!(
+            rewrite_count.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "current-generation content must return before truncate/write"
+        );
+        assert_eq!(std::fs::read_to_string(path).unwrap(), current);
+    }
+
+    #[test]
+    fn spawn_markers_log_fixture_legacy_paths_unchanged() {
+        let claude = include_str!("../claude.rs");
+        let codex = include_str!("../codex.rs");
+        let qwen = include_str!("../qwen.rs");
+        let legacy = "failed to write spawn nonce for {tmux_session_name}: {e}";
+
+        assert!(claude.contains(legacy));
+        assert!(codex.contains(legacy));
+        assert!(qwen.contains(legacy));
+        assert!(
+            claude
+                .contains("failed to write spawn nonce for {tmux_session_name} (claude-tui): {e}")
+        );
+        assert!(
+            codex.contains("failed to write spawn nonce for {tmux_session_name} (codex-tui): {e}")
+        );
+    }
+
+    #[test]
+    fn stamp_spawn_markers_returns_nonce_result_verbatim() {
+        let (_root, _env) = isolated_runtime_root();
+        let success_session = unique_session("nonce-verbatim-success");
+        let nonce = stamp_spawn_markers(&success_session).expect("combined marker success");
+        assert_eq!(
+            std::fs::read_to_string(nonce_path(&success_session)).unwrap(),
+            nonce
+        );
+
+        let direct_session = unique_session("nonce-verbatim-direct-error");
+        let direct_tmp = format!("{}.tmp.{}", nonce_path(&direct_session), std::process::id());
+        std::fs::create_dir(&direct_tmp).expect("block direct nonce temp path");
+        let direct_kind = write_spawn_nonce(&direct_session).unwrap_err().kind();
+
+        let combined_session = unique_session("nonce-verbatim-combined-error");
+        let combined_tmp = format!(
+            "{}.tmp.{}",
+            nonce_path(&combined_session),
+            std::process::id()
+        );
+        std::fs::create_dir(&combined_tmp).expect("block combined nonce temp path");
+        let combined_kind = stamp_spawn_markers(&combined_session).unwrap_err().kind();
+        assert_eq!(combined_kind, direct_kind);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generation_write_failure_emits_exactly_one_warn_and_still_writes_nonce() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_root, _env) = isolated_runtime_root();
+        let session = unique_session("generation-permission-failure");
+        let sessions_dir =
+            std::path::PathBuf::from(crate::services::tmux_common::agentdesk_temp_dir());
+        let sessions_dir_before_create = sessions_dir.clone();
+        let _permission_hook = set_generation_before_create_hook(Arc::new(move || {
+            std::fs::set_permissions(
+                &sessions_dir_before_create,
+                std::fs::Permissions::from_mode(0o500),
+            )
+            .expect("block marker creation");
+        }));
+        let sessions_dir_from_hook = sessions_dir.clone();
+        let _hook = set_spawn_after_generation_hook(Arc::new(move || {
+            std::fs::set_permissions(
+                &sessions_dir_from_hook,
+                std::fs::Permissions::from_mode(0o700),
+            )
+            .expect("restore nonce write permission");
+        }));
+
+        let mut result = None;
+        let logs = capture_warns(|| {
+            result = Some(stamp_spawn_markers(&session));
+        });
+        std::fs::set_permissions(&sessions_dir, std::fs::Permissions::from_mode(0o700))
+            .expect("restore sessions permissions");
+
+        let nonce = result
+            .expect("combined call ran")
+            .expect("nonce still succeeds");
+        assert_eq!(
+            std::fs::read_to_string(nonce_path(&session)).unwrap(),
+            nonce
+        );
+        assert!(!std::path::Path::new(&generation_path(&session)).exists());
+        assert_eq!(logs.lines().count(), 1, "captured WARN events: {logs}");
+        assert_eq!(
+            logs.matches("failed to stamp generation marker").count(),
+            1,
+            "generation failure must emit exactly one WARN: {logs}"
+        );
     }
 }

--- a/src/services/discord/watchers/lifecycle/restore.rs
+++ b/src/services/discord/watchers/lifecycle/restore.rs
@@ -408,8 +408,9 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
                 session_gen,
                 current_gen
             );
-            // Update generation marker to current gen, preserving the
-            // existing mtime.
+            // Update through one fd so a concurrent spawn replacement cannot
+            // receive this wrapper's old mtime. A missing marker is recovered
+            // with create-new/retry inside the helper.
             //
             // #1275 P2 #1: the `.generation` mtime is the wrapper-identity
             // signal used by `watermark_after_output_regression`. Adoption

--- a/src/services/qwen.rs
+++ b/src/services/qwen.rs
@@ -1384,15 +1384,10 @@ fn execute_streaming_local_tmux(
 
     crate::services::platform::tmux::set_option(tmux_session_name, "remain-on-exit", "on");
 
-    let gen_marker_path =
-        crate::services::tmux_common::session_temp_path(tmux_session_name, "generation");
-    let current_gen = crate::services::discord::runtime_store::process_generation();
-    let _ = std::fs::write(&gen_marker_path, current_gen.to_string());
-
     // #3087: stamp a per-spawn nonce in a SEPARATE marker (see claude.rs). The
     // status-panel session-instance key reads this unique nonce instead of the
     // `.generation` mtime, eliminating mtime missing/duplicate collisions.
-    if let Err(e) = crate::services::discord::write_spawn_nonce(tmux_session_name) {
+    if let Err(e) = crate::services::discord::stamp_spawn_markers(tmux_session_name) {
         tracing::warn!("failed to write spawn nonce for {tmux_session_name}: {e}");
     }
 


### PR DESCRIPTION
> 예산 초과 사유: 최종 diff는 9파일 `+626/-82`(변경선 ±708)로 ±191 추정 대비 +270.7%다. 재검증 P1의 atomic new-inode replace와 absent-marker recovery, 6개 뮤테이션 테스트와 3개 로그 픽스처를 독립 테스트로 고정한 비용이며 PR 상한 20파일/±800 안이다.

## 요약

- TUI/legacy 5개 spawn 호출을 `stamp_spawn_markers` 단일 관문으로 합쳐 generation → nonce 순서를 유지했다. 반환형과 성공값은 `write_spawn_nonce`의 `std::io::Result<String>`을 그대로 전달하며 기존 nonce 오류 문구 5개는 바이트 동일하다.
- adoption은 하나의 read+write fd에서 metadata → content 확인 → truncate/write → `File::set_times`를 수행한다. 이미 current generation content이면 no-op다.
- missing marker는 `create_new(true)`로 회복하고, 경쟁 writer가 먼저 만들면 `AlreadyExists`에서 기존-fd 경로로 재시도한다.
- writer 계약과 현재 5개 spawn site를 `change-surfaces.md`에 기록했고 신규 Rust 테스트 9개를 lib inventory manifest에 등록했다.

## 조건 1 — atomic new-inode replace

선택안은 같은 디렉터리의 UUID sibling temp file을 `OpenOptions::create_new(true)`로 만든 뒤 `rename`으로 목적 경로를 교체하는 방식이다. unlink-then-write는 adoption의 absent-marker `create_new`와 같은 inode를 공유할 창이 있으므로 채택하지 않았다.

성공한 stamp에서 `create_new`는 기존 경로를 연 것이 아니라 새 temp inode를 만들고, 동일 디렉터리 `rename`은 목적 이름이 그 inode를 가리키도록 원자 교체한다. 따라서 adoption이 이미 잡은 fd는 교체 전 inode에만 남고 fresh marker에 old mtime을 찍을 수 없다. create/write/metadata/rename 중 하나라도 실패하면 destination을 same-inode overwrite하지 않고 WARN 1건 뒤 spawn을 계속한다. 그러므로 “새 inode” 보장의 주체와 범위는 **성공한 `stamp_session_generation_marker` 호출**이다.

## 조건 2 — absent-marker 회복

adoption의 첫 open이 `NotFound`이면 `create_new(true)`로 marker를 만든다. 그 사이 다른 writer가 만들면 `AlreadyExists`를 받아 loop의 기존-fd open으로 합류한다. `create(true)`는 사용하지 않는다. `adoption_recovers_an_absent_marker_with_nonzero_identity`가 임시 runtime root에서 marker 생성, current content, non-zero mtime identity를 고정한다.

## 조건 3 — C5 정정문

> E-35의 `.generation` 의존은 **5개 심볼 · 4개 독립 집행 단계**다. `shadow_mirror_delivered_frontier_inner`, `exact_receipt_from_inflight`, `write_confirmed_delivery_at_with_lock_authority`, `write_confirmed_frontier_guarded_at_with_lock_authority`가 네 단계이며, `ExactJsonlSourceIdentity::is_authoritative`는 `write_confirmed_delivery_at_with_lock_authority`가 호출하는 하위 predicate다. 따라서 “구조적으로 못 쓴다”가 아니라 **E-35 시점에 그 세션이 부팅 후 adopt됐는지에 따라 비결정적으로 갈린다**가 정확하다. 이는 #5264의 선행성을 강화한다. E-35 PASS만으로는 spawn writer와 adoption writer를 구분할 수 없기 때문이다.

PR #5287은 이 PR에서 수정하지 않았다.

## 재현 실측

- 기준: `origin/main = 309da6db476258afbc3339d9a0e986b42ddbe5d1`, `rustc 1.94.1`.
- 최종 tracked diff: 9파일, `+626/-82`, 변경선 ±708.
- inventory generator의 baseline → 구현 비교:
  - `tmux_session_files`: prod 547 → 712(+165), test 32 → 400(+368)
  - Claude prod 2951 → 2945(-6), Codex 3118 → 3112(-6), Qwen 2195 → 2190(-5), restore 843 → 844(+1)
  - prod 합계 +149, test 합계 +368.
  - generated module inventory 6행, giant registry 3행이 바뀌지만 두 산출물은 `.gitignore` 대상이라 tracked diff는 없다.
- Layer 2는 지정 식별자 검색에서 후보 46파일이다. 제외 기준은 별도 `*_tests.rs`와 `**/tests.rs`이며 inline `#[cfg(test)]` 영역은 파일 수에서 분리하지 못한다. 함수 단위 완전성은 주장하지 않는다.
- targeted module은 10개 테스트(기존 1 + 신규 9)를 실제 실행해 전부 통과했다.
- lib inventory는 manifest/actual 각각 7,673개, delta 0, digest 일치다.

## 뮤테이션

| 변형 | 제거/변조 시 | 복원 시 |
|---|---|---|
| M1 combined helper의 generation stamp 호출 제거 | `spawn_markers_stamp_generation_before_nonce` FAILED — generation identity assert | ok |
| M2 Claude TUI를 nonce-only 호출로 복귀 | `every_spawn_site_uses_the_combined_marker_gate` FAILED — callsite count assert | ok |
| M3 adoption `set_times`를 path reopen으로 복귀 | `adoption_never_stamps_a_fresh_incarnation_with_an_old_mtime` FAILED — fresh mtime assert | ok |
| M3 absent `create_new`/retry 제거 | `adoption_recovers_an_absent_marker_with_nonzero_identity` FAILED — marker existence assert | ok |
| M3 atomic rename을 same-inode write로 변조 | `spawn_stamp_replaces_the_inode` FAILED — inode inequality assert | ok |
| M3 current-content no-op 제거 | `adoption_current_generation_marker_is_a_noop` FAILED — rewrite-count assert | ok |

모든 mutant는 컴파일 성공 뒤 자기 assert로 rc=101이 됐고, 원복 suite는 10/10 ok였다.

## 게이트

| 게이트 | rc |
|---|---:|
| `cargo fmt --all --check` | 0 |
| `cargo check --lib` | 0 |
| `cargo test --lib services::discord::tmux::tmux_session_files::tests -- --test-threads=1` | 0 |
| `python3 scripts/generate_inventory_docs.py` | 0 |
| `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate` | 0 |
| `python3 scripts/check_test_target_integrity.py --verify-lib-inventory` | 0 |
| `TEST_LANE_BASELINE_REF=309da6db476258afbc3339d9a0e986b42ddbe5d1 bash scripts/ci-script-checks.sh` | 0 |
| `git diff --check` | 0 |

`ci-script-checks.sh`는 immutable baseline을 명시했고, 테스트가 요구하는 loopback listener는 OS 임시 포트(`127.0.0.1:0`)만 사용했다.

## 보장하지 않는 범위

- 이 PR은 stamp의 create/write/metadata/rename I/O 실패 시 `.generation` 존재를 보장하지 않는다. spawn은 계속되고 destination은 기존 값 또는 absent 상태로 남을 수 있다.
- 새-inode 보장은 성공한 stamp에 한정된다. crash 또는 오류로 rename까지 완료되지 않은 호출에는 적용하지 않는다.
- 이 PR은 `.generation` 또는 `.spawn_nonce`를 fsync하지 않으며 전원 손실 내구성을 보장하지 않는다.
- wrapper identity는 계속 mtime 기반이다. 모든 파일시스템에서 서로 다른 spawn의 mtime 값이 반드시 유일하다고 보장하지 않는다.
- 기존 `gen=0` 또는 stale-generation durable record를 소급 변환하지 않는다. 회복은 absent marker adoption과 이후 confirmed delivery부터 전방으로 진행된다.
- Layer 2 소비자의 함수 단위 전수를 보장하지 않는다. 위 46파일은 식별자 기반 후보 집합이다.
- source invariant test는 현재 세 provider 파일의 5개 site를 고정하지만 미래의 새 provider 파일을 자동 발견하지 않는다.
- fd 계약은 현재 spawn helper의 atomic replace와 결합된 범위다. 미래 writer가 helper를 우회해 path-visible inode를 제자리 overwrite하면 그 writer까지 막지 않는다.
- 실제 tmux session spawn, Discord delivery, E2E, PostgreSQL, 배포/재시작은 실행하지 않았고 runtime acceptance를 보장하지 않는다.

### adoption I/O 실패 시 partial authority 비보장

adoption은 fail-open이며, 성공 경로의 단일-fd/new-inode 격리만 보장한다. 오류 경로에는 다음 path-visible partial state가 남을 수 있고 이 PR은 이를 원자적으로 롤백하지 않는다.

- 기존 marker의 `set_len(0)` 성공 뒤 `write_all`이 실패하면 같은 inode가 empty/partial content와 truncate/write 시각의 mtime으로 남을 수 있다. prior mtime 복원은 실행되지 않는다.
- content write 성공 뒤 `File::set_times(prior_mtime)`가 실패하면 current content는 남지만 mtime이 회전한다.
- absent marker의 `create_new(true)` 성공 뒤 write가 실패하면 새 empty/partial marker와 nonzero mtime이 path-visible 상태로 남을 수 있다.

이 오류들은 WARN 후 watcher restore를 계속하는 기존 fail-open 계약을 따른다. downstream 일부 권위 소비자는 marker content가 아니라 nonzero/current mtime을 identity로 사용하므로, 같은 wrapper의 기존 durable receipt/frontier를 보수적으로 false-reject하거나 실패 시각의 mtime을 새 identity로 굳힐 수 있다. 따라서 이 PR은 adoption I/O 실패 시 marker content/mtime의 원자성, prior identity 보존, 또는 자동 복구를 보장하지 않는다.

## 2026-08-09 landing rebase identity

- #5292 landed first at main `6719c193ee5d4292f1787092bbae0eca555faf5b`; this branch was then rebased without conflicts to exact head `4866ec5001cb426d7c730fc02b52eeabc1639198`.
- The sole commit is patch-identical to reviewed head `0db3cfa1f42401a2ce12872277ea90915a6c45a0`: range-diff `=`, stable patch-id `5ebeb6bc26fc5902d48b599d5983ac6d43694baf`, raw diff blob `90cb9b6e034ce720dc215af9805162c363cdc913`. Changed-path overlap with #5292 is zero.
- The earlier `309da6db...` measurements and local gate table are the original reviewed-baseline evidence; required GitHub checks are rerunning on this rebased exact head before landing. No implementation or guarantee changed, so the prior dual CLEAN verdict is carried by exact patch identity.