### PR TITLE
feat(ci): add S3a-1 test-suite registry facts

### DIFF
--- a/scripts/check_test_suite_registry.py
+++ b/scripts/check_test_suite_registry.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""Deterministic tracked test-suite facts; policy belongs to #5003 S3a-2."""
+from __future__ import annotations
+import ast, json, posixpath, re, shlex, subprocess, sys
+from collections import Counter, deque
+from dataclasses import dataclass, field
+from enum import Enum
+from functools import lru_cache
+from pathlib import Path, PurePosixPath
+from typing import Collection, Iterable, Mapping, Sequence
+class Family(str, Enum):
+    TESTS_PY = "tests_py"; E2E_PY = "e2e_py"; SCRIPTS_PY = "scripts_py"
+    SHELL = "shell"; GATE = "gate_candidates"
+class CandidateKind(str, Enum):
+    PYTHON_SUITE = "python_suite"; SHELL_SUITE = "shell_suite"; GATE = "gate"
+class ExecStatus(str, Enum):
+    FULL = "FULL"; PARTIAL = "PARTIAL"; GLOB = "GLOB"; NONE = "NONE"
+class PinStatus(str, Enum):
+    PINNED = "PINNED"; REQUIRED_ARRAY = "REQUIRED_ARRAY"
+    GLOB_UNPINNED = "GLOB_UNPINNED"; NONE = "NONE"
+class DiagnosticKind(str, Enum):
+    SOURCE_MISSING = "source_missing"; SOURCE_UNREADABLE = "source_unreadable"
+    SOURCE_MALFORMED = "source_malformed"; TRACKED_INPUT = "tracked_input"
+    PYTHON_MALFORMED = "python_malformed"; HARNESS_MISMATCH = "harness_mismatch"
+    UNSUPPORTED_CALL = "unsupported_call"
+@dataclass(frozen=True)
+class Diagnostic:
+    kind: DiagnosticKind; message: str; source: str | None = None; fatal: bool = False
+@dataclass(frozen=True)
+class Invocation:
+    source: str; command: str; target: str; selector: str | None = None
+    runner: str = "literal"; glob: bool = False
+@dataclass(frozen=True)
+class PinEvidence:
+    source: str; command: str; target: str; status: PinStatus
+@dataclass(frozen=True)
+class Candidate:
+    path: str; family: Family; kind: CandidateKind; execution: ExecStatus; pin: PinStatus
+    tests: tuple[str, ...] = (); executed_tests: tuple[str, ...] = ()
+    invocations: tuple[Invocation, ...] = (); pin_evidence: tuple[PinEvidence, ...] = ()
+    @property
+    def unexecuted_tests(self) -> tuple[str, ...]:
+        return tuple(item for item in self.tests if item not in self.executed_tests)
+@dataclass(frozen=True)
+class FamilyViolation:
+    family: Family; expected_minimum: int; actual: int
+@dataclass(frozen=True)
+class PartialViolation:
+    path: str; targets: tuple[str, ...]; unexecuted_tests: tuple[str, ...]
+DEFAULT_PATTERNS: Mapping[Family, tuple[str, ...]] = {
+    Family.TESTS_PY: ("tests/**/test_*.py",), Family.E2E_PY: ("scripts/e2e/**/test_*.py",),
+    Family.SCRIPTS_PY: ("scripts/**/test_*.py",), Family.SHELL: ("tests/**/test_*.sh",),
+    Family.GATE: ("scripts/check_*.py", "scripts/audit_*.py", "scripts/check-*.py", "scripts/check-*.sh"),
+}
+DEFAULT_SOURCES = ("scripts/ci-script-checks.sh", "justfile", "package.json", "Makefile")
+@dataclass(frozen=True)
+class RegistryConfig:
+    patterns: Mapping[Family, tuple[str, ...]] = field(default_factory=lambda: dict(DEFAULT_PATTERNS)); surface_sources: tuple[str, ...] | None = None
+@dataclass(frozen=True)
+class RegistryResult:
+    candidates: tuple[Candidate, ...]; diagnostics: tuple[Diagnostic, ...]
+    family_counts: Mapping[Family, int]; reachable_sources: tuple[str, ...]
+    reachability_contract: str = "declared roots plus tracked literal shell reachability"
+    @property
+    def input_valid(self) -> bool:
+        return not any(item.fatal for item in self.diagnostics)
+    def _counts(self, name: str, values: Iterable[Enum]) -> Mapping[Enum, int]:
+        found = Counter(getattr(item, name) for item in self.candidates if item.kind is not CandidateKind.GATE)
+        return {value: found.get(value, 0) for value in values}
+    @property
+    def suite_status_counts(self) -> Mapping[ExecStatus, int]:
+        return self._counts("execution", ExecStatus)
+    @property
+    def suite_pin_counts(self) -> Mapping[PinStatus, int]:
+        return self._counts("pin", PinStatus)
+    def family_violations(self, floors: Mapping[Family, int]) -> tuple[FamilyViolation, ...]:
+        return tuple(FamilyViolation(family, floor, self.family_counts.get(family, 0))
+                     for family, floor in sorted(floors.items(), key=lambda row: row[0].value)
+                     if self.family_counts.get(family, 0) < floor)
+    def partial_violations(self, allowed_exact_targets: Collection[tuple[str, str]] = ()) -> tuple[PartialViolation, ...]:
+        allowed, result = set(allowed_exact_targets), []
+        for item in self.candidates:
+            if item.execution is not ExecStatus.PARTIAL:
+                continue
+            targets = tuple(sorted(call.target for call in item.invocations if not call.glob))
+            if not targets or any((item.path, target) not in allowed for target in targets):
+                result.append(PartialViolation(item.path, targets, item.unexecuted_tests))
+        return tuple(result)
+@dataclass(frozen=True)
+class _PythonFacts:
+    tests: tuple[str, ...]; unittest_tests: tuple[str, ...]; live_main: bool
+@lru_cache(maxsize=None)
+def _compile_glob(pattern: str) -> re.Pattern[str]:
+    """Anchor the declared glob grammar; only an explicit ** crosses slash."""
+    out, index = [], 0
+    while index < len(pattern):
+        if pattern.startswith("**/", index):
+            out.append(r"(?:[^/]+/)*"); index += 3
+        elif pattern.startswith("**", index):
+            out.append(r".*"); index += 2
+        elif pattern[index] == "*":
+            out.append(r"[^/]*"); index += 1
+        elif pattern[index] == "?":
+            out.append(r"[^/]"); index += 1
+        else:
+            out.append(re.escape(pattern[index])); index += 1
+    return re.compile("".join(out) + r"\Z")
+def _matches(path: str, patterns: Sequence[str]) -> bool:
+    return any(_compile_glob(pattern).fullmatch(path) for pattern in patterns)
+def _family(path: str, config: RegistryConfig) -> tuple[Family, CandidateKind] | None:
+    if re.match(r"scripts/e2e[^/]*/", path) and not path.startswith("scripts/e2e/"):
+        return None
+    ordered = ((Family.TESTS_PY, CandidateKind.PYTHON_SUITE), (Family.E2E_PY, CandidateKind.PYTHON_SUITE),
+               (Family.SCRIPTS_PY, CandidateKind.PYTHON_SUITE),
+               (Family.SHELL, CandidateKind.SHELL_SUITE),
+               (Family.GATE, CandidateKind.GATE))
+    return next(((family, kind) for family, kind in ordered
+                 if _matches(path, config.patterns.get(family, ()))), None)
+def _tracked(root: Path) -> tuple[tuple[str, ...], Diagnostic | None]:
+    try:
+        run = subprocess.run(("git", "ls-files", "-z"), cwd=root, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except OSError as error:
+        return (), Diagnostic(DiagnosticKind.TRACKED_INPUT, str(error), fatal=True)
+    if run.returncode:
+        return (), Diagnostic(DiagnosticKind.TRACKED_INPUT, run.stderr.decode("utf-8", "replace").strip(), fatal=True)
+    try:
+        paths = (part.decode("utf-8") for part in run.stdout.split(b"\0") if part)
+        return tuple(sorted(paths, key=lambda value: value.encode("utf-8"))), None
+    except UnicodeDecodeError as error:
+        return (), Diagnostic(DiagnosticKind.TRACKED_INPUT, str(error), fatal=True)
+def _read(root: Path, relative: str) -> tuple[str | None, Diagnostic | None]:
+    path = root / relative
+    if not path.exists():
+        return None, Diagnostic(DiagnosticKind.SOURCE_MISSING, f"required input missing: {relative}", relative, True)
+    try:
+        data = path.read_bytes()
+        text = data.decode("utf-8")
+    except (OSError, UnicodeError) as error:
+        return None, Diagnostic(DiagnosticKind.SOURCE_UNREADABLE, f"cannot read {relative}: {error}", relative, True)
+    if "\0" in text:
+        return None, Diagnostic(DiagnosticKind.SOURCE_MALFORMED, f"NUL byte in {relative}", relative, True)
+    return text, None
+def _python_tree(text: str, source: str) -> tuple[ast.Module | None, Diagnostic | None]:
+    try:
+        return ast.parse(text, filename=source), None
+    except SyntaxError as error:
+        return None, Diagnostic(DiagnosticKind.PYTHON_MALFORMED, f"cannot parse {source}: {error}", source, True)
+def _shell_comment(raw: str) -> tuple[str, bool]:
+    single = double = escaped = False
+    for index, char in enumerate(raw):
+        if escaped:
+            escaped = False
+        elif char == "\\" and not single:
+            escaped = True
+        elif char == "'" and not double:
+            single = not single
+        elif char == '"' and not single:
+            double = not double
+        elif char == "#" and not single and not double:
+            return raw[:index], single
+    return raw, single
+def _logical_lines(text: str, source: str) -> tuple[list[str], Diagnostic | None]:
+    lines, pending = [], ""
+    for raw in text.splitlines():
+        line, in_single = _shell_comment(raw)
+        line = line.rstrip()
+        slashes = len(line) - len(line.rstrip("\\"))
+        if slashes % 2 == 1 and not in_single:
+            pending += line[:-1].rstrip() + " "
+        else:
+            lines.append(pending + line.lstrip() if pending else line)
+            pending = ""
+    if pending:
+        return lines, Diagnostic(DiagnosticKind.SOURCE_MALFORMED, f"unterminated backslash continuation in {source}", source, True)
+    return lines, None
+def _segments(command: str) -> list[list[str]]:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|")
+    lexer.whitespace_split, lexer.commenters = True, ""
+    rows, current = [], []
+    for token in lexer:
+        if token and set(token) <= set(";&|"):
+            if current: rows.append(current)
+            current = []
+        else:
+            current.append(token)
+    if current: rows.append(current)
+    return rows
+def _shell_commands(text: str, source: str) -> tuple[list[str], Diagnostic | None]:
+    # Heredoc bodies are another language, not command surfaces.
+    outer, heredoc = [], None
+    for raw in text.splitlines():
+        if heredoc:
+            if raw.strip() == heredoc:
+                heredoc = None
+            continue
+        outer.append(raw)
+        marker = re.search(r"(?<!<)<<-?\s*['\"]?([A-Za-z_]\w*)", _shell_comment(raw)[0])
+        heredoc = marker.group(1) if marker else None
+    if heredoc:
+        return [], Diagnostic(DiagnosticKind.SOURCE_MALFORMED, f"malformed shell in {source}: unterminated heredoc {heredoc}", source, True)
+    physical, error = _logical_lines("\n".join(outer), source)
+    if error:
+        return [], error
+    commands = []
+    for line in physical:
+        command = _shell_comment(line)[0].strip()
+        if not command:
+            continue
+        if '"$(' in command and "<<" in command:
+            command = command.split("$(", 1)[1].strip()
+        if command in {'")"', ")'"}:
+            continue
+        try:
+            _segments(command)
+        except ValueError as problem:
+            # Arbitrary compound shell is outside this grammar. A malformed
+            # recognized runner still fails closed; unrelated syntax is inert.
+            runner = re.match(r"^(?:(?:if|then|do|!)\s+)?(?:[A-Za-z_]\w*=\S+\s+)*(?:(?:bash|sh|python[\d.]*)(?!\s+-c\b)|source|pytest|node|\./\S+\.sh)\b", command)
+            if runner:
+                return commands, Diagnostic(DiagnosticKind.SOURCE_MALFORMED, f"malformed supported shell call in {source}: {problem}", source, True)
+            continue
+        commands.append(command)
+    return commands, None
+def _workflow_payloads(text: str, source: str) -> tuple[list[str], Diagnostic | None]:
+    lines, payloads, index = text.splitlines(), [], 0
+    while index < len(lines):
+        match = re.match(r"^(\s*)(?:-\s+)?([A-Za-z_][\w-]*):\s*(.*?)\s*$", lines[index])
+        if not match:
+            index += 1
+            continue
+        lead, key, value = match.groups()
+        key_column = len(lead) + (2 if lines[index][len(lead):].startswith("- ") else 0)
+        if re.fullmatch(r"[|>][+-]?", value):
+            style, block = value, []
+            index += 1
+            while index < len(lines):
+                raw = lines[index]; width = len(raw) - len(raw.lstrip())
+                if raw.strip() and width <= key_column:
+                    break
+                block.append(raw); index += 1
+            margins = [len(row) - len(row.lstrip()) for row in block if row.strip()]
+            margin = min(margins) if margins else key_column + 1
+            body = [row[margin:] if row.strip() else "" for row in block]
+            if key == "run":
+                payload = ("\n" if style[0] == "|" else " ").join(body)
+                if style.endswith("-"):
+                    payload = payload.rstrip("\n")
+                elif not style.endswith("+"):
+                    payload = payload.rstrip("\n") + "\n"
+                payloads.append(payload)
+            continue
+        if key == "run" and value and not value.startswith("#"):
+            if value.startswith("'"):
+                if len(value) < 2 or not value.endswith("'"):
+                    return payloads, Diagnostic(DiagnosticKind.SOURCE_MALFORMED, f"unterminated quoted run scalar in {source}", source, True)
+                value = value[1:-1].replace("''", "'")
+            elif value.startswith('"'):
+                try:
+                    value = json.loads(value)
+                except json.JSONDecodeError as problem:
+                    return payloads, Diagnostic(DiagnosticKind.SOURCE_MALFORMED, f"malformed quoted run scalar in {source}: {problem}", source, True)
+            payloads.append(value)
+        index += 1
+    return payloads, None
+def _source_commands(text: str, source: str) -> tuple[list[str], Diagnostic | None]:
+    if source == "package.json":
+        try:
+            document = json.loads(text)
+        except json.JSONDecodeError as error:
+            return [], Diagnostic(DiagnosticKind.SOURCE_MALFORMED, f"malformed package.json: {error}", source, True)
+        if not isinstance(document, dict):
+            return [], Diagnostic(DiagnosticKind.SOURCE_MALFORMED, "package.json must be an object", source, True)
+        scripts = document.get("scripts")
+        if scripts is not None and not isinstance(scripts, dict):
+            return [], Diagnostic(DiagnosticKind.SOURCE_MALFORMED, "package.json scripts must be an object", source, True)
+        if scripts and any(not isinstance(value, str) for value in scripts.values()):
+            return [], Diagnostic(DiagnosticKind.SOURCE_MALFORMED, "package.json script values must be strings", source, True)
+        payloads = [value for value in (scripts or {}).values() if isinstance(value, str)]
+    elif source.startswith(".github/workflows/") and source.endswith((".yml", ".yaml")):
+        payloads, error = _workflow_payloads(text, source)
+        if error:
+            return [], error
+    else:
+        payloads = [text]
+    result = []
+    for payload in payloads:
+        commands, error = _shell_commands(payload, source)
+        result.extend(commands)
+        if error:
+            return result, error
+    return result, None
+def _call_head(tokens: Sequence[str]) -> tuple[str, list[str]]:
+    words = list(tokens)
+    while words and words[0] in {"do", "then", "else", "elif", "if", "while", "until", "!"}:
+        words.pop(0)
+    while words and re.fullmatch(r"[A-Za-z_]\w*=.*", words[0]):
+        words.pop(0)
+    return (words[0].lstrip("@+-"), words[1:]) if words else ("", [])
+def _shell_target(tokens: Sequence[str]) -> str | None:
+    executable, args = _call_head(tokens)
+    if executable in {"bash", "sh", "source", "."}:
+        return next((arg for arg in args if not arg.startswith("-")), None)
+    if executable.endswith(".sh") and ("/" in executable or executable.startswith(".")):
+        return executable
+    return None
+def _repo_path(value: str, source: str) -> tuple[str | None, bool]:
+    if value == "$0" or value == "${0}":
+        return source, False
+    base = ""
+    for prefix in ("$SCRIPT_DIR/", "${SCRIPT_DIR}/"):
+        if value.startswith(prefix):
+            base, value = str(PurePosixPath(source).parent), value[len(prefix):]
+            break
+    if "$" in value or "{{" in value or "}}" in value:
+        return None, False
+    normalized = posixpath.normpath(posixpath.join(base, value)).removeprefix("./")
+    escaped = normalized.startswith("/") or normalized == ".." or normalized.startswith("../")
+    return (None, True) if escaped else (normalized, False)
+def _main_guard(test: ast.AST) -> bool:
+    if not isinstance(test, ast.Compare) or len(test.ops) != 1 or not isinstance(test.ops[0], ast.Eq):
+        return False
+    left, right = test.left, test.comparators[0]
+    return ((isinstance(left, ast.Name) and left.id == "__name__" and isinstance(right, ast.Constant) and right.value == "__main__")
+            or (isinstance(right, ast.Name) and right.id == "__name__" and isinstance(left, ast.Constant) and left.value == "__main__"))
+def _contains_main(node: ast.AST) -> bool:
+    if isinstance(node, ast.If):
+        return _main_guard(node.test) and any(_contains_main(child) for child in node.body)
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda,
+                         ast.For, ast.AsyncFor, ast.While, ast.Try, ast.With, ast.AsyncWith)) or type(node).__name__ == "Match":
+        return False
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+        owner = node.func.value
+        if isinstance(owner, ast.Name) and owner.id == "unittest" and node.func.attr == "main":
+            return True
+    return any(_contains_main(child) for child in ast.iter_child_nodes(node))
+def _python_facts(tree: ast.Module) -> _PythonFacts:
+    tests, methods, bases = [], {}, {}
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+            tests.append(node.name)
+        elif isinstance(node, ast.ClassDef):
+            bases[node.name] = tuple(ast.unparse(base) for base in node.bases)
+            methods[node.name] = tuple(f"{node.name}.{child.name}" for child in node.body
+                                       if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                                       and child.name.startswith("test_"))
+            tests.extend(methods[node.name])
+    unittest_classes = {name for name, parents in bases.items()
+                        if any(parent == "TestCase" or parent.endswith(".TestCase") for parent in parents)}
+    while True:
+        expanded = unittest_classes | {name for name, parents in bases.items()
+                                       if any(parent in unittest_classes for parent in parents)}
+        if expanded == unittest_classes:
+            break
+        unittest_classes = expanded
+    unittest_tests = tuple(sorted(test for name in unittest_classes for test in methods.get(name, ())))
+    return _PythonFacts(tuple(sorted(tests)), unittest_tests, any(_contains_main(node) for node in tree.body))
+def _dedupe_calls(items: Iterable[Invocation]) -> tuple[Invocation, ...]:
+    key = lambda item: (item.source, item.command, item.target, item.selector or "", item.runner, item.glob)
+    return tuple(sorted({key(item): item for item in items}.values(), key=key))
+def _dedupe_pins(items: Iterable[PinEvidence]) -> tuple[PinEvidence, ...]:
+    key = lambda item: (item.source, item.command, item.target, item.status.value)
+    return tuple(sorted({key(item): item for item in items}.values(), key=key))
+def _analyze(rows: Sequence[tuple[str, str]], paths: Sequence[str]) -> tuple[dict[str, list[Invocation]], dict[str, list[PinEvidence]], list[Diagnostic]]:
+    calls = {path: [] for path in paths}; pins = {path: [] for path in paths}; diagnostics = []
+    modules = {path[:-3].replace("/", "."): path for path in paths if path.endswith(".py")}
+    bindings: dict[tuple[str, str], list[str]] = {}
+    for source, command in rows:
+        for segment in _segments(command):
+            executable, args = _call_head(segment)
+            if executable == "for" and "in" in args:
+                split = args.index("in")
+                if split == 1:
+                    bindings.setdefault((source, args[0]), []).extend(arg for arg in args[2:] if arg != "do")
+    for source in sorted({row[0] for row in rows}):
+        joined = "\n".join(command for owner, command in rows if owner == source)
+        for match in re.finditer(r"^required_shell_suites\s*=\((.*?)\)", joined, re.M | re.S):
+            for target in re.findall(r"tests/[^\s)'\"]+\.sh", match.group(1)):
+                if target in pins:
+                    pins[target].append(PinEvidence(source, match.group(0), target, PinStatus.REQUIRED_ARRAY))
+    def fatal(source: str, command: str, detail: str) -> None:
+        diagnostics.append(Diagnostic(DiagnosticKind.UNSUPPORTED_CALL, f"{detail}: {command}", source, True))
+    def record(path: str, call: Invocation, status: PinStatus) -> None:
+        if path in calls:
+            calls[path].append(call); pins[path].append(PinEvidence(call.source, call.command, call.target, status))
+    for source, command in rows:
+        for segment in _segments(command):
+            executable, args = _call_head(segment)
+            python = bool(re.fullmatch(r"(?:python\d*(?:\.\d+)?|\$\{?PYTHON\}?)", executable))
+            runner, targets = "", []
+            if executable == "pytest":
+                runner, targets = "pytest", args
+            elif python and args[:2] == ["-m", "unittest"]:
+                runner, targets = "unittest", args[2:]
+            elif python and args[:2] == ["-m", "pytest"]:
+                runner, targets = "pytest", args[2:]
+            elif executable == "node" and args[:1] == ["--test"]:
+                runner, targets = "node", args[1:]
+            if runner:
+                for target in (item for item in targets if not item.startswith("-")):
+                    if "$" in target or "{{" in target or "}}" in target:
+                        fatal(source, command, f"dynamic {runner} target"); continue
+                    if runner == "unittest":
+                        matching = [module for module in modules if target == module or target.startswith(module + ".")]
+                        if matching:
+                            module = max(matching, key=len); selector = target[len(module):].removeprefix(".") or None
+                            record(modules[module], Invocation(source, command, target, selector, runner), PinStatus.PINNED)
+                    elif runner == "pytest":
+                        raw, _, selected = target.partition("::")
+                        wildcard = any(mark in raw for mark in "*?")
+                        for path in paths:
+                            matched = path.endswith(".py") and (path == raw or (wildcard and _matches(path, (raw,)))
+                                                                          or (raw.endswith("/") and path.startswith(raw)))
+                            if matched:
+                                glob = wildcard or path != raw
+                                record(path, Invocation(source, command, target, selected.replace("::", ".") or None,
+                                                        runner, glob), PinStatus.GLOB_UNPINNED if glob else PinStatus.PINNED)
+                continue
+            if python and args and args[0] not in {"-", "-c"} and not args[0].startswith("-"):
+                target, escaped = _repo_path(args[0], source)
+                if escaped:
+                    fatal(source, command, "python target escapes repository")
+                elif target is None:
+                    fatal(source, command, "dynamic python target")
+                elif target in calls:
+                    record(target, Invocation(source, command, target, runner="python-path"), PinStatus.PINNED)
+                continue
+            shell = _shell_target(segment)
+            if shell is None:
+                if executable in {"find", "xargs", "docker"} and any("python" in item or "bash" in item for item in args):
+                    fatal(source, command, f"unsupported {executable} runner construction")
+                continue
+            variable = re.fullmatch(r"\$\{?([A-Za-z_]\w*)\}?", shell)
+            patterns = bindings.get((source, variable.group(1)), ()) if variable else ()
+            if patterns:
+                for pattern in patterns:
+                    if "$" in pattern or "{{" in pattern or "}}" in pattern:
+                        fatal(source, command, "dynamic loop pattern"); continue
+                    for path in paths:
+                        if path.endswith(".sh") and _matches(path, (pattern,)):
+                            record(path, Invocation(source, command, pattern, runner="shell-loop", glob=True),
+                                   PinStatus.GLOB_UNPINNED)
+                continue
+            target, escaped = _repo_path(shell, source)
+            if escaped:
+                fatal(source, command, "shell target escapes repository")
+            elif target is None:
+                fatal(source, command, "dynamic shell target")
+            elif target in calls:
+                record(target, Invocation(source, command, target, runner="shell"), PinStatus.PINNED)
+    return calls, pins, diagnostics
+def scan_registry(root: Path, config: RegistryConfig | None = None) -> RegistryResult:
+    root, config = root.resolve(), config or RegistryConfig()
+    tracked, tracked_error = _tracked(root)
+    diagnostics = [tracked_error] if tracked_error else []
+    selected = [(path, *_family(path, config)) for path in tracked if _family(path, config)]
+    valid, facts = {}, {}
+    for path, _family_name, kind in selected:
+        text, error = _read(root, path)
+        if error:
+            diagnostics.append(error); valid[path] = False; continue
+        if path.endswith(".py"):
+            tree, error = _python_tree(text, path)
+            if error:
+                diagnostics.append(error); valid[path] = False; continue
+            facts[path] = _python_facts(tree)
+        elif path.endswith(".sh"):
+            _, error = _shell_commands(text, path)
+            if error:
+                diagnostics.append(error); valid[path] = False; continue
+        valid[path] = True
+    if config.surface_sources is None:
+        workflows = tuple(path for path in tracked if re.fullmatch(r"\.github/workflows/[^/]+\.ya?ml", path))
+        roots = DEFAULT_SOURCES + workflows
+    else:
+        roots = config.surface_sources
+    queue, seen, rows = deque(roots), set(), []
+    while queue:
+        source = queue.popleft()
+        if source in seen:
+            continue
+        seen.add(source)
+        text, error = _read(root, source)
+        if error:
+            diagnostics.append(error); continue
+        commands, error = _source_commands(text, source)
+        rows.extend((source, command) for command in commands)
+        if error:
+            diagnostics.append(error); continue
+        for command in commands:
+            for segment in _segments(command):
+                target = _shell_target(segment)
+                if target is None:
+                    continue
+                path, escaped = _repo_path(target, source)
+                if not escaped and path in tracked and path.endswith(".sh"):
+                    queue.append(path)
+    paths = [item[0] for item in selected]
+    calls, pins, analysis_diagnostics = _analyze(rows, paths)
+    diagnostics.extend(analysis_diagnostics)
+    candidates = []
+    for path, family, kind in selected:
+        item_calls, item_pins = _dedupe_calls(calls[path]), _dedupe_pins(pins[path])
+        test_facts = facts.get(path, _PythonFacts((), (), False))
+        executed = set()
+        if valid.get(path):
+            for call in item_calls:
+                if call.glob or kind is not CandidateKind.PYTHON_SUITE:
+                    continue
+                if call.runner == "pytest":
+                    selected_tests = test_facts.tests
+                elif call.runner == "unittest":
+                    selected_tests = test_facts.unittest_tests
+                elif call.runner == "python-path" and test_facts.live_main:
+                    selected_tests = test_facts.unittest_tests
+                else:
+                    selected_tests = ()
+                if call.selector:
+                    selected_tests = tuple(test for test in selected_tests
+                                           if test == call.selector or test.startswith(call.selector + "."))
+                executed.update(selected_tests)
+        exact = any(not call.glob for call in item_calls) and valid.get(path, False)
+        glob = any(call.glob for call in item_calls) and valid.get(path, False)
+        if kind is CandidateKind.PYTHON_SUITE:
+            if test_facts.tests and executed == set(test_facts.tests):
+                execution = ExecStatus.FULL
+            elif executed:
+                execution = ExecStatus.PARTIAL
+            elif glob:
+                execution = ExecStatus.GLOB
+            else:
+                execution = ExecStatus.NONE
+            if exact and test_facts.tests and not executed:
+                diagnostics.append(Diagnostic(DiagnosticKind.HARNESS_MISMATCH,
+                                              f"supported command collects no static tests in {path}", path))
+        else:
+            execution = ExecStatus.FULL if exact else ExecStatus.GLOB if glob else ExecStatus.NONE
+        statuses = {evidence.status for evidence in item_pins}
+        pin = (PinStatus.PINNED if PinStatus.PINNED in statuses else
+               PinStatus.REQUIRED_ARRAY if PinStatus.REQUIRED_ARRAY in statuses else
+               PinStatus.GLOB_UNPINNED if PinStatus.GLOB_UNPINNED in statuses else PinStatus.NONE)
+        candidates.append(Candidate(path, family, kind, execution, pin, test_facts.tests,
+                                    tuple(sorted(executed)), item_calls, item_pins))
+    counts = Counter(item[1] for item in selected)
+    family_counts = {family: counts.get(family, 0) for family in Family}
+    diagnostic_key = lambda item: (item.kind.value, item.source or "", item.message, item.fatal)
+    diagnostics = list({diagnostic_key(item): item for item in diagnostics}.values())
+    return RegistryResult(tuple(candidates), tuple(sorted(diagnostics, key=diagnostic_key)), family_counts,
+                          tuple(sorted(seen, key=lambda value: value.encode("utf-8"))))
+def main() -> int:
+    result = scan_registry(Path(__file__).resolve().parents[1])
+    for diagnostic in result.diagnostics:
+        if diagnostic.fatal:
+            print(f"{diagnostic.kind.value}: {diagnostic.message}", file=sys.stderr)
+    return 0 if result.input_valid else 1
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -167,6 +167,9 @@ echo "=== Test-target integrity gate (#5003/#5008) ==="
 "$PYTHON" scripts/check_test_target_integrity.py --verify-lib-inventory
 "$PYTHON" -m unittest tests.test_check_test_target_integrity
 
+echo "=== Test-suite registry core verifier (#5003 S3a-1) ==="
+"$PYTHON" -m unittest tests.test_check_test_suite_registry
+
 echo "=== PostgreSQL test-lane membership gate (#4979, enforced) ==="
 "$PYTHON" scripts/check_pg_test_lane_membership.py --baseline-ref "$TEST_LANE_BASELINE_REF"
 "$PYTHON" -m unittest tests.test_check_pg_test_lane_membership

--- a/tests/test_check_test_suite_registry.py
+++ b/tests/test_check_test_suite_registry.py
@@ -1,0 +1,218 @@
+"""Acceptance and mutation verifier for the S3a-1 registry facts."""
+from __future__ import annotations
+import importlib.util, subprocess, sys, tempfile, unittest
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("check_test_suite_registry", ROOT / "scripts/check_test_suite_registry.py")
+assert SPEC and SPEC.loader
+registry = importlib.util.module_from_spec(SPEC); sys.modules[SPEC.name] = registry; SPEC.loader.exec_module(registry)
+SUITE = """import unittest
+class Parent(unittest.TestCase):
+ def test_one(self): pass
+ def test_two(self): pass
+class Child(Parent):
+ def test_three(self): pass
+"""
+SHELL = "#!/usr/bin/env bash\ntrue\n"
+class Repo:
+    def __init__(self):
+        self.tmp = tempfile.TemporaryDirectory(); self.root = Path(self.tmp.name)
+        subprocess.run(("git", "init", "-q"), cwd=self.root, check=True)
+        self.write("scripts/ci-script-checks.sh", "#!/usr/bin/env bash\n")
+    def __enter__(self): return self
+    def __exit__(self, *_): self.tmp.cleanup()
+    def write(self, name, data, tracked=True):
+        path = self.root / name; path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data if isinstance(data, bytes) else data.encode())
+        if tracked: subprocess.run(("git", "add", name), cwd=self.root, check=True)
+        return path
+    def scan(self, *sources):
+        chosen = sources or ("scripts/ci-script-checks.sh",)
+        return registry.scan_registry(self.root, registry.RegistryConfig(surface_sources=chosen))
+    @staticmethod
+    def candidate(result, path): return next(item for item in result.candidates if item.path == path)
+class RegistryContract(unittest.TestCase):
+    def test_recursive_tracked_families_precedence_and_zero_counts(self):
+        with Repo() as repo:
+            families = ((registry.Family.TESTS_PY, "tests", ".py", SUITE),
+                        (registry.Family.E2E_PY, "scripts/e2e", ".py", SUITE),
+                        (registry.Family.SCRIPTS_PY, "scripts/other", ".py", SUITE),
+                        (registry.Family.SHELL, "tests", ".sh", SHELL))
+            expected = {}
+            for family, base, suffix, body in families:
+                expected[family] = {f"{base}/test_root{suffix}", f"{base}/a/test_one{suffix}", f"{base}/a/b/test_deep{suffix}"}
+                for path in expected[family]: repo.write(path, body)
+            gates = {"scripts/check_root.py", "scripts/audit_root.py", "scripts/check-root.py", "scripts/check-root.sh"}
+            for path in gates: repo.write(path, SHELL if path.endswith(".sh") else "pass\n")
+            for path in ("testers/test_no.py", "scripts/e2ex/test_no.py", "script/test_no.py",
+                         "tests/test_no.pyi", "tests/test_no.bash", "tests/helper.py", "scripts/a/check_deep.py"):
+                repo.write(path, SUITE if path.endswith((".py", ".pyi")) else SHELL)
+            repo.write(".gitignore", "tests/test_ignored.py\n"); repo.write("tests/test_ignored.py", SUITE, tracked=False)
+            result = repo.scan(); grouped = {family: {c.path for c in result.candidates if c.family is family} for family in registry.Family}
+            for family, paths in expected.items(): self.assertEqual(grouped[family], paths, family.value)
+            self.assertEqual(grouped[registry.Family.GATE], gates)
+            self.assertEqual(result.family_counts, {**{key: 3 for key in expected}, registry.Family.GATE: 4})
+            self.assertEqual(result.family_violations({registry.Family.TESTS_PY: 4})[0].actual, 3)
+        with Repo() as empty: self.assertEqual(empty.scan().family_counts, {family: 0 for family in registry.Family})
+    def test_tracked_inputs_fail_closed_without_masking_valid_candidate(self):
+        cases = (("tests/test_gone.sh", SHELL, "missing", 'for x in tests/*.sh; do bash "$x"; done', registry.DiagnosticKind.SOURCE_MISSING),
+                 ("scripts/check_gone.py", "pass\n", "missing", "python3 scripts/check_gone.py", registry.DiagnosticKind.SOURCE_MISSING),
+                 ("tests/test_bad_utf.py", b"\xff", "keep", "python3 tests/test_bad_utf.py", registry.DiagnosticKind.SOURCE_UNREADABLE),
+                 ("tests/test_nul.sh", b"true\0", "keep", "bash tests/test_nul.sh", registry.DiagnosticKind.SOURCE_MALFORMED),
+                 ("tests/test_dir.sh", SHELL, "directory", "bash tests/test_dir.sh", registry.DiagnosticKind.SOURCE_UNREADABLE),
+                 ("scripts/check_bad.py", "if :\n", "keep", "python3 scripts/check_bad.py", registry.DiagnosticKind.PYTHON_MALFORMED),
+                 ("tests/test_cont.sh", "echo x " + "\\", "keep", "bash tests/test_cont.sh", registry.DiagnosticKind.SOURCE_MALFORMED),
+                 ("tests/test_quote.sh", 'bash "unterminated\n', "keep", "bash tests/test_quote.sh", registry.DiagnosticKind.SOURCE_MALFORMED))
+        for path, body, shape, command, kind in cases:
+            with self.subTest(path=path), Repo() as repo:
+                target = repo.write(path, body); repo.write("tests/test_good.py", SUITE)
+                if shape == "missing": target.unlink()
+                elif shape == "directory": target.unlink(); target.mkdir()
+                repo.write("scripts/ci-script-checks.sh", command + "\npython3 -m unittest tests.test_good\n")
+                result = repo.scan(); self.assertFalse(result.input_valid)
+                self.assertEqual(repo.candidate(result, path).execution, registry.ExecStatus.NONE)
+                self.assertEqual(repo.candidate(result, "tests/test_good.py").execution, registry.ExecStatus.FULL)
+                self.assertIn(kind, {item.kind for item in result.diagnostics if item.fatal})
+    def test_declared_root_input_errors_are_fatal(self):
+        for source, payload in (("missing", None), ("package.json", "{"), (".github/workflows/x.yml", 'jobs:\n  x:\n    run: "unterminated\n')):
+            with self.subTest(source=source), Repo() as repo:
+                if payload is not None: repo.write(source, payload)
+                result = repo.scan(source); self.assertFalse(result.input_valid)
+                self.assertTrue(any(item.fatal for item in result.diagnostics))
+    def test_nonexecution_text_and_workflow_scalar_state(self):
+        with Repo() as repo:
+            repo.write("tests/test_meta.py", SUITE); repo.write("tests/test_meta.sh", SHELL); repo.write("tests/test_prose.sh", SHELL)
+            repo.write("scripts/ci-script-checks.sh", """# python3 -m unittest tests.test_meta
+mention=(python3 -m unittest tests.test_meta)
+"python3 -m unittest tests.test_meta"
+self.assertIn("pytest tests/test_meta.py", text)
+echo python3 -m unittest tests.test_meta
+printf '%s' pytest tests/test_meta.py
+echo 'required_shell_suites=(tests/test_prose.sh)'
+required_shell_suites=(tests/test_meta.sh)
+""")
+            result = repo.scan(); self.assertEqual(repo.candidate(result, "tests/test_meta.py").execution, registry.ExecStatus.NONE)
+            self.assertEqual((repo.candidate(result, "tests/test_meta.sh").execution, repo.candidate(result, "tests/test_meta.sh").pin),
+                             (registry.ExecStatus.NONE, registry.PinStatus.REQUIRED_ARRAY))
+            self.assertEqual(repo.candidate(result, "tests/test_prose.sh").pin, registry.PinStatus.NONE)
+            workflow = "name: python3 -m unittest tests.test_meta\ndescription: |\n  run: pytest tests/test_meta.py\njobs:\n  x:\n    steps:\n"
+            repo.write(".github/workflows/x.yml", workflow); self.assertEqual(repo.candidate(repo.scan(".github/workflows/x.yml"), "tests/test_meta.py").execution, registry.ExecStatus.NONE)
+            runs = ("      - run: python3 -m unittest tests.test_meta\n", "      - run: 'python3 -m unittest tests.test_meta'\n",
+                    '      - run: "python3 -m unittest tests.test_meta"\n')
+            runs += tuple(f"      - run: {style}\n          python3 -m unittest \\\n          tests.test_meta\n" for style in ("|", "|-", "|+"))
+            runs += tuple(f"      - run: {style}\n          python3 -m unittest\n          tests.test_meta\n" for style in (">", ">-", ">+"))
+            runs += ("      - description: |\n          run: pytest tests/test_meta.py\n        run: python3 -m unittest tests.test_meta\n",)
+            for run in runs:
+                with self.subTest(run=run.splitlines()[0]):
+                    repo.write(".github/workflows/x.yml", workflow + run)
+                    self.assertEqual(repo.candidate(repo.scan(".github/workflows/x.yml"), "tests/test_meta.py").execution, registry.ExecStatus.FULL)
+    def test_literal_reachability_normalization_cycles_and_source_locality(self):
+        with Repo() as repo:
+            repo.write("tests/test_a.py", SUITE); repo.write("tests/test_b.py", SUITE)
+            repo.write("scripts/driver.sh", 'bash "scripts/sub/child.sh"\n')
+            repo.write("scripts/sub/child.sh", 'bash "$SCRIPT_DIR/../leaf.sh"\n')
+            repo.write("scripts/leaf.sh", 'python3 -m unittest tests.test_a\nbash "$SCRIPT_DIR/driver.sh"\n')
+            repo.write("scripts/other/leaf.sh", "python3 -m unittest tests.test_b\n")
+            repo.write("scripts/ci-script-checks.sh", 'bash "scripts/driver.sh"\n')
+            result = repo.scan(); self.assertEqual(repo.candidate(result, "tests/test_a.py").execution, registry.ExecStatus.FULL)
+            self.assertEqual(repo.candidate(result, "tests/test_b.py").execution, registry.ExecStatus.NONE)
+            self.assertEqual(len(result.reachable_sources), len(set(result.reachable_sources)))
+            self.assertIn("scripts/leaf.sh", result.reachable_sources); self.assertNotIn("scripts/other/leaf.sh", result.reachable_sources)
+            repo.write("scripts/sub/child.sh", 'bash "$SCRIPT_DIR/../../../escape.sh"\n')
+            escaped = repo.scan(); self.assertFalse(escaped.input_valid)
+            self.assertIn(registry.DiagnosticKind.UNSUPPORTED_CALL, {item.kind for item in escaped.diagnostics if item.fatal})
+    def test_dynamic_runner_targets_fail_closed_but_prose_is_inert(self):
+        with Repo() as repo:
+            repo.write("tests/test_dynamic.sh", SHELL)
+            for command in ('target=tests/test_dynamic.sh; bash "$target"', 'bash "{{ target }}"', 'python3 "$target"', 'pytest "$target"', 'node --test "$target"'):
+                repo.write("scripts/ci-script-checks.sh", command + "\n"); result = repo.scan()
+                self.assertFalse(result.input_valid, command); self.assertEqual(repo.candidate(result, "tests/test_dynamic.sh").execution, registry.ExecStatus.NONE)
+                self.assertIn(registry.DiagnosticKind.UNSUPPORTED_CALL, {item.kind for item in result.diagnostics if item.fatal})
+            repo.write("scripts/ci-script-checks.sh", "echo 'bash $target'\n")
+            self.assertTrue(repo.scan().input_valid)
+    def test_static_ids_live_main_inverse_guard_and_harness_mismatch(self):
+        cases = (("unittest.main()", registry.ExecStatus.FULL),
+                 ("if __name__ == '__main__':\n unittest.main()", registry.ExecStatus.FULL),
+                 ("if __name__ != '__main__':\n unittest.main()", registry.ExecStatus.NONE),
+                 ("def hidden():\n unittest.main()", registry.ExecStatus.NONE),
+                 ("class Hidden:\n unittest.main()", registry.ExecStatus.NONE),
+                 ("hidden = lambda: unittest.main()", registry.ExecStatus.NONE),
+                 ("if enabled:\n unittest.main()", registry.ExecStatus.NONE))
+        with Repo() as repo:
+            repo.write("scripts/ci-script-checks.sh", "python3 tests/test_live.py\n")
+            for body, expected in cases:
+                repo.write("tests/test_live.py", SUITE + body + "\n"); result = repo.scan()
+                self.assertEqual(repo.candidate(result, "tests/test_live.py").execution, expected, body)
+            repo.write("tests/test_bare.py", "def test_bare(): pass\n")
+            for command in ("python3 -m unittest tests.test_bare", "python3 tests/test_bare.py"):
+                repo.write("scripts/ci-script-checks.sh", command + "\n"); result = repo.scan()
+                self.assertEqual(repo.candidate(result, "tests/test_bare.py").execution, registry.ExecStatus.NONE)
+                self.assertIn(registry.DiagnosticKind.HARNESS_MISMATCH, {item.kind for item in result.diagnostics})
+            repo.write("scripts/ci-script-checks.sh", "pytest tests/test_bare.py\n")
+            self.assertEqual(repo.candidate(repo.scan(), "tests/test_bare.py").execution, registry.ExecStatus.FULL)
+    def test_exact_method_is_partial_preserves_ids_and_deletion_is_none(self):
+        with Repo() as repo:
+            repo.write("tests/test_partial.py", SUITE); target = "tests.test_partial.Child.test_three"
+            repo.write("scripts/ci-script-checks.sh", f"python3 -m unittest {target}\n"); result = repo.scan(); item = repo.candidate(result, "tests/test_partial.py")
+            self.assertEqual((item.execution, item.executed_tests, item.unexecuted_tests),
+                             (registry.ExecStatus.PARTIAL, ("Child.test_three",), ("Parent.test_one", "Parent.test_two")))
+            self.assertEqual(item.pin_evidence[0].target, target)
+            self.assertEqual(len(result.partial_violations()), 1); self.assertEqual(result.partial_violations({(item.path, target)}), ())
+            repo.write("scripts/ci-script-checks.sh", "python3 -m unittest tests.test_partial\n")
+            self.assertEqual(repo.candidate(repo.scan(), item.path).execution, registry.ExecStatus.FULL)
+            repo.write("scripts/ci-script-checks.sh", "# deleted\n")
+            self.assertEqual(repo.candidate(repo.scan(), item.path).execution, registry.ExecStatus.NONE)
+    def test_orthogonal_axes_exact_provenance_dedupe_and_order(self):
+        with Repo() as repo:
+            for name in "abc": repo.write(f"tests/test_{name}.sh", SHELL)
+            repo.write("scripts/ci-script-checks.sh", 'bash tests/test_a.sh\nrequired_shell_suites=(tests/test_b.sh)\nfor item in tests/*.sh; do\n bash "$item"\ndone\n')
+            repo.write("justfile", "x:\n  bash tests/test_a.sh\n  bash tests/test_a.sh\n")
+            result = repo.scan("scripts/ci-script-checks.sh", "justfile"); a, b, c = (repo.candidate(result, f"tests/test_{name}.sh") for name in "abc")
+            self.assertEqual([(x.execution, x.pin) for x in (a, b, c)], [(registry.ExecStatus.FULL, registry.PinStatus.PINNED),
+                             (registry.ExecStatus.GLOB, registry.PinStatus.REQUIRED_ARRAY), (registry.ExecStatus.GLOB, registry.PinStatus.GLOB_UNPINNED)])
+            exact = [x for x in a.pin_evidence if x.status is registry.PinStatus.PINNED]
+            self.assertEqual([(x.source, x.command, x.target) for x in exact], [("justfile", "bash tests/test_a.sh", "tests/test_a.sh"),
+                             ("scripts/ci-script-checks.sh", "bash tests/test_a.sh", "tests/test_a.sh")])
+            required = next(x for x in b.pin_evidence if x.status is registry.PinStatus.REQUIRED_ARRAY)
+            self.assertEqual((required.source, required.command, required.target),
+                             ("scripts/ci-script-checks.sh", "required_shell_suites=(tests/test_b.sh)", "tests/test_b.sh"))
+            glob = next(x for x in c.invocations if x.glob); self.assertEqual((glob.source, glob.command, glob.target), ("scripts/ci-script-checks.sh", 'bash "$item"', "tests/*.sh"))
+            self.assertEqual(result, repo.scan("scripts/ci-script-checks.sh", "justfile"))
+    def test_path_segment_globs_root_and_explicit_recursive_cases(self):
+        with Repo() as repo:
+            fixtures = {"tests/test_root.py": SUITE, "tests/a/test_deep.py": SUITE, "tests/test_root.sh": SHELL, "tests/a/test_deep.sh": SHELL}
+            for path, body in fixtures.items(): repo.write(path, body)
+            for py, shell, expected in (("tests/*.py", "tests/*.sh", (registry.ExecStatus.GLOB, registry.ExecStatus.NONE, registry.ExecStatus.GLOB, registry.ExecStatus.NONE)),
+                                        ("tests/**/*.py", "tests/**/*.sh", (registry.ExecStatus.GLOB,) * 4)):
+                repo.write("scripts/ci-script-checks.sh", f'pytest {py}\nfor x in {shell}; do bash "$x"; done\n')
+                result = repo.scan(); self.assertEqual(tuple(repo.candidate(result, path).execution for path in fixtures), expected)
+    def test_comment_continuation_order_and_odd_even_parity(self):
+        slash = "\\"
+        cases = (("# docs " + slash + "\n", True), ("true # docs " + slash + "\n", True),
+                 ("printf '%s' '#' " + slash + "\n", False), ("printf '%s' \\# " + slash + "\n", False),
+                 ("printf '%s' ok " + slash * 2 + "\n", True), ("printf '%s' ok " + slash + "\n", False))
+        for body, valid in cases:
+            with self.subTest(body=body), Repo() as repo:
+                repo.write("tests/test_cont.sh", "#!/bin/sh\n" + body); repo.write("scripts/ci-script-checks.sh", "bash tests/test_cont.sh\n")
+                result = repo.scan(); self.assertEqual(result.input_valid, valid)
+                self.assertEqual(repo.candidate(result, "tests/test_cont.sh").execution, registry.ExecStatus.FULL if valid else registry.ExecStatus.NONE)
+    def test_reused_loop_variable_retains_every_pattern(self):
+        with Repo() as repo:
+            repo.write("tests/first/test_a.sh", SHELL); repo.write("tests/second/test_b.sh", SHELL)
+            repo.write("scripts/ci-script-checks.sh", 'for item in tests/first/*.sh; do bash "$item"; done\nfor item in tests/second/*.sh; do bash "$item"; done\n')
+            result = repo.scan(); first = repo.candidate(result, "tests/first/test_a.sh")
+            self.assertEqual(first.execution, registry.ExecStatus.GLOB)
+            self.assertEqual({item.target for item in first.invocations}, {"tests/first/*.sh"})
+            self.assertEqual(repo.candidate(result, "tests/second/test_b.sh").execution, registry.ExecStatus.GLOB)
+    def test_declared_roots_and_report_gate_are_independent_facts(self):
+        with Repo() as repo:
+            for name in ("report", "just", "make", "package"): repo.write(f"tests/test_{name}.py", SUITE)
+            repo.write("scripts/audit_report.py", "print('report only')\n")
+            repo.write("scripts/ci-script-checks.sh", "python3 -m unittest tests.test_report\n")
+            repo.write("justfile", "x:\n  python3 -m unittest tests.test_just\n")
+            repo.write("Makefile", "x:\n\tpython3 -m unittest tests.test_make\n")
+            repo.write("package.json", '{"scripts":{"x":"python3 -m unittest tests.test_package"}}\n')
+            result = repo.scan("scripts/ci-script-checks.sh", "justfile", "Makefile", "package.json")
+            self.assertEqual(repo.candidate(result, "scripts/audit_report.py").execution, registry.ExecStatus.NONE)
+            self.assertEqual([repo.candidate(result, f"tests/test_{name}.py").execution for name in ("report", "just", "make", "package")], [registry.ExecStatus.FULL] * 4)
+if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
## Summary

Clean-room reconstruction of the minimum #5003 S3a-1 registry core after the terminal review cap on #5291.

- Adds `scripts/check_test_suite_registry.py`, a deterministic tracked-index fact scanner.
- Adds a 13-test table-driven verifier covering all r1/r2/r3 P1 counterexamples and required positive controls.
- Adds only the verifier suite to `scripts/ci-script-checks.sh`; the registry core is **not** wired as an enforcing CI gate.

## Dependency and exact base

- Dependency PR #5293: **MERGED**
- #5293 merge commit: `283dad5f43b630fb5d19c14a077f7aceb5e5a743`
- replacement base / pre-edit HEAD / current `origin/main`: `283dad5f43b630fb5d19c14a077f7aceb5e5a743`
- replacement head: `a1eeaf2639ba98ec7c7e4632408247ace81895c2`
- merge-base with `origin/main`: `283dad5f43b630fb5d19c14a077f7aceb5e5a743`

The branch and worktree were created directly from that exact fetched main. No old #5291 commit, hunk, patch, merge, cherry-pick, or rebase was reused.

## Scope

Included only:

1. registry fact core;
2. complete table-driven verifier;
3. standalone verifier invocation in the script-check driver.

Explicitly excluded:

- S3a-2 allowlist, production family floors/baselines, policy enforcement, warn/enforce modes, cross-seals, or registry-core CI gate;
- S3b suite wiring, required-array expansion, harness/PARTIAL repair, allowlist burn-down, or application/config changes;
- P2 work and unrelated cleanup.

## Measured facts

| fact | exact base | replacement | delta |
|---|---:|---:|---:|
| candidates | 95 | 97 | +2 |
| tests Python family | 48 | 49 | +1 verifier |
| e2e Python family | 9 | 9 | 0 |
| other scripts Python family | 2 | 2 | 0 |
| shell family | 12 | 12 | 0 |
| gate candidates | 24 | 25 | +1 report-only core |
| execution FULL / PARTIAL / GLOB / NONE | 40 / 1 / 10 / 20 | 41 / 1 / 10 / 20 | FULL +1 |
| pin PINNED / REQUIRED_ARRAY / GLOB_UNPINNED / NONE | 41 / 1 / 9 / 20 | 42 / 1 / 9 / 20 | PINNED +1 |

Both scans were valid with zero diagnostics. Python `NONE` debt remains 20 modules / 261 static IDs. The preserved `PARTIAL` is `tests/test_audit_maintainability.py`: 50 defined / 2 executed / 48 unexecuted.

The new verifier is independently `FULL/PINNED` with 13 static IDs. The new registry core is independently a report-only gate candidate at `NONE/NONE`.

## Size

| file | additions | deletions |
|---|---:|---:|
| `scripts/check_test_suite_registry.py` | 556 | 0 |
| `scripts/ci-script-checks.sh` | 3 | 0 |
| `tests/test_check_test_suite_registry.py` | 218 | 0 |
| **total** | **777** | **0** |

Surface: 3 changed files; full churn 777, below the hard cap of 800.

## Direct validation

All prescribed commands returned rc=0:

- `python3 -m unittest tests.test_check_test_suite_registry` — 13 tests OK
- `python3 -m py_compile scripts/check_test_suite_registry.py tests/test_check_test_suite_registry.py`
- `bash -n scripts/ci-script-checks.sh`
- `python3 scripts/check_test_suite_registry.py`
- `python3 scripts/generate_inventory_docs.py` — all generated outputs unchanged
- `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate`
- `git diff --check`

The aggregate script-check driver, Cargo/Rust, actual shell/E2E suites, and live/runtime operations were not run, per slice redlines.

## Mutation proof

Each temporary fixture proved that its script and verifier resolved to the same temporary root. Every mutant had compile rc=0, standalone import rc=0, verifier rc=1 through named `FAIL` assertions (no import/error death), and restored-source verifier rc=0.

| cluster / exact transformation | killed by |
|---|---|
| recursive matcher `(?:[^/]+/)*` → `(?:[^/]+/)?` | `test_recursive_tracked_families_precedence_and_zero_counts` |
| candidate validation diagnostic/invalid assignment → forced valid | `test_tracked_inputs_fail_closed_without_masking_valid_candidate` |
| workflow state reader → naive every-`run:` physical-line extraction | `test_nonexecution_text_and_workflow_scalar_state` |
| dynamic-path guard and literal-shell BFS disabled | `test_dynamic_runner_targets_fail_closed_but_prose_is_inert`, `test_literal_reachability_normalization_cycles_and_source_locality` |
| positive main-guard predicate removed | `test_static_ids_live_main_inverse_guard_and_harness_mismatch` |
| pin dedupe key collapsed to target/status | `test_orthogonal_axes_exact_provenance_dedupe_and_order` |
| segment `*` matcher `[^/]*` → `.*` | `test_path_segment_globs_root_and_explicit_recursive_cases` |
| odd-parity continuation check → any trailing backslash | `test_comment_continuation_order_and_odd_even_parity` |
| loop binding append → overwrite | `test_reused_loop_variable_retains_every_pattern` |

## Replacement handling

This PR is the prospective replacement for #5291 only after a fresh implementation-separated review, green required CI, and landing readiness. Old #5291 remains **OPEN/draft** throughout review and must remain so until this replacement actually lands. This PR is draft and must not be merged by this implementation turn.

Part of #5003.
