### PR TITLE
fix(#5263): rebuild durable-delivery post-deploy probe

### DIFF
--- a/docs/e2e/multi-provider-e2e.md
+++ b/docs/e2e/multi-provider-e2e.md
@@ -126,6 +126,79 @@ health/queue degradation. `E-26` through `E-29` are explicit
 CronCreate live creation, Codex modern-schema production-parser/live stream,
 Codex live tool-command coverage, and `claude-e` tool-use-to-text completeness.
 
+`E-35` preserves the headless `E-1` and adds one normal Discord short-response
+turn. It passes only when the newly observed outbound Discord response ID has
+exactly one authoritative receipt and that receipt has a same-generation
+covering frontier in the local atomic sidecar record. Inbound prompt IDs, old
+frontiers, completed-turn ledgers, leases, and in-memory offsets cannot pass it.
+For production-written records, that receipt also binds the provider, owner
+filename, source and delivery channels, and range; requires nonempty tmux session
+and turn nonce identities; and was current-generation at writer-lock time. On
+this probed short terminal path, reaching the writer follows that turn's
+successful lease commit. E-35 therefore detects both a frontier-only partial
+write and a normal-to-headless `send_prompt` regression that omits the receipt.
+The post-deploy invocation disables reset/force-cancel and rechecks standby,
+target-idle/queue state, and its cell lease before setup and immediately before
+the normal prompt. Busy or dirty residue becomes `unevaluable` without cleanup.
+The prompt-time recheck narrows the nominal gate-return-to-prompt window from
+368 seconds to 0 seconds, and the last-mailbox-snapshot-to-prompt window from
+373 seconds to 5 seconds. It does not close the TOCTOU: local filesystem and
+scheduling have no hard bound, and a turn can start after the recheck and before
+send.
+
+The component timeouts total **1,422 seconds**: two safety gates contribute
+`2 × (5 + 5 + 5) = 30`; setup POST/sleep and pre-send fetch contribute
+`180 + 8 + 180`; prompt POST/sleep, response wait, and durable poll contribute
+`180 + 3 + 240 + 15`; two final refetches plus settle contribute
+`2 × 180 + 1 = 361`; post-scenario idle and teardown contribute `45 + 180`.
+The single **900-second operational cutoff** covers the gate, lease,
+setup/send/fetch HTTP, response wait, record poll, final refetch, idle check, and
+teardown, but it is deliberately not the component sum. Expiry is a fail-open
+finding after `DEPLOY_OK`.
+
+#5264 is a hard prerequisite only for default `claude-tui` live acceptance.
+`claude-pipe` is allowed as `partial coverage`, but is not S8 TUI-surface
+evidence. The minimum positive claim is: 이 노드의 이번 배포 세대에서 E-35의
+한 short-response normal Discord turn이 confirmed durable record funnel을
+통과해, 그 새 Discord response에 결속된 exact receipt와 covering frontier를
+atomic sidecar record에 남겼다. Here “이번 배포 세대” means the local
+post-`DEPLOY_OK` probe transaction; it does not bind a peer, deployed commit SHA,
+or poll-time-current tmux generation. The proof also does not cover power-loss
+durability, every provider/call site, long/fallback/recovery/headless paths,
+completed-ledger persistence, lease acquisition/clear/restart reconciliation,
+continuous health, or S8 rollout. E-35 PASS does not distinguish the spawn writer
+from the `restore.rs` old-generation adoption writer because the durable record
+does not encode which writer produced it.
+
+The durable funnel depends on exactly **five symbols** arranged as **four
+independent enforcement stages**:
+
+1. `shadow_mirror_delivered_frontier_inner` rejects a zero generation and an
+   empty or invalid source range.
+2. `exact_receipt_from_inflight` binds the current inflight/source identity to
+   the receipt and current generation.
+3. `write_confirmed_delivery_at_with_lock_authority` enforces the receipt/frontier
+   coupling. Inside this delivery-writer stage it calls the fifth symbol,
+   `ExactJsonlSourceIdentity::is_authoritative`, as a subordinate predicate that
+   rejects zero or incomplete source identity; that predicate is not a fifth
+   independent enforcement stage.
+4. `write_confirmed_frontier_guarded_at_with_lock_authority` holds writer-lock
+   authority and rereads the current generation to reject a stale writer.
+
+When `.generation` remains absent, ledger-only state cannot satisfy the
+receipt/frontier conjunct. Adoption can create the marker first and allow the
+redundant current-generation defenses to pass together, so without #5264 default
+`claude-tui` acceptance can be a nondeterministic green. An E-35 PASS also includes
+post-scenario mailbox/queue idle evidence. The safety gate depends directly on
+private `lease._read_lease` because no public read API exists; an underscore-
+function refactor can leave E-35 fail-closed and `unevaluable` until the coupling
+is updated.
+
+E-35 alone supplies the durable-record provenance above. The full post-deploy
+E-1 + E-35 sequence additionally checks that the existing headless relay
+round-trip still works; it does not turn the headless E-1 response into S8 TUI
+durability evidence or broaden E-35 to the excluded paths.
+
 ## #2943 Scenario Coverage And Gaps
 
 Covered P0/P1 backlog items:

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -2640,6 +2640,12 @@ POST_DEPLOY_SMOKE_CORE_API_ENDPOINTS=(
 POST_DEPLOY_SMOKE_LOG_LINES="${AGENTDESK_POST_DEPLOY_SMOKE_LOG_LINES:-500}"
 POST_DEPLOY_SMOKE_WARN_LIMIT="${AGENTDESK_POST_DEPLOY_SMOKE_WARN_LIMIT:-5}"
 POST_DEPLOY_SMOKE_RELAY_CELL="${AGENTDESK_POST_DEPLOY_SMOKE_RELAY_CELL:-claude-tui}"
+# The E-35 phase from lease acquisition through scenario execution is capped,
+# including its live safety gate, setup/send/fetch HTTP, response wait, record
+# poll, refetch, idle check, and teardown. The component timeouts total 1,422
+# seconds; 900 seconds is an operational cutoff, not that component sum.
+# Reset costs zero because E-35 forbids reset/force-cancel.
+POST_DEPLOY_SMOKE_E35_DEADLINE_S="${AGENTDESK_POST_DEPLOY_SMOKE_E35_DEADLINE_S:-900}"
 POST_DEPLOY_SMOKE_CREATE_ISSUE="${AGENTDESK_POST_DEPLOY_SMOKE_CREATE_ISSUE:-off}"
 POST_DEPLOY_SMOKE_STAMP="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || printf 'unknown')-$$"
 POST_DEPLOY_SMOKE_EVIDENCE="$ADK_REL/logs/post-deploy-smoke-${POST_DEPLOY_SMOKE_STAMP}.log"
@@ -2648,6 +2654,9 @@ POST_DEPLOY_SMOKE_HEALTH_BODY=""
 POST_DEPLOY_SMOKE_HEALTH_DETAIL_BODY=""
 POST_DEPLOY_SMOKE_SESSIONS_BODY=""
 POST_DEPLOY_SMOKE_FAILURES=()
+POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID=""
+POST_DEPLOY_SMOKE_DURABLE_COVERAGE="unevaluable: E-35 did not run"
+POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE="evaluated"
 
 # >>> BEGIN wedge-check region (#5244) — coverage is report-only and point-in-time
 POST_DEPLOY_SMOKE_WEDGE_MARKER_COVERAGE='evaluated: %s stall-state marker(s) observed (point-in-time)'; POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE="${POST_DEPLOY_SMOKE_WEDGE_MARKER_COVERAGE/\%s/0}"
@@ -3009,6 +3018,8 @@ PY
         return 1
     fi
 
+    POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID="$channel_id"
+
     # E-1 is a real live turn, so reuse the E2E driver's mailbox/session busy
     # predicates against the authenticated core-probe snapshots before sending.
     # An unreadable snapshot skips the injection fail-open: safety requires
@@ -3118,6 +3129,49 @@ PY
     _post_deploy_smoke_note "relay E-1 round-trip=pass" || return 1
 }
 
+_post_deploy_smoke_check_durable_record() {
+    local output log report status rc=0
+    # #5264 is a hard prerequisite only for default claude-tui live acceptance.
+    # claude-pipe is partial coverage and is not S8 TUI-surface evidence.
+    if [ -z "$POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID" ]; then
+        _post_deploy_smoke_note "durable_record_probe=unevaluable: E-35 channel unavailable; probe did not run" || return 1
+        return 0
+    fi
+    output="$ADK_REL/logs/post-deploy-smoke-durable-${POST_DEPLOY_SMOKE_STAMP}"
+    log="$POST_DEPLOY_SMOKE_TMP_DIR/relay-e35.log"
+    (
+        cd "$REPO" || exit 1
+        python3 scripts/e2e/run_tui_relay.py \
+            --base-url "http://${ADK_DEFAULT_LOOPBACK}:${REL_PORT}" \
+            --cell "$POST_DEPLOY_SMOKE_RELAY_CELL" \
+            --channel-id "$POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID" \
+            --scenarios "$REPO/tests/e2e/tui_relay/scenarios" \
+            --filter E-35 --no-reset-before-each \
+            --phase-deadline-s "$POST_DEPLOY_SMOKE_E35_DEADLINE_S" \
+            --output "$output" --queue-runtime-root "$ADK_REL/runtime" \
+            --required-agent-mode real_live --required-coverage-class live
+    ) > "$log" 2>&1 || rc=$?
+    tail -n 40 "$log" >> "$POST_DEPLOY_SMOKE_EVIDENCE" 2>/dev/null || true
+    report="$output/report.${POST_DEPLOY_SMOKE_RELAY_CELL}.json"
+    status=$(python3 - "$report" 2>> "$POST_DEPLOY_SMOKE_EVIDENCE" <<'PY' || printf 'unevaluable'
+import json, sys
+try:
+    report = json.load(open(sys.argv[1], encoding="utf-8"))
+    probes = [s.get("durable_record_probe", {}) for s in report.get("scenarios", []) if s.get("id") == "E-35"]
+    print(probes[-1].get("status", "unevaluable") if probes else "unevaluable")
+except Exception:
+    print("unevaluable")
+PY
+    )
+    POST_DEPLOY_SMOKE_DURABLE_COVERAGE="$status"
+    if [ "$rc" -eq 0 ] && [ "$status" = "evaluated" ]; then
+        _post_deploy_smoke_note "durable_record_probe=evaluated: exact durable receipt and covering frontier observed" || return 1
+        return 0
+    fi
+    _post_deploy_smoke_fail "durable_record_probe=${status}: E-35 rc=${rc}; no cleanup attempted; dirty/active residue may remain (evidence: ${output})" || true
+    return 1
+}
+
 _run_post_deploy_functional_smoke() {
     local failed=0
     mkdir -p "$ADK_REL/logs" || return 1
@@ -3135,6 +3189,9 @@ _run_post_deploy_functional_smoke() {
         failed=1
     fi
     if ! _post_deploy_smoke_check_relay_round_trip; then
+        failed=1
+    fi
+    if ! _post_deploy_smoke_check_durable_record; then
         failed=1
     fi
     rm -rf "$POST_DEPLOY_SMOKE_TMP_DIR" 2>/dev/null || true
@@ -3157,6 +3214,7 @@ _report_post_deploy_smoke_failure() {
         printf -- '- Port: `%s`\n' "$REL_PORT"
         printf -- '- Evidence: `%s`\n\n' "$POST_DEPLOY_SMOKE_EVIDENCE"
         printf -- '- Relay wedge coverage: `%s`\n\n' "${POST_DEPLOY_SMOKE_WEDGE_COVERAGE:-not run: wedge check did not execute}"
+        printf -- "- Durable record coverage: \`%s\`\n\n" "${POST_DEPLOY_SMOKE_DURABLE_COVERAGE:-unevaluable: E-35 did not run}"
         printf '## Findings\n\n'
         for finding in "${POST_DEPLOY_SMOKE_FAILURES[@]}"; do
             printf -- '- %s\n' "$finding"
@@ -3175,6 +3233,8 @@ draft: ${draft_path}
 evidence: ${POST_DEPLOY_SMOKE_EVIDENCE}"
     alert_text="${alert_text}
 relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE:-not run: wedge check did not execute}"
+    alert_text="${alert_text}
+durable record coverage: ${POST_DEPLOY_SMOKE_DURABLE_COVERAGE:-unevaluable: E-35 did not run}"
     for finding in "${POST_DEPLOY_SMOKE_FAILURES[@]}"; do
         alert_text="${alert_text}
 - ${finding}"
@@ -3238,6 +3298,11 @@ echo "▸ Running post-deploy functional smoke (#4262)..."
 # The smoke function runs from an `if` guard, suspending `set -e` within it;
 # each fallible step is nevertheless explicitly guarded or carries `|| return`.
 if _run_post_deploy_functional_smoke; then
+    if case "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE:$POST_DEPLOY_SMOKE_DURABLE_COVERAGE" in
+        "$POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE:$POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE") true ;;
+        *) false ;;
+    esac
+    then
     case "$POST_DEPLOY_SMOKE_WEDGE_COVERAGE" in
         "$POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE")
             echo "✓ Post-deploy functional smoke passed (relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}; evidence: $POST_DEPLOY_SMOKE_EVIDENCE)"
@@ -3246,6 +3311,10 @@ if _run_post_deploy_functional_smoke; then
             echo "△ Post-deploy functional smoke completed with coverage gap (relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}; evidence: $POST_DEPLOY_SMOKE_EVIDENCE)"
             ;;
     esac
+            echo "  durable record coverage: ${POST_DEPLOY_SMOKE_DURABLE_COVERAGE}"
+    else
+            echo "△ Post-deploy functional smoke completed with coverage gap (relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}; durable record coverage: ${POST_DEPLOY_SMOKE_DURABLE_COVERAGE}; evidence: $POST_DEPLOY_SMOKE_EVIDENCE)"
+    fi
 else
     echo "⚠ POST-DEPLOY FUNCTIONAL SMOKE FAILED — deploy remains healthy (fail-open)"
     echo "  relay wedge coverage: ${POST_DEPLOY_SMOKE_WEDGE_COVERAGE}"

--- a/scripts/e2e/run_tui_relay.py
+++ b/scripts/e2e/run_tui_relay.py
@@ -32,6 +32,7 @@ import datetime as dt
 import json
 import math
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -44,7 +45,7 @@ import yaml  # type: ignore[import-untyped]
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from tui_relay import assertions, discord, fixtures, lease, tmux  # noqa: E402
+from tui_relay import assertions, discord, durable_delivery, fixtures, lease, tmux  # noqa: E402
 
 
 SUPPORTED_CELLS: tuple[str, ...] = (
@@ -64,6 +65,7 @@ COVERAGE_CLASS_RANK = {
 }
 REAL_PROVIDER_STEP_KEYS: tuple[str, ...] = (
     "send_prompt",
+    "send_discord_prompt",
     "send_provider_hold_prompt",
     "send_timed_response_prompt",
     "send_prompts_concurrent",
@@ -150,7 +152,29 @@ REPORT_RECORD_KEYS: tuple[str, ...] = (
     "real_provider_contacted",
     "controlled_harness_evidence",
     "failure_attribution",
+    "durable_record_probe",
+    "dirty_active_residue",
 )
+
+
+class PhaseDeadlineExpired(BaseException):
+    """Hard wall-clock deadline; bypass scenario cleanup and preserve residue."""
+
+
+def _arm_phase_deadline(seconds: float):
+    previous = signal.getsignal(signal.SIGALRM)
+
+    def expire(_signum, _frame):
+        raise PhaseDeadlineExpired(f"E-35 phase exceeded {seconds:g}s")
+
+    signal.signal(signal.SIGALRM, expire)
+    signal.setitimer(signal.ITIMER_REAL, max(seconds, 0.001))
+    return previous
+
+
+def _disarm_phase_deadline(previous) -> None:
+    signal.setitimer(signal.ITIMER_REAL, 0)
+    signal.signal(signal.SIGALRM, previous)
 
 
 class ScenarioStepAssertionError(assertions.AssertionError):
@@ -265,6 +289,12 @@ def parse_args() -> argparse.Namespace:
         "--turn-start-timeout-s",
         default=turn_start_timeout_default,
         help="How long send_prompt retries transient mailbox-busy turn/start responses.",
+    )
+    parser.add_argument(
+        "--phase-deadline-s",
+        type=float,
+        default=None,
+        help="Hard wall-clock limit from lease acquisition through selected scenario execution.",
     )
     parser.add_argument(
         "--required-agent-mode",
@@ -2083,6 +2113,67 @@ def _mailbox_busy_reasons(mailbox: dict[str, Any]) -> list[str]:
     return reasons
 
 
+def durable_probe_safety_gate(
+    *, base_url: str, cell: str, channel_id: str, runtime_root: Path, lease_run_id: str
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    try:
+        status, health = _read_api_json(base_url, "/api/health", timeout=5)
+        detail = _read_health_detail(base_url, timeout=5)
+        sessions_status, sessions_payload = _read_api_json(
+            base_url, "/api/sessions", timeout=5
+        )
+    except Exception as error:  # noqa: BLE001 - unreadable safety state forbids injection
+        return {
+            "status": "unevaluable",
+            "dirty_active_residue": True,
+            "reasons": [f"safety state unreadable: {type(error).__name__}: {error}"],
+        }
+    if status >= 400 or not isinstance(health, dict) or health.get("cluster_standby") is not False:
+        reasons.append("cluster_standby is true or unreadable")
+    mailboxes = detail.get("mailboxes")
+    provider = cell_provider(cell)
+    targets = [
+        box for box in mailboxes if isinstance(box, dict)
+        and _mailbox_channel_id(box) == str(channel_id)
+        and _mailbox_provider(box) == provider
+    ] if isinstance(mailboxes, list) else []
+    if not targets:
+        reasons.append("target mailbox unavailable")
+    for mailbox in targets:
+        reasons.extend(_mailbox_busy_reasons(mailbox))
+    sessions = (
+        sessions_payload.get("sessions")
+        if isinstance(sessions_payload, dict)
+        else sessions_payload
+    )
+    if sessions_status >= 400 or not isinstance(sessions, list):
+        reasons.append("target sessions unavailable")
+    else:
+        workspace = cell_workspace_substring(cell)
+        for session in sessions:
+            if not isinstance(session, dict):
+                continue
+            state = str(session.get("status") or "").lower()
+            session_channel = str(
+                session.get("channel_id") or session.get("channelId") or ""
+            )
+            session_key = str(session.get("session_key") or "")
+            if state in {"turn_active", "turn_busy", "active"} and (
+                session_channel == str(channel_id) or workspace in session_key
+            ):
+                reasons.append(f"active target session={session_key or session_channel}")
+    reasons.extend(_runtime_queue_violations(
+        runtime_root=runtime_root, provider=provider, channel_id=str(channel_id)
+    ))
+    held = lease._read_lease(lease.lease_path_for(cell))  # noqa: SLF001
+    if not held or held.get("run_id") != lease_run_id:
+        reasons.append("E2E cell lease is not held by this probe")
+    if reasons:
+        return {"status": "unevaluable", "dirty_active_residue": True, "reasons": reasons}
+    return {"status": "idle", "dirty_active_residue": False}
+
+
 def _mailbox_idle_evidence(mailbox: dict[str, Any]) -> dict[str, Any]:
     """Capture the /api/health/detail idle fields a regression like #2935 watches.
 
@@ -2768,7 +2859,22 @@ def run_scenario(
             )
         return result
 
-    if args.reset_before_each and not args.dry_run and not is_local_fixture_scenario(scenario):
+    durable_probe = bool(scenario.get("durable_delivery_probe"))
+    if durable_probe and not args.dry_run:
+        safety = durable_probe_safety_gate(
+            base_url=args.base_url,
+            cell=cell,
+            channel_id=target_channel_id,
+            runtime_root=Path(args.queue_runtime_root),
+            lease_run_id=f"{cell}-{run_id}",
+        )
+        if safety["status"] != "idle":
+            result["status"] = "fail"
+            result["reason"] = "E-35 safety gate refused injection"
+            result["durable_record_probe"] = {"status": "unevaluable", "reason": result["reason"]}
+            result["dirty_active_residue"] = safety
+            return result
+    if args.reset_before_each and not durable_probe and not args.dry_run and not is_local_fixture_scenario(scenario):
         runtime_root = Path(args.queue_runtime_root)
         result["resets"] = [
             reset_channel_state(
@@ -2999,6 +3105,11 @@ def run_one_cell(
         "provider_identity": provider_identity(cell, channel_id),
         "real_provider_contacted": False,
     }
+    if scenario.get("durable_delivery_probe"):
+        record["durable_record_probe"] = {
+            "status": "unevaluable", "reason": "response not observed",
+        }
+        record["dirty_active_residue"] = {"possible": True, "cleanup_attempted": False}
     if partial_record_sink is not None:
         partial_record_sink["record"] = record
 
@@ -3048,7 +3159,28 @@ def run_one_cell(
             record.setdefault("controlled_harness_evidence", []).append(
                 controlled_evidence
             )
-        if "send_prompt" in step:
+        if "send_discord_prompt" in step:
+            _prepare_first_prompt_window()
+            if scenario.get("durable_delivery_probe"):
+                safety = durable_probe_safety_gate(
+                    base_url=args.base_url,
+                    cell=cell,
+                    channel_id=channel_id,
+                    runtime_root=Path(args.queue_runtime_root),
+                    lease_run_id=f"{cell}-{run_id}",
+                )
+                if safety["status"] != "idle":
+                    record["dirty_active_residue"] = safety
+                    return record
+            window.mark_prompt_sent()
+            last_sent_prompt = str(step["send_discord_prompt"]).replace("{run_id}", run_id)
+            response = client.send(channel_id, last_sent_prompt)
+            record["durable_record_probe"]["inbound_prompt_id"] = str(
+                response.get("message_id") or response.get("id") or ""
+            )
+            _mark_real_provider_contacted(record, declared_agent_mode=declared_agent_mode, dry_run=dry_run)
+            time.sleep(3)
+        elif "send_prompt" in step:
             _prepare_first_prompt_window()
             window.mark_prompt_sent()
             last_sent_prompt = str(step["send_prompt"])
@@ -3142,7 +3274,7 @@ def run_one_cell(
         elif "wait_idle_s" in step:
             time.sleep(float(step["wait_idle_s"]))
         elif "wait_for_discord_text" in step:
-            needle = step["wait_for_discord_text"]
+            needle = str(step["wait_for_discord_text"]).replace("{run_id}", run_id)
             found, observed = wait_for_discord_text_with_tui_idle_draft_guard(
                 client=client,
                 channel_id=channel_id,
@@ -3179,6 +3311,26 @@ def run_one_cell(
                     f"diagnostic={_payload_summary(diagnostic, max_chars=1400)}",
                     record=record,
                 )
+            if scenario.get("durable_delivery_probe"):
+                response_id = str(found.get("id") or "")
+                record["durable_record_probe"] = durable_delivery.poll_records(
+                    Path(args.queue_runtime_root),
+                    provider=cell_provider(cell),
+                    channel_id=channel_id,
+                    message_id=response_id,
+                )
+                record["durable_record_probe"]["coverage_scope"] = (
+                    "partial coverage; not S8 TUI-surface evidence"
+                    if cell == "claude-pipe"
+                    else "default claude-tui live acceptance"
+                )
+                if record["durable_record_probe"]["status"] != "evaluated":
+                    _update_record_window_snapshot(record, window)
+                    raise ScenarioStepAssertionError(
+                        f"durable record probe {record['durable_record_probe']['status']}: "
+                        f"{record['durable_record_probe']['reason']}",
+                        record=record,
+                    )
         elif "wait_for_raw_discord_text" in step:
             needle = step["wait_for_raw_discord_text"]
             predicate = lambda message: (  # noqa: E731
@@ -3510,6 +3662,8 @@ def run_one_cell(
             runtime_root=Path(args.queue_runtime_root),
         )
         record["post_scenario_idle"] = idle_check
+        if scenario.get("durable_delivery_probe"):
+            record["dirty_active_residue"] = {"possible": False, "cleanup_attempted": False}
         record["assertions"].append(
             {
                 "spec": {"post_scenario_cell_idle": True},
@@ -4101,13 +4255,35 @@ def main() -> int:
     )
 
     lease_token = f"{cell}-{run_id}"
-    with lease.acquire(lease_token, cell=cell) if not args.dry_run else _null_lease(run_id):
-        results: list[dict[str, Any]] = []
-        for scenario in scenarios:
-            print(f"[e2e] running {scenario.get('id')} cell={cell}")
-            result = run_scenario(scenario, args=args, run_id=run_id, client=client)
-            print(f"[e2e]   → {result['status']} {result.get('reason') or ''}")
-            results.append(result)
+    results: list[dict[str, Any]] = []
+    previous_alarm = _arm_phase_deadline(args.phase_deadline_s) if args.phase_deadline_s else None
+    try:
+        with lease.acquire(lease_token, cell=cell) if not args.dry_run else _null_lease(run_id):
+            for scenario in scenarios:
+                print(f"[e2e] running {scenario.get('id')} cell={cell}")
+                result = run_scenario(scenario, args=args, run_id=run_id, client=client)
+                print(f"[e2e]   → {result['status']} {result.get('reason') or ''}")
+                results.append(result)
+    except PhaseDeadlineExpired as error:
+        results.append({
+            "id": "E-35", "cell": cell, "provider": cell_provider(cell),
+            "runtime": cell_runtime(cell), "status": "fail", "reason": str(error),
+            "durable_record_probe": {"status": "unevaluable", "reason": str(error)},
+            "dirty_active_residue": {"possible": True, "cleanup_attempted": False},
+        })
+    except Exception as error:  # lease/safety setup failed before an artifact existed
+        if not args.phase_deadline_s:
+            raise
+        reason = f"E-35 phase unevaluable: {type(error).__name__}: {error}"
+        results.append({
+            "id": "E-35", "cell": cell, "provider": cell_provider(cell),
+            "runtime": cell_runtime(cell), "status": "fail", "reason": reason,
+            "durable_record_probe": {"status": "unevaluable", "reason": reason},
+            "dirty_active_residue": {"possible": True, "cleanup_attempted": False},
+        })
+    finally:
+        if previous_alarm is not None:
+            _disarm_phase_deadline(previous_alarm)
 
     # Always cell-tag the report filename so an orchestrator that passes a
     # shared --output dir for all 5 cells never overwrites a sibling report.

--- a/scripts/e2e/tui_relay/durable_delivery.py
+++ b/scripts/e2e/tui_relay/durable_delivery.py
@@ -1,0 +1,121 @@
+"""Read-after-write validator for the E-35 durable delivery record probe."""
+import json
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+
+def _int(value: Any, minimum: int = 1) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= minimum else None
+
+
+def _range(value: Any) -> tuple[int, int] | None:
+    if not isinstance(value, list) or len(value) != 2:
+        return None
+    start, end = (_int(value[0], 0), _int(value[1]))
+    if start is None or end is None or end <= start:
+        return None
+    return start, end
+
+
+def _matching_receipt(receipt: Any, *, provider: str, channel_id: int,
+                      message_id: int, owner_id: int) -> dict[str, Any] | None:
+    if not isinstance(receipt, dict) or not isinstance(receipt.get("source"), dict):
+        return None
+    source = receipt["source"]
+    source_range = _range(source.get("range"))
+    generation = _int(source.get("generation_mtime_ns"))
+    authoritative = (
+        source.get("provider") == provider
+        and bool(source.get("tmux_session_name"))
+        and bool(source.get("turn_nonce"))
+        and _int(source.get("offset_authority_channel_id")) == owner_id
+        and _int(source.get("delivery_channel_id")) == channel_id
+        and _int(receipt.get("delivery_channel_id")) == channel_id
+        and _int(receipt.get("message_id")) == message_id
+    )
+    if not authoritative or source_range is None or generation is None:
+        return None
+    return {"range": source_range, "generation_mtime_ns": generation}
+
+
+def scan_records(runtime_root: Path, *, provider: str, channel_id: str,
+                 message_id: str) -> dict[str, Any]:
+    provider_dir = runtime_root / "discord_delivery_records" / provider
+    try:
+        paths = sorted(provider_dir.glob("*.json"))
+    except OSError as error:
+        return {"status": "unevaluable", "reason": f"record scan unavailable: {error}"}
+    if not provider_dir.is_dir():
+        return {"status": "unevaluable", "reason": f"record directory unavailable: {provider_dir}"}
+    channel, message = _int(channel_id), _int(message_id)
+    if channel is None or message is None:
+        return {"status": "unevaluable", "reason": "invalid response identity"}
+    matches: list[tuple[Path, dict[str, Any], dict[str, Any]]] = []
+    malformed: list[str] = []
+    for path in paths:
+        try:
+            owner = _int(path.stem)
+            record = json.loads(path.read_text(encoding="utf-8"))
+            if owner is None or not isinstance(record, dict):
+                raise ValueError("invalid owner filename or record object")
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            malformed.append(f"{path.name}: {type(error).__name__}")
+            continue
+        receipts = record.get("confirmed_deliveries") or []
+        if not isinstance(receipts, list):
+            malformed.append(f"{path.name}: confirmed_deliveries is not a list")
+            continue
+        for receipt in receipts:
+            exact = _matching_receipt(receipt, provider=provider, channel_id=channel,
+                                      message_id=message, owner_id=owner)
+            if exact is not None:
+                matches.append((path, exact, record))
+
+    if len(matches) != 1:
+        reason = f"expected one exact receipt, found {len(matches)}"
+        if malformed:
+            reason += f"; malformed={malformed[:4]}"
+        return {"status": "failed", "reason": reason, "exact_receipts": len(matches)}
+    path, receipt, record = matches[0]
+    frontier = record.get("delivered_frontier")
+    frontier_range = _range(frontier.get("range")) if isinstance(frontier, dict) else None
+    covered = (
+        frontier_range is not None
+        and _int(frontier.get("generation_mtime_ns")) == receipt["generation_mtime_ns"]
+        and frontier_range[1] >= receipt["range"][1]
+        and _int(frontier.get("panel_channel_id")) == channel
+    )
+    if not covered:
+        return {"status": "failed", "reason": "exact receipt lacks covering frontier"}
+    return {
+        "status": "evaluated",
+        "reason": "exact durable receipt and covering frontier observed",
+        "record": str(path),
+        "response_message_id": str(message),
+    }
+
+
+def poll_records(
+    runtime_root: Path, *, provider: str, channel_id: str, message_id: str,
+    timeout_s: float = 15.0,
+    interval_s: float = 0.25,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    started = monotonic()
+    deadline = started + max(timeout_s, 0.0)
+    result = scan_records(runtime_root, provider=provider, channel_id=channel_id,
+                          message_id=message_id)
+    while result["status"] != "evaluated" and monotonic() < deadline:
+        sleep(min(interval_s, max(0.0, deadline - monotonic())))
+        result = scan_records(runtime_root, provider=provider, channel_id=channel_id,
+                              message_id=message_id)
+    result["elapsed_s"] = round(monotonic() - started, 3)
+    return result

--- a/scripts/e2e/tui_relay/durable_delivery.py
+++ b/scripts/e2e/tui_relay/durable_delivery.py
@@ -5,20 +5,39 @@ from pathlib import Path
 from typing import Any, Callable
 
 
-def _int(value: Any, minimum: int = 1) -> int | None:
-    if isinstance(value, bool):
+def _json_int(value: Any, minimum: int = 1) -> int | None:
+    if type(value) is not int:
         return None
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
+    return value if value >= minimum else None
+
+
+def _expected_id(value: Any) -> int | None:
+    if (
+        not isinstance(value, str)
+        or not value
+        or not value.isascii()
+        or not value.isdecimal()
+    ):
         return None
-    return parsed if parsed >= minimum else None
+    parsed = int(value, 10)
+    return parsed if parsed >= 1 else None
+
+
+def _owner_id(value: str) -> int | None:
+    if not value or not value.isascii() or not value.isdecimal():
+        return None
+    parsed = int(value, 10)
+    return parsed if parsed >= 1 else None
+
+
+def _identity_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
 
 
 def _range(value: Any) -> tuple[int, int] | None:
     if not isinstance(value, list) or len(value) != 2:
         return None
-    start, end = (_int(value[0], 0), _int(value[1]))
+    start, end = (_json_int(value[0], 0), _json_int(value[1]))
     if start is None or end is None or end <= start:
         return None
     return start, end
@@ -30,23 +49,34 @@ def _matching_receipt(receipt: Any, *, provider: str, channel_id: int,
         return None
     source = receipt["source"]
     source_range = _range(source.get("range"))
-    generation = _int(source.get("generation_mtime_ns"))
+    generation = _json_int(source.get("generation_mtime_ns"))
     authoritative = (
-        source.get("provider") == provider
-        and bool(source.get("tmux_session_name"))
-        and bool(source.get("turn_nonce"))
-        and _int(source.get("offset_authority_channel_id")) == owner_id
-        and _int(source.get("delivery_channel_id")) == channel_id
-        and _int(receipt.get("delivery_channel_id")) == channel_id
-        and _int(receipt.get("message_id")) == message_id
+        _identity_string(source.get("provider"))
+        and source.get("provider") == provider
+        and _identity_string(source.get("tmux_session_name"))
+        and _identity_string(source.get("turn_nonce"))
+        and _json_int(source.get("offset_authority_channel_id")) == owner_id
+        and _json_int(source.get("delivery_channel_id")) == channel_id
+        and _json_int(receipt.get("delivery_channel_id")) == channel_id
+        and _json_int(receipt.get("message_id")) == message_id
     )
     if not authoritative or source_range is None or generation is None:
         return None
     return {"range": source_range, "generation_mtime_ns": generation}
 
 
-def scan_records(runtime_root: Path, *, provider: str, channel_id: str,
-                 message_id: str) -> dict[str, Any]:
+def _invalid_query() -> dict[str, Any]:
+    return {
+        "status": "failed",
+        "reason": (
+            "invalid query identity: provider must be a nonempty string and "
+            "channel_id/message_id must be nonzero ASCII decimal strings"
+        ),
+    }
+
+
+def _scan_records(runtime_root: Path, *, provider: str, channel_id: int,
+                  message_id: int) -> dict[str, Any]:
     provider_dir = runtime_root / "discord_delivery_records" / provider
     try:
         paths = sorted(provider_dir.glob("*.json"))
@@ -54,14 +84,11 @@ def scan_records(runtime_root: Path, *, provider: str, channel_id: str,
         return {"status": "unevaluable", "reason": f"record scan unavailable: {error}"}
     if not provider_dir.is_dir():
         return {"status": "unevaluable", "reason": f"record directory unavailable: {provider_dir}"}
-    channel, message = _int(channel_id), _int(message_id)
-    if channel is None or message is None:
-        return {"status": "unevaluable", "reason": "invalid response identity"}
     matches: list[tuple[Path, dict[str, Any], dict[str, Any]]] = []
     malformed: list[str] = []
     for path in paths:
         try:
-            owner = _int(path.stem)
+            owner = _owner_id(path.stem)
             record = json.loads(path.read_text(encoding="utf-8"))
             if owner is None or not isinstance(record, dict):
                 raise ValueError("invalid owner filename or record object")
@@ -73,8 +100,8 @@ def scan_records(runtime_root: Path, *, provider: str, channel_id: str,
             malformed.append(f"{path.name}: confirmed_deliveries is not a list")
             continue
         for receipt in receipts:
-            exact = _matching_receipt(receipt, provider=provider, channel_id=channel,
-                                      message_id=message, owner_id=owner)
+            exact = _matching_receipt(receipt, provider=provider, channel_id=channel_id,
+                                      message_id=message_id, owner_id=owner)
             if exact is not None:
                 matches.append((path, exact, record))
 
@@ -88,9 +115,9 @@ def scan_records(runtime_root: Path, *, provider: str, channel_id: str,
     frontier_range = _range(frontier.get("range")) if isinstance(frontier, dict) else None
     covered = (
         frontier_range is not None
-        and _int(frontier.get("generation_mtime_ns")) == receipt["generation_mtime_ns"]
+        and _json_int(frontier.get("generation_mtime_ns")) == receipt["generation_mtime_ns"]
         and frontier_range[1] >= receipt["range"][1]
-        and _int(frontier.get("panel_channel_id")) == channel
+        and _json_int(frontier.get("panel_channel_id")) == channel_id
     )
     if not covered:
         return {"status": "failed", "reason": "exact receipt lacks covering frontier"}
@@ -98,8 +125,18 @@ def scan_records(runtime_root: Path, *, provider: str, channel_id: str,
         "status": "evaluated",
         "reason": "exact durable receipt and covering frontier observed",
         "record": str(path),
-        "response_message_id": str(message),
+        "response_message_id": str(message_id),
     }
+
+
+def scan_records(runtime_root: Path, *, provider: str, channel_id: str,
+                 message_id: str) -> dict[str, Any]:
+    channel, message = _expected_id(channel_id), _expected_id(message_id)
+    if not _identity_string(provider) or channel is None or message is None:
+        return _invalid_query()
+    return _scan_records(
+        runtime_root, provider=provider, channel_id=channel, message_id=message
+    )
 
 
 def poll_records(
@@ -111,11 +148,16 @@ def poll_records(
 ) -> dict[str, Any]:
     started = monotonic()
     deadline = started + max(timeout_s, 0.0)
-    result = scan_records(runtime_root, provider=provider, channel_id=channel_id,
-                          message_id=message_id)
+    channel, message = _expected_id(channel_id), _expected_id(message_id)
+    if not _identity_string(provider) or channel is None or message is None:
+        result = _invalid_query()
+        result["elapsed_s"] = round(monotonic() - started, 3)
+        return result
+    result = _scan_records(runtime_root, provider=provider, channel_id=channel,
+                           message_id=message)
     while result["status"] != "evaluated" and monotonic() < deadline:
         sleep(min(interval_s, max(0.0, deadline - monotonic())))
-        result = scan_records(runtime_root, provider=provider, channel_id=channel_id,
-                              message_id=message_id)
+        result = _scan_records(runtime_root, provider=provider, channel_id=channel,
+                               message_id=message)
     result["elapsed_s"] = round(monotonic() - started, 3)
     return result

--- a/scripts/e2e/tui_relay/test_durable_delivery.py
+++ b/scripts/e2e/tui_relay/test_durable_delivery.py
@@ -61,14 +61,133 @@ class RecordFixtures(unittest.TestCase):
     def write(self, record: dict, owner: str = "42") -> None:
         (self.records / f"{owner}.json").write_text(json.dumps(record), encoding="utf-8")
 
-    def scan(self, message_id: str = "222") -> dict:
+    def scan(
+        self,
+        message_id: str = "222",
+        *,
+        channel_id: str = "99",
+        provider: str = "claude",
+    ) -> dict:
         return durable_delivery.scan_records(
-            self.root, provider="claude", channel_id="99", message_id=message_id
+            self.root, provider=provider, channel_id=channel_id, message_id=message_id
         )
 
     def test_exact_response_receipt_and_covering_frontier_are_evaluated(self):
         self.write(_record(_receipt(222), end=30))
         self.assertEqual(self.scan()["status"], "evaluated")
+
+    def test_raw_authority_numbers_require_exact_json_integers(self):
+        cases = (
+            ("receipt message fractional", ("confirmed_deliveries", 0, "message_id"), 222.9),
+            ("receipt message integer float", ("confirmed_deliveries", 0, "message_id"), 222.0),
+            ("receipt message numeric string", ("confirmed_deliveries", 0, "message_id"), "222"),
+            ("receipt message bool", ("confirmed_deliveries", 0, "message_id"), True),
+            ("receipt message null", ("confirmed_deliveries", 0, "message_id"), None),
+            ("receipt message list", ("confirmed_deliveries", 0, "message_id"), [222]),
+            ("receipt message object", ("confirmed_deliveries", 0, "message_id"), {"id": 222}),
+            ("receipt range start", ("confirmed_deliveries", 0, "source", "range", 0), 10.9),
+            ("receipt range end", ("confirmed_deliveries", 0, "source", "range", 1), 20.9),
+            (
+                "receipt generation",
+                ("confirmed_deliveries", 0, "source", "generation_mtime_ns"),
+                77.9,
+            ),
+            (
+                "offset authority channel",
+                ("confirmed_deliveries", 0, "source", "offset_authority_channel_id"),
+                42.9,
+            ),
+            (
+                "source delivery channel",
+                ("confirmed_deliveries", 0, "source", "delivery_channel_id"),
+                99.9,
+            ),
+            (
+                "receipt delivery channel",
+                ("confirmed_deliveries", 0, "delivery_channel_id"),
+                99.9,
+            ),
+            ("frontier range start", ("delivered_frontier", "range", 0), 10.9),
+            ("frontier range end", ("delivered_frontier", "range", 1), 30.9),
+            (
+                "frontier generation",
+                ("delivered_frontier", "generation_mtime_ns"),
+                77.9,
+            ),
+            ("frontier channel", ("delivered_frontier", "panel_channel_id"), 99.9),
+        )
+        for name, path, malformed in cases:
+            with self.subTest(name=name):
+                record = _record(_receipt(222), end=30)
+                target = record
+                for component in path[:-1]:
+                    target = target[component]
+                target[path[-1]] = malformed
+                self.write(record)
+                result = self.scan()
+                self.assertEqual(result["status"], "failed", result)
+
+    def test_receipt_identity_fields_require_nonempty_strings(self):
+        cases = (
+            ("tmux integer", "tmux_session_name", 1),
+            ("turn nonce list", "turn_nonce", ["n"]),
+            ("tmux whitespace", "tmux_session_name", "  \t"),
+            ("turn nonce whitespace", "turn_nonce", "\n"),
+        )
+        for name, field, malformed in cases:
+            with self.subTest(name=name):
+                receipt = _receipt(222)
+                receipt["source"][field] = malformed
+                self.write(_record(receipt))
+                result = self.scan()
+                self.assertEqual(result["status"], "failed", result)
+
+    def test_source_and_expected_provider_require_nonempty_strings(self):
+        for malformed in (1, ["claude"], {"name": "claude"}, True, "", "  "):
+            with self.subTest(record_provider=malformed):
+                receipt = _receipt(222)
+                receipt["source"]["provider"] = malformed
+                self.write(_record(receipt))
+                self.assertEqual(self.scan()["status"], "failed")
+            with self.subTest(expected_provider=malformed):
+                result = self.scan(provider=malformed)
+                self.assertEqual(result["status"], "failed", result)
+                self.assertIn("invalid query identity", result["reason"])
+
+    def test_owner_filename_requires_nonzero_ascii_decimal(self):
+        for owner in (" 42", "+42", "42.0", "true", ""):
+            with self.subTest(owner=owner):
+                path = self.records / f"{owner}.json"
+                path.write_text(json.dumps(_record(_receipt(222))), encoding="utf-8")
+                result = self.scan()
+                self.assertEqual(result["status"], "failed", result)
+                path.unlink()
+
+    def test_expected_ids_require_nonzero_ascii_decimal_strings(self):
+        malformed_values = (
+            " 99", "99 ", "+99", "-99", "99.0", "9.9e1", "true", "", "0", "９９", 99, True
+        )
+        self.write(_record(_receipt(222)))
+        for field in ("channel_id", "message_id"):
+            for malformed in malformed_values:
+                with self.subTest(field=field, value=malformed):
+                    kwargs = {field: malformed}
+                    result = self.scan(**kwargs)
+                    self.assertEqual(result["status"], "failed", result)
+                    self.assertIn("invalid query identity", result["reason"])
+
+    def test_poll_rejects_malformed_expected_id_without_retry(self):
+        ticks = iter((0.0, 0.0))
+        result = durable_delivery.poll_records(
+            self.root,
+            provider="claude",
+            channel_id="99",
+            message_id="222.9",
+            monotonic=lambda: next(ticks),
+            sleep=lambda _seconds: self.fail("malformed query retried"),
+        )
+        self.assertEqual(result["status"], "failed", result)
+        self.assertIn("invalid query identity", result["reason"])
 
     def test_inbound_prompt_id_cannot_substitute_for_outbound_response_id(self):
         self.write(_record(_receipt(111)))

--- a/scripts/e2e/tui_relay/test_durable_delivery.py
+++ b/scripts/e2e/tui_relay/test_durable_delivery.py
@@ -1,0 +1,362 @@
+"""Fixtures for the E-35 exact durable record and live-safety contracts."""
+
+from __future__ import annotations
+
+import json
+import signal
+import sys
+import tempfile
+import time
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "scripts" / "e2e"))
+
+import run_tui_relay as driver  # noqa: E402
+from tui_relay import durable_delivery  # noqa: E402
+
+
+def _receipt(message_id: int, *, generation: int = 77, nonce: str = "turn-1") -> dict:
+    return {
+        "source": {
+            "provider": "claude",
+            "tmux_session_name": "AgentDesk-claude-e2e",
+            "turn_nonce": nonce,
+            "range": [10, 20],
+            "generation_mtime_ns": generation,
+            "offset_authority_channel_id": 42,
+            "delivery_channel_id": 99,
+        },
+        "delivery_channel_id": 99,
+        "message_id": message_id,
+    }
+
+
+def _record(*receipts: dict, generation: int = 77, end: int = 20) -> dict:
+    return {
+        "delivered_frontier": {
+            "range": [10, end],
+            "generation_mtime_ns": generation,
+            "attempts": 1,
+            "panel_msg_id": 222,
+            "panel_channel_id": 99,
+        },
+        "confirmed_deliveries": list(receipts),
+    }
+
+
+class RecordFixtures(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.records = self.root / "discord_delivery_records" / "claude"
+        self.records.mkdir(parents=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write(self, record: dict, owner: str = "42") -> None:
+        (self.records / f"{owner}.json").write_text(json.dumps(record), encoding="utf-8")
+
+    def scan(self, message_id: str = "222") -> dict:
+        return durable_delivery.scan_records(
+            self.root, provider="claude", channel_id="99", message_id=message_id
+        )
+
+    def test_exact_response_receipt_and_covering_frontier_are_evaluated(self):
+        self.write(_record(_receipt(222), end=30))
+        self.assertEqual(self.scan()["status"], "evaluated")
+
+    def test_inbound_prompt_id_cannot_substitute_for_outbound_response_id(self):
+        self.write(_record(_receipt(111)))
+        result = self.scan("222")
+        self.assertEqual(result["status"], "failed", result)
+        self.assertEqual(result["exact_receipts"], 0)
+
+    def test_same_message_multiple_receipts_is_deterministic_failure(self):
+        self.write(_record(_receipt(222), _receipt(222, nonce="turn-2")))
+        result = self.scan()
+        self.assertEqual(result["status"], "failed", result)
+        self.assertEqual(result["exact_receipts"], 2)
+
+    def test_receipt_frontier_generation_mismatch_is_failed(self):
+        self.write(_record(_receipt(222, generation=77), generation=88))
+        self.assertEqual(self.scan()["status"], "failed")
+
+    def test_receipt_range_requires_covering_frontier(self):
+        self.write(_record(_receipt(222), end=15))
+        self.assertEqual(self.scan()["status"], "failed")
+
+    def test_frontier_panel_channel_must_match_delivery_channel(self):
+        self.write(_record(_receipt(222)))
+        record_path = self.records / "42.json"
+        record = json.loads(record_path.read_text())
+        record["delivered_frontier"]["panel_channel_id"] = 100
+        record_path.write_text(json.dumps(record))
+        self.assertEqual(self.scan()["status"], "failed")
+
+    def test_receipt_requires_nonempty_tmux_session_and_turn_nonce(self):
+        receipt = _receipt(222)
+        receipt["source"]["tmux_session_name"] = ""
+        receipt["source"]["turn_nonce"] = ""
+        self.write(_record(receipt))
+        self.assertEqual(self.scan()["status"], "failed")
+
+    def test_receipt_owner_must_match_record_filename(self):
+        self.write(_record(_receipt(222)), owner="7")
+        self.assertEqual(self.scan()["status"], "failed")
+
+    def test_unrelated_generation_marker_does_not_override_committed_record_proof(self):
+        self.write(_record(_receipt(222)))
+        (self.root / "AgentDesk-claude-e2e.generation").write_text("88")
+        self.assertEqual(self.scan()["status"], "evaluated")
+
+    def test_zero_generation_cannot_supply_durable_commit_proof(self):
+        self.write(_record(_receipt(222, generation=0), generation=0))
+        result = self.scan()
+        self.assertEqual(result["status"], "failed", result)
+        self.assertEqual(result["exact_receipts"], 0)
+
+    def test_delayed_write_is_observed_by_bounded_poll(self):
+        calls = 0
+
+        def sleep(_seconds: float) -> None:
+            nonlocal calls
+            calls += 1
+            self.write(_record(_receipt(222)))
+
+        ticks = iter((0.0, 0.0, 0.1, 0.1, 0.2))
+        result = durable_delivery.poll_records(
+            self.root,
+            provider="claude",
+            channel_id="99",
+            message_id="222",
+            timeout_s=1,
+            monotonic=lambda: next(ticks),
+            sleep=sleep,
+        )
+        self.assertEqual(result["status"], "evaluated", result)
+        self.assertEqual(calls, 1)
+
+    def test_poll_timeout_never_promotes_old_frontier(self):
+        self.write(_record(_receipt(111)))
+        result = durable_delivery.poll_records(
+            self.root,
+            provider="claude",
+            channel_id="99",
+            message_id="222",
+            timeout_s=0,
+        )
+        self.assertEqual(result["status"], "failed", result)
+
+
+class SafetyAndDeadlineFixtures(unittest.TestCase):
+    def _args(self, root: str) -> Namespace:
+        return Namespace(
+            base_url="http://agentdesk.test",
+            cell="claude-tui",
+            channel_id="99",
+            thread_channel_id=None,
+            reset_before_each=True,
+            dry_run=False,
+            queue_runtime_root=root,
+            hard_reset_session_each=False,
+            allow_destructive=False,
+            required_agent_mode=None,
+            required_coverage_class=None,
+        )
+
+    def _scenario(self) -> dict:
+        return {
+            "id": "E-35",
+            "agent_mode": "none",
+            "coverage_class": "live",
+            "cells": ["claude-tui"],
+            "durable_delivery_probe": True,
+            "steps": [{"send_discord_prompt": "marker"}],
+            "assertions": [],
+        }
+
+    def test_preexisting_active_mailbox_is_unevaluable_without_reset(self):
+        scenario = {**self._scenario()}
+        busy_mailbox = {
+            "provider": "claude",
+            "channel_id": "99",
+            "agent_turn_status": "active",
+            "relay_stall_state": "healthy",
+            "relay_health": {"active_turn": "none"},
+        }
+        with tempfile.TemporaryDirectory() as root, patch.object(
+            driver,
+            "_read_api_json",
+            side_effect=[
+                (200, {"cluster_standby": False}),
+                (200, {"sessions": []}),
+            ],
+        ) as read_api, patch.object(
+            driver, "_read_health_detail", return_value={"mailboxes": [busy_mailbox]}
+        ) as read_detail, patch.object(
+            driver.lease,
+            "_read_lease",
+            return_value={"run_id": "claude-tui-fixture", "acquired_at": 1.0},
+        ), patch.object(driver, "reset_channel_state") as reset, patch.object(
+            driver, "run_one_cell", return_value={}
+        ) as run_one:
+            result = driver.run_scenario(
+                scenario,
+                args=self._args(root),
+                run_id="fixture",
+                client=object(),
+            )
+        self.assertEqual(result["status"], "fail", result)
+        self.assertEqual(
+            (result.get("durable_record_probe") or {}).get("status"),
+            "unevaluable",
+            result,
+        )
+        self.assertTrue(result["dirty_active_residue"]["dirty_active_residue"])
+        self.assertIn("agent_turn_status=active", result["dirty_active_residue"]["reasons"])
+        self.assertEqual(read_api.call_count, 2)
+        read_detail.assert_called_once()
+        run_one.assert_not_called()
+        reset.assert_not_called()
+
+    def test_safety_gate_requires_current_probe_lease_ownership(self):
+        idle_mailbox = {
+            "provider": "claude",
+            "channel_id": "99",
+            "agent_turn_status": "idle",
+            "relay_stall_state": "healthy",
+            "relay_health": {"active_turn": "none"},
+        }
+        with tempfile.TemporaryDirectory() as root, patch.object(
+            driver,
+            "_read_api_json",
+            side_effect=[
+                (200, {"cluster_standby": False}),
+                (200, {"sessions": []}),
+            ],
+        ), patch.object(
+            driver, "_read_health_detail", return_value={"mailboxes": [idle_mailbox]}
+        ), patch.object(driver.lease, "_read_lease", return_value=None):
+            result = driver.durable_probe_safety_gate(
+                base_url="http://agentdesk.test",
+                cell="claude-tui",
+                channel_id="99",
+                runtime_root=Path(root),
+                lease_run_id="claude-tui-fixture",
+            )
+        self.assertEqual(result["status"], "unevaluable", result)
+        self.assertIn("E2E cell lease is not held by this probe", result["reasons"])
+
+    def test_idle_gate_pass_never_enters_reset_for_durable_probe(self):
+        with tempfile.TemporaryDirectory() as root, patch.object(
+            driver,
+            "durable_probe_safety_gate",
+            return_value={"status": "idle", "dirty_active_residue": False},
+        ) as gate, patch.object(driver, "reset_channel_state") as reset, patch.object(
+            driver, "run_one_cell", return_value={}
+        ) as run_one, patch.object(driver.time, "sleep"):
+            result = driver.run_scenario(
+                self._scenario(),
+                args=self._args(root),
+                run_id="fixture",
+                client=object(),
+            )
+        self.assertNotEqual(result.get("reason"), "E-35 safety gate refused injection")
+        gate.assert_called_once()
+        run_one.assert_called_once()
+        reset.assert_not_called()
+
+    def test_prompt_recheck_refuses_new_busy_state_without_cleanup(self):
+        class Client:
+            def send_control(self, _channel, _content): return {"message_id": "100"}
+            def fetch_messages(self, _channel, **_kwargs): return []
+            def send(self, _channel, _content): raise AssertionError("prompt sent")
+
+        idle = {"status": "idle", "dirty_active_residue": False}
+        busy = {
+            "status": "unevaluable",
+            "dirty_active_residue": True,
+            "reasons": ["agent_turn_status=active"],
+        }
+        with tempfile.TemporaryDirectory() as root, patch.object(
+            driver, "durable_probe_safety_gate", side_effect=[idle, busy]
+        ) as gate, patch.object(driver, "reset_channel_state") as reset, patch.object(
+            driver.time, "sleep"
+        ):
+            result = driver.run_scenario(
+                {**self._scenario(), "agent_mode": "real_live"},
+                args=self._args(root),
+                run_id="fixture",
+                client=Client(),
+            )
+        self.assertEqual(gate.call_count, 2)
+        self.assertEqual(result["status"], "fail", result)
+        self.assertEqual(result["durable_record_probe"]["status"], "unevaluable")
+        self.assertEqual(result["dirty_active_residue"], busy)
+        reset.assert_not_called()
+
+    def test_recheck_to_send_residual_window_and_honesty_claim_are_pinned(self):
+        state = {"prompt_sent_after_recheck_race": False}
+        class Client:
+            base_url = "http://agentdesk.test"
+            def send_control(self, _channel, _content): return {"message_id": "100"}
+            def fetch_messages(self, _channel, **_kwargs): return []
+
+            def send(self, _channel, _content):
+                state["prompt_sent_after_recheck_race"] = True
+                return {"message_id": "111"}
+
+        scenario = {
+            **self._scenario(),
+            "agent_mode": "real_live",
+            "steps": [
+                {"send_discord_prompt": "marker"},
+                {"wait_for_discord_text": "marker", "timeout_s": 1},
+            ],
+        }
+        idle = {"status": "idle", "dirty_active_residue": False}
+        with tempfile.TemporaryDirectory() as root, patch.object(
+            driver, "durable_probe_safety_gate", return_value=idle
+        ) as gate, patch.object(driver.time, "sleep"), patch.object(
+            driver,
+            "wait_for_discord_text_with_tui_idle_draft_guard",
+            return_value=({"id": "222"}, []),
+        ), patch.object(
+            driver.durable_delivery,
+            "poll_records",
+            return_value={"status": "evaluated", "reason": "fixture"},
+        ), patch.object(driver, "assert_cell_idle", return_value={"status": "idle"}):
+            result = driver.run_scenario(
+                scenario,
+                args=self._args(root),
+                run_id="fixture",
+                client=Client(),
+            )
+        claim = " ".join((ROOT / "docs/e2e/multi-provider-e2e.md").read_text().split())
+        self.assertIn(
+            "the prompt-time recheck narrows the nominal gate-return-to-prompt window "
+            "from 368 seconds to 0 seconds, and the last-mailbox-snapshot-to-prompt "
+            "window from 373 seconds to 5 seconds. it does not close the toctou",
+            claim.lower(),
+        )
+        self.assertEqual(gate.call_count, 2)
+        self.assertTrue(state["prompt_sent_after_recheck_race"])
+        self.assertEqual(result["status"], "pass", result)
+
+    @unittest.skipUnless(hasattr(signal, "setitimer"), "POSIX wall-clock timer required")
+    def test_phase_deadline_interrupts_blocking_work(self):
+        previous = driver._arm_phase_deadline(0.02)  # noqa: SLF001
+        try:
+            with self.assertRaises(driver.PhaseDeadlineExpired):
+                time.sleep(1)
+        finally:
+            driver._disarm_phase_deadline(previous)  # noqa: SLF001
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/tui_relay/scenarios/E-35-durable-delivery-record.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-35-durable-delivery-record.yaml
@@ -1,0 +1,15 @@
+id: E-35
+title: 새 normal Discord response의 exact durable receipt + covering frontier
+agent_mode: real_live
+coverage_class: live
+cells: [claude-pipe, claude-tui]
+isolation: required
+durable_delivery_probe: true
+# #5264 is a hard prerequisite only for default claude-tui live acceptance.
+# claude-pipe is partial coverage and is not S8 TUI-surface evidence.
+steps:
+  - send_discord_prompt: "응답에 정확히 한 줄로 [E2E:E35:{run_id}:OK] 만 출력해줘."
+  - wait_for_discord_text: "[E2E:E35:{run_id}:OK]"
+    timeout_s: 240
+assertions:
+  - text_present: "[E2E:E35:"

--- a/tests/test_deploy_smoke_wedge_coverage_5244.sh
+++ b/tests/test_deploy_smoke_wedge_coverage_5244.sh
@@ -36,16 +36,31 @@ fi
 runner_source="$TMP_ROOT/runner.sh"
 sed -n '/^_run_post_deploy_functional_smoke()/,/^_report_post_deploy_smoke_failure()/p' "$DEPLOY_SH" \
     | sed '$d' > "$runner_source"
-runner_output=$(bash -s -- "$runner_source" "$TMP_ROOT" <<'CHILD'
+DISPOSITION="$TMP_ROOT/disposition.sh"
+disposition_begin=$(grep -nF '# >>> BEGIN smoke-disposition region (#5244)' "$DEPLOY_SH" | cut -d: -f1 || true)
+disposition_end=$(grep -nF '# <<< END smoke-disposition region (#5244)' "$DEPLOY_SH" | cut -d: -f1 || true)
+sed -n "$((disposition_begin + 1)),$((disposition_end - 1))p" "$DEPLOY_SH" > "$DISPOSITION"
+durable_clean_coverage=$(sed -n 's/^POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE="\([^"]*\)"$/\1/p' "$DEPLOY_SH" | head -1 || true)
+[ -n "$durable_clean_coverage" ] || fail 'durable clean coverage declaration is missing'
+
+runner_output=$(DURABLE_CLEAN_COVERAGE="$durable_clean_coverage" bash -s -- "$runner_source" "$TMP_ROOT" "$DISPOSITION" <<'CHILD'
 set -euo pipefail
-runner_source="$1"; root="$2"; eval "$(<"$runner_source")"
+runner_source="$1"; root="$2"; disposition_source="$3"; eval "$(<"$runner_source")"
 ADK_REL="$root"; POST_DEPLOY_SMOKE_EVIDENCE="$root/runner.evidence"; POST_DEPLOY_SMOKE_TMP_DIR=""; POST_DEPLOY_SMOKE_FAILURES=(); POST_DEPLOY_SMOKE_STAMP=runner; REL_PORT=0; runner_wedge_called=0
-_post_deploy_smoke_note() { :; }; _post_deploy_smoke_probe_apis() { return 0; }; _post_deploy_smoke_check_wedges() { runner_wedge_called=1; return 0; }; _post_deploy_smoke_check_fail_closed_warn_rate() { return 0; }; _post_deploy_smoke_check_relay_round_trip() { return 0; }
+POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID=""; POST_DEPLOY_SMOKE_WEDGE_COVERAGE="clean-sentinel"; POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE="clean-sentinel"; POST_DEPLOY_SMOKE_DURABLE_COVERAGE="unevaluable: E-35 did not run"; POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE="$DURABLE_CLEAN_COVERAGE"
+_post_deploy_smoke_note() { :; }; _post_deploy_smoke_probe_apis() { return 0; }; _post_deploy_smoke_check_wedges() { runner_wedge_called=1; return 0; }; _post_deploy_smoke_check_fail_closed_warn_rate() { return 0; }
+# E-1 rc-0 skip fixture: leave the channel unset, so the durable probe returns 0.
+_post_deploy_smoke_check_relay_round_trip() { POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID=""; return 0; }
+_post_deploy_smoke_check_durable_record() { [ -z "$POST_DEPLOY_SMOKE_RELAY_CHANNEL_ID" ] || return 1; return 0; }
 if _run_post_deploy_functional_smoke; then rc=0; else rc=$?; fi
+eval "$(<"$disposition_source")"
 printf 'CASE_DONE runner rc=%s wedge_called=%s\n' "$rc" "$runner_wedge_called"
 CHILD
 )
 grep -q 'CASE_DONE runner rc=0 wedge_called=1' <<< "$runner_output" || fail 'smoke runner did not execute check_wedges in its parent shell'
+grep -q '△ Post-deploy functional smoke completed with coverage gap' <<< "$runner_output" || fail 'E-1 skip did not produce a coverage gap'
+grep -q 'durable record coverage: unevaluable: E-35 did not run' <<< "$runner_output" || fail 'E-1 skip omitted durable coverage'
+! grep -q '✓ Post-deploy functional smoke passed' <<< "$runner_output" || fail 'E-1 skip produced a false pass'
 
 cleanup_to_signal=$(sed -n '/^_cleanup_on_exit()/,/^_handle_cleanup_signal()/p' "$DEPLOY_SH")
 grep -q '_finalize_detached_helper' <<< "$cleanup_to_signal" || fail 'cleanup text does not contain finalizer'
@@ -272,17 +287,15 @@ CHILD
 )
 grep -q 'CASE_DONE rc=1 coverage=not evaluated: startup recovery in progress' <<< "$observation_race_output" || fail 'observation evidence failure reverted to not-run coverage'
 
-DISPOSITION="$TMP_ROOT/disposition.sh"
-disposition_begin=$(grep -nF '# >>> BEGIN smoke-disposition region (#5244)' "$DEPLOY_SH" | cut -d: -f1 || true)
-disposition_end=$(grep -nF '# <<< END smoke-disposition region (#5244)' "$DEPLOY_SH" | cut -d: -f1 || true)
-sed -n "$((disposition_begin + 1)),$((disposition_end - 1))p" "$DEPLOY_SH" > "$DISPOSITION"
 disposition_case() {
-    local label="$1" smoke_rc="$2" coverage="$3" clean_coverage="$4" expected="$5"
+    local label="$1" smoke_rc="$2" coverage="$3" durable_coverage="$4" expected="$5"
     local output
-    output=$(SMOKE_RC="$smoke_rc" COVERAGE="$coverage" CLEAN_COVERAGE="$clean_coverage" bash -s -- "$DISPOSITION" <<'CHILD'
+    output=$(SMOKE_RC="$smoke_rc" COVERAGE="$coverage" DURABLE_COVERAGE="$durable_coverage" CLEAN_COVERAGE=clean-sentinel DURABLE_CLEAN_COVERAGE="$durable_clean_coverage" bash -s -- "$DISPOSITION" <<'CHILD'
 set -euo pipefail
 POST_DEPLOY_SMOKE_WEDGE_COVERAGE="$COVERAGE"
 POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE="$CLEAN_COVERAGE"
+POST_DEPLOY_SMOKE_DURABLE_COVERAGE="$DURABLE_COVERAGE"
+POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE="$DURABLE_CLEAN_COVERAGE"
 POST_DEPLOY_SMOKE_EVIDENCE=/tmp/5244-disposition.evidence
 POST_DEPLOY_SMOKE_TMP_DIR=""
 POST_DEPLOY_SMOKE_FAILURES=()
@@ -294,10 +307,42 @@ CHILD
     )
     grep -q 'CASE_DONE disposition' <<< "$output" || fail "$label: disposition completion token missing"
     grep -q "$expected" <<< "$output" || fail "$label: expected [$expected]"
+    if [ "$label" = evaluated_clean ]; then
+        grep -q 'durable record coverage: evaluated' <<< "$output" || fail "$label: durable summary missing"
+    fi
 }
-disposition_case evaluated_clean 0 clean-sentinel clean-sentinel 'passed (relay wedge coverage: clean-sentinel'
-disposition_case coverage_gap 0 'not evaluated: startup recovery in progress' clean-sentinel 'completed with coverage gap'
-disposition_case failed 1 'unevaluable: health/detail scan failed' clean-sentinel 'REPORT_CALLED'
+disposition_case evaluated_clean 0 clean-sentinel evaluated 'passed (relay wedge coverage: clean-sentinel'
+disposition_case skip_unevaluable 0 clean-sentinel 'unevaluable: E-35 did not run' 'completed with coverage gap (relay wedge coverage: clean-sentinel; durable record coverage: unevaluable: E-35 did not run'
+disposition_case plain_unevaluable 0 clean-sentinel unevaluable 'completed with coverage gap'
+disposition_case failed_nonclean 0 clean-sentinel failed 'completed with coverage gap'
+disposition_case coverage_gap 0 'not evaluated: startup recovery in progress' evaluated 'completed with coverage gap'
+disposition_case failed 1 'unevaluable: health/detail scan failed' failed 'REPORT_CALLED'
+
+if [ -z "${MUTATION_CHILD:-}" ]; then
+    for mutation in logical_and_removed unevaluable_as_clean; do
+        mut="$TMP_ROOT/mut-$mutation.sh"
+        if [ "$mutation" = logical_and_removed ]; then
+            sed \
+                -e 's/\$POST_DEPLOY_SMOKE_WEDGE_COVERAGE:\$POST_DEPLOY_SMOKE_DURABLE_COVERAGE/\$POST_DEPLOY_SMOKE_WEDGE_COVERAGE/g' \
+                -e 's/\$POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE:\$POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE/\$POST_DEPLOY_SMOKE_WEDGE_CLEAN_COVERAGE/g' \
+                "$DEPLOY_SH" > "$mut"
+            expected='E-1 skip produced a false pass'
+        else
+            sed 's/^POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE="evaluated"$/POST_DEPLOY_SMOKE_DURABLE_CLEAN_COVERAGE="unevaluable: E-35 did not run"/' \
+                "$DEPLOY_SH" > "$mut"
+            expected='skip_unevaluable: expected'
+        fi
+        if ! bash -n "$mut" > "$mut.bash-n" 2>&1; then
+            fail "$mutation was not syntactically valid"
+        elif MUTATION_CHILD=1 DEPLOY_SH_OVERRIDE="$mut" bash "$0" > "$mut.out" 2>&1; then
+            fail "$mutation survived the skip fixture"
+        elif grep -q "$expected" "$mut.out"; then
+            printf 'MUTATION_CASE %s bash_n=0 fixture_rc=1\n' "$mutation"
+        else
+            fail "$mutation died without its target fixture self-assertion"
+        fi
+    done
+fi
 
 if [ "$failures" -ne 0 ]; then
     printf 'test_deploy_smoke_wedge_coverage_5244: %s assertion(s) failed\n' "$failures" >&2


### PR DESCRIPTION
## Summary

- Rebuilds the minimum #5263 surface directly from `origin/main` at `309da6db476258afbc3339d9a0e986b42ddbe5d1`; this supersedes #5287 without modifying or closing it.
- Preserves headless E-1 and adds E-35: one normal Discord short-response turn must yield exactly one authoritative durable receipt plus a same-generation covering frontier.
- Makes the final smoke disposition `wedge clean ∧ durable exact evaluated`: only that pair prints `✓ passed`; every other success-returning pair prints fail-open `△ coverage gap` with both values. `failed`, `unevaluable`, and `unevaluable: ...` are never clean.

Closes #5263

## Durable contract and limits

E-35 rejects stale, zero, incomplete, duplicate, response-ID-mismatched, owner/channel/source-identity-mismatched, range-uncovered, and generation-mismatched records; every raw receipt/frontier authority number must be an exact JSON integer, provider/tmux/nonce identities must be nonempty strings, owner filenames must be unsigned decimal IDs, and only expected query channel/message IDs accept nonzero ASCII decimal strings at the boundary. It rechecks standby, mailbox/session/queue idleness, and the probe's cell lease immediately before the normal prompt. That recheck narrows the nominal gate-return-to-prompt window from 368s to 0s and the last-mailbox-snapshot-to-prompt window from 373s to 5s, but local scheduling/filesystem TOCTOU remains and a turn can start after recheck but before send.

The committed contract has exactly **five symbols and four independent enforcement stages**:

1. `shadow_mirror_delivered_frontier_inner`
2. `exact_receipt_from_inflight`
3. `write_confirmed_delivery_at_with_lock_authority`
4. `write_confirmed_frontier_guarded_at_with_lock_authority`

The fifth symbol, `ExactJsonlSourceIdentity::is_authoritative`, is a subordinate predicate called under stage 3's delivery writer, not a separate enforcement stage. The durable record has no writer-kind field, so E-35 cannot distinguish the spawn writer from the `restore.rs` adoption writer.

The actual component timeout sum is **1,422 seconds**:

`2 × (5 + 5 + 5) + 180 + 8 + 180 + 180 + 3 + 240 + 15 + (2 × 180 + 1) + 45 + 180 = 1,422`.

The **900-second value is an operational cutoff**, not the component sum. Expiry is recorded as unevaluable/fail-open after `DEPLOY_OK`; it does not add rollback, exit poisoning, restart, watchdog, source-manifest, or peer-deploy control flow.

## Surface and size

- 7 files, `+1045/-23 = 1068` changed lines: 268 over the 20-file / ±800-line budget.
- Production/Python+shell surface: 3 files, `+419/-11`; Rust: 0 files / 0 lines.
- The overage is indivisible for this slice: the 481-line exact receipt/provenance/live-safety fixture seals stale/zero/incomplete/strict-schema/identity/frontier/prompt-recheck behavior, and the deploy fixture seals the E-1 rc=0 skip plus both required K1 false-green mutants. Removing either restores the reviewed false-green/provenance gaps.
- `scripts/deploy-release.sh` is `+69/-0` versus base; all #5274 base protections remain.

## Verification

- `bash -n scripts/deploy-release.sh` — rc 0
- `shellcheck scripts/deploy-release.sh` — rc 1; exactly the base's existing SC1091/SC2016 informational set, no new warning/error
- `python3 -m unittest scripts.e2e.tui_relay.test_durable_delivery` — rc 0, 24 tests
- pytest attempt — rc 1 because this environment has no `pytest` module
- strict JSON integer mutant (`int(value)` coercion restored) — `py_compile` rc 0, targeted authority fixture rc 1 on its own false-green assertions
- `bash tests/test_deploy_smoke_wedge_coverage_5244.sh` — rc 0
  - durable conjunct removed: mutant remains syntactically valid, target fixture rc 1
  - prefixed `unevaluable` classified clean: mutant remains syntactically valid, target fixture rc 1
- #5274 bounded suite, restricted sandbox — rc 2, skipped=4, remaining assertions passed
- #5274 bounded suite, OS-assigned `127.0.0.1:0` — rc 0, skipped=0
- `bash scripts/ci-script-checks.sh` — rc 1 at its existing immutable `TEST_LANE_BASELINE_REF` requirement; no gate was modified or bypassed
- full aggregate with the exact base and OS temporary-port allowance — rc 0
- `git diff --check` and staged diff check — rc 0
- predecessor exact-head remote CI runs `31298237475` / `31298225477` were green; new exact-head runs `31300390185` / `31300388749` were observed in progress read-only after push and were not rerun manually

## Explicitly not guaranteed

- `test_durable_delivery.py` is not wired into required CI; #5003 S3 owns Python fixture registration, and this PR does not change `scripts/ci-script-checks.sh` wiring.
- No live E-35/Discord delivery, deployment, rollback, restart, launchctl, watchdog, peer deployment, tmux/mailbox manipulation, generation-marker mutation, or PostgreSQL access was performed.
- This does not prove power-loss durability, poll-time marker rotation, every provider/call site, long/fallback/recovery/headless paths, completed-ledger persistence, general lease reconciliation, peer/commit binding, continuous monitoring, or S8 rollout.
- Deploy-call-block mutation, SIGALRM redesign, private `lease._read_lease` cleanup, poll-time rotation, continuous monitoring, and S8 rollout remain out of scope.
