### PR TITLE
fix(relay): canonicalize managed Codex TUI delivery

### DIFF
--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -3680,6 +3680,8 @@ services::discord::recovery_engine::rebind_runtime::tests::claude_rebind_with_le
 services::discord::recovery_engine::rebind_runtime::tests::claude_rebind_with_selector_transcript_uses_claude_tui_output_path
 services::discord::recovery_engine::rebind_runtime::tests::claude_rebind_without_runtime_marker_does_not_promote_transcript_to_claude_tui
 services::discord::recovery_engine::rebind_runtime::tests::claude_rebind_without_transcript_candidate_uses_default_wrapper_output_path
+services::discord::recovery_engine::rebind_runtime::tests::codex_canonical_relay_durably_offsets_done_and_translates_runtime_ready
+services::discord::recovery_engine::rebind_runtime::tests::codex_canonical_relay_replays_uncommitted_suffix_without_duplicate_prefix
 services::discord::recovery_engine::rebind_runtime::tests::codex_rebind_relay_generation_fences_superseded_same_path_writer
 services::discord::recovery_engine::rebind_runtime::tests::codex_rebind_rollout_cursor_does_not_move_backward_for_same_rollout
 services::discord::recovery_engine::rebind_runtime::tests::codex_rebind_rollout_cursor_persists_explicit_monotonic_offset
@@ -5032,6 +5034,7 @@ services::discord::tmux::watcher_lifecycle::restore_tests::restored_session_cwd_
 services::discord::tmux::watcher_lifecycle::restore_tests::restored_session_cwd_channel_isolation_pg_tests::watcher_recovery_cwd_does_not_cross_channels
 services::discord::tmux::watcher_lifecycle::restore_tests::restored_session_cwd_channel_isolation_pg_tests::watcher_recovery_cwd_legacy_null_channel_id_not_reused
 services::discord::tmux::watcher_lifecycle::tests::tests::cancel_suppression_only_applies_before_terminal_delivery
+services::discord::tmux::watcher_lifecycle::tests::tests::canonical_codex_foreground_replaces_post_restart_raw_incumbent
 services::discord::tmux::watcher_lifecycle::tests::tests::delivered_then_idle_death_surfaces_no_lifecycle_signal
 services::discord::tmux::watcher_lifecycle::tests::tests::forced_rebind_replaces_live_same_output_incumbent
 services::discord::tmux::watcher_lifecycle::tests::tests::genuine_mid_turn_crash_triggers_restart_handoff
@@ -5314,6 +5317,7 @@ services::discord::tui_prompt_relay::tests::codex_external_input_relay_output_pa
 services::discord::tui_prompt_relay::tests::codex_idle_prompt_tails_only_new_ssh_direct_prompt
 services::discord::tui_prompt_relay::tests::codex_ownerless_external_input_undelivered_turn_needs_rollout_repair
 services::discord::tui_prompt_relay::tests::codex_rehydrate_thread_session_resolves_thread_channel_id
+services::discord::tui_prompt_relay::tests::codex_synthetic_start_uses_canonical_path_and_cursor
 services::discord::tui_prompt_relay::tests::command_message_skill_wakeup_preserves_assistant_relay_lifecycle
 services::discord::tui_prompt_relay::tests::compact_continuation_injection_skips_synthetic_and_leaves_mailbox_free
 services::discord::tui_prompt_relay::tests::confirmed_existing_session_is_not_dead_even_if_pane_probes_flake
@@ -5716,6 +5720,7 @@ services::discord::turn_bridge::terminal_controller_cutover::tests::bridge_short
 services::discord::turn_bridge::terminal_controller_cutover::tests::bridge_short_replace_controller::bridge_short_replace_partial_failure_no_advance
 services::discord::turn_bridge::terminal_controller_cutover::tests::bridge_short_replace_controller::bridge_short_replace_routes_edit_to_delivery_channel
 services::discord::turn_bridge::terminal_controller_cutover::tests::bridge_short_replace_controller::bridge_terminal_lease_range_pins_cutover
+services::discord::turn_bridge::terminal_controller_cutover::tests::bridge_short_replace_controller::codex_canonical_range_cuts_over_without_runtime_ready_dependency
 services::discord::turn_bridge::terminal_delivery::relay_state_contract_refs::contract_symbols_exist
 services::discord::turn_bridge::terminal_delivery::tests::a0_characterization_tests::a0_terminal_delivery_predicate_boundary_is_strictly_greater_than_2000
 services::discord::turn_bridge::terminal_delivery::tests::a0_characterization_tests::a0_terminal_delivery_predicate_gates_on_can_chain_and_over_limit
@@ -7157,6 +7162,7 @@ services::tui_prompt_dedupe::tests::clear_external_input_relay_lease_if_generati
 services::tui_prompt_dedupe::tests::clear_external_input_relay_lease_if_matches_preserves_newer_turn
 services::tui_prompt_dedupe::tests::clears_runtime_binding_by_tmux_session
 services::tui_prompt_dedupe::tests::codex_and_qwen_keep_claude_interrupt_text_as_user_prompt
+services::tui_prompt_dedupe::tests::codex_canonical_offsets_advance_atomically_or_not_at_all
 services::tui_prompt_dedupe::tests::codex_distinct_message_entry_ids_publish_distinct_direct_prompts
 services::tui_prompt_dedupe::tests::dedup_suppressed_candidate_does_not_record_entry_id
 services::tui_prompt_dedupe::tests::deferred_anchor_completion_is_isolated_by_provider_and_session

--- a/scripts/lib_test_inventory_manifest.txt
+++ b/scripts/lib_test_inventory_manifest.txt
@@ -5720,7 +5720,6 @@ services::discord::turn_bridge::terminal_controller_cutover::tests::bridge_short
 services::discord::turn_bridge::terminal_controller_cutover::tests::bridge_short_replace_controller::bridge_short_replace_partial_failure_no_advance
 services::discord::turn_bridge::terminal_controller_cutover::tests::bridge_short_replace_controller::bridge_short_replace_routes_edit_to_delivery_channel
 services::discord::turn_bridge::terminal_controller_cutover::tests::bridge_short_replace_controller::bridge_terminal_lease_range_pins_cutover
-services::discord::turn_bridge::terminal_controller_cutover::tests::bridge_short_replace_controller::codex_canonical_range_cuts_over_without_runtime_ready_dependency
 services::discord::turn_bridge::terminal_delivery::relay_state_contract_refs::contract_symbols_exist
 services::discord::turn_bridge::terminal_delivery::tests::a0_characterization_tests::a0_terminal_delivery_predicate_boundary_is_strictly_greater_than_2000
 services::discord::turn_bridge::terminal_delivery::tests::a0_characterization_tests::a0_terminal_delivery_predicate_gates_on_can_chain_and_over_limit

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -573,7 +573,7 @@ fn direct_tui_material_fallback_reason(options: &CodexLaunchOptions) -> Option<&
     None
 }
 
-fn register_codex_tui_idle_relay_binding(
+pub(crate) fn register_codex_tui_idle_relay_binding(
     tmux_session_name: &str,
     tail_result: &crate::services::codex_tui::rollout_tail::CodexTuiTailResult,
 ) {
@@ -1211,6 +1211,7 @@ pub fn execute_command_streaming(
     goals_enabled: Option<bool>,
     compact_token_limit: Option<u64>,
     force_fresh_provider_session: bool,
+    canonical_discord_delivery: bool,
 ) -> Result<(), String> {
     #[cfg(unix)]
     let entrypoint_supports_tui_hosting =
@@ -1328,6 +1329,7 @@ pub fn execute_command_streaming(
                     readonly_mode,
                     compact_token_limit,
                     force_fresh_provider_session,
+                    canonical_discord_delivery,
                 );
             }
             log_codex_runtime_kind(
@@ -1767,6 +1769,7 @@ fn execute_streaming_local_tui_tmux(
     readonly_mode: bool,
     compact_token_limit: Option<u64>,
     force_fresh_provider_session: bool,
+    canonical_discord_delivery: bool,
 ) -> Result<(), String> {
     let warm_followup_enabled =
         crate::services::codex_tui::warm_followup::codex_tui_warm_followup_enabled();
@@ -1835,6 +1838,7 @@ fn execute_streaming_local_tui_tmux(
             cancel_token.clone(),
             tmux_session_name,
             report_channel_id,
+            canonical_discord_delivery,
         ) {
             crate::services::codex_tui::warm_followup::CodexWarmFollowupOutcome::Terminal(
                 result,
@@ -1865,6 +1869,21 @@ fn execute_streaming_local_tui_tmux(
     crate::services::tmux_common::cleanup_session_temp_files(tmux_session_name);
     crate::services::codex_tui::session::CodexTuiSessionFiles::for_tmux_session(tmux_session_name)
         .cleanup_best_effort();
+
+    let canonical_relay = canonical_discord_delivery
+        .then(|| {
+            crate::services::discord::CodexCanonicalRelay::start(
+                tmux_session_name,
+                sender.clone(),
+                true,
+                Some(0),
+            )
+        })
+        .transpose()?;
+    let provider_sender = canonical_relay
+        .as_ref()
+        .map(crate::services::discord::CodexCanonicalRelay::sender)
+        .unwrap_or_else(|| sender.clone());
 
     let CodexTuiLaunchScript {
         script_path,
@@ -1941,7 +1960,7 @@ fn execute_streaming_local_tui_tmux(
         resume_params,
         working_dir,
         rollout_modified_since,
-        sender.clone(),
+        provider_sender.clone(),
         cancel_token,
         tmux_session_name,
         prompt,
@@ -1957,12 +1976,29 @@ fn execute_streaming_local_tui_tmux(
         None => return Ok(()),
     };
 
+    let tail_result_for_binding = tail_result.clone();
     emit_codex_tui_post_tail_handoff(
         tail_result,
-        sender,
+        provider_sender.clone(),
         cancel_token_for_post_tail,
         tmux_session_name,
-    )
+        !canonical_discord_delivery,
+    )?;
+    drop(provider_sender);
+    if let Some(canonical_relay) = canonical_relay {
+        let canonical = canonical_relay.finish()?;
+        if canonical.terminal_records == 0 {
+            return Err("Codex canonical relay closed without a terminal record".to_string());
+        }
+        register_codex_tui_idle_relay_binding(tmux_session_name, &tail_result_for_binding);
+        debug_assert_eq!(
+            canonical.end_offset,
+            std::fs::metadata(&canonical.output_path)
+                .map(|metadata| metadata.len())
+                .unwrap_or(canonical.end_offset)
+        );
+    }
+    Ok(())
 }
 
 /// Resolve the rollout-tail result for the Codex Direct TUI launch.
@@ -2051,6 +2087,7 @@ pub(crate) fn emit_codex_tui_post_tail_handoff(
     sender: Sender<StreamMessage>,
     cancel_token_for_post_tail: Option<std::sync::Arc<CancelToken>>,
     tmux_session_name: &str,
+    register_idle_binding: bool,
 ) -> Result<(), String> {
     let cancel_observed =
         || crate::services::provider::cancel_requested(cancel_token_for_post_tail.as_deref());
@@ -2099,7 +2136,9 @@ pub(crate) fn emit_codex_tui_post_tail_handoff(
         // different: it scans Codex's rollout after the bridge has gone idle,
         // so it still needs the rollout binding even when RuntimeReady is
         // suppressed by the post-turn readiness guard.
-        register_codex_tui_idle_relay_binding(tmux_session_name, &tail_result);
+        if register_idle_binding {
+            register_codex_tui_idle_relay_binding(tmux_session_name, &tail_result);
+        }
 
         // #2325: gate the RuntimeReady handoff on the Codex TUI composer
         // actually being ready for input. RuntimeReady is the signal the
@@ -3743,6 +3782,7 @@ mod remote_dispatch_gate_tests {
             None,
             None,
             None,
+            false,
             false,
         );
 

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -595,6 +595,17 @@ pub(crate) fn register_codex_tui_idle_relay_binding(
     );
 }
 
+pub(crate) fn codex_canonical_terminal_required(
+    read_result: &crate::services::provider::ReadOutputResult,
+    cancel_requested: bool,
+) -> bool {
+    !cancel_requested
+        && !matches!(
+            read_result,
+            crate::services::provider::ReadOutputResult::Cancelled { .. }
+        )
+}
+
 fn codex_tui_idle_relay_binding(
     tmux_session_name: &str,
     tail_result: &crate::services::codex_tui::rollout_tail::CodexTuiTailResult,
@@ -1977,6 +1988,10 @@ fn execute_streaming_local_tui_tmux(
     };
 
     let tail_result_for_binding = tail_result.clone();
+    let canonical_terminal_required = codex_canonical_terminal_required(
+        &tail_result_for_binding.read_result,
+        crate::services::provider::cancel_requested(cancel_token_for_post_tail.as_deref()),
+    );
     emit_codex_tui_post_tail_handoff(
         tail_result,
         provider_sender.clone(),
@@ -1987,16 +2002,10 @@ fn execute_streaming_local_tui_tmux(
     drop(provider_sender);
     if let Some(canonical_relay) = canonical_relay {
         let canonical = canonical_relay.finish()?;
-        if canonical.terminal_records == 0 {
+        if canonical.terminal_records == 0 && canonical_terminal_required {
             return Err("Codex canonical relay closed without a terminal record".to_string());
         }
         register_codex_tui_idle_relay_binding(tmux_session_name, &tail_result_for_binding);
-        debug_assert_eq!(
-            canonical.end_offset,
-            std::fs::metadata(&canonical.output_path)
-                .map(|metadata| metadata.len())
-                .unwrap_or(canonical.end_offset)
-        );
     }
     Ok(())
 }

--- a/src/services/codex_tui/warm_followup.rs
+++ b/src/services/codex_tui/warm_followup.rs
@@ -300,6 +300,7 @@ pub(crate) fn try_codex_tui_warm_followup(
     cancel_token: Option<std::sync::Arc<CancelToken>>,
     tmux_session_name: &str,
     report_channel_id: Option<u64>,
+    canonical_discord_delivery: bool,
 ) -> CodexWarmFollowupOutcome {
     let marker = super::session::read_codex_tui_rollout_marker(tmux_session_name);
     let fingerprint = codex_tui_launch_options_fingerprint(launch_options);
@@ -401,6 +402,27 @@ pub(crate) fn try_codex_tui_warm_followup(
         crate::services::tui_prompt_dedupe::register_tmux_channel(tmux_session_name, channel_id);
     }
 
+    let canonical_relay = if canonical_discord_delivery {
+        let committed_start =
+            crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(tmux_session_name)
+                .map(|binding| binding.relay_last_offset());
+        match crate::services::discord::CodexCanonicalRelay::start(
+            tmux_session_name,
+            sender.clone(),
+            false,
+            committed_start,
+        ) {
+            Ok(relay) => Some(relay),
+            Err(error) => return CodexWarmFollowupOutcome::Terminal(Err(error)),
+        }
+    } else {
+        None
+    };
+    let provider_sender = canonical_relay
+        .as_ref()
+        .map(crate::services::discord::CodexCanonicalRelay::sender)
+        .unwrap_or_else(|| sender.clone());
+
     match super::input::submit_codex_followup_prompt(
         tmux_session_name,
         prompt,
@@ -492,7 +514,7 @@ pub(crate) fn try_codex_tui_warm_followup(
         rollout_path,
         start_offset,
         session_id,
-        sender.clone(),
+        provider_sender.clone(),
         cancel_token.clone(),
         || crate::services::tmux_diagnostics::tmux_session_has_live_pane(tmux_session_name),
         tmux_session_name,
@@ -505,12 +527,40 @@ pub(crate) fn try_codex_tui_warm_followup(
         }
         Err(error) => return CodexWarmFollowupOutcome::Terminal(Err(error)),
     };
-    CodexWarmFollowupOutcome::Terminal(crate::services::codex::emit_codex_tui_post_tail_handoff(
+    let tail_result_for_binding = tail_result.clone();
+    let handoff = crate::services::codex::emit_codex_tui_post_tail_handoff(
         tail_result,
-        sender,
+        provider_sender.clone(),
         cancel_token,
         tmux_session_name,
-    ))
+        !canonical_discord_delivery,
+    );
+    drop(provider_sender);
+    if let Err(error) = handoff {
+        return CodexWarmFollowupOutcome::Terminal(Err(error));
+    }
+    if let Some(canonical_relay) = canonical_relay {
+        let canonical = match canonical_relay.finish() {
+            Ok(result) if result.terminal_records > 0 => result,
+            Ok(_) => {
+                return CodexWarmFollowupOutcome::Terminal(Err(
+                    "Codex canonical warm relay closed without a terminal record".to_string(),
+                ));
+            }
+            Err(error) => return CodexWarmFollowupOutcome::Terminal(Err(error)),
+        };
+        crate::services::codex::register_codex_tui_idle_relay_binding(
+            tmux_session_name,
+            &tail_result_for_binding,
+        );
+        debug_assert_eq!(
+            canonical.end_offset,
+            std::fs::metadata(&canonical.output_path)
+                .map(|metadata| metadata.len())
+                .unwrap_or(canonical.end_offset)
+        );
+    }
+    CodexWarmFollowupOutcome::Terminal(Ok(()))
 }
 
 #[cfg(test)]

--- a/src/services/codex_tui/warm_followup.rs
+++ b/src/services/codex_tui/warm_followup.rs
@@ -528,6 +528,10 @@ pub(crate) fn try_codex_tui_warm_followup(
         Err(error) => return CodexWarmFollowupOutcome::Terminal(Err(error)),
     };
     let tail_result_for_binding = tail_result.clone();
+    let canonical_terminal_required = crate::services::codex::codex_canonical_terminal_required(
+        &tail_result_for_binding.read_result,
+        cancel_requested(cancel_token.as_deref()),
+    );
     let handoff = crate::services::codex::emit_codex_tui_post_tail_handoff(
         tail_result,
         provider_sender.clone(),
@@ -540,8 +544,8 @@ pub(crate) fn try_codex_tui_warm_followup(
         return CodexWarmFollowupOutcome::Terminal(Err(error));
     }
     if let Some(canonical_relay) = canonical_relay {
-        let canonical = match canonical_relay.finish() {
-            Ok(result) if result.terminal_records > 0 => result,
+        let _canonical = match canonical_relay.finish() {
+            Ok(result) if result.terminal_records > 0 || !canonical_terminal_required => result,
             Ok(_) => {
                 return CodexWarmFollowupOutcome::Terminal(Err(
                     "Codex canonical warm relay closed without a terminal record".to_string(),
@@ -552,12 +556,6 @@ pub(crate) fn try_codex_tui_warm_followup(
         crate::services::codex::register_codex_tui_idle_relay_binding(
             tmux_session_name,
             &tail_result_for_binding,
-        );
-        debug_assert_eq!(
-            canonical.end_offset,
-            std::fs::metadata(&canonical.output_path)
-                .map(|metadata| metadata.len())
-                .unwrap_or(canonical.end_offset)
         );
     }
     CodexWarmFollowupOutcome::Terminal(Ok(()))

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -73,6 +73,18 @@ mod sidecar_interaction;
 mod standby_relay;
 // #1074: landing zone for the future recovery-engine module split (restart / runtime / manual_rebind; see `docs/recovery-paths.md`). Named `recovery_paths` to avoid shadowing the `recovery_engine as recovery` alias until the split lands.
 mod recovery_engine;
+pub(crate) struct CodexCanonicalRelay {
+    sender: Option<std::sync::mpsc::Sender<crate::services::agent_protocol::StreamMessage>>,
+    join: Option<std::thread::JoinHandle<Result<CodexCanonicalRelayResult, String>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CodexCanonicalRelayResult {
+    pub(crate) output_path: String,
+    pub(crate) start_offset: u64,
+    pub(crate) end_offset: u64,
+    pub(crate) terminal_records: u64,
+}
 mod recovery_paths;
 mod restart_mode;
 // #1074: session identity parsing SSoT (legacy + namespaced session_key forms).

--- a/src/services/discord/recovery_engine/rebind_runtime.rs
+++ b/src/services/discord/recovery_engine/rebind_runtime.rs
@@ -1856,6 +1856,14 @@ mod tests {
         assert_eq!(rollout_path, &result.output_path);
         assert_eq!(*last_offset, result.end_offset);
         assert_eq!(result.terminal_records, 1);
+        assert!(!crate::services::codex::codex_canonical_terminal_required(
+            &crate::services::provider::ReadOutputResult::Cancelled { offset: 0 },
+            false,
+        ));
+        assert!(!crate::services::codex::codex_canonical_terminal_required(
+            &crate::services::provider::ReadOutputResult::Completed { offset: 0 },
+            true,
+        ));
         assert_eq!(
             std::fs::read_to_string(&result.output_path)
                 .unwrap()
@@ -1889,12 +1897,37 @@ mod tests {
         let first_result = first.finish().unwrap();
         drop(first_receiver);
 
+        let raw_rollout = tmp.path().join("rollout.jsonl");
+        std::fs::write(&raw_rollout, "{}\n").unwrap();
+        let mut ownerless = crate::services::discord::InflightTurnState::new(
+            ProviderKind::Codex,
+            42,
+            None,
+            0,
+            101,
+            0,
+            "external".to_string(),
+            None,
+            Some(tmux.to_string()),
+            Some(first_result.output_path.clone()),
+            None,
+            0,
+        );
+        ownerless.runtime_kind = Some(RuntimeHandoffKind::CodexTui);
+        ownerless.turn_source = crate::services::discord::inflight::TurnSource::ExternalInput;
+        ownerless.injected_prompt_message_id = Some(101);
+        crate::services::discord::inflight::save_inflight_state(&ownerless).unwrap();
+        let rehydrated = crate::services::discord::tui_prompt_relay::rehydration::codex_tui_rehydrated_binding_from_rollout_path(
+            tmux, &raw_rollout, None,
+        ).unwrap();
+        assert_eq!(rehydrated.relay_last_offset(), 0);
+
         let (second_downstream, second_receiver) = std::sync::mpsc::channel();
         let second = crate::services::discord::CodexCanonicalRelay::start(
             tmux,
             second_downstream,
             false,
-            Some(0),
+            Some(rehydrated.relay_last_offset()),
         )
         .unwrap();
         let second_sender = second.sender();

--- a/src/services/discord/recovery_engine/rebind_runtime.rs
+++ b/src/services/discord/recovery_engine/rebind_runtime.rs
@@ -1796,10 +1796,129 @@ mod tests {
                 replacement_generation,
             )
             .expect("write replacement generation")
+            .is_some()
         );
         let relay = std::fs::read_to_string(&relay_path).expect("read relay");
         assert!(!relay.contains("stale old response"));
         assert!(relay.contains("current response"));
+    }
+
+    #[test]
+    fn codex_canonical_relay_durably_offsets_done_and_translates_runtime_ready() {
+        let _guard = lock_test_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _root = EnvGuard::set_path("AGENTDESK_ROOT_DIR", tmp.path());
+        let tmux = "AgentDesk-codex-canonical-order";
+        let (downstream, receiver) = std::sync::mpsc::channel();
+        let relay =
+            crate::services::discord::CodexCanonicalRelay::start(tmux, downstream, true, Some(0))
+                .expect("start canonical relay");
+        let sender = relay.sender();
+        sender
+            .send(StreamMessage::Text {
+                content: "answer".to_string(),
+            })
+            .unwrap();
+        sender
+            .send(StreamMessage::Done {
+                result: "answer".to_string(),
+                session_id: Some("thread-1".to_string()),
+            })
+            .unwrap();
+        sender
+            .send(StreamMessage::RuntimeReady {
+                handoff: RuntimeHandoff::CodexTui {
+                    rollout_path: "/raw/rollout.jsonl".to_string(),
+                    thread_id: Some("thread-1".to_string()),
+                    tmux_session_name: tmux.to_string(),
+                    last_offset: 91_000,
+                },
+            })
+            .unwrap();
+        drop(sender);
+        let result = relay.finish().expect("finish canonical relay");
+        let messages = receiver.try_iter().collect::<Vec<_>>();
+        assert!(matches!(messages[0], StreamMessage::OutputOffset { .. }));
+        assert!(matches!(messages[1], StreamMessage::Text { .. }));
+        assert!(matches!(messages[2], StreamMessage::OutputOffset { .. }));
+        assert!(matches!(messages[3], StreamMessage::Done { .. }));
+        let StreamMessage::RuntimeReady { handoff } = &messages[5] else {
+            panic!("translated RuntimeReady missing");
+        };
+        let RuntimeHandoff::CodexTui {
+            rollout_path,
+            last_offset,
+            ..
+        } = handoff
+        else {
+            panic!("wrong handoff kind");
+        };
+        assert_eq!(rollout_path, &result.output_path);
+        assert_eq!(*last_offset, result.end_offset);
+        assert_eq!(result.terminal_records, 1);
+        assert_eq!(
+            std::fs::read_to_string(&result.output_path)
+                .unwrap()
+                .lines()
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn codex_canonical_relay_replays_uncommitted_suffix_without_duplicate_prefix() {
+        let _guard = lock_test_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _root = EnvGuard::set_path("AGENTDESK_ROOT_DIR", tmp.path());
+        let tmux = "AgentDesk-codex-canonical-replay";
+        let (first_downstream, first_receiver) = std::sync::mpsc::channel();
+        let first = crate::services::discord::CodexCanonicalRelay::start(
+            tmux,
+            first_downstream,
+            true,
+            Some(0),
+        )
+        .unwrap();
+        let first_sender = first.sender();
+        first_sender
+            .send(StreamMessage::Text {
+                content: "prefix".to_string(),
+            })
+            .unwrap();
+        drop(first_sender);
+        let first_result = first.finish().unwrap();
+        drop(first_receiver);
+
+        let (second_downstream, second_receiver) = std::sync::mpsc::channel();
+        let second = crate::services::discord::CodexCanonicalRelay::start(
+            tmux,
+            second_downstream,
+            false,
+            Some(0),
+        )
+        .unwrap();
+        let second_sender = second.sender();
+        second_sender
+            .send(StreamMessage::Text {
+                content: "prefix".to_string(),
+            })
+            .unwrap();
+        second_sender
+            .send(StreamMessage::Done {
+                result: "prefix".to_string(),
+                session_id: None,
+            })
+            .unwrap();
+        drop(second_sender);
+        let second_result = second.finish().unwrap();
+        assert!(second_receiver.try_iter().count() >= 4);
+        let lines = std::fs::read_to_string(&second_result.output_path)
+            .unwrap()
+            .lines()
+            .count();
+        assert_eq!(lines, 2, "replay must not append the existing prefix again");
+        assert_eq!(second_result.start_offset, 0);
+        assert!(second_result.end_offset > first_result.end_offset);
     }
 
     #[test]

--- a/src/services/discord/recovery_engine/rebind_runtime/codex_relay_generation.rs
+++ b/src/services/discord/recovery_engine/rebind_runtime/codex_relay_generation.rs
@@ -92,10 +92,6 @@ pub(super) fn write_message(
         .map_err(|error| format!("stat {} after write: {error}", relay_path.display()))
 }
 
-/// Synchronous raw-rollout -> canonical JSONL -> bridge adapter shared by
-/// managed and external Codex-TUI turns.  The bridge never sees a message until
-/// its normalized record is durable, and raw rollout offsets never cross this
-/// boundary.
 impl crate::services::discord::CodexCanonicalRelay {
     pub(crate) fn sender(
         &self,

--- a/src/services/discord/recovery_engine/rebind_runtime/codex_relay_generation.rs
+++ b/src/services/discord/recovery_engine/rebind_runtime/codex_relay_generation.rs
@@ -61,7 +61,7 @@ pub(super) fn write_message(
     already_normalized_replay_events: &mut std::collections::VecDeque<serde_json::Value>,
     relay_generation_gate: &CodexRebindRelayGenerationGate,
     relay_generation: u64,
-) -> Result<bool, String> {
+) -> Result<Option<u64>, String> {
     use std::io::Write;
 
     let current_generation = relay_generation_gate
@@ -71,19 +71,311 @@ pub(super) fn write_message(
         return Err("Codex TUI rebind relay generation was superseded".to_string());
     }
     let Some(json) = super::codex_rebind_stream_message_json(message) else {
-        return Ok(false);
+        return Ok(None);
     };
     if super::codex_rebind_should_skip_existing_normalized_event(
         &json,
         already_normalized_replay_events,
     ) {
-        return Ok(false);
+        return Ok(None);
     }
     serde_json::to_writer(&mut *output, &json)
         .map_err(|error| format!("serialize normalized Codex rebind event: {error}"))?;
     output
         .write_all(b"\n")
         .and_then(|_| output.flush())
+        .and_then(|_| output.sync_data())
         .map_err(|error| format!("write {}: {error}", relay_path.display()))?;
-    Ok(true)
+    output
+        .metadata()
+        .map(|metadata| Some(metadata.len()))
+        .map_err(|error| format!("stat {} after write: {error}", relay_path.display()))
+}
+
+/// Synchronous raw-rollout -> canonical JSONL -> bridge adapter shared by
+/// managed and external Codex-TUI turns.  The bridge never sees a message until
+/// its normalized record is durable, and raw rollout offsets never cross this
+/// boundary.
+impl crate::services::discord::CodexCanonicalRelay {
+    pub(crate) fn sender(
+        &self,
+    ) -> std::sync::mpsc::Sender<crate::services::agent_protocol::StreamMessage> {
+        self.sender
+            .as_ref()
+            .expect("canonical relay sender unavailable after finish")
+            .clone()
+    }
+
+    pub(crate) fn close_input(&mut self) {
+        self.sender.take();
+    }
+
+    pub(crate) fn finish(
+        mut self,
+    ) -> Result<crate::services::discord::CodexCanonicalRelayResult, String> {
+        self.sender.take();
+        self.join
+            .take()
+            .expect("canonical relay join unavailable after finish")
+            .join()
+            .map_err(|_| "Codex canonical relay panicked".to_string())?
+    }
+
+    fn close_and_join(&mut self) {
+        self.sender.take();
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+impl Drop for crate::services::discord::CodexCanonicalRelay {
+    fn drop(&mut self) {
+        self.close_and_join();
+    }
+}
+
+impl crate::services::discord::CodexCanonicalRelay {
+    pub(crate) fn start(
+        tmux_session_name: &str,
+        downstream: std::sync::mpsc::Sender<crate::services::agent_protocol::StreamMessage>,
+        truncate_output: bool,
+        committed_start_offset: Option<u64>,
+    ) -> Result<Self, String> {
+        let output_path =
+            crate::services::tmux_common::session_temp_path(tmux_session_name, "jsonl");
+        let (generation_gate, generation) = prepare(&output_path, truncate_output)
+            .map_err(|error| format!("prepare Codex canonical relay: {error}"))?;
+        let output = std::path::PathBuf::from(&output_path);
+        super::codex_rebind_ensure_jsonl_append_boundary(&output)?;
+        let physical_end = std::fs::metadata(&output)
+            .map(|metadata| metadata.len())
+            .map_err(|error| format!("stat Codex canonical relay {output_path}: {error}"))?;
+        let start_offset = if truncate_output {
+            0
+        } else {
+            committed_start_offset.unwrap_or(physical_end)
+        };
+        if start_offset > physical_end {
+            return Err(format!(
+                "Codex canonical committed offset {start_offset} exceeds EOF {physical_end}"
+            ));
+        }
+        let mut replay_events = codex_canonical_replay_events(&output, start_offset)?;
+        let mut writer = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&output)
+            .map_err(|error| format!("open Codex canonical relay {output_path}: {error}"))?;
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let join = std::thread::Builder::new()
+            .name("codex_canonical_relay".to_string())
+            .spawn(move || {
+                let mut end_offset = start_offset;
+                let mut terminal_records = 0_u64;
+                let mut known_response = String::new();
+                for message in receiver {
+                    match message {
+                        crate::services::agent_protocol::StreamMessage::OutputOffset { .. } => {
+                            continue;
+                        }
+                        crate::services::agent_protocol::StreamMessage::RuntimeReady {
+                            handoff:
+                                crate::services::agent_protocol::RuntimeHandoff::CodexTui {
+                                    thread_id,
+                                    tmux_session_name,
+                                    ..
+                                },
+                        } => {
+                            if !replay_events.is_empty() {
+                                return Err(
+                                    "Codex canonical replay suffix remained before RuntimeReady"
+                                        .to_string(),
+                                );
+                            }
+                            downstream
+                                .send(
+                                    crate::services::agent_protocol::StreamMessage::OutputOffset {
+                                        offset: end_offset,
+                                    },
+                                )
+                                .map_err(|_| {
+                                    "bridge receiver closed before canonical RuntimeReady"
+                                        .to_string()
+                                })?;
+                            downstream
+                            .send(
+                                crate::services::agent_protocol::StreamMessage::RuntimeReady {
+                                    handoff:
+                                        crate::services::agent_protocol::RuntimeHandoff::CodexTui {
+                                            rollout_path: output.display().to_string(),
+                                            thread_id,
+                                            tmux_session_name,
+                                            last_offset: end_offset,
+                                        },
+                                },
+                            )
+                            .map_err(|_| {
+                                "bridge receiver closed during canonical RuntimeReady".to_string()
+                            })?;
+                            continue;
+                        }
+                        message => {
+                            if let crate::services::agent_protocol::StreamMessage::Done {
+                                result,
+                                ..
+                            } = &message
+                                && let Some(suffix) =
+                                    super::codex_rebind_done_result_suffix(&known_response, result)
+                            {
+                                if let Some(offset) = write_or_replay_codex_canonical_message(
+                                    &mut writer,
+                                    &output,
+                                    crate::services::agent_protocol::StreamMessage::Text {
+                                        content: suffix.clone(),
+                                    },
+                                    &mut replay_events,
+                                    &generation_gate,
+                                    generation,
+                                )? {
+                                    end_offset = offset;
+                                }
+                                known_response.push_str(&suffix);
+                            }
+                            if let crate::services::agent_protocol::StreamMessage::Text {
+                                content,
+                            } = &message
+                            {
+                                known_response.push_str(content);
+                            }
+                            let is_terminal = matches!(
+                                &message,
+                                crate::services::agent_protocol::StreamMessage::Done { .. }
+                                    | crate::services::agent_protocol::StreamMessage::Error { .. }
+                            );
+                            if let Some(offset) = write_or_replay_codex_canonical_message(
+                                &mut writer,
+                                &output,
+                                message.clone(),
+                                &mut replay_events,
+                                &generation_gate,
+                                generation,
+                            )? {
+                                end_offset = offset;
+                                downstream
+                                .send(
+                                    crate::services::agent_protocol::StreamMessage::OutputOffset {
+                                        offset: end_offset,
+                                    },
+                                )
+                                .map_err(|_| {
+                                    "bridge receiver closed before canonical message".to_string()
+                                })?;
+                                if is_terminal {
+                                    terminal_records = terminal_records.saturating_add(1);
+                                }
+                            }
+                            downstream.send(message).map_err(|_| {
+                                "bridge receiver closed during canonical message".to_string()
+                            })?;
+                        }
+                    }
+                }
+                if !replay_events.is_empty() {
+                    return Err("Codex canonical replay suffix was not fully consumed".to_string());
+                }
+                Ok(crate::services::discord::CodexCanonicalRelayResult {
+                    output_path: output.display().to_string(),
+                    start_offset,
+                    end_offset,
+                    terminal_records,
+                })
+            })
+            .map_err(|error| format!("spawn Codex canonical relay: {error}"))?;
+        Ok(Self {
+            sender: Some(sender),
+            join: Some(join),
+        })
+    }
+}
+
+fn codex_canonical_replay_events(
+    path: &std::path::Path,
+    start_offset: u64,
+) -> Result<std::collections::VecDeque<(serde_json::Value, u64)>, String> {
+    use std::io::{BufRead, Seek};
+
+    let mut file = std::fs::File::open(path)
+        .map_err(|error| format!("open canonical replay {}: {error}", path.display()))?;
+    if start_offset > 0 {
+        file.seek(std::io::SeekFrom::Start(start_offset - 1))
+            .map_err(|error| format!("seek canonical replay {}: {error}", path.display()))?;
+        let mut prior = [0_u8; 1];
+        std::io::Read::read_exact(&mut file, &mut prior)
+            .map_err(|error| format!("read canonical replay boundary: {error}"))?;
+        if prior[0] != b'\n' {
+            return Err("Codex canonical committed offset is not a JSONL boundary".to_string());
+        }
+    }
+    file.seek(std::io::SeekFrom::Start(start_offset))
+        .map_err(|error| format!("seek canonical replay {}: {error}", path.display()))?;
+    let mut reader = std::io::BufReader::new(file);
+    let mut cursor = start_offset;
+    let mut replay = std::collections::VecDeque::new();
+    loop {
+        let mut line = String::new();
+        let bytes = reader
+            .read_line(&mut line)
+            .map_err(|error| format!("read canonical replay {}: {error}", path.display()))?;
+        if bytes == 0 {
+            break;
+        }
+        cursor = cursor.saturating_add(bytes as u64);
+        if !line.ends_with('\n') {
+            return Err("Codex canonical replay ends with a partial record".to_string());
+        }
+        let json = serde_json::from_str(line.trim_end_matches('\n'))
+            .map_err(|error| format!("parse canonical replay {}: {error}", path.display()))?;
+        replay.push_back((json, cursor));
+    }
+    Ok(replay)
+}
+
+fn write_or_replay_codex_canonical_message(
+    output: &mut std::fs::File,
+    path: &std::path::Path,
+    message: crate::services::agent_protocol::StreamMessage,
+    replay: &mut std::collections::VecDeque<(serde_json::Value, u64)>,
+    generation_gate: &CodexRebindRelayGenerationGate,
+    generation: u64,
+) -> Result<Option<u64>, String> {
+    use std::io::Write;
+
+    let Some(json) = super::codex_rebind_stream_message_json(message) else {
+        return Ok(None);
+    };
+    let current_generation = generation_gate
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    if *current_generation != generation {
+        return Err("Codex canonical relay generation was superseded".to_string());
+    }
+    if let Some((expected, end)) = replay.front() {
+        if expected != &json {
+            return Err("Codex canonical replay diverged from raw rollout".to_string());
+        }
+        let end = *end;
+        replay.pop_front();
+        return Ok(Some(end));
+    }
+    serde_json::to_writer(&mut *output, &json)
+        .map_err(|error| format!("serialize canonical Codex event: {error}"))?;
+    output
+        .write_all(b"\n")
+        .and_then(|_| output.flush())
+        .and_then(|_| output.sync_data())
+        .map_err(|error| format!("write canonical {}: {error}", path.display()))?;
+    output
+        .metadata()
+        .map(|metadata| Some(metadata.len()))
+        .map_err(|error| format!("stat canonical {}: {error}", path.display()))
 }

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -1210,6 +1210,7 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
                             codex_goals_override,
                             compact_token_limit_for_codex,
                             force_fresh_provider_session,
+                            false,
                         ),
                         ProviderKind::Gemini => gemini::execute_command_streaming(
                             &context_prompt,

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2181,6 +2181,13 @@ pub(super) async fn handle_text_message(
     // Pause the tmux-session owner watcher before writing to the provider
     // FIFO. In thread follow-ups, the watcher may be owned by the parent
     // channel rather than the requested thread channel.
+    let watcher_claim_source = if provider == ProviderKind::Codex
+        && prelaunch_runtime_kind == Some(RuntimeHandoffKind::CodexTui)
+    {
+        "turn_start_codex_normalized"
+    } else {
+        "turn_start_message"
+    };
     let _ = attach_paused_turn_watcher_for_inflight(
         shared,
         http.clone(),
@@ -2189,7 +2196,7 @@ pub(super) async fn handle_text_message(
         watcher_tmux_name,
         watcher_output_path,
         inflight_offset,
-        "turn_start_message",
+        watcher_claim_source,
         final_thread_parent.map(|(parent_channel_id, _)| parent_channel_id),
         &mut inflight_state,
     );
@@ -2319,6 +2326,7 @@ pub(super) async fn handle_text_message(
                             codex_goals_override,
                             compact_token_limit_for_codex,
                             force_fresh_provider_session,
+                            true,
                         ),
                         ProviderKind::Gemini => gemini::execute_command_streaming(
                             &context_prompt,

--- a/src/services/discord/tui_prompt_relay/codex_idle_rollout.rs
+++ b/src/services/discord/tui_prompt_relay/codex_idle_rollout.rs
@@ -438,6 +438,13 @@ pub(super) fn spawn_codex_idle_rollout_relay(shared: Arc<SharedData>) {
 }
 
 #[cfg(unix)]
+pub(super) fn closed_codex_idle_bridge_receiver() -> mpsc::Receiver<StreamMessage> {
+    let (sender, receiver) = mpsc::channel();
+    drop(sender);
+    receiver
+}
+
+#[cfg(unix)]
 async fn run_codex_idle_response_tail(
     shared: Arc<SharedData>,
     tmux_session_name: String,
@@ -610,7 +617,7 @@ async fn run_codex_idle_response_tail(
         .await;
         return;
     }
-    let (_closed_tx, reader_rx) = mpsc::channel();
+    let reader_rx = closed_codex_idle_bridge_receiver();
     let delivery_result = stream_tui_idle_response_through_bridge(
         &shared,
         ProviderKind::Codex,

--- a/src/services/discord/tui_prompt_relay/codex_idle_rollout.rs
+++ b/src/services/discord/tui_prompt_relay/codex_idle_rollout.rs
@@ -34,6 +34,43 @@ fn advance_codex_tui_runtime_binding_and_marker_offset(
 }
 
 #[cfg(unix)]
+fn commit_codex_tui_canonical_delivery_offsets(
+    tmux_session_name: &str,
+    rollout_path: &std::path::Path,
+    raw_offset: u64,
+    canonical_path: &str,
+    canonical_offset: u64,
+) -> bool {
+    let rollout_path_str = rollout_path.to_str().unwrap_or_default();
+    if !crate::services::tui_prompt_dedupe::advance_codex_canonical_runtime_offsets(
+        tmux_session_name,
+        rollout_path_str,
+        raw_offset,
+        canonical_path,
+        canonical_offset,
+    ) {
+        return false;
+    }
+    if let Err(error) =
+        crate::services::codex_tui::session::advance_codex_tui_rollout_marker_start_offset(
+            tmux_session_name,
+            rollout_path,
+            raw_offset,
+        )
+    {
+        tracing::warn!(
+            tmux_session_name,
+            rollout_path = %rollout_path.display(),
+            raw_offset,
+            canonical_offset,
+            error,
+            "failed to persist Codex raw discovery cursor after canonical delivery"
+        );
+    }
+    true
+}
+
+#[cfg(unix)]
 pub(super) fn spawn_codex_idle_rollout_relay(shared: Arc<SharedData>) {
     if CODEX_IDLE_ROLLOUT_RELAY_STARTED.swap(true, Ordering::AcqRel) {
         return;
@@ -417,6 +454,36 @@ async fn run_codex_idle_response_tail(
         &lease,
     );
     let (reader_tx, reader_rx) = mpsc::channel::<StreamMessage>();
+    let committed_canonical_offset =
+        crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(&tmux_session_name)
+            .map(|binding| binding.relay_last_offset());
+    let mut canonical_relay = match crate::services::discord::CodexCanonicalRelay::start(
+        &tmux_session_name,
+        reader_tx,
+        false,
+        committed_canonical_offset,
+    ) {
+        Ok(relay) => relay,
+        Err(error) => {
+            tracing::warn!(
+                tmux_session_name = %tmux_session_name,
+                error,
+                "failed to start Codex idle canonical relay"
+            );
+            finish_tui_direct_synthetic_turn_if_current(
+                &shared,
+                &ProviderKind::Codex,
+                channel_id,
+                &tmux_session_name,
+                lease.session_key.as_deref(),
+                "codex_tui_direct_canonical_start_failed",
+            )
+            .await;
+            return;
+        }
+    };
+    let raw_sender = canonical_relay.sender();
+    canonical_relay.close_input();
     let (offset_tx, offset_rx) = tokio::sync::oneshot::channel::<Result<u64, String>>();
     let rollout_for_reader = rollout_path.clone();
     let tmux_for_reader = tmux_session_name.clone();
@@ -428,7 +495,7 @@ async fn run_codex_idle_response_tail(
                     &rollout_for_reader,
                     start_offset,
                     None,
-                    reader_tx,
+                    raw_sender,
                     None,
                     || {
                         crate::services::tmux_diagnostics::tmux_session_has_live_pane(
@@ -446,27 +513,10 @@ async fn run_codex_idle_response_tail(
         })
         .expect("spawn codex idle response tail reader thread");
 
-    let buffered = tokio::task::spawn_blocking(move || {
-        let mut prefix: Vec<StreamMessage> = Vec::new();
-        let mut has_content = false;
-        while let Ok(message) = reader_rx.recv() {
-            let is_content = idle_stream_message_is_content(&message);
-            let is_terminal = matches!(message, StreamMessage::Done { .. });
-            prefix.push(message);
-            if is_content {
-                has_content = true;
-                break;
-            }
-            if is_terminal {
-                break;
-            }
-        }
-        (prefix, has_content, reader_rx)
-    })
-    .await;
-
-    let (prefix, has_content, reader_rx) = match buffered {
-        Ok(buffered) => buffered,
+    let buffered =
+        tokio::task::spawn_blocking(move || reader_rx.into_iter().collect::<Vec<_>>()).await;
+    let prefix = match buffered {
+        Ok(prefix) => prefix,
         Err(error) => {
             tracing::warn!(
                 tmux_session_name = %tmux_session_name,
@@ -486,16 +536,69 @@ async fn run_codex_idle_response_tail(
             return;
         }
     };
+    let canonical = match tokio::task::spawn_blocking(move || canonical_relay.finish()).await {
+        Ok(Ok(result)) if result.terminal_records > 0 => result,
+        Ok(Ok(_)) => {
+            tracing::warn!(
+                tmux_session_name = %tmux_session_name,
+                "Codex idle canonical relay closed without a terminal record"
+            );
+            finish_tui_direct_synthetic_turn_if_current(
+                &shared,
+                &ProviderKind::Codex,
+                channel_id,
+                &tmux_session_name,
+                lease.session_key.as_deref(),
+                "codex_tui_direct_canonical_terminal_missing",
+            )
+            .await;
+            return;
+        }
+        Ok(Err(error)) => {
+            tracing::warn!(
+                tmux_session_name = %tmux_session_name,
+                error,
+                "Codex idle canonical relay failed"
+            );
+            finish_tui_direct_synthetic_turn_if_current(
+                &shared,
+                &ProviderKind::Codex,
+                channel_id,
+                &tmux_session_name,
+                lease.session_key.as_deref(),
+                "codex_tui_direct_canonical_failed",
+            )
+            .await;
+            return;
+        }
+        Err(error) => {
+            tracing::warn!(error = %error, "Codex idle canonical relay join failed");
+            return;
+        }
+    };
+    let final_offset = match offset_rx.await {
+        Ok(Ok(offset)) => offset,
+        Ok(Err(error)) => {
+            tracing::warn!(
+                tmux_session_name = %tmux_session_name,
+                rollout_path = %rollout_path.display(),
+                error = %error,
+                "codex idle rollout response tail failed"
+            );
+            return;
+        }
+        Err(_) => return,
+    };
+    let has_content = prefix.iter().any(idle_stream_message_is_content);
 
     if !has_content {
-        let _ = tokio::task::spawn_blocking(move || while reader_rx.recv().is_ok() {}).await;
-        if let Ok(Ok(final_offset)) = offset_rx.await {
-            advance_codex_tui_runtime_binding_and_marker_offset(
-                &tmux_session_name,
-                &rollout_path,
-                final_offset,
-            );
-        }
+        let _ = commit_codex_tui_canonical_delivery_offsets(
+            &tmux_session_name,
+            &rollout_path,
+            final_offset,
+            &canonical.output_path,
+            canonical.end_offset,
+        );
         finish_tui_direct_synthetic_turn_if_current(
             &shared,
             &ProviderKind::Codex,
@@ -507,13 +610,14 @@ async fn run_codex_idle_response_tail(
         .await;
         return;
     }
+    let (_closed_tx, reader_rx) = mpsc::channel();
     let delivery_result = stream_tui_idle_response_through_bridge(
         &shared,
         ProviderKind::Codex,
         channel_id,
         &tmux_session_name,
-        &rollout_path,
-        start_offset,
+        std::path::Path::new(&canonical.output_path),
+        canonical.start_offset,
         &prompt_text,
         prefix,
         reader_rx,
@@ -531,36 +635,14 @@ async fn run_codex_idle_response_tail(
         )
         .await;
     }
-    match offset_rx.await {
-        Ok(Ok(final_offset))
-            if tui_idle_tail_stream_should_commit_runtime_binding_offset(
-                delivery_result.is_ok(),
-            ) =>
-        {
-            advance_codex_tui_runtime_binding_and_marker_offset(
-                &tmux_session_name,
-                &rollout_path,
-                final_offset,
-            );
-        }
-        Ok(Err(error)) => {
-            tracing::warn!(
-                tmux_session_name = %tmux_session_name,
-                rollout_path = %rollout_path.display(),
-                error = %error,
-                "codex idle rollout response tail failed"
-            );
-            finish_tui_direct_synthetic_turn_if_current(
-                &shared,
-                &ProviderKind::Codex,
-                channel_id,
-                &tmux_session_name,
-                lease.session_key.as_deref(),
-                "codex_tui_direct_tail_failed",
-            )
-            .await;
-        }
-        _ => {}
+    if tui_idle_tail_stream_should_commit_runtime_binding_offset(delivery_result.is_ok()) {
+        let _ = commit_codex_tui_canonical_delivery_offsets(
+            &tmux_session_name,
+            &rollout_path,
+            final_offset,
+            &canonical.output_path,
+            canonical.end_offset,
+        );
     }
 }
 

--- a/src/services/discord/tui_prompt_relay/rehydration.rs
+++ b/src/services/discord/tui_prompt_relay/rehydration.rs
@@ -735,9 +735,20 @@ pub(in crate::services::discord) fn codex_tui_rehydrated_binding_from_rollout_pa
         .unwrap_or(0);
     let relay_output_path =
         crate::services::tmux_common::session_temp_path(tmux_session_name, "jsonl");
-    let relay_last_offset = std::fs::metadata(&relay_output_path)
+    let physical_relay_end = std::fs::metadata(&relay_output_path)
         .map(|metadata| metadata.len())
         .unwrap_or(0);
+    let relay_last_offset = super::super::inflight::load_inflight_states(&ProviderKind::Codex)
+        .into_iter()
+        .find(|state| {
+            super::synthetic_start::codex_ownerless_external_input_inflight_needs_rollout_recovery(
+                state,
+                tmux_session_name,
+            ) && state.output_path.as_deref() == Some(relay_output_path.as_str())
+        })
+        .map(|state| state.turn_start_offset.unwrap_or(state.last_offset))
+        .unwrap_or(physical_relay_end)
+        .min(physical_relay_end);
     Some(crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
         runtime_kind: RuntimeHandoffKind::CodexTui,
         output_path: rollout_path.display().to_string(),

--- a/src/services/discord/tui_prompt_relay/synthetic_start.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start.rs
@@ -46,6 +46,22 @@ pub(in crate::services::discord) fn synthetic_start_offset_carry_forward(
     relay_last_offset.max(committed_relay_offset.unwrap_or(0))
 }
 
+pub(super) fn canonical_codex_synthetic_coordinates(
+    provider: &ProviderKind,
+    binding: Option<&crate::services::tui_prompt_dedupe::TuiRuntimeBinding>,
+) -> Option<(std::path::PathBuf, u64)> {
+    binding
+        .filter(|binding| {
+            provider == &ProviderKind::Codex && binding.runtime_kind == RuntimeHandoffKind::CodexTui
+        })
+        .map(|binding| {
+            (
+                std::path::PathBuf::from(binding.relay_output_path()),
+                binding.relay_last_offset(),
+            )
+        })
+}
+
 pub(super) async fn claim_tui_direct_synthetic_turn(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
@@ -59,14 +75,23 @@ pub(super) async fn claim_tui_direct_synthetic_turn(
         crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(tmux_session_name);
     let binding =
         external_input_relay_binding(provider.as_str(), tmux_session_name, channel_id, binding);
-    let output_path = external_input_relay_output_path(
-        shared,
-        provider.as_str(),
-        tmux_session_name,
-        channel_id,
-        binding.as_ref(),
-    );
-    let relay_last_offset = external_input_relay_start_offset(provider, binding.as_ref());
+    let canonical_codex_coordinates =
+        canonical_codex_synthetic_coordinates(provider, binding.as_ref());
+    let output_path = canonical_codex_coordinates
+        .as_ref()
+        .map(|(path, _)| path.clone())
+        .or_else(|| {
+            external_input_relay_output_path(
+                shared,
+                provider.as_str(),
+                tmux_session_name,
+                channel_id,
+                binding.as_ref(),
+            )
+        });
+    let relay_last_offset = canonical_codex_coordinates
+        .map(|(_, offset)| offset)
+        .unwrap_or_else(|| external_input_relay_start_offset(provider, binding.as_ref()));
     // #3358 round 2: carry the committed frontier forward, but ONLY for the
     // CURRENT wrapper generation (stale → `None` → no content skip).
     // The `tmux` module is `#[cfg(unix)]`; on non-unix targets (windows CI

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -2457,6 +2457,22 @@ fn bridge_adapter_tail_guard_clears_only_current_external_lease() {
         tmux,
         original.clone(),
     );
+    let (bridge_tx, bridge_rx) = std::sync::mpsc::channel();
+    assert_eq!(
+        forward_idle_stream_into_bridge(
+            vec![StreamMessage::Done {
+                result: "done".to_string(),
+                session_id: None,
+            }],
+            super::codex_idle_rollout::closed_codex_idle_bridge_receiver(),
+            bridge_tx,
+        ),
+        0,
+    );
+    assert!(matches!(
+        bridge_rx.recv_timeout(std::time::Duration::from_millis(10)),
+        Ok(StreamMessage::Done { .. })
+    ));
 
     {
         let _guard = TuiDirectExternalInputLeaseGuard::new(

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -3189,6 +3189,26 @@ fn codex_external_input_relay_output_path_uses_rollout_not_wrapper() {
     );
 }
 
+#[test]
+fn codex_synthetic_start_uses_canonical_path_and_cursor() {
+    let binding = crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
+        runtime_kind: RuntimeHandoffKind::CodexTui,
+        output_path: "/tmp/raw-rollout.jsonl".to_string(),
+        relay_output_path: Some("/tmp/canonical-relay.jsonl".to_string()),
+        input_fifo_path: None,
+        session_id: Some("thread".to_string()),
+        last_offset: 92_000,
+        relay_last_offset: Some(640),
+    };
+    assert_eq!(
+        synthetic_start::canonical_codex_synthetic_coordinates(
+            &ProviderKind::Codex,
+            Some(&binding),
+        ),
+        Some((std::path::PathBuf::from("/tmp/canonical-relay.jsonl"), 640))
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn codex_external_input_binding_refreshes_from_live_rollout_marker() {

--- a/src/services/discord/turn_bridge/terminal_controller_cutover.rs
+++ b/src/services/discord/turn_bridge/terminal_controller_cutover.rs
@@ -1876,18 +1876,5 @@ mod tests {
                 true, "short", false, true
             ));
         }
-
-        #[test]
-        fn codex_canonical_range_cuts_over_without_runtime_ready_dependency() {
-            let canonical_start = 640_u64;
-            let canonical_end = 812_u64;
-            let ordered_range = canonical_end > canonical_start;
-            assert!(bridge_short_replace_cutover_decision(
-                true,
-                "canonical Codex answer",
-                ordered_range,
-                true,
-            ));
-        }
     }
 }

--- a/src/services/discord/turn_bridge/terminal_controller_cutover.rs
+++ b/src/services/discord/turn_bridge/terminal_controller_cutover.rs
@@ -1876,5 +1876,18 @@ mod tests {
                 true, "short", false, true
             ));
         }
+
+        #[test]
+        fn codex_canonical_range_cuts_over_without_runtime_ready_dependency() {
+            let canonical_start = 640_u64;
+            let canonical_end = 812_u64;
+            let ordered_range = canonical_end > canonical_start;
+            assert!(bridge_short_replace_cutover_decision(
+                true,
+                "canonical Codex answer",
+                ordered_range,
+                true,
+            ));
+        }
     }
 }

--- a/src/services/discord/watchers/lifecycle/claims.rs
+++ b/src/services/discord/watchers/lifecycle/claims.rs
@@ -171,6 +171,10 @@ pub(crate) fn restore_scan_should_skip_existing_watcher(
     !cancelled && !paused && existing_output_path == restored_output_path
 }
 
+fn canonical_codex_foreground_claim(source: &str) -> bool {
+    source == "turn_start_codex_normalized"
+}
+
 /// #226/#1170: Atomically claim a tmux session for watcher creation.
 /// Returns true if the claim succeeded (caller should spawn the watcher).
 /// Returns false if a watcher already exists (caller should skip).
@@ -347,13 +351,14 @@ pub(crate) fn claim_watcher(
     {
         let turn_start_uses_provisional_output_path =
             matches!(source, "turn_start_message" | "turn_start_headless");
+        let canonical_codex_foreground = canonical_codex_foreground_claim(source);
         let output_path_changed = existing_output_path != requested_output_path;
         let replace_paused_incumbent = existing_paused && !turn_start_uses_provisional_output_path;
         // Turn admission resolves the canonical pre-handoff wrapper path. Once a
         // healthy watcher has adopted the provider-native runtime transcript,
         // that provisional path must not downgrade the live registry binding.
-        let replace_for_output_path =
-            output_path_changed && !turn_start_uses_provisional_output_path;
+        let replace_for_output_path = output_path_changed
+            && (canonical_codex_foreground || !turn_start_uses_provisional_output_path);
         let replaces_existing = force_replace_live_same_tmux
             || existing_cancelled
             || replace_paused_incumbent
@@ -386,6 +391,7 @@ pub(crate) fn claim_watcher(
                     force_replace_live_same_tmux,
                     replace_paused_incumbent,
                     output_path_changed,
+                    canonical_codex_foreground,
                     "watcher claim cancelled same-tmux incumbent before spawning replacement"
                 );
             }

--- a/src/services/discord/watchers/lifecycle/tests.rs
+++ b/src/services/discord/watchers/lifecycle/tests.rs
@@ -157,6 +157,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn canonical_codex_foreground_replaces_post_restart_raw_incumbent() {
+        let watchers = TmuxWatcherRegistry::new();
+        let owner = ChannelId::new(1_485_506_232_256_168_140);
+        let tmux = "AgentDesk-codex-post-restart-canonical";
+        let incumbent = test_watcher_handle(tmux, "/tmp/raw-rollout.jsonl");
+        let incumbent_cancel = incumbent.cancel.clone();
+        assert!(try_claim_watcher(&watchers, owner, incumbent));
+
+        let outcome = claim_or_reuse_watcher(
+            &watchers,
+            owner,
+            test_watcher_handle(tmux, "/tmp/canonical-relay.jsonl"),
+            &ProviderKind::Codex,
+            "turn_start_codex_normalized",
+        );
+
+        assert_eq!(outcome.action, WatcherClaimAction::SpawnReplacedStale);
+        assert!(incumbent_cancel.load(Ordering::Relaxed));
+        assert_eq!(watchers.len(), 1);
+        assert_eq!(
+            watchers.get(&owner).unwrap().output_path,
+            "/tmp/canonical-relay.jsonl"
+        );
+    }
+
     /// #4455: a crossed-provider-turn Codex rebind must replace even a live
     /// same-session/same-output incumbent. Reuse would leave its stale
     /// `current_msg_id` render seed and converter generation in authority.

--- a/src/services/provider_exec.rs
+++ b/src/services/provider_exec.rs
@@ -188,6 +188,7 @@ pub async fn execute_structured_with_context(
                     None,
                     None,
                     false,
+                    false,
                 ),
                 ProviderExecutionAdapter::Gemini => gemini::execute_command_streaming(
                     &prompt,

--- a/src/services/tui_prompt_dedupe/runtime_binding.rs
+++ b/src/services/tui_prompt_dedupe/runtime_binding.rs
@@ -756,3 +756,28 @@ pub(crate) fn advance_tmux_runtime_binding_offset(
     entry.recorded_at = Instant::now();
     true
 }
+
+/// Advance Codex's raw discovery cursor and canonical relay cursor as one
+/// in-memory state transition. A path mismatch updates neither coordinate.
+pub(crate) fn advance_codex_canonical_runtime_offsets(
+    tmux_session_name: &str,
+    raw_output_path: &str,
+    raw_offset: u64,
+    canonical_output_path: &str,
+    canonical_offset: u64,
+) -> bool {
+    let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+    state.purge_expired();
+    let Some(entry) = state.runtime_by_tmux.get_mut(tmux_session_name.trim()) else {
+        return false;
+    };
+    if entry.value.output_path != raw_output_path
+        || entry.value.relay_output_path.as_deref() != Some(canonical_output_path)
+    {
+        return false;
+    }
+    entry.value.last_offset = raw_offset;
+    entry.value.relay_last_offset = Some(canonical_offset);
+    entry.recorded_at = Instant::now();
+    true
+}

--- a/src/services/tui_prompt_dedupe/tests.rs
+++ b/src/services/tui_prompt_dedupe/tests.rs
@@ -2739,3 +2739,48 @@ fn extract_yields_none_entry_id_when_uuid_absent() {
     assert_eq!(prompt, "no uuid here");
     assert_eq!(entry_id, None);
 }
+
+#[test]
+fn codex_canonical_offsets_advance_atomically_or_not_at_all() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    reset_state();
+    let tmux = "AgentDesk-codex-canonical-offsets";
+    register_tmux_runtime_binding(
+        tmux,
+        TuiRuntimeBinding {
+            runtime_kind: RuntimeHandoffKind::CodexTui,
+            output_path: "/tmp/raw.jsonl".to_string(),
+            relay_output_path: Some("/tmp/canonical.jsonl".to_string()),
+            input_fifo_path: None,
+            session_id: Some("thread".to_string()),
+            last_offset: 100,
+            relay_last_offset: Some(20),
+        },
+    );
+    assert!(!advance_codex_canonical_runtime_offsets(
+        tmux,
+        "/tmp/wrong.jsonl",
+        200,
+        "/tmp/canonical.jsonl",
+        40,
+    ));
+    let unchanged = runtime_binding_for_tmux_session(tmux).unwrap();
+    assert_eq!(
+        (unchanged.last_offset, unchanged.relay_last_offset),
+        (100, Some(20))
+    );
+    assert!(advance_codex_canonical_runtime_offsets(
+        tmux,
+        "/tmp/raw.jsonl",
+        200,
+        "/tmp/canonical.jsonl",
+        40,
+    ));
+    let advanced = runtime_binding_for_tmux_session(tmux).unwrap();
+    assert_eq!(
+        (advanced.last_offset, advanced.relay_last_offset),
+        (200, Some(40))
+    );
+}


### PR DESCRIPTION
Closes #5264

## What changed

- routes ordinary managed and idle/external Codex TUI output through one synchronous canonical JSONL adapter
- persists each normalized record and canonical end offset before forwarding the matching bridge message
- keeps raw rollout discovery offsets separate from the canonical delivery frontier
- translates successful RuntimeReady coordinates without weakening the existing #2399 readiness decision
- replaces the provisional post-restart raw watcher with the canonical foreground watcher
- joins the adapter on warm fallback/error/drop before caller cleanup
- explicitly closes the idle bridge sender before awaiting delivery, avoiding a self-deadlock
- treats zero-terminal cold and warm cancellation as a normal cancellation outcome
- seeds ownerless restart replay from the persisted canonical frontier so an uncommitted suffix is
  replayed once instead of appended again
- explicitly excludes the headless greeting path

## Scope

- 17 allowlisted files
- 999 raw changed lines (913 additions, 86 deletions)
- no generic schema, health/recovery framework, headless authority, marker, deploy, mailbox, or PG changes

## Verification

- `cargo fmt --all -- --check`
- `cargo check --lib`
- `cargo clippy --workspace --all-targets --all-features -- -W clippy::all`
- focused canonical/rebind/warm/idle/watcher/synthetic/rehydration library tests
- production-path regressions for bounded idle return plus lease release, cold/warm cancellation,
  and ownerless restart replay of one exact uncommitted canonical suffix
- lib inventory, hotfile, maintainability, generated inventory, and delivery-journal raw-writer gates
- complete `scripts/ci-script-checks.sh` with immutable baseline `4248bdf5eb5eefe10b5395d6e5c0c11519186b0a`
- seven original bounded mutants plus three review-targeted mutants killed; restored exact tree rechecked

## Not run

- no deploy or live TUI/Discord/receipt exercise in this implementation lane; draft remains for separated review and later authorized live evidence
