### PR TITLE
#5003 S3a-1 — test-suite registry core + verifier suite

### DIFF
--- a/scripts/check_test_suite_registry.py
+++ b/scripts/check_test_suite_registry.py
@@ -1,12 +1,6 @@
 """Tracked test-suite registry core; policy/enforcement belongs to S3a-2."""
 from __future__ import annotations
-import ast
-import fnmatch
-import json
-import posixpath
-import re
-import shlex
-import subprocess
+import ast, json, posixpath, re, shlex, subprocess
 from collections import Counter, deque
 from dataclasses import dataclass, field
 from enum import Enum
@@ -78,51 +72,43 @@ class RegistryResult:
     def suite_pin_counts(self) -> Mapping[PinStatus, int]:
         return self._counts("pin", PinStatus)
     def family_violations(self, floors: Mapping[Family, int]) -> tuple[FamilyViolation, ...]:
-        return tuple(FamilyViolation(f, minimum, self.family_counts.get(f, 0))
-                     for f, minimum in sorted(floors.items(), key=lambda item: item[0].value)
-                     if self.family_counts.get(f, 0) < minimum)
+        return tuple(FamilyViolation(f, minimum, self.family_counts.get(f, 0)) for f, minimum in
+                     sorted(floors.items(), key=lambda item: item[0].value) if self.family_counts.get(f, 0) < minimum)
     def partial_violations(self, allowed_exact_targets: Collection[tuple[str, str]] = ()) -> tuple[PartialViolation, ...]:
         allowed, violations = set(allowed_exact_targets), []
         for candidate in self.candidates:
             if candidate.execution is not ExecStatus.PARTIAL:
                 continue
-            targets = tuple(sorted(call.target + (f".{call.selector}" if call.selector else "")
-                                   for call in candidate.invocations if not call.glob))
+            targets = tuple(sorted(call.target + (f".{call.selector}" if call.selector else "") for call in candidate.invocations if not call.glob))
             if not targets or not all((candidate.path, target) in allowed for target in targets):
                 violations.append(PartialViolation(candidate.path, targets, candidate.unexecuted_tests))
         return tuple(violations)
 @dataclass(frozen=True)
 class _PythonTests:
     all: tuple[str, ...]; unittest: tuple[str, ...]; has_unittest_main: bool
-def _matches(path: str, patterns: Sequence[str]) -> bool:
-    """Match only the registry's anchored POSIX family grammar; **/ is zero-or-more directories."""
-    def expression(pattern: str) -> str:
-        escaped = re.escape(pattern).replace(r"\*\*/", r"(?:[^/]+/)*")
-        return escaped.replace(r"\*", r"[^/]*").replace(r"\?", r"[^/]")
-    return any(re.fullmatch(expression(pattern), path) is not None for pattern in patterns)
+def _compile_glob(pattern: str) -> re.Pattern[str]:
+    """Compile the supported anchored POSIX glob grammar; only ** crosses directories."""
+    escaped = re.escape(pattern).replace(r"\*\*/", r"(?:[^/]+/)*").replace(r"\*\*", r".*")
+    return re.compile(escaped.replace(r"\*", r"[^/]*").replace(r"\?", r"[^/]"))
+def _matches(path: str, patterns: Sequence[str]) -> bool: return any(_compile_glob(pattern).fullmatch(path) for pattern in patterns)
 def _family(path: str, config: RegistryConfig) -> tuple[Family, CandidateKind] | None:
-    ordered = ((Family.TESTS_PY, CandidateKind.PYTHON_SUITE), (Family.E2E_PY, CandidateKind.PYTHON_SUITE),
-               (Family.SCRIPTS_PY, CandidateKind.PYTHON_SUITE),
+    ordered = ((Family.TESTS_PY, CandidateKind.PYTHON_SUITE), (Family.E2E_PY, CandidateKind.PYTHON_SUITE), (Family.SCRIPTS_PY, CandidateKind.PYTHON_SUITE),
                (Family.SHELL, CandidateKind.SHELL_SUITE), (Family.GATE, CandidateKind.GATE))
-    return next(((family, kind) for family, kind in ordered
-                 if _matches(path, config.patterns.get(family, ()))), None)
+    return next(((family, kind) for family, kind in ordered if _matches(path, config.patterns.get(family, ()))), None)
 def _tracked_files(root: Path) -> tuple[list[str], Diagnostic | None]:
     try:
-        run = subprocess.run(["git", "ls-files", "-z"], cwd=root, check=False,
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        run = subprocess.run(["git", "ls-files", "-z"], cwd=root, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except OSError as error:
         return [], Diagnostic(DiagnosticKind.TRACKED_INPUT, str(error), fatal=True)
     if run.returncode:
-        return [], Diagnostic(DiagnosticKind.TRACKED_INPUT,
-                              run.stderr.decode("utf-8", "replace").strip(), fatal=True)
+        return [], Diagnostic(DiagnosticKind.TRACKED_INPUT, run.stderr.decode("utf-8", "replace").strip(), fatal=True)
     try:
         return sorted(part.decode() for part in run.stdout.split(b"\0") if part), None
     except UnicodeDecodeError as error:
         return [], Diagnostic(DiagnosticKind.TRACKED_INPUT, str(error), fatal=True)
 def _read_source(root: Path, relative: str) -> tuple[str | None, Diagnostic | None]:
     path = root / relative
-    if not path.exists():
-        return None, Diagnostic(DiagnosticKind.SOURCE_MISSING, f"required source missing: {relative}", relative, True)
+    if not path.exists(): return None, Diagnostic(DiagnosticKind.SOURCE_MISSING, f"required source missing: {relative}", relative, True)
     try:
         text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeError) as error:
@@ -134,27 +120,30 @@ def _parse_python(text: str, path: str) -> tuple[ast.Module | None, Diagnostic |
     try:
         return ast.parse(text, filename=path), None
     except SyntaxError as error:
-        return None, Diagnostic(DiagnosticKind.PYTHON_MALFORMED,
-                                f"cannot parse {path}: {error}", path, True)
+        return None, Diagnostic(DiagnosticKind.PYTHON_MALFORMED, f"cannot parse {path}: {error}", path, True)
 def _logical_lines(text: str, source: str) -> tuple[list[str], Diagnostic | None]:
     result, pending = [], ""
     for raw in text.splitlines():
-        line = raw.rstrip()
+        line = _strip_comment(raw).rstrip()
         if line.endswith("\\"):
             pending += line[:-1].rstrip() + " "
         else:
             result.append(pending + line.lstrip() if pending else line)
             pending = ""
-    error = (Diagnostic(DiagnosticKind.SOURCE_MALFORMED,
-                        f"unterminated backslash continuation in {source}", source, True)
-             if pending else None)
+    error = Diagnostic(DiagnosticKind.SOURCE_MALFORMED, f"unterminated backslash continuation in {source}", source, True) if pending else None
     return result, error
 def _strip_comment(line: str) -> str:
-    single = double = False
+    single = double = escaped = False
     for index, char in enumerate(line):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and not single:
+            escaped = True
+            continue
         if char == "'" and not double:
             single = not single
-        elif char == '"' and not single and (not index or line[index - 1] != "\\"):
+        elif char == '"' and not single:
             double = not double
         elif char == "#" and not single and not double:
             return line[:index]
@@ -162,11 +151,11 @@ def _strip_comment(line: str) -> str:
 def _workflow_payloads(text: str) -> list[str]:
     lines, payloads, index = text.splitlines(), [], 0
     while index < len(lines):
-        match = re.match(r"^(\s*)(?:-\s+)?run:\s*(.*?)\s*$", lines[index])
+        match = re.match(r"^(\s*)(?:(-\s+))?([A-Za-z_][\w-]*):\s*(.*?)\s*$", lines[index])
         if not match:
             index += 1
             continue
-        indent, value = len(match.group(1)), match.group(2)
+        indent, key, value = len(match.group(1)) + len(match.group(2) or ""), match.group(3), match.group(4)
         if re.fullmatch(r"[|>][+-]?", value):
             block, index = [], index + 1
             while index < len(lines):
@@ -178,9 +167,10 @@ def _workflow_payloads(text: str) -> list[str]:
                 index += 1
             widths = [len(line) - len(line.lstrip()) for line in block if line.strip()]
             margin = min(widths) if widths else 0
-            payloads.append("\n".join(line[margin:] for line in block))
+            if key == "run":
+                payloads.append(("\n" if value.startswith("|") else " ").join(line[margin:] for line in block))
             continue
-        if value and not value.startswith("#"):
+        if key == "run" and value and not value.startswith("#"):
             if len(value) > 1 and value[0] == value[-1] and value[0] in "'\"":
                 try:
                     value = ast.literal_eval(value)
@@ -208,12 +198,10 @@ def _source_commands(text: str, source: str) -> tuple[list[str], Diagnostic | No
         try:
             payload = json.loads(text)
         except json.JSONDecodeError as error:
-            return [], Diagnostic(DiagnosticKind.SOURCE_MALFORMED,
-                                  f"malformed package.json: {error}", source, True)
+            return [], Diagnostic(DiagnosticKind.SOURCE_MALFORMED, f"malformed package.json: {error}", source, True)
         scripts = payload.get("scripts") if isinstance(payload, dict) else None
         if scripts is not None and not isinstance(scripts, dict):
-            return [], Diagnostic(DiagnosticKind.SOURCE_MALFORMED,
-                                  "package.json scripts must be an object", source, True)
+            return [], Diagnostic(DiagnosticKind.SOURCE_MALFORMED, "package.json scripts must be an object", source, True)
         payloads = [value for value in (scripts or {}).values() if isinstance(value, str)]
     elif source.startswith(".github/workflows/") and source.endswith((".yml", ".yaml")):
         payloads = _workflow_payloads(text)
@@ -235,8 +223,7 @@ def _source_commands(text: str, source: str) -> tuple[list[str], Diagnostic | No
             if match := re.search(r"(?<!<)<<-?(?!<)\s*['\"]?([A-Za-z_]\w*)", command):
                 delimiter = match.group(1)
     if delimiter:
-        return commands, Diagnostic(DiagnosticKind.SOURCE_MALFORMED,
-                                    f"unterminated heredoc in {source}", source, True)
+        return commands, Diagnostic(DiagnosticKind.SOURCE_MALFORMED, f"unterminated heredoc in {source}", source, True)
     validated, pending = [], ""
     for command in commands:
         pending = f"{pending}\n{command}".strip()
@@ -245,11 +232,9 @@ def _source_commands(text: str, source: str) -> tuple[list[str], Diagnostic | No
         except ValueError as error:
             if "No closing quotation" in str(error):
                 continue
-            return validated, Diagnostic(DiagnosticKind.SOURCE_MALFORMED,
-                                         f"malformed shell command in {source}: {error}", source, True)
+            return validated, Diagnostic(DiagnosticKind.SOURCE_MALFORMED, f"malformed shell command in {source}: {error}", source, True)
         validated.append(pending); pending = ""
-    error = (Diagnostic(DiagnosticKind.SOURCE_MALFORMED,
-                        f"malformed shell command in {source}: unterminated quote", source, True) if pending else None)
+    error = Diagnostic(DiagnosticKind.SOURCE_MALFORMED, f"malformed shell command in {source}: unterminated quote", source, True) if pending else None
     return validated, error
 def _live_unittest_main(node: ast.AST) -> bool:
     if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
@@ -291,8 +276,7 @@ def _command_head(tokens: Sequence[str]) -> tuple[str, list[str]]:
     if not words:
         return "", []
     return words[0].lstrip("@+-"), words[1:]
-def _dynamic(value: str) -> bool:
-    return "$" in value or "{{" in value or "}}" in value
+def _dynamic(value: str) -> bool: return "$" in value or "{{" in value or "}}" in value
 def _repo_path(value: str, source: str) -> tuple[str | None, bool]:
     script_dir = None
     for prefix in ("$SCRIPT_DIR/", "${SCRIPT_DIR}/"):
@@ -303,8 +287,7 @@ def _repo_path(value: str, source: str) -> tuple[str | None, bool]:
         return None, False
     raw = posixpath.join(script_dir, value) if script_dir else value
     normalized = posixpath.normpath(raw)
-    if normalized.startswith("/") or normalized == ".." or normalized.startswith("../"):
-        return None, True
+    if normalized.startswith("/") or normalized == ".." or normalized.startswith("../"): return None, True
     return normalized.removeprefix("./"), False
 def _unique_invocations(values: Iterable[Invocation]) -> tuple[Invocation, ...]:
     key = lambda item: (item.source, item.command, item.target, item.selector or "", item.glob, item.runner)
@@ -373,7 +356,7 @@ def _collect_invocations(commands: Iterable[tuple[str, str]], candidates: Sequen
                         raw, _, selector = target.partition("::")
                         glob = any(char in raw for char in "*?[")
                         for path in candidates:
-                            if path.endswith(".py") and (path == raw or (glob and fnmatch.fnmatchcase(path, raw))
+                            if path.endswith(".py") and (path == raw or (glob and _matches(path, (raw,)))
                                                         or (raw.endswith("/") and path.startswith(raw))):
                                 status = PinStatus.GLOB_UNPINNED if glob or path != raw else PinStatus.PINNED
                                 record(path, Invocation(source, raw, selector or None,
@@ -386,7 +369,7 @@ def _collect_invocations(commands: Iterable[tuple[str, str]], candidates: Sequen
                 pattern = loop_vars.get((source, variable)) if target.startswith("$") else None
                 if pattern:
                     for path in candidates:
-                        if fnmatch.fnmatchcase(path, pattern):
+                        if _matches(path, (pattern,)):
                             record(path, Invocation(source, pattern, glob=True,
                                                     runner="shell", command=command), PinStatus.GLOB_UNPINNED)
                     continue

--- a/scripts/check_test_suite_registry.py
+++ b/scripts/check_test_suite_registry.py
@@ -1,0 +1,572 @@
+"""Static registry core for tracked test suites and script gates.
+
+This module deliberately contains no allowlist or enforcement CLI.  S3a-2 owns
+that policy.  Reachability here is limited to configured CI roots plus literal
+shell-script calls recursively reached from those roots; dynamic command
+construction is reported as unsupported instead of being treated as unwired.
+"""
+
+from __future__ import annotations
+
+import ast
+import fnmatch
+import json
+import re
+import subprocess
+from collections import Counter, deque
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path, PurePosixPath
+from typing import Collection, Iterable, Mapping, Sequence
+
+
+class Family(str, Enum):
+    TESTS_PY = "tests_py"
+    E2E_PY = "e2e_py"
+    SCRIPTS_PY = "scripts_py"
+    SHELL = "shell"
+    GATE = "gate_candidates"
+
+
+class CandidateKind(str, Enum):
+    PYTHON_SUITE = "python_suite"
+    SHELL_SUITE = "shell_suite"
+    GATE = "gate"
+
+
+class ExecStatus(str, Enum):
+    FULL = "FULL"
+    PARTIAL = "PARTIAL"
+    GLOB = "GLOB"
+    NONE = "NONE"
+
+
+class PinStatus(str, Enum):
+    PINNED = "PINNED"
+    REQUIRED_ARRAY = "REQUIRED_ARRAY"
+    GLOB_UNPINNED = "GLOB_UNPINNED"
+    NONE = "NONE"
+
+
+class DiagnosticKind(str, Enum):
+    SOURCE_MISSING = "source_missing"
+    SOURCE_UNREADABLE = "source_unreadable"
+    SOURCE_MALFORMED = "source_malformed"
+    TRACKED_INPUT = "tracked_input"
+    PYTHON_MALFORMED = "python_malformed"
+    HARNESS_MISMATCH = "harness_mismatch"
+    UNSUPPORTED_CALL = "unsupported_call"
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    kind: DiagnosticKind
+    message: str
+    source: str | None = None
+    fatal: bool = False
+
+
+@dataclass(frozen=True)
+class Invocation:
+    source: str
+    target: str
+    selector: str | None = None
+    glob: bool = False
+    runner: str = "literal"
+
+
+@dataclass(frozen=True)
+class Candidate:
+    path: str
+    family: Family
+    kind: CandidateKind
+    execution: ExecStatus
+    pin: PinStatus
+    tests: tuple[str, ...] = ()
+    executed_tests: tuple[str, ...] = ()
+    invocations: tuple[Invocation, ...] = ()
+
+    @property
+    def unexecuted_tests(self) -> tuple[str, ...]:
+        return tuple(test for test in self.tests if test not in self.executed_tests)
+
+
+@dataclass(frozen=True)
+class FamilyViolation:
+    family: Family
+    expected_minimum: int
+    actual: int
+
+
+@dataclass(frozen=True)
+class PartialViolation:
+    path: str
+    targets: tuple[str, ...]
+    unexecuted_tests: tuple[str, ...]
+
+
+DEFAULT_PATTERNS: Mapping[Family, tuple[str, ...]] = {
+    Family.TESTS_PY: ("tests/test_*.py", "tests/**/test_*.py"),
+    Family.E2E_PY: ("scripts/e2e/test_*.py", "scripts/e2e/**/test_*.py"),
+    Family.SCRIPTS_PY: ("scripts/test_*.py", "scripts/**/test_*.py"),
+    Family.SHELL: ("tests/test_*.sh", "tests/**/test_*.sh"),
+    Family.GATE: (
+        "scripts/check_*.py", "scripts/audit_*.py",
+        "scripts/check-*.py", "scripts/check-*.sh",
+    ),
+}
+DEFAULT_SOURCES = (
+    "scripts/ci-script-checks.sh", "justfile", "package.json", "Makefile",
+)
+
+
+@dataclass(frozen=True)
+class RegistryConfig:
+    patterns: Mapping[Family, tuple[str, ...]] = field(
+        default_factory=lambda: dict(DEFAULT_PATTERNS)
+    )
+    surface_sources: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True)
+class RegistryResult:
+    candidates: tuple[Candidate, ...]
+    diagnostics: tuple[Diagnostic, ...]
+    family_counts: Mapping[Family, int]
+    reachable_sources: tuple[str, ...]
+    reachability_contract: str = "configured roots + recursive literal shell calls"
+
+    @property
+    def input_valid(self) -> bool:
+        return not any(diagnostic.fatal for diagnostic in self.diagnostics)
+
+    @property
+    def suite_status_counts(self) -> Mapping[ExecStatus, int]:
+        counts = Counter(
+            candidate.execution for candidate in self.candidates
+            if candidate.kind is not CandidateKind.GATE
+        )
+        return {status: counts.get(status, 0) for status in ExecStatus}
+
+    @property
+    def suite_pin_counts(self) -> Mapping[PinStatus, int]:
+        counts = Counter(
+            candidate.pin for candidate in self.candidates
+            if candidate.kind is not CandidateKind.GATE
+        )
+        return {status: counts.get(status, 0) for status in PinStatus}
+
+    def family_violations(
+        self, floors: Mapping[Family, int]
+    ) -> tuple[FamilyViolation, ...]:
+        return tuple(
+            FamilyViolation(family, minimum, self.family_counts.get(family, 0))
+            for family, minimum in sorted(floors.items(), key=lambda item: item[0].value)
+            if self.family_counts.get(family, 0) < minimum
+        )
+
+    def partial_violations(
+        self, allowed_exact_targets: Collection[tuple[str, str]] = ()
+    ) -> tuple[PartialViolation, ...]:
+        allowed = set(allowed_exact_targets)
+        violations = []
+        for candidate in self.candidates:
+            if candidate.execution is not ExecStatus.PARTIAL:
+                continue
+            targets = tuple(sorted(
+                invocation.target + (f".{invocation.selector}" if invocation.selector else "")
+                for invocation in candidate.invocations if not invocation.glob
+            ))
+            if targets and all((candidate.path, target) in allowed for target in targets):
+                continue
+            violations.append(PartialViolation(candidate.path, targets, candidate.unexecuted_tests))
+        return tuple(violations)
+
+
+@dataclass(frozen=True)
+class _PythonTests:
+    all: tuple[str, ...]
+    unittest: tuple[str, ...]
+    has_unittest_main: bool
+
+
+def _matches(path: str, patterns: Sequence[str]) -> bool:
+    return any(PurePosixPath(path).match(pattern) for pattern in patterns)
+
+
+def _family(path: str, config: RegistryConfig) -> tuple[Family, CandidateKind] | None:
+    ordered = (
+        (Family.TESTS_PY, CandidateKind.PYTHON_SUITE),
+        (Family.E2E_PY, CandidateKind.PYTHON_SUITE),
+        (Family.SCRIPTS_PY, CandidateKind.PYTHON_SUITE),
+        (Family.SHELL, CandidateKind.SHELL_SUITE),
+        (Family.GATE, CandidateKind.GATE),
+    )
+    for family, kind in ordered:
+        if _matches(path, config.patterns.get(family, ())):
+            return family, kind
+    return None
+
+
+def _tracked_files(repo_root: Path) -> tuple[list[str], Diagnostic | None]:
+    try:
+        run = subprocess.run(
+            ["git", "ls-files", "-z"], cwd=repo_root, check=False,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+    except OSError as error:
+        return [], Diagnostic(DiagnosticKind.TRACKED_INPUT, str(error), fatal=True)
+    if run.returncode:
+        detail = run.stderr.decode("utf-8", "replace").strip()
+        return [], Diagnostic(DiagnosticKind.TRACKED_INPUT, detail, fatal=True)
+    try:
+        paths = [part.decode("utf-8") for part in run.stdout.split(b"\0") if part]
+    except UnicodeDecodeError as error:
+        return [], Diagnostic(DiagnosticKind.TRACKED_INPUT, str(error), fatal=True)
+    return sorted(paths), None
+
+
+def _read_source(repo_root: Path, relative: str) -> tuple[str | None, Diagnostic | None]:
+    path = repo_root / relative
+    if not path.exists():
+        return None, Diagnostic(
+            DiagnosticKind.SOURCE_MISSING, f"required source missing: {relative}",
+            relative, True,
+        )
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        return None, Diagnostic(
+            DiagnosticKind.SOURCE_UNREADABLE, f"cannot read {relative}: {error}",
+            relative, True,
+        )
+    if "\0" in text:
+        return None, Diagnostic(
+            DiagnosticKind.SOURCE_MALFORMED, f"NUL byte in {relative}", relative, True,
+        )
+    return text, None
+
+
+def _logical_lines(text: str, source: str) -> tuple[list[str], Diagnostic | None]:
+    result: list[str] = []
+    pending = ""
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if line.endswith("\\"):
+            pending += line[:-1].rstrip() + " "
+            continue
+        result.append(pending + line.lstrip() if pending else line)
+        pending = ""
+    if pending:
+        return result, Diagnostic(
+            DiagnosticKind.SOURCE_MALFORMED,
+            f"unterminated backslash continuation in {source}", source, True,
+        )
+    return result, None
+
+
+def _strip_comment(line: str) -> str:
+    single = double = False
+    for index, char in enumerate(line):
+        if char == "'" and not double:
+            single = not single
+        elif char == '"' and not single and (index == 0 or line[index - 1] != "\\"):
+            double = not double
+        elif char == "#" and not single and not double:
+            return line[:index]
+    return line
+
+
+def _source_commands(text: str, source: str) -> tuple[list[str], Diagnostic | None]:
+    if source == "package.json":
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as error:
+            return [], Diagnostic(
+                DiagnosticKind.SOURCE_MALFORMED,
+                f"malformed package.json: {error}", source, True,
+            )
+        scripts = payload.get("scripts") if isinstance(payload, dict) else None
+        if scripts is not None and not isinstance(scripts, dict):
+            return [], Diagnostic(
+                DiagnosticKind.SOURCE_MALFORMED,
+                "package.json scripts must be an object", source, True,
+            )
+        return [value for value in (scripts or {}).values() if isinstance(value, str)], None
+    lines, error = _logical_lines(text, source)
+    commands = []
+    for line in lines:
+        command = _strip_comment(line).strip()
+        if not command or re.match(r"(?:self\.)?assert\w*\s*\(", command):
+            continue
+        if (
+            not command.startswith("required_shell_suites=")
+            and re.match(r"[A-Za-z_]\w*\s*=\s*[('\"\[]", command)
+        ):
+            continue
+        commands.append(command)
+    return commands, error
+
+
+def _python_tests(repo_root: Path, path: str) -> tuple[_PythonTests | None, Diagnostic | None]:
+    try:
+        tree = ast.parse((repo_root / path).read_text(encoding="utf-8"), filename=path)
+    except (OSError, UnicodeError, SyntaxError) as error:
+        return None, Diagnostic(
+            DiagnosticKind.PYTHON_MALFORMED, f"cannot parse {path}: {error}", path, True,
+        )
+    all_tests: list[str] = []
+    class_tests: dict[str, list[str]] = {}
+    class_bases: dict[str, list[str]] = {}
+    has_main = False
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+            all_tests.append(node.name)
+        if isinstance(node, ast.ClassDef):
+            class_bases[node.name] = [ast.unparse(base) for base in node.bases]
+            class_tests[node.name] = []
+            for child in node.body:
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name.startswith("test_"):
+                    test_id = f"{node.name}.{child.name}"
+                    all_tests.append(test_id)
+                    class_tests[node.name].append(test_id)
+    unittest_classes = {
+        name for name, bases in class_bases.items()
+        if any(base == "TestCase" or base.endswith(".TestCase") for base in bases)
+    }
+    changed = True
+    while changed:
+        changed = False
+        for name, bases in class_bases.items():
+            if name not in unittest_classes and any(base in unittest_classes for base in bases):
+                unittest_classes.add(name)
+                changed = True
+    unittest_tests = [
+        test for name in unittest_classes for test in class_tests.get(name, ())
+    ]
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            has_main = has_main or (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "unittest" and node.func.attr == "main"
+            )
+    return _PythonTests(tuple(sorted(all_tests)), tuple(sorted(unittest_tests)), has_main), None
+
+
+_UNITTEST = re.compile(r"(?:^|\s)-m\s+unittest\s+(.+)")
+_PYTEST = re.compile(r"(?:^|\s)(?:python\S*\s+-m\s+)?pytest\s+(.+)")
+_PYTHON_PATH = re.compile(r'(?:^|\s)(?:"?\$PYTHON"?|python\d*(?:\.\d+)?)\s+((?:tests|scripts)/[^\s;|&]+\.py)')
+_SHELL_PATH = re.compile(r"(?:^|\s)(?:bash|sh|source)\s+((?:tests|scripts)/[^\s;|&]+\.sh)")
+_DIRECT_SHELL = re.compile(r"(?:^|\s)\./((?:tests|scripts)/[^\s;|&]+\.sh)")
+_GATE_PATH = re.compile(r'(?:^|\s)(?:"?\$PYTHON"?|python\S*)\s+(scripts/(?:check[_-]|audit_)[^\s;|&]+\.py)')
+
+
+def _words(tail: str) -> list[str]:
+    return re.findall(r"[A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)+|(?:tests|scripts)/[^\s;|&]+", tail)
+
+
+def _collect_invocations(
+    commands: Iterable[tuple[str, str]], candidates: Sequence[str]
+) -> tuple[dict[str, list[Invocation]], set[str], set[str], list[Diagnostic]]:
+    invocations: dict[str, list[Invocation]] = {path: [] for path in candidates}
+    required: set[str] = set()
+    reached_scripts: set[str] = set()
+    diagnostics: list[Diagnostic] = []
+    modules = {path[:-3].replace("/", "."): path for path in candidates if path.endswith(".py")}
+    combined = " ".join(command for _, command in commands)
+    for array in re.findall(r"required_shell_suites\s*=\(([^)]*)\)", combined):
+        required.update(re.findall(r"tests/[^\s)]+\.sh", array))
+    for variable, pattern in re.findall(
+        r"for\s+(\w+)\s+in\s+(tests/[^\s;]+\.sh)", combined
+    ):
+        if re.search(
+            rf"\b(?:bash|sh)\s+[\"']?\${{{variable}}}|"
+            rf"\b(?:bash|sh)\s+[\"']?\${variable}", combined,
+        ):
+            for path in candidates:
+                if fnmatch.fnmatchcase(path, pattern):
+                    invocations[path].append(Invocation("shell-glob", pattern, glob=True))
+    for source, command in commands:
+        if re.search(r"\b(?:xargs|docker\s+run)\b|\bfind\b.*-(?:exec|execdir)\b", command) and re.search(r"test_|unittest|pytest", command):
+            diagnostics.append(Diagnostic(
+                DiagnosticKind.UNSUPPORTED_CALL,
+                f"unsupported dynamic test invocation: {command}", source, True,
+            ))
+        unit = _UNITTEST.search(command)
+        if unit:
+            if "$" in unit.group(1):
+                diagnostics.append(Diagnostic(
+                    DiagnosticKind.UNSUPPORTED_CALL,
+                    f"dynamic unittest target: {unit.group(1)}", source, True,
+                ))
+            for target in _words(unit.group(1)):
+                matches = [module for module in modules if target == module or target.startswith(module + ".")]
+                if not matches:
+                    if "$" in target:
+                        diagnostics.append(Diagnostic(
+                            DiagnosticKind.UNSUPPORTED_CALL,
+                            f"dynamic unittest target: {target}", source, True,
+                        ))
+                    continue
+                module = max(matches, key=len)
+                selector = target[len(module) + 1:] if target != module else None
+                path = modules[module]
+                invocations[path].append(Invocation(source, module, selector, runner="unittest"))
+        pytest = _PYTEST.search(command)
+        if pytest:
+            if "$" in pytest.group(1):
+                diagnostics.append(Diagnostic(
+                    DiagnosticKind.UNSUPPORTED_CALL,
+                    f"dynamic pytest target: {pytest.group(1)}", source, True,
+                ))
+            for target in _words(pytest.group(1)):
+                raw_path, _, selector = target.partition("::")
+                for path in candidates:
+                    if not path.endswith(".py"):
+                        continue
+                    is_glob = any(char in raw_path for char in "*?[")
+                    if path == raw_path or (is_glob and fnmatch.fnmatchcase(path, raw_path)) or (
+                        raw_path.endswith("/") and path.startswith(raw_path)
+                    ):
+                        invocations[path].append(Invocation(
+                            source, raw_path, selector or None,
+                            is_glob or path != raw_path, "pytest",
+                        ))
+        for regex in (_SHELL_PATH, _DIRECT_SHELL):
+            for match in regex.finditer(command):
+                path = match.group(1)
+                if path in invocations:
+                    invocations[path].append(Invocation(source, path))
+                if path.startswith("scripts/"):
+                    reached_scripts.add(path)
+        for match in re.finditer(
+            r'(?:bash|sh|source)\s+["\']?\$SCRIPT_DIR/([^\s"\']+\.sh)', command
+        ):
+            path = str(PurePosixPath(source).parent / match.group(1))
+            if path in invocations:
+                invocations[path].append(Invocation(source, path))
+            reached_scripts.add(path)
+        for match in _PYTHON_PATH.finditer(command):
+            path = match.group(1).strip('"\'')
+            if path in invocations:
+                invocations[path].append(Invocation(source, path, runner="script"))
+        for match in _GATE_PATH.finditer(command):
+            path = match.group(1).strip('"\'')
+            if path in invocations:
+                invocations[path].append(Invocation(source, path))
+    return invocations, required, reached_scripts, diagnostics
+
+
+def scan_registry(repo_root: Path, config: RegistryConfig | None = None) -> RegistryResult:
+    config = config or RegistryConfig()
+    tracked, tracked_error = _tracked_files(repo_root)
+    diagnostics: list[Diagnostic] = [tracked_error] if tracked_error else []
+    classified = [(path, _family(path, config)) for path in tracked]
+    classified = [(path, value) for path, value in classified if value is not None]
+    candidate_paths = [path for path, _ in classified]
+    counts = Counter(family for _, (family, _) in classified)
+
+    sources = list(config.surface_sources or DEFAULT_SOURCES)
+    if config.surface_sources is None:
+        workflows = sorted(path for path in tracked if fnmatch.fnmatchcase(path, ".github/workflows/*.yml"))
+        if not workflows:
+            diagnostics.append(Diagnostic(
+                DiagnosticKind.SOURCE_MISSING, "no tracked .github/workflows/*.yml sources", fatal=True,
+            ))
+        sources.extend(workflows)
+    reachable: list[str] = []
+    queued = deque(sources)
+    seen: set[str] = set()
+    all_invocations: dict[str, list[Invocation]] = {path: [] for path in candidate_paths}
+    required: set[str] = set()
+    while queued:
+        source = queued.popleft()
+        if source in seen:
+            continue
+        seen.add(source)
+        text, error = _read_source(repo_root, source)
+        if error:
+            diagnostics.append(error)
+            continue
+        reachable.append(source)
+        source_commands, malformed = _source_commands(text or "", source)
+        if malformed:
+            diagnostics.append(malformed)
+        batch = [(source, command) for command in source_commands]
+        found, found_required, reached, unsupported = _collect_invocations(batch, candidate_paths)
+        for path, values in found.items():
+            all_invocations[path].extend(values)
+        required.update(found_required)
+        diagnostics.extend(unsupported)
+        for path in sorted(reached):
+            if path in tracked and path not in seen:
+                queued.append(path)
+
+    records: list[Candidate] = []
+    for path, (family, kind) in classified:
+        calls = tuple(all_invocations[path])
+        direct = tuple(call for call in calls if not call.glob)
+        glob = tuple(call for call in calls if call.glob)
+        tests: tuple[str, ...] = ()
+        executed: set[str] = set()
+        harness_mismatch = False
+        if kind is CandidateKind.PYTHON_SUITE:
+            parsed, error = _python_tests(repo_root, path)
+            if error:
+                diagnostics.append(error)
+            elif parsed:
+                tests = parsed.all
+                module = path[:-3].replace("/", ".")
+                for call in direct:
+                    if call.runner == "pytest":
+                        if call.selector:
+                            selector = call.selector.replace("::", ".")
+                            executed.update(test for test in parsed.all if test == selector or test.startswith(selector + "."))
+                        else:
+                            executed.update(parsed.all)
+                    elif call.target == path:
+                        if parsed.has_unittest_main:
+                            executed.update(parsed.unittest)
+                        else:
+                            harness_mismatch = True
+                    elif call.target == module:
+                        if not parsed.unittest:
+                            harness_mismatch = True
+                        elif call.selector:
+                            executed.update(test for test in parsed.unittest if test == call.selector or test.startswith(call.selector + "."))
+                        else:
+                            executed.update(parsed.unittest)
+                if harness_mismatch:
+                    diagnostics.append(Diagnostic(
+                        DiagnosticKind.HARNESS_MISMATCH,
+                        f"execution form for {path} selects zero tests", path,
+                    ))
+                if glob:
+                    executed.update(parsed.all)
+        if direct and kind is not CandidateKind.PYTHON_SUITE:
+            execution = ExecStatus.FULL
+        elif direct and executed == set(tests) and tests and not any(call.selector for call in direct):
+            execution = ExecStatus.FULL
+        elif direct and executed:
+            execution = ExecStatus.PARTIAL
+        elif glob:
+            execution = ExecStatus.GLOB
+        else:
+            execution = ExecStatus.NONE
+        if direct and execution is not ExecStatus.NONE:
+            pin = PinStatus.PINNED
+        elif path in required:
+            pin = PinStatus.REQUIRED_ARRAY
+        elif glob:
+            pin = PinStatus.GLOB_UNPINNED
+        else:
+            pin = PinStatus.NONE
+        records.append(Candidate(
+            path, family, kind, execution, pin, tests,
+            tuple(sorted(executed)), calls,
+        ))
+    return RegistryResult(
+        tuple(records), tuple(diagnostics),
+        {family: counts.get(family, 0) for family in Family},
+        tuple(reachable),
+    )

--- a/scripts/check_test_suite_registry.py
+++ b/scripts/check_test_suite_registry.py
@@ -1,572 +1,531 @@
-"""Static registry core for tracked test suites and script gates.
-
-This module deliberately contains no allowlist or enforcement CLI.  S3a-2 owns
-that policy.  Reachability here is limited to configured CI roots plus literal
-shell-script calls recursively reached from those roots; dynamic command
-construction is reported as unsupported instead of being treated as unwired.
-"""
-
+"""Tracked test-suite registry core; policy/enforcement belongs to S3a-2."""
 from __future__ import annotations
-
 import ast
 import fnmatch
 import json
+import posixpath
 import re
+import shlex
 import subprocess
 from collections import Counter, deque
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path, PurePosixPath
 from typing import Collection, Iterable, Mapping, Sequence
-
-
 class Family(str, Enum):
-    TESTS_PY = "tests_py"
-    E2E_PY = "e2e_py"
-    SCRIPTS_PY = "scripts_py"
-    SHELL = "shell"
-    GATE = "gate_candidates"
-
-
+    TESTS_PY = "tests_py"; E2E_PY = "e2e_py"; SCRIPTS_PY = "scripts_py"
+    SHELL = "shell"; GATE = "gate_candidates"
 class CandidateKind(str, Enum):
-    PYTHON_SUITE = "python_suite"
-    SHELL_SUITE = "shell_suite"
-    GATE = "gate"
-
-
+    PYTHON_SUITE = "python_suite"; SHELL_SUITE = "shell_suite"; GATE = "gate"
 class ExecStatus(str, Enum):
-    FULL = "FULL"
-    PARTIAL = "PARTIAL"
-    GLOB = "GLOB"
-    NONE = "NONE"
-
-
+    FULL = "FULL"; PARTIAL = "PARTIAL"; GLOB = "GLOB"; NONE = "NONE"
 class PinStatus(str, Enum):
-    PINNED = "PINNED"
-    REQUIRED_ARRAY = "REQUIRED_ARRAY"
-    GLOB_UNPINNED = "GLOB_UNPINNED"
-    NONE = "NONE"
-
-
+    PINNED = "PINNED"; REQUIRED_ARRAY = "REQUIRED_ARRAY"
+    GLOB_UNPINNED = "GLOB_UNPINNED"; NONE = "NONE"
 class DiagnosticKind(str, Enum):
-    SOURCE_MISSING = "source_missing"
-    SOURCE_UNREADABLE = "source_unreadable"
-    SOURCE_MALFORMED = "source_malformed"
-    TRACKED_INPUT = "tracked_input"
-    PYTHON_MALFORMED = "python_malformed"
-    HARNESS_MISMATCH = "harness_mismatch"
+    SOURCE_MISSING = "source_missing"; SOURCE_UNREADABLE = "source_unreadable"
+    SOURCE_MALFORMED = "source_malformed"; TRACKED_INPUT = "tracked_input"
+    PYTHON_MALFORMED = "python_malformed"; HARNESS_MISMATCH = "harness_mismatch"
     UNSUPPORTED_CALL = "unsupported_call"
-
-
 @dataclass(frozen=True)
 class Diagnostic:
-    kind: DiagnosticKind
-    message: str
-    source: str | None = None
-    fatal: bool = False
-
-
+    kind: DiagnosticKind; message: str; source: str | None = None; fatal: bool = False
 @dataclass(frozen=True)
 class Invocation:
-    source: str
-    target: str
-    selector: str | None = None
-    glob: bool = False
-    runner: str = "literal"
-
-
+    source: str; target: str; selector: str | None = None; glob: bool = False
+    runner: str = "literal"; command: str = ""
+@dataclass(frozen=True)
+class PinEvidence:
+    source: str; target: str; command: str; status: PinStatus
 @dataclass(frozen=True)
 class Candidate:
-    path: str
-    family: Family
-    kind: CandidateKind
-    execution: ExecStatus
-    pin: PinStatus
-    tests: tuple[str, ...] = ()
-    executed_tests: tuple[str, ...] = ()
-    invocations: tuple[Invocation, ...] = ()
-
+    path: str; family: Family; kind: CandidateKind; execution: ExecStatus; pin: PinStatus
+    tests: tuple[str, ...] = (); executed_tests: tuple[str, ...] = ()
+    invocations: tuple[Invocation, ...] = (); pin_evidence: tuple[PinEvidence, ...] = ()
     @property
     def unexecuted_tests(self) -> tuple[str, ...]:
         return tuple(test for test in self.tests if test not in self.executed_tests)
-
-
 @dataclass(frozen=True)
 class FamilyViolation:
-    family: Family
-    expected_minimum: int
-    actual: int
-
-
+    family: Family; expected_minimum: int; actual: int
 @dataclass(frozen=True)
 class PartialViolation:
-    path: str
-    targets: tuple[str, ...]
-    unexecuted_tests: tuple[str, ...]
-
-
+    path: str; targets: tuple[str, ...]; unexecuted_tests: tuple[str, ...]
 DEFAULT_PATTERNS: Mapping[Family, tuple[str, ...]] = {
-    Family.TESTS_PY: ("tests/test_*.py", "tests/**/test_*.py"),
-    Family.E2E_PY: ("scripts/e2e/test_*.py", "scripts/e2e/**/test_*.py"),
-    Family.SCRIPTS_PY: ("scripts/test_*.py", "scripts/**/test_*.py"),
-    Family.SHELL: ("tests/test_*.sh", "tests/**/test_*.sh"),
-    Family.GATE: (
-        "scripts/check_*.py", "scripts/audit_*.py",
-        "scripts/check-*.py", "scripts/check-*.sh",
-    ),
+    Family.TESTS_PY: ("tests/**/test_*.py",), Family.E2E_PY: ("scripts/e2e/**/test_*.py",),
+    Family.SCRIPTS_PY: ("scripts/**/test_*.py",), Family.SHELL: ("tests/**/test_*.sh",),
+    Family.GATE: ("scripts/check_*.py", "scripts/audit_*.py", "scripts/check-*.py", "scripts/check-*.sh"),
 }
-DEFAULT_SOURCES = (
-    "scripts/ci-script-checks.sh", "justfile", "package.json", "Makefile",
-)
-
-
+DEFAULT_SOURCES = ("scripts/ci-script-checks.sh", "justfile", "package.json", "Makefile")
 @dataclass(frozen=True)
 class RegistryConfig:
-    patterns: Mapping[Family, tuple[str, ...]] = field(
-        default_factory=lambda: dict(DEFAULT_PATTERNS)
-    )
-    surface_sources: tuple[str, ...] | None = None
-
-
+    patterns: Mapping[Family, tuple[str, ...]] = field(default_factory=lambda: dict(DEFAULT_PATTERNS)); surface_sources: tuple[str, ...] | None = None
 @dataclass(frozen=True)
 class RegistryResult:
-    candidates: tuple[Candidate, ...]
-    diagnostics: tuple[Diagnostic, ...]
-    family_counts: Mapping[Family, int]
-    reachable_sources: tuple[str, ...]
+    candidates: tuple[Candidate, ...]; diagnostics: tuple[Diagnostic, ...]
+    family_counts: Mapping[Family, int]; reachable_sources: tuple[str, ...]
     reachability_contract: str = "configured roots + recursive literal shell calls"
-
     @property
     def input_valid(self) -> bool:
-        return not any(diagnostic.fatal for diagnostic in self.diagnostics)
-
+        return not any(item.fatal for item in self.diagnostics)
+    def _counts(self, attribute: str, values: Iterable[Enum]) -> Mapping[Enum, int]:
+        counts = Counter(getattr(c, attribute) for c in self.candidates if c.kind is not CandidateKind.GATE)
+        return {value: counts.get(value, 0) for value in values}
     @property
     def suite_status_counts(self) -> Mapping[ExecStatus, int]:
-        counts = Counter(
-            candidate.execution for candidate in self.candidates
-            if candidate.kind is not CandidateKind.GATE
-        )
-        return {status: counts.get(status, 0) for status in ExecStatus}
-
+        return self._counts("execution", ExecStatus)
     @property
     def suite_pin_counts(self) -> Mapping[PinStatus, int]:
-        counts = Counter(
-            candidate.pin for candidate in self.candidates
-            if candidate.kind is not CandidateKind.GATE
-        )
-        return {status: counts.get(status, 0) for status in PinStatus}
-
-    def family_violations(
-        self, floors: Mapping[Family, int]
-    ) -> tuple[FamilyViolation, ...]:
-        return tuple(
-            FamilyViolation(family, minimum, self.family_counts.get(family, 0))
-            for family, minimum in sorted(floors.items(), key=lambda item: item[0].value)
-            if self.family_counts.get(family, 0) < minimum
-        )
-
-    def partial_violations(
-        self, allowed_exact_targets: Collection[tuple[str, str]] = ()
-    ) -> tuple[PartialViolation, ...]:
-        allowed = set(allowed_exact_targets)
-        violations = []
+        return self._counts("pin", PinStatus)
+    def family_violations(self, floors: Mapping[Family, int]) -> tuple[FamilyViolation, ...]:
+        return tuple(FamilyViolation(f, minimum, self.family_counts.get(f, 0))
+                     for f, minimum in sorted(floors.items(), key=lambda item: item[0].value)
+                     if self.family_counts.get(f, 0) < minimum)
+    def partial_violations(self, allowed_exact_targets: Collection[tuple[str, str]] = ()) -> tuple[PartialViolation, ...]:
+        allowed, violations = set(allowed_exact_targets), []
         for candidate in self.candidates:
             if candidate.execution is not ExecStatus.PARTIAL:
                 continue
-            targets = tuple(sorted(
-                invocation.target + (f".{invocation.selector}" if invocation.selector else "")
-                for invocation in candidate.invocations if not invocation.glob
-            ))
-            if targets and all((candidate.path, target) in allowed for target in targets):
-                continue
-            violations.append(PartialViolation(candidate.path, targets, candidate.unexecuted_tests))
+            targets = tuple(sorted(call.target + (f".{call.selector}" if call.selector else "")
+                                   for call in candidate.invocations if not call.glob))
+            if not targets or not all((candidate.path, target) in allowed for target in targets):
+                violations.append(PartialViolation(candidate.path, targets, candidate.unexecuted_tests))
         return tuple(violations)
-
-
 @dataclass(frozen=True)
 class _PythonTests:
-    all: tuple[str, ...]
-    unittest: tuple[str, ...]
-    has_unittest_main: bool
-
-
+    all: tuple[str, ...]; unittest: tuple[str, ...]; has_unittest_main: bool
 def _matches(path: str, patterns: Sequence[str]) -> bool:
-    return any(PurePosixPath(path).match(pattern) for pattern in patterns)
-
-
+    """Match only the registry's anchored POSIX family grammar; **/ is zero-or-more directories."""
+    def expression(pattern: str) -> str:
+        escaped = re.escape(pattern).replace(r"\*\*/", r"(?:[^/]+/)*")
+        return escaped.replace(r"\*", r"[^/]*").replace(r"\?", r"[^/]")
+    return any(re.fullmatch(expression(pattern), path) is not None for pattern in patterns)
 def _family(path: str, config: RegistryConfig) -> tuple[Family, CandidateKind] | None:
-    ordered = (
-        (Family.TESTS_PY, CandidateKind.PYTHON_SUITE),
-        (Family.E2E_PY, CandidateKind.PYTHON_SUITE),
-        (Family.SCRIPTS_PY, CandidateKind.PYTHON_SUITE),
-        (Family.SHELL, CandidateKind.SHELL_SUITE),
-        (Family.GATE, CandidateKind.GATE),
-    )
-    for family, kind in ordered:
-        if _matches(path, config.patterns.get(family, ())):
-            return family, kind
-    return None
-
-
-def _tracked_files(repo_root: Path) -> tuple[list[str], Diagnostic | None]:
+    ordered = ((Family.TESTS_PY, CandidateKind.PYTHON_SUITE), (Family.E2E_PY, CandidateKind.PYTHON_SUITE),
+               (Family.SCRIPTS_PY, CandidateKind.PYTHON_SUITE),
+               (Family.SHELL, CandidateKind.SHELL_SUITE), (Family.GATE, CandidateKind.GATE))
+    return next(((family, kind) for family, kind in ordered
+                 if _matches(path, config.patterns.get(family, ()))), None)
+def _tracked_files(root: Path) -> tuple[list[str], Diagnostic | None]:
     try:
-        run = subprocess.run(
-            ["git", "ls-files", "-z"], cwd=repo_root, check=False,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        )
+        run = subprocess.run(["git", "ls-files", "-z"], cwd=root, check=False,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except OSError as error:
         return [], Diagnostic(DiagnosticKind.TRACKED_INPUT, str(error), fatal=True)
     if run.returncode:
-        detail = run.stderr.decode("utf-8", "replace").strip()
-        return [], Diagnostic(DiagnosticKind.TRACKED_INPUT, detail, fatal=True)
+        return [], Diagnostic(DiagnosticKind.TRACKED_INPUT,
+                              run.stderr.decode("utf-8", "replace").strip(), fatal=True)
     try:
-        paths = [part.decode("utf-8") for part in run.stdout.split(b"\0") if part]
+        return sorted(part.decode() for part in run.stdout.split(b"\0") if part), None
     except UnicodeDecodeError as error:
         return [], Diagnostic(DiagnosticKind.TRACKED_INPUT, str(error), fatal=True)
-    return sorted(paths), None
-
-
-def _read_source(repo_root: Path, relative: str) -> tuple[str | None, Diagnostic | None]:
-    path = repo_root / relative
+def _read_source(root: Path, relative: str) -> tuple[str | None, Diagnostic | None]:
+    path = root / relative
     if not path.exists():
-        return None, Diagnostic(
-            DiagnosticKind.SOURCE_MISSING, f"required source missing: {relative}",
-            relative, True,
-        )
+        return None, Diagnostic(DiagnosticKind.SOURCE_MISSING, f"required source missing: {relative}", relative, True)
     try:
         text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeError) as error:
-        return None, Diagnostic(
-            DiagnosticKind.SOURCE_UNREADABLE, f"cannot read {relative}: {error}",
-            relative, True,
-        )
+        return None, Diagnostic(DiagnosticKind.SOURCE_UNREADABLE, f"cannot read {relative}: {error}", relative, True)
     if "\0" in text:
-        return None, Diagnostic(
-            DiagnosticKind.SOURCE_MALFORMED, f"NUL byte in {relative}", relative, True,
-        )
+        return None, Diagnostic(DiagnosticKind.SOURCE_MALFORMED, f"NUL byte in {relative}", relative, True)
     return text, None
-
-
+def _parse_python(text: str, path: str) -> tuple[ast.Module | None, Diagnostic | None]:
+    try:
+        return ast.parse(text, filename=path), None
+    except SyntaxError as error:
+        return None, Diagnostic(DiagnosticKind.PYTHON_MALFORMED,
+                                f"cannot parse {path}: {error}", path, True)
 def _logical_lines(text: str, source: str) -> tuple[list[str], Diagnostic | None]:
-    result: list[str] = []
-    pending = ""
+    result, pending = [], ""
     for raw in text.splitlines():
         line = raw.rstrip()
         if line.endswith("\\"):
             pending += line[:-1].rstrip() + " "
-            continue
-        result.append(pending + line.lstrip() if pending else line)
-        pending = ""
-    if pending:
-        return result, Diagnostic(
-            DiagnosticKind.SOURCE_MALFORMED,
-            f"unterminated backslash continuation in {source}", source, True,
-        )
-    return result, None
-
-
+        else:
+            result.append(pending + line.lstrip() if pending else line)
+            pending = ""
+    error = (Diagnostic(DiagnosticKind.SOURCE_MALFORMED,
+                        f"unterminated backslash continuation in {source}", source, True)
+             if pending else None)
+    return result, error
 def _strip_comment(line: str) -> str:
     single = double = False
     for index, char in enumerate(line):
         if char == "'" and not double:
             single = not single
-        elif char == '"' and not single and (index == 0 or line[index - 1] != "\\"):
+        elif char == '"' and not single and (not index or line[index - 1] != "\\"):
             double = not double
         elif char == "#" and not single and not double:
             return line[:index]
     return line
-
-
+def _workflow_payloads(text: str) -> list[str]:
+    lines, payloads, index = text.splitlines(), [], 0
+    while index < len(lines):
+        match = re.match(r"^(\s*)(?:-\s+)?run:\s*(.*?)\s*$", lines[index])
+        if not match:
+            index += 1
+            continue
+        indent, value = len(match.group(1)), match.group(2)
+        if re.fullmatch(r"[|>][+-]?", value):
+            block, index = [], index + 1
+            while index < len(lines):
+                raw = lines[index]
+                width = len(raw) - len(raw.lstrip())
+                if raw.strip() and width <= indent:
+                    break
+                block.append(raw)
+                index += 1
+            widths = [len(line) - len(line.lstrip()) for line in block if line.strip()]
+            margin = min(widths) if widths else 0
+            payloads.append("\n".join(line[margin:] for line in block))
+            continue
+        if value and not value.startswith("#"):
+            if len(value) > 1 and value[0] == value[-1] and value[0] in "'\"":
+                try:
+                    value = ast.literal_eval(value)
+                except (SyntaxError, ValueError):
+                    pass
+            payloads.append(value)
+        index += 1
+    return payloads
+def _segments(command: str) -> list[list[str]]:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|")
+    lexer.whitespace_split, lexer.commenters = True, ""
+    segments, current = [], []
+    for token in lexer:
+        if token and set(token) <= set(";&|"):
+            if current:
+                segments.append(current)
+            current = []
+        else:
+            current.append(token)
+    if current:
+        segments.append(current)
+    return segments
 def _source_commands(text: str, source: str) -> tuple[list[str], Diagnostic | None]:
     if source == "package.json":
         try:
             payload = json.loads(text)
         except json.JSONDecodeError as error:
-            return [], Diagnostic(
-                DiagnosticKind.SOURCE_MALFORMED,
-                f"malformed package.json: {error}", source, True,
-            )
+            return [], Diagnostic(DiagnosticKind.SOURCE_MALFORMED,
+                                  f"malformed package.json: {error}", source, True)
         scripts = payload.get("scripts") if isinstance(payload, dict) else None
         if scripts is not None and not isinstance(scripts, dict):
-            return [], Diagnostic(
-                DiagnosticKind.SOURCE_MALFORMED,
-                "package.json scripts must be an object", source, True,
-            )
-        return [value for value in (scripts or {}).values() if isinstance(value, str)], None
-    lines, error = _logical_lines(text, source)
-    commands = []
-    for line in lines:
-        command = _strip_comment(line).strip()
-        if not command or re.match(r"(?:self\.)?assert\w*\s*\(", command):
-            continue
-        if (
-            not command.startswith("required_shell_suites=")
-            and re.match(r"[A-Za-z_]\w*\s*=\s*[('\"\[]", command)
-        ):
-            continue
-        commands.append(command)
-    return commands, error
-
-
-def _python_tests(repo_root: Path, path: str) -> tuple[_PythonTests | None, Diagnostic | None]:
-    try:
-        tree = ast.parse((repo_root / path).read_text(encoding="utf-8"), filename=path)
-    except (OSError, UnicodeError, SyntaxError) as error:
-        return None, Diagnostic(
-            DiagnosticKind.PYTHON_MALFORMED, f"cannot parse {path}: {error}", path, True,
-        )
-    all_tests: list[str] = []
-    class_tests: dict[str, list[str]] = {}
-    class_bases: dict[str, list[str]] = {}
-    has_main = False
+            return [], Diagnostic(DiagnosticKind.SOURCE_MALFORMED,
+                                  "package.json scripts must be an object", source, True)
+        payloads = [value for value in (scripts or {}).values() if isinstance(value, str)]
+    elif source.startswith(".github/workflows/") and source.endswith((".yml", ".yaml")):
+        payloads = _workflow_payloads(text)
+    else:
+        payloads = [text]
+    commands, delimiter = [], None
+    for payload in payloads:
+        lines, error = _logical_lines(payload, source)
+        if error:
+            return commands, error
+        for line in lines:
+            if delimiter:
+                delimiter = None if line.strip() == delimiter else delimiter
+                continue
+            command = _strip_comment(line).strip()
+            if not command or re.match(r"(?:self\.)?assert\w*\s*\(", command):
+                continue
+            commands.append(command)
+            if match := re.search(r"(?<!<)<<-?(?!<)\s*['\"]?([A-Za-z_]\w*)", command):
+                delimiter = match.group(1)
+    if delimiter:
+        return commands, Diagnostic(DiagnosticKind.SOURCE_MALFORMED,
+                                    f"unterminated heredoc in {source}", source, True)
+    validated, pending = [], ""
+    for command in commands:
+        pending = f"{pending}\n{command}".strip()
+        try:
+            _segments(pending)
+        except ValueError as error:
+            if "No closing quotation" in str(error):
+                continue
+            return validated, Diagnostic(DiagnosticKind.SOURCE_MALFORMED,
+                                         f"malformed shell command in {source}: {error}", source, True)
+        validated.append(pending); pending = ""
+    error = (Diagnostic(DiagnosticKind.SOURCE_MALFORMED,
+                        f"malformed shell command in {source}: unterminated quote", source, True) if pending else None)
+    return validated, error
+def _live_unittest_main(node: ast.AST) -> bool:
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+        return False
+    if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "unittest" and node.func.attr == "main"):
+        return True
+    return any(_live_unittest_main(child) for child in ast.iter_child_nodes(node))
+def _python_tests(tree: ast.Module) -> _PythonTests:
+    all_tests, class_tests, bases = [], {}, {}
     for node in tree.body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
             all_tests.append(node.name)
         if isinstance(node, ast.ClassDef):
-            class_bases[node.name] = [ast.unparse(base) for base in node.bases]
-            class_tests[node.name] = []
+            bases[node.name], class_tests[node.name] = [ast.unparse(base) for base in node.bases], []
             for child in node.body:
                 if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name.startswith("test_"):
                     test_id = f"{node.name}.{child.name}"
                     all_tests.append(test_id)
                     class_tests[node.name].append(test_id)
-    unittest_classes = {
-        name for name, bases in class_bases.items()
-        if any(base == "TestCase" or base.endswith(".TestCase") for base in bases)
-    }
-    changed = True
-    while changed:
-        changed = False
-        for name, bases in class_bases.items():
-            if name not in unittest_classes and any(base in unittest_classes for base in bases):
-                unittest_classes.add(name)
-                changed = True
-    unittest_tests = [
-        test for name in unittest_classes for test in class_tests.get(name, ())
-    ]
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-            has_main = has_main or (
-                isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "unittest" and node.func.attr == "main"
-            )
-    return _PythonTests(tuple(sorted(all_tests)), tuple(sorted(unittest_tests)), has_main), None
-
-
-_UNITTEST = re.compile(r"(?:^|\s)-m\s+unittest\s+(.+)")
-_PYTEST = re.compile(r"(?:^|\s)(?:python\S*\s+-m\s+)?pytest\s+(.+)")
-_PYTHON_PATH = re.compile(r'(?:^|\s)(?:"?\$PYTHON"?|python\d*(?:\.\d+)?)\s+((?:tests|scripts)/[^\s;|&]+\.py)')
-_SHELL_PATH = re.compile(r"(?:^|\s)(?:bash|sh|source)\s+((?:tests|scripts)/[^\s;|&]+\.sh)")
-_DIRECT_SHELL = re.compile(r"(?:^|\s)\./((?:tests|scripts)/[^\s;|&]+\.sh)")
-_GATE_PATH = re.compile(r'(?:^|\s)(?:"?\$PYTHON"?|python\S*)\s+(scripts/(?:check[_-]|audit_)[^\s;|&]+\.py)')
-
-
-def _words(tail: str) -> list[str]:
-    return re.findall(r"[A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)+|(?:tests|scripts)/[^\s;|&]+", tail)
-
-
-def _collect_invocations(
-    commands: Iterable[tuple[str, str]], candidates: Sequence[str]
-) -> tuple[dict[str, list[Invocation]], set[str], set[str], list[Diagnostic]]:
-    invocations: dict[str, list[Invocation]] = {path: [] for path in candidates}
-    required: set[str] = set()
-    reached_scripts: set[str] = set()
-    diagnostics: list[Diagnostic] = []
+    unittest_classes = {name for name, values in bases.items()
+                        if any(value == "TestCase" or value.endswith(".TestCase") for value in values)}
+    while True:
+        expanded = unittest_classes | {name for name, values in bases.items()
+                                       if any(value in unittest_classes for value in values)}
+        if expanded == unittest_classes:
+            break
+        unittest_classes = expanded
+    unittest_tests = [test for name in unittest_classes for test in class_tests.get(name, ())]
+    return _PythonTests(tuple(sorted(all_tests)), tuple(sorted(unittest_tests)),
+                        any(_live_unittest_main(node) for node in tree.body))
+def _command_head(tokens: Sequence[str]) -> tuple[str, list[str]]:
+    words = list(tokens)
+    while words and words[0] in {"do", "then", "else", "elif", "if", "while", "until", "!"}:
+        words.pop(0)
+    while words and re.match(r"^[A-Za-z_]\w*=", words[0]):
+        words.pop(0)
+    if not words:
+        return "", []
+    return words[0].lstrip("@+-"), words[1:]
+def _dynamic(value: str) -> bool:
+    return "$" in value or "{{" in value or "}}" in value
+def _repo_path(value: str, source: str) -> tuple[str | None, bool]:
+    script_dir = None
+    for prefix in ("$SCRIPT_DIR/", "${SCRIPT_DIR}/"):
+        if value.startswith(prefix):
+            script_dir, value = str(PurePosixPath(source).parent), value[len(prefix):]
+            break
+    if _dynamic(value):
+        return None, False
+    raw = posixpath.join(script_dir, value) if script_dir else value
+    normalized = posixpath.normpath(raw)
+    if normalized.startswith("/") or normalized == ".." or normalized.startswith("../"):
+        return None, True
+    return normalized.removeprefix("./"), False
+def _unique_invocations(values: Iterable[Invocation]) -> tuple[Invocation, ...]:
+    key = lambda item: (item.source, item.command, item.target, item.selector or "", item.glob, item.runner)
+    return tuple(sorted({key(item): item for item in values}.values(), key=key))
+def _unique_pins(values: Iterable[PinEvidence]) -> tuple[PinEvidence, ...]:
+    key = lambda item: (item.source, item.command, item.target, item.status.value)
+    return tuple(sorted({key(item): item for item in values}.values(), key=key))
+def _collect_invocations(commands: Iterable[tuple[str, str]], candidates: Sequence[str]) -> tuple[
+        dict[str, list[Invocation]], dict[str, list[PinEvidence]], set[str], list[Diagnostic]]:
+    calls = {path: [] for path in candidates}
+    pins = {path: [] for path in candidates}
+    reached, diagnostics = set(), []
     modules = {path[:-3].replace("/", "."): path for path in candidates if path.endswith(".py")}
-    combined = " ".join(command for _, command in commands)
-    for array in re.findall(r"required_shell_suites\s*=\(([^)]*)\)", combined):
-        required.update(re.findall(r"tests/[^\s)]+\.sh", array))
-    for variable, pattern in re.findall(
-        r"for\s+(\w+)\s+in\s+(tests/[^\s;]+\.sh)", combined
-    ):
-        if re.search(
-            rf"\b(?:bash|sh)\s+[\"']?\${{{variable}}}|"
-            rf"\b(?:bash|sh)\s+[\"']?\${variable}", combined,
-        ):
-            for path in candidates:
-                if fnmatch.fnmatchcase(path, pattern):
-                    invocations[path].append(Invocation("shell-glob", pattern, glob=True))
-    for source, command in commands:
-        if re.search(r"\b(?:xargs|docker\s+run)\b|\bfind\b.*-(?:exec|execdir)\b", command) and re.search(r"test_|unittest|pytest", command):
-            diagnostics.append(Diagnostic(
-                DiagnosticKind.UNSUPPORTED_CALL,
-                f"unsupported dynamic test invocation: {command}", source, True,
-            ))
-        unit = _UNITTEST.search(command)
-        if unit:
-            if "$" in unit.group(1):
-                diagnostics.append(Diagnostic(
-                    DiagnosticKind.UNSUPPORTED_CALL,
-                    f"dynamic unittest target: {unit.group(1)}", source, True,
-                ))
-            for target in _words(unit.group(1)):
-                matches = [module for module in modules if target == module or target.startswith(module + ".")]
-                if not matches:
-                    if "$" in target:
-                        diagnostics.append(Diagnostic(
-                            DiagnosticKind.UNSUPPORTED_CALL,
-                            f"dynamic unittest target: {target}", source, True,
-                        ))
-                    continue
-                module = max(matches, key=len)
-                selector = target[len(module) + 1:] if target != module else None
-                path = modules[module]
-                invocations[path].append(Invocation(source, module, selector, runner="unittest"))
-        pytest = _PYTEST.search(command)
-        if pytest:
-            if "$" in pytest.group(1):
-                diagnostics.append(Diagnostic(
-                    DiagnosticKind.UNSUPPORTED_CALL,
-                    f"dynamic pytest target: {pytest.group(1)}", source, True,
-                ))
-            for target in _words(pytest.group(1)):
-                raw_path, _, selector = target.partition("::")
-                for path in candidates:
-                    if not path.endswith(".py"):
+    rows = list(commands)
+    by_source: dict[str, list[str]] = {}
+    loop_vars: dict[tuple[str, str], str] = {}
+    for source, command in rows:
+        by_source.setdefault(source, []).append(command)
+        for segment in _segments(command):
+            executable, args = _command_head(segment)
+            if executable == "for" and "in" in args:
+                split = args.index("in")
+                if split == 1 and split + 1 < len(args):
+                    loop_vars[source, args[0]] = args[split + 1]
+    for source, source_commands in by_source.items():
+        joined = "\n".join(source_commands)
+        for match in re.finditer(r"required_shell_suites\s*=\((.*?)\)", joined, re.S):
+            declaration = match.group(0)
+            for path in re.findall(r"tests/[^\s)]+\.sh", match.group(1)):
+                if path in pins:
+                    pins[path].append(PinEvidence(source, path, declaration, PinStatus.REQUIRED_ARRAY))
+    def record(path: str, call: Invocation, status: PinStatus = PinStatus.PINNED) -> None:
+        if path in calls:
+            calls[path].append(call)
+            pins[path].append(PinEvidence(call.source, call.target, call.command, status))
+    def unsupported(source: str, command: str, detail: str) -> None:
+        diagnostics.append(Diagnostic(DiagnosticKind.UNSUPPORTED_CALL,
+                                      f"{detail}: {command}", source, True))
+    for source, command in rows:
+        for segment in _segments(command):
+            executable, args = _command_head(segment)
+            python = bool(re.fullmatch(r"(?:python\d*(?:\.\d+)?|\$\{?PYTHON\}?)", executable))
+            runner, targets = "", []
+            if executable == "pytest":
+                runner, targets = "pytest", args
+            elif python and len(args) >= 2 and args[:2] == ["-m", "unittest"]:
+                runner, targets = "unittest", args[2:]
+            elif python and len(args) >= 2 and args[:2] == ["-m", "pytest"]:
+                runner, targets = "pytest", args[2:]
+            if runner:
+                for target in targets:
+                    if target.startswith("-"):
                         continue
-                    is_glob = any(char in raw_path for char in "*?[")
-                    if path == raw_path or (is_glob and fnmatch.fnmatchcase(path, raw_path)) or (
-                        raw_path.endswith("/") and path.startswith(raw_path)
-                    ):
-                        invocations[path].append(Invocation(
-                            source, raw_path, selector or None,
-                            is_glob or path != raw_path, "pytest",
-                        ))
-        for regex in (_SHELL_PATH, _DIRECT_SHELL):
-            for match in regex.finditer(command):
-                path = match.group(1)
-                if path in invocations:
-                    invocations[path].append(Invocation(source, path))
-                if path.startswith("scripts/"):
-                    reached_scripts.add(path)
-        for match in re.finditer(
-            r'(?:bash|sh|source)\s+["\']?\$SCRIPT_DIR/([^\s"\']+\.sh)', command
-        ):
-            path = str(PurePosixPath(source).parent / match.group(1))
-            if path in invocations:
-                invocations[path].append(Invocation(source, path))
-            reached_scripts.add(path)
-        for match in _PYTHON_PATH.finditer(command):
-            path = match.group(1).strip('"\'')
-            if path in invocations:
-                invocations[path].append(Invocation(source, path, runner="script"))
-        for match in _GATE_PATH.finditer(command):
-            path = match.group(1).strip('"\'')
-            if path in invocations:
-                invocations[path].append(Invocation(source, path))
-    return invocations, required, reached_scripts, diagnostics
-
-
+                    if _dynamic(target):
+                        unsupported(source, command, f"dynamic {runner} target")
+                        continue
+                    if runner == "unittest":
+                        matches = [module for module in modules
+                                   if target == module or target.startswith(module + ".")]
+                        if matches:
+                            module = max(matches, key=len)
+                            selector = target[len(module) + 1:] if target != module else None
+                            record(modules[module], Invocation(source, module, selector,
+                                                               runner="unittest", command=command))
+                    else:
+                        raw, _, selector = target.partition("::")
+                        glob = any(char in raw for char in "*?[")
+                        for path in candidates:
+                            if path.endswith(".py") and (path == raw or (glob and fnmatch.fnmatchcase(path, raw))
+                                                        or (raw.endswith("/") and path.startswith(raw))):
+                                status = PinStatus.GLOB_UNPINNED if glob or path != raw else PinStatus.PINNED
+                                record(path, Invocation(source, raw, selector or None,
+                                                        status is PinStatus.GLOB_UNPINNED,
+                                                        "pytest", command), status)
+                continue
+            if executable in {"bash", "sh", "source"}:
+                target = next((arg for arg in args if not arg.startswith("-")), "")
+                variable = target.removeprefix("${").removesuffix("}").removeprefix("$")
+                pattern = loop_vars.get((source, variable)) if target.startswith("$") else None
+                if pattern:
+                    for path in candidates:
+                        if fnmatch.fnmatchcase(path, pattern):
+                            record(path, Invocation(source, pattern, glob=True,
+                                                    runner="shell", command=command), PinStatus.GLOB_UNPINNED)
+                    continue
+                if not target:
+                    continue
+                if target in {"$0", "${0}"}:
+                    continue
+                if _dynamic(target) and not target.startswith(("$SCRIPT_DIR/", "${SCRIPT_DIR}/")):
+                    unsupported(source, command, "dynamic shell target")
+                    continue
+                path, escaped = _repo_path(target, source)
+                if escaped:
+                    unsupported(source, command, "shell target escapes repository")
+                    continue
+                if path and path.endswith(".sh"):
+                    record(path, Invocation(source, path, runner="shell", command=command))
+                    if path.startswith("scripts/"):
+                        reached.add(path)
+                continue
+            if executable.startswith("./"):
+                path, escaped = _repo_path(executable, source)
+                if escaped:
+                    unsupported(source, command, "shell target escapes repository")
+                elif path and path.endswith(".sh"):
+                    record(path, Invocation(source, path, runner="shell", command=command))
+                    if path.startswith("scripts/"):
+                        reached.add(path)
+                continue
+            if python and args:
+                target = args[0]
+                if _dynamic(target):
+                    unsupported(source, command, "dynamic python target")
+                    continue
+                path, escaped = _repo_path(target, source)
+                if not escaped and path and path.endswith(".py") and path in calls:
+                    record(path, Invocation(source, path, runner="script", command=command))
+                continue
+            if executable in {"xargs", "find", "docker"} and re.search(r"test_|unittest|pytest|-exec", command):
+                unsupported(source, command, "unsupported dynamic test invocation")
+    return calls, pins, reached, diagnostics
 def scan_registry(repo_root: Path, config: RegistryConfig | None = None) -> RegistryResult:
     config = config or RegistryConfig()
-    tracked, tracked_error = _tracked_files(repo_root)
-    diagnostics: list[Diagnostic] = [tracked_error] if tracked_error else []
-    classified = [(path, _family(path, config)) for path in tracked]
-    classified = [(path, value) for path, value in classified if value is not None]
-    candidate_paths = [path for path, _ in classified]
+    tracked, error = _tracked_files(repo_root)
+    diagnostics = [error] if error else []
+    classified = [(path, value) for path in tracked if (value := _family(path, config))]
+    paths = [path for path, _ in classified]
     counts = Counter(family for _, (family, _) in classified)
-
+    parsed_inputs: dict[str, ast.Module | str | None] = {}
+    for path, _ in classified:
+        text, read_error = _read_source(repo_root, path)
+        if read_error:
+            diagnostics.append(read_error)
+            parsed_inputs[path] = None
+        elif path.endswith(".py"):
+            tree, parse_error = _parse_python(text or "", path)
+            diagnostics.extend([parse_error] if parse_error else [])
+            parsed_inputs[path] = tree
+        else:
+            _, malformed = _source_commands(text or "", path)
+            diagnostics.extend([malformed] if malformed else [])
+            parsed_inputs[path] = None if malformed else text
     sources = list(config.surface_sources or DEFAULT_SOURCES)
     if config.surface_sources is None:
-        workflows = sorted(path for path in tracked if fnmatch.fnmatchcase(path, ".github/workflows/*.yml"))
+        workflows = sorted(path for path in tracked
+                           if path.startswith(".github/workflows/") and path.endswith((".yml", ".yaml")))
         if not workflows:
-            diagnostics.append(Diagnostic(
-                DiagnosticKind.SOURCE_MISSING, "no tracked .github/workflows/*.yml sources", fatal=True,
-            ))
+            diagnostics.append(Diagnostic(DiagnosticKind.SOURCE_MISSING,
+                                          "no tracked .github/workflows/*.yml sources", fatal=True))
         sources.extend(workflows)
-    reachable: list[str] = []
-    queued = deque(sources)
-    seen: set[str] = set()
-    all_invocations: dict[str, list[Invocation]] = {path: [] for path in candidate_paths}
-    required: set[str] = set()
-    while queued:
-        source = queued.popleft()
+    reachable, queue, seen = [], deque(sources), set()
+    all_calls, all_pins = {path: [] for path in paths}, {path: [] for path in paths}
+    while queue:
+        source = queue.popleft()
         if source in seen:
             continue
         seen.add(source)
-        text, error = _read_source(repo_root, source)
-        if error:
-            diagnostics.append(error)
+        text, read_error = _read_source(repo_root, source)
+        if read_error:
+            diagnostics.append(read_error)
             continue
         reachable.append(source)
-        source_commands, malformed = _source_commands(text or "", source)
+        commands, malformed = _source_commands(text or "", source)
+        diagnostics.extend([malformed] if malformed else [])
         if malformed:
-            diagnostics.append(malformed)
-        batch = [(source, command) for command in source_commands]
-        found, found_required, reached, unsupported = _collect_invocations(batch, candidate_paths)
-        for path, values in found.items():
-            all_invocations[path].extend(values)
-        required.update(found_required)
+            continue
+        found, pins, reached, unsupported = _collect_invocations(
+            ((source, command) for command in commands), paths)
+        for path in paths:
+            all_calls[path].extend(found[path])
+            all_pins[path].extend(pins[path])
         diagnostics.extend(unsupported)
-        for path in sorted(reached):
-            if path in tracked and path not in seen:
-                queued.append(path)
-
-    records: list[Candidate] = []
+        queue.extend(path for path in sorted(reached) if path in tracked and path not in seen)
+    records = []
     for path, (family, kind) in classified:
-        calls = tuple(all_invocations[path])
-        direct = tuple(call for call in calls if not call.glob)
-        glob = tuple(call for call in calls if call.glob)
-        tests: tuple[str, ...] = ()
-        executed: set[str] = set()
-        harness_mismatch = False
-        if kind is CandidateKind.PYTHON_SUITE:
-            parsed, error = _python_tests(repo_root, path)
-            if error:
-                diagnostics.append(error)
-            elif parsed:
-                tests = parsed.all
-                module = path[:-3].replace("/", ".")
-                for call in direct:
-                    if call.runner == "pytest":
-                        if call.selector:
-                            selector = call.selector.replace("::", ".")
-                            executed.update(test for test in parsed.all if test == selector or test.startswith(selector + "."))
-                        else:
-                            executed.update(parsed.all)
-                    elif call.target == path:
-                        if parsed.has_unittest_main:
-                            executed.update(parsed.unittest)
-                        else:
-                            harness_mismatch = True
-                    elif call.target == module:
-                        if not parsed.unittest:
-                            harness_mismatch = True
-                        elif call.selector:
-                            executed.update(test for test in parsed.unittest if test == call.selector or test.startswith(call.selector + "."))
-                        else:
-                            executed.update(parsed.unittest)
-                if harness_mismatch:
-                    diagnostics.append(Diagnostic(
-                        DiagnosticKind.HARNESS_MISMATCH,
-                        f"execution form for {path} selects zero tests", path,
-                    ))
-                if glob:
-                    executed.update(parsed.all)
-        if direct and kind is not CandidateKind.PYTHON_SUITE:
+        calls, pin_evidence = _unique_invocations(all_calls[path]), _unique_pins(all_pins[path])
+        direct, globs = tuple(call for call in calls if not call.glob), tuple(call for call in calls if call.glob)
+        tests, executed, mismatch = (), set(), False
+        data = parsed_inputs[path]
+        if kind is CandidateKind.PYTHON_SUITE and isinstance(data, ast.Module):
+            parsed, module = _python_tests(data), path[:-3].replace("/", ".")
+            tests = parsed.all
+            for call in direct:
+                if call.runner == "pytest":
+                    selector = (call.selector or "").replace("::", ".")
+                    executed.update(test for test in parsed.all
+                                    if not selector or test == selector or test.startswith(selector + "."))
+                elif call.target == path:
+                    executed.update(parsed.unittest if parsed.has_unittest_main else ())
+                    mismatch |= not parsed.has_unittest_main or not parsed.unittest
+                elif call.target == module:
+                    selected = (test for test in parsed.unittest
+                                if not call.selector or test == call.selector
+                                or test.startswith(call.selector + "."))
+                    before = len(executed)
+                    executed.update(selected)
+                    mismatch |= len(executed) == before and not parsed.unittest
+            if globs:
+                executed.update(parsed.all)
+            if mismatch:
+                diagnostics.append(Diagnostic(DiagnosticKind.HARNESS_MISMATCH,
+                                              f"execution form for {path} selects zero tests", path))
+        valid = data is not None
+        if not valid:
+            execution = ExecStatus.NONE
+        elif kind is not CandidateKind.PYTHON_SUITE and direct:
             execution = ExecStatus.FULL
-        elif direct and executed == set(tests) and tests and not any(call.selector for call in direct):
+        elif direct and tests and executed == set(tests) and not any(call.selector for call in direct):
             execution = ExecStatus.FULL
         elif direct and executed:
             execution = ExecStatus.PARTIAL
-        elif glob:
+        elif globs:
             execution = ExecStatus.GLOB
         else:
             execution = ExecStatus.NONE
-        if direct and execution is not ExecStatus.NONE:
-            pin = PinStatus.PINNED
-        elif path in required:
-            pin = PinStatus.REQUIRED_ARRAY
-        elif glob:
-            pin = PinStatus.GLOB_UNPINNED
-        else:
-            pin = PinStatus.NONE
-        records.append(Candidate(
-            path, family, kind, execution, pin, tests,
-            tuple(sorted(executed)), calls,
-        ))
-    return RegistryResult(
-        tuple(records), tuple(diagnostics),
-        {family: counts.get(family, 0) for family in Family},
-        tuple(reachable),
-    )
+        statuses = {item.status for item in pin_evidence}
+        pin = next((status for status in (PinStatus.PINNED, PinStatus.REQUIRED_ARRAY,
+                                          PinStatus.GLOB_UNPINNED) if status in statuses), PinStatus.NONE)
+        records.append(Candidate(path, family, kind, execution, pin, tests,
+                                 tuple(sorted(executed)), calls, pin_evidence))
+    diagnostics = list(dict.fromkeys(diagnostics))
+    return RegistryResult(tuple(records), tuple(diagnostics),
+                          {family: counts.get(family, 0) for family in Family}, tuple(reachable))

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -168,6 +168,9 @@ echo "=== Test-target integrity gate (#5003/#5008) ==="
 "$PYTHON" scripts/check_test_target_integrity.py --verify-lib-inventory
 "$PYTHON" -m unittest tests.test_check_test_target_integrity
 
+echo "=== Test-suite registry core tests (#5003 S3a-1) ==="
+"$PYTHON" -m unittest tests.test_check_test_suite_registry
+
 echo "=== PostgreSQL test-lane membership gate (#4979, enforced) ==="
 "$PYTHON" scripts/check_pg_test_lane_membership.py --baseline-ref "$TEST_LANE_BASELINE_REF"
 "$PYTHON" -m unittest tests.test_check_pg_test_lane_membership

--- a/tests/test_check_test_suite_registry.py
+++ b/tests/test_check_test_suite_registry.py
@@ -1,14 +1,11 @@
 """Mutation fixtures for the #5003 S3a-1 test-suite registry core."""
-
 from __future__ import annotations
-
 import importlib.util
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
-
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "check_test_suite_registry.py"
 SPEC = importlib.util.spec_from_file_location("check_test_suite_registry", SCRIPT)
@@ -16,46 +13,35 @@ assert SPEC and SPEC.loader
 registry = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = registry
 SPEC.loader.exec_module(registry)
-
 SUITE = """import unittest
 class Alpha(unittest.TestCase):
     def test_one(self): pass
     def test_two(self): pass
 """
-
-
 class FixtureRepo:
     def __init__(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.root = Path(self.temporary.name)
         subprocess.run(["git", "init", "-q"], cwd=self.root, check=True)
         self.write("scripts/ci-script-checks.sh", "#!/usr/bin/env bash\n")
-
     def close(self) -> None:
         self.temporary.cleanup()
-
     def write(self, path: str, text: str, *, tracked: bool = True) -> None:
         target = self.root / path
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(text, encoding="utf-8")
         if tracked:
             subprocess.run(["git", "add", path], cwd=self.root, check=True)
-
     def scan(self, **changes: object) -> registry.RegistryResult:
-        config = registry.RegistryConfig(
-            surface_sources=("scripts/ci-script-checks.sh",), **changes
-        )
+        sources = changes.pop("surface_sources", ("scripts/ci-script-checks.sh",))
+        config = registry.RegistryConfig(surface_sources=sources, **changes)
         return registry.scan_registry(self.root, config)
-
-
 class RegistryMutationSuite(unittest.TestCase):
     def setUp(self) -> None:
         self.repo = FixtureRepo()
         self.addCleanup(self.repo.close)
-
     def candidate(self, result: registry.RegistryResult, path: str) -> registry.Candidate:
         return next(candidate for candidate in result.candidates if candidate.path == path)
-
     def test_m1_tracked_unwired_is_none_and_m2_literal_wiring_makes_full(self) -> None:
         self.repo.write("tests/test_zz_mutant.py", SUITE)
         self.repo.write("tests/test_untracked_fixture.py", SUITE, tracked=False)
@@ -64,7 +50,6 @@ class RegistryMutationSuite(unittest.TestCase):
         self.assertEqual(self.candidate(result, "tests/test_zz_mutant.py").execution, registry.ExecStatus.NONE)
         self.repo.write("scripts/ci-script-checks.sh", '"$PYTHON" -m unittest tests.test_zz_mutant\n')
         self.assertEqual(self.candidate(self.repo.scan(), "tests/test_zz_mutant.py").execution, registry.ExecStatus.FULL)
-
     def test_m3_deleted_call_becomes_none_and_m5_wired_identity_remains_exact(self) -> None:
         self.repo.write("tests/test_wired.py", SUITE)
         self.repo.write("scripts/ci-script-checks.sh", '"$PYTHON" -m unittest tests.test_wired\n')
@@ -72,7 +57,6 @@ class RegistryMutationSuite(unittest.TestCase):
         self.assertEqual((wired.path, wired.execution), ("tests/test_wired.py", registry.ExecStatus.FULL))
         self.repo.write("scripts/ci-script-checks.sh", "#!/usr/bin/env bash\n")
         self.assertEqual(self.candidate(self.repo.scan(), wired.path).execution, registry.ExecStatus.NONE)
-
     def test_m4_each_family_glob_loss_trips_its_shrink_only_floor(self) -> None:
         fixtures = {
             "tests/test_a.py": SUITE, "scripts/e2e/test_b.py": SUITE,
@@ -89,7 +73,23 @@ class RegistryMutationSuite(unittest.TestCase):
                 patterns[family] = ()
                 mutated = self.repo.scan(patterns=patterns)
                 self.assertEqual(mutated.family_violations(baseline)[0].family, family)
-
+    def test_recursive_family_matcher_covers_zero_one_and_deep_directories(self) -> None:
+        fixtures = (
+            (registry.Family.TESTS_PY, "tests/a/b/test_deep.py", SUITE),
+            (registry.Family.E2E_PY, "scripts/e2e/a/b/test_deep.py", SUITE),
+            (registry.Family.SCRIPTS_PY, "scripts/a/b/test_deep.py", SUITE),
+            (registry.Family.SHELL, "tests/a/b/test_deep.sh", "#!/bin/sh\ntrue\n"),
+        )
+        for family, path, text in fixtures:
+            with self.subTest(family=family.value):
+                repo = FixtureRepo()
+                self.addCleanup(repo.close)
+                repo.write(path, text)
+                result = repo.scan()
+                self.assertEqual(result.family_counts[family], 1)
+                self.assertEqual([item.path for item in result.candidates], [path])
+        self.assertTrue(registry._matches("tests/test_root.py", registry.DEFAULT_PATTERNS[registry.Family.TESTS_PY]))
+        self.assertTrue(registry._matches("tests/a/test_one.py", registry.DEFAULT_PATTERNS[registry.Family.TESTS_PY]))
     def test_m6_unittest_and_python_path_zero_test_harness_is_not_wiring(self) -> None:
         bare = "def test_bare(): pass\n"
         self.repo.write("tests/test_bare.py", bare)
@@ -106,7 +106,16 @@ class RegistryMutationSuite(unittest.TestCase):
         self.repo.write("tests/test_runner.py", SUITE + "\nif __name__ == '__main__': unittest.main()\n")
         self.repo.write("scripts/ci-script-checks.sh", "python3 tests/test_runner.py\n")
         self.assertEqual(self.candidate(self.repo.scan(), "tests/test_runner.py").execution, registry.ExecStatus.FULL)
-
+        dead = SUITE + "\ndef never_called():\n    unittest.main()\n"
+        self.repo.write("tests/test_dead_main.py", dead)
+        self.repo.write("scripts/ci-script-checks.sh", "python3 tests/test_dead_main.py\n")
+        result = self.repo.scan()
+        self.assertEqual(self.candidate(result, "tests/test_dead_main.py").execution, registry.ExecStatus.NONE)
+        self.assertIn(registry.DiagnosticKind.HARNESS_MISMATCH, {d.kind for d in result.diagnostics})
+        for body in ("unittest.main()", "if __name__ == '__main__':\n    raise SystemExit(unittest.main())"):
+            self.repo.write("tests/test_live_main.py", SUITE + "\n" + body + "\n")
+            self.repo.write("scripts/ci-script-checks.sh", "python3 tests/test_live_main.py\n")
+            self.assertEqual(self.candidate(self.repo.scan(), "tests/test_live_main.py").execution, registry.ExecStatus.FULL)
     def test_m6b_four_backslash_continuations_are_all_full(self) -> None:
         paths = [f"tests/test_continuation_{index}.py" for index in range(4)]
         for path in paths:
@@ -115,7 +124,6 @@ class RegistryMutationSuite(unittest.TestCase):
         command = '"$PYTHON" -m unittest \\\n  ' + " \\\n  ".join(modules) + "\n"
         self.repo.write("scripts/ci-script-checks.sh", command)
         self.assertEqual([self.candidate(self.repo.scan(), path).execution for path in paths], [registry.ExecStatus.FULL] * 4)
-
     def test_m7_report_gate_and_own_suite_are_independent_cross_seal_records(self) -> None:
         self.repo.write("scripts/audit_report.py", "print('report only')\n")
         self.repo.write("tests/test_audit_report.py", SUITE)
@@ -125,7 +133,6 @@ class RegistryMutationSuite(unittest.TestCase):
         self.assertEqual(self.candidate(result, "tests/test_audit_report.py").execution, registry.ExecStatus.FULL)
         self.repo.write("scripts/ci-script-checks.sh", "#!/usr/bin/env bash\n")
         self.assertEqual(self.candidate(self.repo.scan(), "tests/test_audit_report.py").execution, registry.ExecStatus.NONE)
-
     def test_missing_unreadable_and_malformed_sources_are_explicit_fatal_results(self) -> None:
         missing = registry.scan_registry(
             self.repo.root, registry.RegistryConfig(surface_sources=("missing",))
@@ -142,7 +149,31 @@ class RegistryMutationSuite(unittest.TestCase):
             self.repo.root, registry.RegistryConfig(surface_sources=("unreadable",))
         )
         self.assertIn(registry.DiagnosticKind.SOURCE_UNREADABLE, {d.kind for d in unreadable.diagnostics if d.fatal})
-
+    def test_tracked_candidate_validation_is_shared_and_fail_closed(self) -> None:
+        cases = (
+            ("tests/test_gone.sh", "#!/bin/sh\ntrue\n", None, "for x in tests/*.sh; do bash \"$x\"; done\n", registry.DiagnosticKind.SOURCE_MISSING),
+            ("scripts/check_gone.py", "print('ok')\n", None, "python3 scripts/check_gone.py\n", registry.DiagnosticKind.SOURCE_MISSING),
+            ("tests/test_dir.sh", "true\n", "directory", "bash tests/test_dir.sh\n", registry.DiagnosticKind.SOURCE_UNREADABLE),
+            ("tests/test_nul.sh", "\0", "keep", "bash tests/test_nul.sh\n", registry.DiagnosticKind.SOURCE_MALFORMED),
+            ("tests/test_cont.sh", "echo still \\", "keep", "bash tests/test_cont.sh\n", registry.DiagnosticKind.SOURCE_MALFORMED),
+            ("scripts/check_bad.py", "if :\n", "keep", "python3 scripts/check_bad.py\n", registry.DiagnosticKind.PYTHON_MALFORMED),
+        )
+        for path, text, shape, command, diagnostic in cases:
+            with self.subTest(path=path):
+                repo = FixtureRepo()
+                self.addCleanup(repo.close)
+                repo.write(path, text)
+                if shape is None:
+                    (repo.root / path).unlink()
+                elif shape == "directory":
+                    (repo.root / path).unlink()
+                    (repo.root / path).mkdir()
+                repo.write("scripts/ci-script-checks.sh", command)
+                result = repo.scan()
+                candidate = next(item for item in result.candidates if item.path == path)
+                self.assertFalse(result.input_valid)
+                self.assertEqual(candidate.execution, registry.ExecStatus.NONE)
+                self.assertIn(diagnostic, {item.kind for item in result.diagnostics if item.fatal})
     def test_comments_assertions_arrays_and_strings_do_not_execute_candidates(self) -> None:
         self.repo.write("tests/test_mentions.py", SUITE)
         self.repo.write("tests/test_mentions.sh", "#!/bin/sh\ntrue\n")
@@ -150,13 +181,28 @@ class RegistryMutationSuite(unittest.TestCase):
 # "$PYTHON" -m unittest tests.test_mentions
 mention=("$PYTHON" -m unittest tests.test_mentions)
 self.assertIn("python -m unittest tests.test_mentions", lines)
+echo 'python -m unittest tests.test_mentions'
+echo python -m unittest tests.test_mentions
+printf '%s' pytest tests/test_mentions.py
 required_shell_suites=(tests/test_mentions.sh)
 """)
         result = self.repo.scan()
         self.assertEqual(self.candidate(result, "tests/test_mentions.py").execution, registry.ExecStatus.NONE)
         shell = self.candidate(result, "tests/test_mentions.sh")
         self.assertEqual((shell.execution, shell.pin), (registry.ExecStatus.NONE, registry.PinStatus.REQUIRED_ARRAY))
-
+    def test_recipe_text_and_workflow_metadata_are_not_commands(self) -> None:
+        self.repo.write("tests/test_meta.py", SUITE)
+        self.repo.write("justfile", "check:\n  echo python -m unittest tests.test_meta\n")
+        self.repo.write("Makefile", "check:\n\tprintf pytest tests/test_meta.py\n")
+        result = self.repo.scan(surface_sources=("justfile", "Makefile"))
+        self.assertEqual(self.candidate(result, "tests/test_meta.py").execution, registry.ExecStatus.NONE)
+        workflow = "name: pytest tests/test_meta.py\ndescription: |\n  pytest tests/test_meta.py\n# run: pytest tests/test_meta.py\nuses: pytest tests/test_meta.py\njobs:\n  x:\n    name: python -m unittest tests.test_meta\n"
+        self.repo.write(".github/workflows/ci.yml", workflow)
+        result = self.repo.scan(surface_sources=(".github/workflows/ci.yml",))
+        self.assertEqual(self.candidate(result, "tests/test_meta.py").execution, registry.ExecStatus.NONE)
+        for run in ("      - run: python -m unittest tests.test_meta\n", "      - run: |\n          python -m unittest tests.test_meta\n"):
+            self.repo.write(".github/workflows/ci.yml", workflow + "    steps:\n" + run); result = self.repo.scan(surface_sources=(".github/workflows/ci.yml",))
+            self.assertEqual(self.candidate(result, "tests/test_meta.py").execution, registry.ExecStatus.FULL)
     def test_exact_method_selection_is_partial_and_preserves_unexecuted_ids(self) -> None:
         self.repo.write("tests/test_partial.py", SUITE + "\nclass Beta(unittest.TestCase):\n    def test_three(self): pass\n")
         self.repo.write("scripts/ci-script-checks.sh", '"$PYTHON" -m unittest tests.test_partial.Alpha.test_one\n')
@@ -168,7 +214,6 @@ required_shell_suites=(tests/test_mentions.sh)
         target = "tests.test_partial.Alpha.test_one"
         self.assertEqual(result.partial_violations({(candidate.path, target)}), ())
         self.assertEqual(len(result.partial_violations()), 1)
-
     def test_shell_full_required_array_and_glob_unpinned_axes_are_distinct(self) -> None:
         for name in "abc":
             self.repo.write(f"tests/test_{name}.sh", "#!/bin/sh\ntrue\n")
@@ -184,18 +229,37 @@ done
         self.assertEqual(observed["a"], (registry.ExecStatus.FULL, registry.PinStatus.PINNED))
         self.assertEqual(observed["b"], (registry.ExecStatus.GLOB, registry.PinStatus.REQUIRED_ARRAY))
         self.assertEqual(observed["c"], (registry.ExecStatus.GLOB, registry.PinStatus.GLOB_UNPINNED))
-
+        direct, required, glob = (self.candidate(result, f"tests/test_{name}.sh") for name in "abc")
+        direct_pin = next(item for item in direct.pin_evidence if item.status is registry.PinStatus.PINNED)
+        required_pin = next(item for item in required.pin_evidence if item.status is registry.PinStatus.REQUIRED_ARRAY)
+        self.assertEqual((direct_pin.source, direct_pin.command), ("scripts/ci-script-checks.sh", "bash tests/test_a.sh"))
+        self.assertEqual((required_pin.source, required_pin.command), ("scripts/ci-script-checks.sh", "required_shell_suites=(tests/test_b.sh)"))
+        self.assertEqual((glob.invocations[0].source, glob.invocations[0].command), ("scripts/ci-script-checks.sh", 'bash "$shell_test"'))
+        self.assertEqual((glob.pin_evidence[0].source, glob.pin_evidence[0].target), ("scripts/ci-script-checks.sh", "tests/*.sh"))
+        self.repo.write("justfile", "x:\n  bash tests/test_a.sh\n  bash tests/test_a.sh\n")
+        sources = ("scripts/ci-script-checks.sh", "justfile")
+        evidence = self.candidate(self.repo.scan(surface_sources=sources), "tests/test_a.sh").pin_evidence
+        self.assertEqual([item.source for item in evidence if item.status is registry.PinStatus.PINNED], sorted(sources))
     def test_literal_shell_call_chain_is_recursive_and_dynamic_shape_is_fatal(self) -> None:
         self.repo.write("tests/test_chain.py", SUITE)
-        self.repo.write("scripts/driver.sh", '#!/bin/sh\n"$PYTHON" -m unittest tests.test_chain\n')
-        self.repo.write("scripts/ci-script-checks.sh", "bash scripts/driver.sh\n")
+        self.repo.write("scripts/leaf.sh", '#!/bin/sh\n"$PYTHON" -m unittest tests.test_chain\nbash "$SCRIPT_DIR/sub/driver.sh"\n')
+        self.repo.write("scripts/sub/driver.sh", '#!/bin/sh\nbash "$SCRIPT_DIR/../leaf.sh"\n')
+        self.repo.write("scripts/driver.sh", '#!/bin/sh\nbash "$SCRIPT_DIR/sub/driver.sh"\n')
+        self.repo.write("scripts/ci-script-checks.sh", 'bash "scripts/driver.sh"\n')
         result = self.repo.scan()
         self.assertEqual(self.candidate(result, "tests/test_chain.py").execution, registry.ExecStatus.FULL)
         self.assertIn("scripts/driver.sh", result.reachable_sources)
+        self.assertEqual(len(result.reachable_sources), len(set(result.reachable_sources)))
+        self.repo.write("tests/test_dynamic.sh", "#!/bin/sh\ntrue\n")
+        for target in ('$target', '${target}', '{{ target }}', '$SCRIPT_DIR/../../../escape.sh'):
+            self.repo.write("scripts/ci-script-checks.sh", f'target=tests/test_dynamic.sh; bash "{target}"\n')
+            dynamic = self.repo.scan()
+            self.assertEqual(self.candidate(dynamic, "tests/test_dynamic.sh").execution, registry.ExecStatus.NONE)
+            self.assertIn(registry.DiagnosticKind.UNSUPPORTED_CALL, {d.kind for d in dynamic.diagnostics if d.fatal})
+        self.repo.write("scripts/ci-script-checks.sh", "echo 'bash $target'\n")
+        self.assertNotIn(registry.DiagnosticKind.UNSUPPORTED_CALL, {d.kind for d in self.repo.scan().diagnostics})
         self.repo.write("scripts/ci-script-checks.sh", "find tests -name 'test_*.py' -exec python3 {} \\;\n")
         unsupported = self.repo.scan()
         self.assertIn(registry.DiagnosticKind.UNSUPPORTED_CALL, {d.kind for d in unsupported.diagnostics if d.fatal})
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_check_test_suite_registry.py
+++ b/tests/test_check_test_suite_registry.py
@@ -196,13 +196,31 @@ required_shell_suites=(tests/test_mentions.sh)
         self.repo.write("Makefile", "check:\n\tprintf pytest tests/test_meta.py\n")
         result = self.repo.scan(surface_sources=("justfile", "Makefile"))
         self.assertEqual(self.candidate(result, "tests/test_meta.py").execution, registry.ExecStatus.NONE)
-        workflow = "name: pytest tests/test_meta.py\ndescription: |\n  pytest tests/test_meta.py\n# run: pytest tests/test_meta.py\nuses: pytest tests/test_meta.py\njobs:\n  x:\n    name: python -m unittest tests.test_meta\n"
+        workflow = "name: pytest tests/test_meta.py\ndescription: |\n  run: pytest tests/test_meta.py\n# run: pytest tests/test_meta.py\nuses: pytest tests/test_meta.py\njobs:\n  x:\n    name: python -m unittest tests.test_meta\n"
         self.repo.write(".github/workflows/ci.yml", workflow)
         result = self.repo.scan(surface_sources=(".github/workflows/ci.yml",))
         self.assertEqual(self.candidate(result, "tests/test_meta.py").execution, registry.ExecStatus.NONE)
-        for run in ("      - run: python -m unittest tests.test_meta\n", "      - run: |\n          python -m unittest tests.test_meta\n"):
+        runs = ("      - run: python -m unittest tests.test_meta\n", "      - run: 'python -m unittest tests.test_meta'\n", '      - run: "python -m unittest tests.test_meta"\n')
+        runs += tuple(f"      - run: {style}\n          python -m unittest{suffix}\n" for style, suffix in (("|", " \\\n          tests.test_meta"), ("|-", " tests.test_meta"), ("|+", " tests.test_meta"), (">", "\n          tests.test_meta"), (">-", "\n          tests.test_meta"), (">+", "\n          tests.test_meta")))
+        runs += ("      - description: |\n          run: pytest tests/test_meta.py\n        run: python -m unittest tests.test_meta\n",)
+        for run in runs:
             self.repo.write(".github/workflows/ci.yml", workflow + "    steps:\n" + run); result = self.repo.scan(surface_sources=(".github/workflows/ci.yml",))
             self.assertEqual(self.candidate(result, "tests/test_meta.py").execution, registry.ExecStatus.FULL)
+    def test_execution_globs_are_path_segment_anchored(self) -> None:
+        fixtures = {"tests/test_root.py": SUITE, "tests/a/test_nested.py": SUITE, "tests/test_root.sh": "true\n", "tests/a/test_nested.sh": "true\n"}
+        for path, text in fixtures.items(): self.repo.write(path, text)
+        for patterns, expected in ((("tests/*.py", "tests/*.sh"), [registry.ExecStatus.GLOB, registry.ExecStatus.NONE] * 2), (("tests/**/*.py", "tests/**/*.sh"), [registry.ExecStatus.GLOB] * 4)):
+            self.repo.write("scripts/ci-script-checks.sh", f"pytest {patterns[0]}\nfor item in {patterns[1]}; do bash \"$item\"; done\n")
+            self.assertEqual([self.candidate(self.repo.scan(), path).execution for path in fixtures], expected)
+    def test_comment_backslashes_are_not_false_continuations(self) -> None:
+        cases = (("# harmless documentation \\", True), ("true # harmless documentation \\", True), ("printf '%s' '#' \\", False), ("printf '%s' \\# \\", False))
+        for text, valid in cases:
+            with self.subTest(text=text):
+                repo = FixtureRepo(); self.addCleanup(repo.close)
+                repo.write("tests/test_comment.sh", "#!/bin/sh\n" + text + "\n"); repo.write("scripts/ci-script-checks.sh", "bash tests/test_comment.sh\n")
+                result = repo.scan()
+                self.assertEqual(result.input_valid, valid)
+                self.assertEqual(next(c for c in result.candidates if c.path == "tests/test_comment.sh").execution, registry.ExecStatus.FULL if valid else registry.ExecStatus.NONE)
     def test_exact_method_selection_is_partial_and_preserves_unexecuted_ids(self) -> None:
         self.repo.write("tests/test_partial.py", SUITE + "\nclass Beta(unittest.TestCase):\n    def test_three(self): pass\n")
         self.repo.write("scripts/ci-script-checks.sh", '"$PYTHON" -m unittest tests.test_partial.Alpha.test_one\n')

--- a/tests/test_check_test_suite_registry.py
+++ b/tests/test_check_test_suite_registry.py
@@ -1,0 +1,201 @@
+"""Mutation fixtures for the #5003 S3a-1 test-suite registry core."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_test_suite_registry.py"
+SPEC = importlib.util.spec_from_file_location("check_test_suite_registry", SCRIPT)
+assert SPEC and SPEC.loader
+registry = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = registry
+SPEC.loader.exec_module(registry)
+
+SUITE = """import unittest
+class Alpha(unittest.TestCase):
+    def test_one(self): pass
+    def test_two(self): pass
+"""
+
+
+class FixtureRepo:
+    def __init__(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        subprocess.run(["git", "init", "-q"], cwd=self.root, check=True)
+        self.write("scripts/ci-script-checks.sh", "#!/usr/bin/env bash\n")
+
+    def close(self) -> None:
+        self.temporary.cleanup()
+
+    def write(self, path: str, text: str, *, tracked: bool = True) -> None:
+        target = self.root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+        if tracked:
+            subprocess.run(["git", "add", path], cwd=self.root, check=True)
+
+    def scan(self, **changes: object) -> registry.RegistryResult:
+        config = registry.RegistryConfig(
+            surface_sources=("scripts/ci-script-checks.sh",), **changes
+        )
+        return registry.scan_registry(self.root, config)
+
+
+class RegistryMutationSuite(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repo = FixtureRepo()
+        self.addCleanup(self.repo.close)
+
+    def candidate(self, result: registry.RegistryResult, path: str) -> registry.Candidate:
+        return next(candidate for candidate in result.candidates if candidate.path == path)
+
+    def test_m1_tracked_unwired_is_none_and_m2_literal_wiring_makes_full(self) -> None:
+        self.repo.write("tests/test_zz_mutant.py", SUITE)
+        self.repo.write("tests/test_untracked_fixture.py", SUITE, tracked=False)
+        result = self.repo.scan()
+        self.assertEqual([c.path for c in result.candidates], ["tests/test_zz_mutant.py"])
+        self.assertEqual(self.candidate(result, "tests/test_zz_mutant.py").execution, registry.ExecStatus.NONE)
+        self.repo.write("scripts/ci-script-checks.sh", '"$PYTHON" -m unittest tests.test_zz_mutant\n')
+        self.assertEqual(self.candidate(self.repo.scan(), "tests/test_zz_mutant.py").execution, registry.ExecStatus.FULL)
+
+    def test_m3_deleted_call_becomes_none_and_m5_wired_identity_remains_exact(self) -> None:
+        self.repo.write("tests/test_wired.py", SUITE)
+        self.repo.write("scripts/ci-script-checks.sh", '"$PYTHON" -m unittest tests.test_wired\n')
+        wired = self.candidate(self.repo.scan(), "tests/test_wired.py")
+        self.assertEqual((wired.path, wired.execution), ("tests/test_wired.py", registry.ExecStatus.FULL))
+        self.repo.write("scripts/ci-script-checks.sh", "#!/usr/bin/env bash\n")
+        self.assertEqual(self.candidate(self.repo.scan(), wired.path).execution, registry.ExecStatus.NONE)
+
+    def test_m4_each_family_glob_loss_trips_its_shrink_only_floor(self) -> None:
+        fixtures = {
+            "tests/test_a.py": SUITE, "scripts/e2e/test_b.py": SUITE,
+            "scripts/test_c.py": SUITE, "tests/test_d.sh": "#!/bin/sh\ntrue\n",
+            "scripts/check_e.py": "print('gate')\n",
+        }
+        for path, text in fixtures.items():
+            self.repo.write(path, text)
+        baseline = self.repo.scan().family_counts
+        self.assertEqual({family: baseline[family] for family in registry.Family}, {family: 1 for family in registry.Family})
+        for family in registry.Family:
+            with self.subTest(family=family.value):
+                patterns = dict(registry.DEFAULT_PATTERNS)
+                patterns[family] = ()
+                mutated = self.repo.scan(patterns=patterns)
+                self.assertEqual(mutated.family_violations(baseline)[0].family, family)
+
+    def test_m6_unittest_and_python_path_zero_test_harness_is_not_wiring(self) -> None:
+        bare = "def test_bare(): pass\n"
+        self.repo.write("tests/test_bare.py", bare)
+        for command in (
+            '"$PYTHON" -m unittest tests.test_bare\n',
+            "python3 tests/test_bare.py\n",
+        ):
+            self.repo.write("scripts/ci-script-checks.sh", command)
+            result = self.repo.scan()
+            self.assertEqual(self.candidate(result, "tests/test_bare.py").execution, registry.ExecStatus.NONE)
+            self.assertIn(registry.DiagnosticKind.HARNESS_MISMATCH, {d.kind for d in result.diagnostics})
+        self.repo.write("scripts/ci-script-checks.sh", "pytest tests/test_bare.py\n")
+        self.assertEqual(self.candidate(self.repo.scan(), "tests/test_bare.py").execution, registry.ExecStatus.FULL)
+        self.repo.write("tests/test_runner.py", SUITE + "\nif __name__ == '__main__': unittest.main()\n")
+        self.repo.write("scripts/ci-script-checks.sh", "python3 tests/test_runner.py\n")
+        self.assertEqual(self.candidate(self.repo.scan(), "tests/test_runner.py").execution, registry.ExecStatus.FULL)
+
+    def test_m6b_four_backslash_continuations_are_all_full(self) -> None:
+        paths = [f"tests/test_continuation_{index}.py" for index in range(4)]
+        for path in paths:
+            self.repo.write(path, SUITE)
+        modules = [path[:-3].replace("/", ".") for path in paths]
+        command = '"$PYTHON" -m unittest \\\n  ' + " \\\n  ".join(modules) + "\n"
+        self.repo.write("scripts/ci-script-checks.sh", command)
+        self.assertEqual([self.candidate(self.repo.scan(), path).execution for path in paths], [registry.ExecStatus.FULL] * 4)
+
+    def test_m7_report_gate_and_own_suite_are_independent_cross_seal_records(self) -> None:
+        self.repo.write("scripts/audit_report.py", "print('report only')\n")
+        self.repo.write("tests/test_audit_report.py", SUITE)
+        self.repo.write("scripts/ci-script-checks.sh", '"$PYTHON" -m unittest tests.test_audit_report\n')
+        result = self.repo.scan()
+        self.assertEqual(self.candidate(result, "scripts/audit_report.py").execution, registry.ExecStatus.NONE)
+        self.assertEqual(self.candidate(result, "tests/test_audit_report.py").execution, registry.ExecStatus.FULL)
+        self.repo.write("scripts/ci-script-checks.sh", "#!/usr/bin/env bash\n")
+        self.assertEqual(self.candidate(self.repo.scan(), "tests/test_audit_report.py").execution, registry.ExecStatus.NONE)
+
+    def test_missing_unreadable_and_malformed_sources_are_explicit_fatal_results(self) -> None:
+        missing = registry.scan_registry(
+            self.repo.root, registry.RegistryConfig(surface_sources=("missing",))
+        )
+        self.assertFalse(missing.input_valid)
+        self.assertIn(registry.DiagnosticKind.SOURCE_MISSING, {d.kind for d in missing.diagnostics})
+        self.repo.write("package.json", "{")
+        malformed = registry.scan_registry(
+            self.repo.root, registry.RegistryConfig(surface_sources=("package.json",))
+        )
+        self.assertIn(registry.DiagnosticKind.SOURCE_MALFORMED, {d.kind for d in malformed.diagnostics if d.fatal})
+        (self.repo.root / "unreadable").mkdir()
+        unreadable = registry.scan_registry(
+            self.repo.root, registry.RegistryConfig(surface_sources=("unreadable",))
+        )
+        self.assertIn(registry.DiagnosticKind.SOURCE_UNREADABLE, {d.kind for d in unreadable.diagnostics if d.fatal})
+
+    def test_comments_assertions_arrays_and_strings_do_not_execute_candidates(self) -> None:
+        self.repo.write("tests/test_mentions.py", SUITE)
+        self.repo.write("tests/test_mentions.sh", "#!/bin/sh\ntrue\n")
+        self.repo.write("scripts/ci-script-checks.sh", """
+# "$PYTHON" -m unittest tests.test_mentions
+mention=("$PYTHON" -m unittest tests.test_mentions)
+self.assertIn("python -m unittest tests.test_mentions", lines)
+required_shell_suites=(tests/test_mentions.sh)
+""")
+        result = self.repo.scan()
+        self.assertEqual(self.candidate(result, "tests/test_mentions.py").execution, registry.ExecStatus.NONE)
+        shell = self.candidate(result, "tests/test_mentions.sh")
+        self.assertEqual((shell.execution, shell.pin), (registry.ExecStatus.NONE, registry.PinStatus.REQUIRED_ARRAY))
+
+    def test_exact_method_selection_is_partial_and_preserves_unexecuted_ids(self) -> None:
+        self.repo.write("tests/test_partial.py", SUITE + "\nclass Beta(unittest.TestCase):\n    def test_three(self): pass\n")
+        self.repo.write("scripts/ci-script-checks.sh", '"$PYTHON" -m unittest tests.test_partial.Alpha.test_one\n')
+        result = self.repo.scan()
+        candidate = self.candidate(result, "tests/test_partial.py")
+        self.assertEqual(candidate.execution, registry.ExecStatus.PARTIAL)
+        self.assertEqual(candidate.executed_tests, ("Alpha.test_one",))
+        self.assertEqual(candidate.unexecuted_tests, ("Alpha.test_two", "Beta.test_three"))
+        target = "tests.test_partial.Alpha.test_one"
+        self.assertEqual(result.partial_violations({(candidate.path, target)}), ())
+        self.assertEqual(len(result.partial_violations()), 1)
+
+    def test_shell_full_required_array_and_glob_unpinned_axes_are_distinct(self) -> None:
+        for name in "abc":
+            self.repo.write(f"tests/test_{name}.sh", "#!/bin/sh\ntrue\n")
+        self.repo.write("scripts/ci-script-checks.sh", """
+bash tests/test_a.sh
+required_shell_suites=(tests/test_b.sh)
+for shell_test in tests/*.sh; do
+  bash "$shell_test"
+done
+""")
+        result = self.repo.scan()
+        observed = {name: (self.candidate(result, f"tests/test_{name}.sh").execution, self.candidate(result, f"tests/test_{name}.sh").pin) for name in "abc"}
+        self.assertEqual(observed["a"], (registry.ExecStatus.FULL, registry.PinStatus.PINNED))
+        self.assertEqual(observed["b"], (registry.ExecStatus.GLOB, registry.PinStatus.REQUIRED_ARRAY))
+        self.assertEqual(observed["c"], (registry.ExecStatus.GLOB, registry.PinStatus.GLOB_UNPINNED))
+
+    def test_literal_shell_call_chain_is_recursive_and_dynamic_shape_is_fatal(self) -> None:
+        self.repo.write("tests/test_chain.py", SUITE)
+        self.repo.write("scripts/driver.sh", '#!/bin/sh\n"$PYTHON" -m unittest tests.test_chain\n')
+        self.repo.write("scripts/ci-script-checks.sh", "bash scripts/driver.sh\n")
+        result = self.repo.scan()
+        self.assertEqual(self.candidate(result, "tests/test_chain.py").execution, registry.ExecStatus.FULL)
+        self.assertIn("scripts/driver.sh", result.reachable_sources)
+        self.repo.write("scripts/ci-script-checks.sh", "find tests -name 'test_*.py' -exec python3 {} \\;\n")
+        unsupported = self.repo.scan()
+        self.assertIn(registry.DiagnosticKind.UNSUPPORTED_CALL, {d.kind for d in unsupported.diagnostics if d.fatal})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Implement the #5003 S3a-1 registry core and verifier suite only. The r3 revision closes the three core-boundary P1 findings from the fresh review at `37be8434f785390f5308268c567f9804b4e569a1`.
- Preserve the independent execution axis (`FULL | PARTIAL | GLOB | NONE`), pin axis (`PINNED | REQUIRED_ARRAY | GLOB_UNPINNED | NONE`), exact execution/pin provenance, recursive families, fail-closed tracked inputs, literal reachability, dynamic-target rejection, and live unittest harness checks.
- Run only `tests.test_check_test_suite_registry` from `scripts/ci-script-checks.sh`; registry policy/enforcement remains S3a-2.

## P1 r3 closure

| P1 | Implemented contract |
|---|---|
| Workflow block state/folding | The minimal workflow reader tracks key indentation and consumes every `|`/`>` block as a block, so embedded `run:` text under metadata is inert. Actual `run: |`, `|-`, `|+` preserve newlines; actual `run: >`, `>-`, `>+` space-fold ordinary same-indent content. Inline and quoted scalars plus literal-block backslash continuation remain supported. A sibling real `run:` after a metadata block is recognized. |
| Execution glob slash boundary | Family, pytest, and shell-loop glob selection share one anchored POSIX matcher. `*` and `?` cannot cross `/`; `**` is the only recursive form and `**/` matches zero or more directories. Root-only `tests/*.py`/`*.sh` no longer wires nested candidates, while `tests/**/*.py`/`*.sh` covers root and deep candidates. Exact literal paths and deterministic evidence are unchanged. |
| Comment/backslash ordering | Shell comments are removed quote/escape-aware before continuation detection. Comment-only and command-trailing comments ending in `\` remain valid; quoted `#`, escaped `#`, and real command continuations retain their shell meaning. Unterminated real continuation remains fatal `SOURCE_MALFORMED`. |

## Slice boundary

This draft is still **S3a-1 only**.

- S3a-2 owns allowlists, shrink-only family baselines, the registry-gate CI invocation, enforcement, and cross-seal.
- S3b owns actual unwired-suite wiring/repair and the current `tests.test_audit_maintainability` PARTIAL repair.
- No S3a-2/S3b behavior, policy, wiring, or PARTIAL repair is included here.

## Dependency / landing block

Old S1 PR #5288 is superseded. Replacement PR #5293 is currently OPEN at head `1c1e7322dbc12096b8699a50e8b6a56dc2af7069`. This branch did not merge, cherry-pick, or rebase #5293 or the old branch.

**Do not land #5291** until #5293 merges. After that merge: refetch the new `origin/main`, rebase this branch, recount family/execution/pin/evidence and the full surface, rerun every allowed gate, and obtain a fresh review at the new exact head. Current counts are provisional until that sequence completes.

## Measured contract at `cb460a68e8a1a1c0bb3aac5f85d6dcab0bbf9170`

- Family: `tests_py=49`, `e2e_py=8`, `scripts_py=2`, `shell=12`, `gate_candidates=25`.
- Suite execution: `FULL=41`, `PARTIAL=1`, `GLOB=10`, `NONE=19`.
- Suite pin: `PINNED=42`, `REQUIRED_ARRAY=1`, `GLOB_UNPINNED=9`, `NONE=19`.
- Existing PARTIAL remains 50 defined / 2 executed / 48 unexecuted at exact target `tests.test_audit_maintainability.FooterViewWritesCheck`.
- Python `NONE` remains 19 modules / 237 static test IDs. Fatal/other diagnostics on the tracked tree: 0; `input_valid=True`.
- Exact evidence remains 89 execution invocations and 90 pin evidence records with deterministic source/command/target provenance.

## Tests, mutations, and gates

- Verifier suite: 16 tests, rc=0. The original 14-test assertions remain; the three P1 fixtures are table-driven within the verifier.
- Three syntax/import-safe r3 source mutants all compile/import with rc=0 and return target-suite rc=1: folded workflow blocks reverted to literal newlines; execution matching reverted to slash-crossing `fnmatch.fnmatchcase`; continuation detection reverted to raw-line-before-comment ordering.
- `python3 -m unittest tests.test_check_test_suite_registry` — rc=0, 16 tests.
- `python3 -m py_compile scripts/check_test_suite_registry.py tests/test_check_test_suite_registry.py` — rc=0.
- `bash -n scripts/ci-script-checks.sh` — rc=0.
- `python3 scripts/check_test_suite_registry.py` — rc=0.
- `python3 scripts/generate_inventory_docs.py` — rc=0, all generated outputs unchanged.
- `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate` — rc=0.
- `git diff --check` — rc=0.

## Size and supported boundary

Exact full PR surface against merge-base `309da6db476258afbc3339d9a0e986b42ddbe5d1`: 3 files, `+800/-0`; no existing assertion was deleted or weakened.

This is intentionally not a complete YAML, shell, Make, just, or eval interpreter. Workflow support is limited to literal `run:` scalar/block payloads plus indentation-based block exclusion; folded blank/more-indented YAML semantics, anchors, templates, and matrices remain unsupported. The anchored glob grammar supports segment-local `*`/`?` and recursive `**`/`**/`. Arbitrary dynamic evaluators, composite/reusable workflows, arbitrary Python subprocess construction, runtime collection/count floors, and shell assertion floors remain out of scope.
